### PR TITLE
ci: set errcheck to ignore test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,3 +62,5 @@ linters-settings:
     suggest-new: true
   misspell:
     locale: US
+  errcheck:
+    ignoretests: true


### PR DESCRIPTION
This PR modifies `errcheck` in the ci pipeline to ignore `_test.go` files. 