### PR TITLE
ci: increase run timeout to 5m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  timeout: 5m
+
 linters:
   enable:
     - bodyclose
@@ -58,7 +61,6 @@ linters-settings:
     max-blank-identifiers: 3
   golint:
     min-confidence: 0
-    timeout: 2m
   maligned:
     suggest-new: true
   misspell:


### PR DESCRIPTION
This PR increases the ci run timeout to 5m as per @tzdybal 's suggestion. 

Copying the implementation here: https://github.com/celestiaorg/optimint/blob/main/.golangci.yml