### PR TITLE
block: create `Fetcher` interface

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/celestiaorg/celestia-core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var newBlockSubscriber = "NewBlock/Events"
-var newBlockEventQuery = types.QueryForEvent(types.EventNewBlock).String()
 
 func TestEmbeddedClientLifecycle(t *testing.T) {
 	client := MockEmbeddedClient()

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"context"
+	"sync"
+
+	rpctypes "github.com/celestiaorg/celestia-core/rpc/core/types"
+	"github.com/celestiaorg/celestia-core/types"
+	"github.com/celestiaorg/celestia-node/service/block"
+)
+
+const newBlockSubscriber = "NewBlock/Events"
+
+var newBlockEventQuery = types.QueryForEvent(types.EventNewBlock).String()
+
+type BlockFetcher struct {
+	Client
+
+	mux        sync.Mutex
+	newBlockCh chan *block.Raw
+}
+
+// NewBlockFetcher returns a new `BlockFetcher`.
+func NewBlockFetcher(client Client) *BlockFetcher {
+	return &BlockFetcher{
+		Client: client,
+	}
+}
+
+// GetBlock queries Core for a `Block` at the given height.
+func (f *BlockFetcher) GetBlock(ctx context.Context, height *int64) (*block.Raw, error) {
+	raw, err := f.Block(ctx, height)
+	return raw.Block, err
+}
+
+// SubscribeNewBlockEvent subscribes to new block events from Core, returning
+// a new block event channel on success.
+func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *block.Raw, error) {
+	// start the client if not started yet
+	if !f.IsRunning() {
+		if err := f.Start(); err != nil {
+			return nil, err
+		}
+	}
+	eventChan, err := f.Subscribe(ctx, newBlockSubscriber, newBlockEventQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a wrapper channel for translating ResultEvent to *core.Block
+	newBlockChan := make(chan *block.Raw)
+	f.mux.Lock()
+	f.newBlockCh = newBlockChan
+	f.mux.Unlock()
+
+	go func(eventChan <-chan rpctypes.ResultEvent, newBlockChan chan *block.Raw) {
+		for {
+			newEvent := <-eventChan
+			rawBlock, ok := newEvent.Data.(types.EventDataNewBlock)
+			if !ok {
+				// TODO log & ignore? or errChan?
+				continue
+			}
+			newBlockChan <- rawBlock.Block
+		}
+	}(eventChan, newBlockChan)
+
+	return newBlockChan, nil
+}
+
+// UnsubscribeNewBlockEvent stops the subscription to new block events from Core.
+func (f *BlockFetcher) UnsubscribeNewBlockEvent(ctx context.Context) error {
+	// close the new block channel
+	close(f.newBlockCh)
+	f.mux.Lock()
+	f.newBlockCh = nil
+	f.mux.Unlock()
+
+	return f.Unsubscribe(ctx, newBlockSubscriber, newBlockEventQuery)
+}

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -59,9 +59,9 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *bloc
 			case <-ctx.Done():
 				return
 			case newEvent, ok := <-eventChan:
-			if !ok {
-				return
-			}
+				if !ok {
+					return
+				}
 				newBlock, ok := newEvent.Data.(types.EventDataNewBlock)
 				if !ok {
 					log.Warnf("unexpected event: %v", newEvent)
@@ -86,9 +86,9 @@ func (f *BlockFetcher) UnsubscribeNewBlockEvent(ctx context.Context) error {
 		return fmt.Errorf("no new block event channel found")
 	}
 	defer func() {
-		  close(f.newBlockCh)
-		  f.newBlockCh = nil
-	}
+		close(f.newBlockCh)
+		f.newBlockCh = nil
+	}()
 
 	return f.client.Unsubscribe(ctx, newBlockSubscriber, newBlockEventQuery)
 }

--- a/core/fetcher_test.go
+++ b/core/fetcher_test.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockFetcher_GetBlock_and_SubscribeNewBlockEvent(t *testing.T) {
+	client := MockEmbeddedClient()
+	fetcher := NewBlockFetcher(client)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// generate some blocks
+	newBlockChan, err := fetcher.SubscribeNewBlockEvent(ctx)
+	require.NoError(t, err)
+
+	for i := 1; i < 3; i++ {
+		newBlockFromChan := <-newBlockChan
+
+		block, err := fetcher.GetBlock(ctx, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, newBlockFromChan, block)
+	}
+
+	require.NoError(t, fetcher.UnsubscribeNewBlockEvent(ctx))
+	require.NoError(t, client.Stop())
+}

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -34,5 +34,6 @@ func Components(cfg *Config) fx.Option {
 
 			return core.NewEmbedded(cfg.EmbeddedConfig)
 		}),
+		fx.Provide(core.NewBlockFetcher),
 	)
 }

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -34,6 +34,5 @@ func Components(cfg *Config) fx.Option {
 
 			return core.NewEmbedded(cfg.EmbeddedConfig)
 		}),
-		fx.Provide(core.NewBlockFetcher),
 	)
 }

--- a/node/full.go
+++ b/node/full.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/node/core"
 	"github.com/celestiaorg/celestia-node/node/p2p"
+	"github.com/celestiaorg/celestia-node/service/block"
 )
 
 // NewFull assembles a new Full Node from required components.
@@ -29,5 +30,6 @@ func fullComponents(cfg *Config) fx.Option {
 		// components
 		p2p.Components(cfg.P2P),
 		core.Components(cfg.Core),
+		fx.Provide(block.NewBlockService),
 	)
 }

--- a/node/full.go
+++ b/node/full.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/fx"
 
+	coreclient "github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/node/core"
 	"github.com/celestiaorg/celestia-node/node/p2p"
 	"github.com/celestiaorg/celestia-node/service/block"
@@ -26,10 +27,13 @@ func fullComponents(cfg *Config) fx.Option {
 		fx.Provide(func() *Config {
 			return cfg
 		}),
-
+		// provide the block Fetcher
+		fx.Provide(func(client coreclient.Client) block.Fetcher {
+			return coreclient.NewBlockFetcher(client)
+		}),
+		fx.Provide(block.NewBlockService),
 		// components
 		p2p.Components(cfg.P2P),
 		core.Components(cfg.Core),
-		fx.Provide(block.NewBlockService),
 	)
 }

--- a/node/full_test.go
+++ b/node/full_test.go
@@ -40,6 +40,7 @@ func TestFullLifecycle(t *testing.T) {
 	require.NotZero(t, node.Type)
 	require.NotNil(t, node.Host)
 	require.NotNil(t, node.CoreClient)
+	require.NotNil(t, node.BlockServ)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/node/node.go
+++ b/node/node.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/core"
+	"github.com/celestiaorg/celestia-node/service/block"
 )
 
 var log = logging.Logger("node")
@@ -38,6 +39,12 @@ type Node struct {
 	DataExchange exchange.Interface
 	// p2p protocols
 	PubSub *pubsub.PubSub
+	// BlockService provides access to the node's Block Service
+	// TODO @renaynay: I don't like the concept of storing individual services on the node,
+	// TODO maybe create a struct in full.go that contains `FullServices` (all expected services to be running on a
+	// TODO full node) and in light, same thing `LightServices` (all expected services to be running in a light node.
+	// TODO `FullServices` can include `LightServices` + other services.
+	BlockServ *block.Service `optional:"true"`
 }
 
 // newNode creates a new Node from given DI options.

--- a/service/block/interface.go
+++ b/service/block/interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 )
 
-// Fetcher encompasses the behavior necessary to fetch new blocks.
+// Fetcher encompasses the behavior necessary to fetch new "raw" blocks.
 type Fetcher interface {
 	GetBlock(ctx context.Context, height *int64) (*Raw, error)
 	SubscribeNewBlockEvent(ctx context.Context) (<-chan *Raw, error)

--- a/service/block/interface.go
+++ b/service/block/interface.go
@@ -1,0 +1,12 @@
+package block
+
+import (
+	"context"
+)
+
+// Fetcher encompasses the behavior necessary to fetch new blocks.
+type Fetcher interface {
+	GetBlock(ctx context.Context, height *int64) (*Raw, error)
+	SubscribeNewBlockEvent(ctx context.Context) (<-chan *Raw, error)
+	UnsubscribeNewBlockEvent(ctx context.Context) error
+}

--- a/service/block/service.go
+++ b/service/block/service.go
@@ -6,8 +6,7 @@ import (
 
 // Service represents the Block service that can be started / stopped on a `Full` node.
 // Service contains 4 main functionalities:
-//		1. Fetching "raw" blocks from either Celestia Core or other Celestia Full nodes. // TODO note: this will
-//		 TODO eventually take place on the p2p level.
+//		1. Fetching "raw" blocks from either Celestia Core or other Celestia Full nodes.
 // 		2. Erasure coding the "raw" blocks and producing a DataAvailabilityHeader + verifying the Data root.
 // 		3. Storing erasure coded blocks.
 // 		4. Serving erasure coded blocks to other `Full` node peers. // TODO note: optional for devnet
@@ -23,9 +22,18 @@ func NewBlockService(fetcher Fetcher) *Service {
 }
 
 // Start starts the block Service.
+// TODO @renaynay: make sure `Start` eventually has the same signature as `Stop`
 func (s *Service) Start(ctx context.Context) (<-chan *Raw, error) {
-	return s.fetcher.SubscribeNewBlockEvent(ctx)
+	return s.fetcher.SubscribeNewBlockEvent(ctx) // TODO this will eventually be self contained within the block package
 }
+
+// go listen() {
+// 		select {
+// 		case <- ctx.Done():
+// 			return
+//		case <- newBlock:
+// 			handle(newBlock)
+//}
 
 // Stop stops the block Service.
 func (s *Service) Stop(ctx context.Context) error {

--- a/service/block/service.go
+++ b/service/block/service.go
@@ -9,7 +9,7 @@ import (
 //		1. Fetching "raw" blocks from either Celestia Core or other Celestia Full nodes.
 // 		2. Erasure coding the "raw" blocks and producing a DataAvailabilityHeader + verifying the Data root.
 // 		3. Storing erasure coded blocks.
-// 		4. Serving erasure coded blocks to other `Full` node peers. // TODO note: optional for devnet
+// 		4. Serving erasure coded blocks to other `Full` node peers.
 type Service struct {
 	fetcher Fetcher
 }
@@ -24,16 +24,9 @@ func NewBlockService(fetcher Fetcher) *Service {
 // Start starts the block Service.
 // TODO @renaynay: make sure `Start` eventually has the same signature as `Stop`
 func (s *Service) Start(ctx context.Context) (<-chan *Raw, error) {
-	return s.fetcher.SubscribeNewBlockEvent(ctx) // TODO this will eventually be self contained within the block package
+	// TODO @renaynay: this will eventually be self contained within the block package
+	return s.fetcher.SubscribeNewBlockEvent(ctx)
 }
-
-// go listen() {
-// 		select {
-// 		case <- ctx.Done():
-// 			return
-//		case <- newBlock:
-// 			handle(newBlock)
-//}
 
 // Stop stops the block Service.
 func (s *Service) Stop(ctx context.Context) error {

--- a/service/block/service.go
+++ b/service/block/service.go
@@ -1,0 +1,33 @@
+package block
+
+import (
+	"context"
+)
+
+// Service represents the Block service that can be started / stopped on a `Full` node.
+// Service contains 4 main functionalities:
+//		1. Fetching "raw" blocks from either Celestia Core or other Celestia Full nodes. // TODO note: this will
+//		 TODO eventually take place on the p2p level.
+// 		2. Erasure coding the "raw" blocks and producing a DataAvailabilityHeader + verifying the Data root.
+// 		3. Storing erasure coded blocks.
+// 		4. Serving erasure coded blocks to other `Full` node peers. // TODO note: optional for devnet
+type Service struct {
+	fetcher Fetcher
+}
+
+// NewBlockService creates a new instance of block Service.
+func NewBlockService(fetcher Fetcher) *Service {
+	return &Service{
+		fetcher: fetcher,
+	}
+}
+
+// Start starts the block Service.
+func (s *Service) Start(ctx context.Context) (<-chan *Raw, error) {
+	return s.fetcher.SubscribeNewBlockEvent(ctx)
+}
+
+// Stop stops the block Service.
+func (s *Service) Stop(ctx context.Context) error {
+	return s.fetcher.UnsubscribeNewBlockEvent(ctx)
+}

--- a/service/block/types.go
+++ b/service/block/types.go
@@ -1,0 +1,9 @@
+package block
+
+import (
+	core "github.com/celestiaorg/celestia-core/types"
+)
+
+// Raw is an alias to a "raw" Core block. It is "raw" because
+// it is still awaiting erasure coding.
+type Raw = core.Block


### PR DESCRIPTION
This PR introduces a block `Fetcher` interface that will encompass the behaviour necessary for the `BlockService` to get new blocks either directly from a Core node or from the Celestia network.

It also adds an implementation of `Fetcher` for the Core `Client`

TODO 
- [x] Add `BlockService` to `Full` node

Related to #25 and #26 