### PR TITLE
ci: increase golint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters-settings:
     max-blank-identifiers: 3
   golint:
     min-confidence: 0
+    timeout: 2m
   maligned:
     suggest-new: true
   misspell:


### PR DESCRIPTION
This PR increases the golint timeout to 2m due to this timeout failure on my other PR: 
https://github.com/celestiaorg/celestia-node/pull/48/checks?check_run_id=3508270276
