### PR TITLE
core: add tests for remote node

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"testing"
 
+	"github.com/celestiaorg/celestia-core/node"
 	"github.com/celestiaorg/celestia-core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestClientLifecycle(t *testing.T) {
+var newBlockSubscriber = "NewBlock/Events"
+
+func TestEmbeddedClientLifecycle(t *testing.T) {
 	client := MockClient()
-	err := client.Stop()
-	require.NoError(t, err)
+	require.NoError(t, client.Stop())
 }
 
-func TestClient_Status(t *testing.T) {
+func TestEmbeddedClient_Status(t *testing.T) {
 	client := MockClient()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -25,17 +27,16 @@ func TestClient_Status(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, status)
 
-	err = client.Stop()
-	require.NoError(t, err)
+	require.NoError(t, client.Stop())
 }
 
-func TestClient_StartBlockSubscription_And_GetBlock(t *testing.T) {
+func TestEmbeddedClient_StartBlockSubscription_And_GetBlock(t *testing.T) {
 	client := MockClient()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	eventChan, err := client.Subscribe(ctx, "NewBlock/Events", types.QueryForEvent(types.EventNewBlock).String())
+	eventChan, err := client.Subscribe(ctx, newBlockSubscriber, types.QueryForEvent(types.EventNewBlock).String())
 	require.NoError(t, err)
 
 	for i := 1; i <= 3; i++ {
@@ -47,6 +48,78 @@ func TestClient_StartBlockSubscription_And_GetBlock(t *testing.T) {
 	}
 
 	// unsubscribe to event channel
-	err = client.Unsubscribe(ctx, "NewBlock/Events", types.QueryForEvent(types.EventNewBlock).String())
+	require.NoError(t, client.Unsubscribe(ctx, newBlockSubscriber, types.QueryForEvent(types.EventNewBlock).String()))
+	require.NoError(t, client.Stop())
+}
+
+func TestRemoteClientLifecycle(t *testing.T) {
+	remote := StartMockNode()
+
+	protocol, ip := getRemoteEndpoint(remote)
+
+	client, err := NewRemote(protocol, ip)
 	require.NoError(t, err)
+
+	require.NoError(t, client.Start())
+	require.NoError(t, client.Stop())
+	require.NoError(t, remote.Stop())
+}
+
+func TestRemoteClient_Status(t *testing.T) {
+	remote := StartMockNode()
+	protocol, ip := getRemoteEndpoint(remote)
+	client, err := NewRemote(protocol, ip)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// client must be `started` before performing requests
+	err = client.Start()
+	require.NoError(t, err)
+
+	status, err := client.Status(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, status)
+
+	require.NoError(t, client.Stop())
+	require.NoError(t, remote.Stop())
+}
+
+func TestRemoteClient_StartBlockSubscription_And_GetBlock(t *testing.T) {
+	remote := StartMockNode()
+	protocol, ip := getRemoteEndpoint(remote)
+	client, err := NewRemote(protocol, ip)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// client must be `started` before subscribing to new block events.
+	err = client.Start()
+	require.NoError(t, err)
+
+	eventChan, err := client.Subscribe(ctx, newBlockSubscriber, types.QueryForEvent(types.EventNewBlock).String())
+	require.NoError(t, err)
+
+	for i := 1; i <= 3; i++ {
+		<-eventChan
+		// check that `Block` works as intended (passing nil to get block at latest height)
+		block, err := client.Block(ctx, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(i), block.Block.Height)
+	}
+
+	// unsubscribe to event channel
+	require.NoError(t, client.Unsubscribe(ctx, newBlockSubscriber, types.QueryForEvent(types.EventNewBlock).String()))
+	require.NoError(t, client.Stop())
+	require.NoError(t, remote.Stop())
+}
+
+// getRemoteEndpoint returns the protocol and ip of the remote node.
+func getRemoteEndpoint(remote *node.Node) (string, string) {
+	endpoint := remote.Config().RPC.ListenAddress
+	// protocol = "tcp"
+	protocol, ip := endpoint[:3], endpoint[6:]
+	return protocol, ip
 }

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -18,8 +18,8 @@ func MockEmbeddedClient() Client {
 	return NewEmbeddedFromNode(StartMockNode())
 }
 
-// StartRemoteClient returns a started mock Core Client
-// from the remote Core node process.
+// StartRemoteClient returns a started remote Core node process, as well its
+// mock Core Client.
 func StartRemoteClient() (*node.Node, Client, error) {
 	remote := StartMockNode()
 	protocol, ip := getRemoteEndpoint(remote)

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -6,14 +6,31 @@ import (
 	rpctest "github.com/celestiaorg/celestia-core/rpc/test"
 )
 
-// StartMockNode starts a mock core node background process and returns it.
+// StartMockNode starts a mock Core node background process and returns it.
 func StartMockNode() *node.Node {
 	app := kvstore.NewApplication()
 	app.RetainBlocks = 10
 	return rpctest.StartTendermint(app, rpctest.SuppressStdout, rpctest.RecreateConfig)
 }
 
-// MockClient returns a started Mock Core Client.
-func MockClient() Client {
+// MockEmbeddedClient returns a started mock Core Client.
+func MockEmbeddedClient() Client {
 	return NewEmbeddedFromNode(StartMockNode())
+}
+
+// StartRemoteClient returns a started mock Core Client
+// from the remote Core node process.
+func StartRemoteClient() (*node.Node, Client, error) {
+	remote := StartMockNode()
+	protocol, ip := getRemoteEndpoint(remote)
+	client, err := NewRemote(protocol, ip)
+	return remote, client, err
+}
+
+// getRemoteEndpoint returns the protocol and ip of the remote node.
+func getRemoteEndpoint(remote *node.Node) (string, string) {
+	endpoint := remote.Config().RPC.ListenAddress
+	// protocol = "tcp"
+	protocol, ip := endpoint[:3], endpoint[6:]
+	return protocol, ip
 }

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -10,7 +10,7 @@ import (
 func StartMockNode() *node.Node {
 	app := kvstore.NewApplication()
 	app.RetainBlocks = 10
-	return rpctest.StartTendermint(app, rpctest.SuppressStdout)
+	return rpctest.StartTendermint(app, rpctest.SuppressStdout, rpctest.RecreateConfig)
 }
 
 // MockClient returns a started Mock Core Client.


### PR DESCRIPTION
This PR adds test for remote core node. 

#51 depends on this PR.