### PR TITLE
libs/keystore: introduce Keystore a crypto key manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/libp2p/go-libp2p-peerstore v0.2.8
 	github.com/libp2p/go-libp2p-pubsub v0.5.4
 	github.com/libp2p/go-libp2p-routing-helpers v0.2.3
+	github.com/multiformats/go-base32 v0.0.4
 	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/fx v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -861,8 +861,9 @@ github.com/mr-tron/base58 v1.1.2/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjW
 github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
-github.com/multiformats/go-base32 v0.0.3 h1:tw5+NhuwaOjJCC5Pp82QuXbrmLzWg7uxlMFp8Nq/kkI=
 github.com/multiformats/go-base32 v0.0.3/go.mod h1:pLiuGC8y0QR3Ue4Zug5UzK9LjgbkL8NSQj0zQ5Nz/AA=
+github.com/multiformats/go-base32 v0.0.4 h1:+qMh4a2f37b4xTNs6mqitDinryCI+tfO2dRVMN9mjSE=
+github.com/multiformats/go-base32 v0.0.4/go.mod h1:jNLFzjPZtp3aIARHbJRZIaPuspdH0J6q39uUM5pnABM=
 github.com/multiformats/go-base36 v0.1.0 h1:JR6TyF7JjGd3m6FbLU2cOxhC0Li8z8dLNGQ89tUg4F4=
 github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoRdUUOENyW/Vv6sM=
 github.com/multiformats/go-multiaddr v0.0.1/go.mod h1:xKVEak1K9cS1VdmPZW3LSIb6lgmoS58qz/pzqmAxV44=

--- a/libs/keystore/fs_keystore.go
+++ b/libs/keystore/fs_keystore.go
@@ -1,0 +1,126 @@
+package keystore
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// fsKeystore implements persistent Keystore over OS filesystem.
+type fsKeystore struct {
+	path string
+}
+
+// NewFSKeystore creates a new Keystore over OS filesystem.
+// The path must point to a directory. It is created automatically if necessary.
+func NewFSKeystore(path string) (Keystore, error) {
+	err := os.Mkdir(path, 0755)
+	if err != nil && !os.IsExist(err) {
+		return nil, fmt.Errorf("keystore: failed to make a dir: %w", err)
+	}
+	return &fsKeystore{path: path}, nil
+}
+
+func (f *fsKeystore) Put(n KeyName, pk PrivKey) error {
+	path := f.pathTo(n.Base32())
+
+	_, err := os.Stat(path)
+	if err == nil {
+		return fmt.Errorf("keystore: key '%s' already exists", n)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("keystore: check before writing key '%s' failed: %w", n, err)
+	}
+
+	data, err := json.Marshal(pk)
+	if err != nil {
+		return fmt.Errorf("keystore: failed to marshal key '%s': %w", n, err)
+	}
+
+	err = os.WriteFile(path, data, 0600)
+	if err != nil {
+		return fmt.Errorf("keystore: failed to write key '%s': %w", n, err)
+	}
+	return nil
+}
+
+func (f *fsKeystore) Get(n KeyName) (PrivKey, error) {
+	path := f.pathTo(n.Base32())
+
+	st, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PrivKey{}, fmt.Errorf("keystore: key '%s' not found", n)
+		}
+
+		return PrivKey{}, fmt.Errorf("keystore: check before reading key '%s' failed: %w", n, err)
+	}
+
+	if err := checkPerms(st.Mode()); err != nil {
+		return PrivKey{}, fmt.Errorf("keystore: permissions of key '%s' are too relaxed: %w", n, err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return PrivKey{}, fmt.Errorf("keystore: failed read key '%s': %w", n, err)
+	}
+
+	var key PrivKey
+	err = json.Unmarshal(data, &key)
+	if err != nil {
+		return PrivKey{}, fmt.Errorf("keystore: failed to unmarshal key '%s': %w", n, err)
+	}
+	return key, nil
+}
+
+func (f *fsKeystore) Delete(n KeyName) error {
+	path := f.pathTo(n.Base32())
+
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("keystore: key '%s' not found", n)
+	} else if err != nil {
+		return fmt.Errorf("keystore: check before reading key '%s' failed: %w", n, err)
+	}
+
+	err = os.Remove(path)
+	if err != nil {
+		return fmt.Errorf("keystore: failed to delete key '%s': %w", n, err)
+	}
+	return nil
+}
+
+func (f *fsKeystore) List() ([]KeyName, error) {
+	entries, err := fs.ReadDir(os.DirFS(filepath.Dir(f.path)), filepath.Base(f.path))
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]KeyName, len(entries))
+	for i, e := range entries {
+		kn, err := KeyNameFromBase32(e.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		if err := checkPerms(e.Type()); err != nil {
+			return nil, fmt.Errorf("keystore: permissions of key '%s' are too relaxed: %w", kn, err)
+		}
+
+		names[i] = kn
+	}
+
+	return names, nil
+}
+
+func (f *fsKeystore) pathTo(file string) string {
+	return filepath.Join(f.path, file)
+}
+
+func checkPerms(perms os.FileMode) error {
+	if perms&0077 != 0 {
+		return fmt.Errorf("required: 0600, got: %#o", perms)
+	}
+	return nil
+}

--- a/libs/keystore/fs_keystore_test.go
+++ b/libs/keystore/fs_keystore_test.go
@@ -1,0 +1,31 @@
+package keystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFSKeystore(t *testing.T) {
+	kstore, err := NewFSKeystore(t.TempDir() + "/keystore")
+	require.NoError(t, err)
+
+	err = kstore.Put("test", PrivKey{Body: []byte("test_private_key")})
+	require.NoError(t, err)
+
+	key, err := kstore.Get("test")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("test_private_key"), key.Body)
+
+	keys, err := kstore.List()
+	require.NoError(t, err)
+	assert.Len(t, keys, 1)
+
+	err = kstore.Delete("test")
+	require.NoError(t, err)
+
+	keys, err = kstore.List()
+	require.NoError(t, err)
+	assert.Len(t, keys, 0)
+}

--- a/libs/keystore/keystore.go
+++ b/libs/keystore/keystore.go
@@ -1,0 +1,53 @@
+package keystore
+
+import (
+	"fmt"
+
+	"github.com/multiformats/go-base32"
+)
+
+type (
+	// KeyName represents private key name.
+	KeyName string
+
+	// PrivKey represents private key with arbitrary body.
+	PrivKey struct {
+		Body []byte `json:"body"`
+
+		// TODO(@Wondertan): At later point, it might make sense to have a Type.
+	}
+)
+
+// Keystore is meant to manage private keys.
+type Keystore interface {
+	// Put stores given PrivKey.
+	Put(KeyName, PrivKey) error
+
+	// Get reads PrivKey using given KeyName.
+	Get(KeyName) (PrivKey, error)
+
+	// Delete erases PrivKey using given KeyName.
+	Delete(name KeyName) error
+
+	// List lists all stored key names.
+	List() ([]KeyName, error)
+}
+
+// KeyNameFromBase32 decodes KeyName from Base32 format.
+func KeyNameFromBase32(bs string) (KeyName, error) {
+	name, err := base32.RawStdEncoding.DecodeString(bs)
+	if err != nil {
+		return "", fmt.Errorf("keystore: can't convert base32 string to key name: %w", err)
+	}
+
+	return KeyName(name), nil
+}
+
+// Base32 formats KeyName to Base32 format.
+func (kn KeyName) Base32() string {
+	return base32.RawStdEncoding.EncodeToString([]byte(kn))
+}
+
+func (kn KeyName) String() string {
+	return string(kn)
+}

--- a/libs/keystore/map_keystore.go
+++ b/libs/keystore/map_keystore.go
@@ -1,0 +1,67 @@
+package keystore
+
+import (
+	"fmt"
+	"sync"
+)
+
+// mapKeystore is a simple in-memory Keystore implementation.
+type mapKeystore struct {
+	keys   map[KeyName]PrivKey
+	keysLk sync.Mutex
+}
+
+// NewMapKeystore constructs in-memory Keystore.
+func NewMapKeystore() Keystore {
+	return &mapKeystore{keys: make(map[KeyName]PrivKey)}
+}
+
+func (m *mapKeystore) Put(n KeyName, k PrivKey) error {
+	m.keysLk.Lock()
+	defer m.keysLk.Unlock()
+
+	_, ok := m.keys[n]
+	if ok {
+		return fmt.Errorf("keystore: key '%s' already exists", n)
+	}
+
+	m.keys[n] = k
+	return nil
+}
+
+func (m *mapKeystore) Get(n KeyName) (PrivKey, error) {
+	m.keysLk.Lock()
+	defer m.keysLk.Unlock()
+
+	k, ok := m.keys[n]
+	if !ok {
+		return PrivKey{}, fmt.Errorf("keystore: key '%s' not found", n)
+	}
+
+	return k, nil
+}
+
+func (m *mapKeystore) Delete(n KeyName) error {
+	m.keysLk.Lock()
+	defer m.keysLk.Unlock()
+
+	_, ok := m.keys[n]
+	if !ok {
+		return fmt.Errorf("keystore: key '%s' not found", n)
+	}
+
+	delete(m.keys, n)
+	return nil
+}
+
+func (m *mapKeystore) List() ([]KeyName, error) {
+	m.keysLk.Lock()
+	defer m.keysLk.Unlock()
+
+	keys := make([]KeyName, 0, len(m.keys))
+	for k := range m.keys {
+		keys = append(keys, k)
+	}
+
+	return keys, nil
+}

--- a/libs/keystore/map_keystore_test.go
+++ b/libs/keystore/map_keystore_test.go
@@ -1,0 +1,29 @@
+package keystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapKeystore(t *testing.T) {
+	kstore := NewMapKeystore()
+	err := kstore.Put("test", PrivKey{Body: []byte("test_private_key")})
+	require.NoError(t, err)
+
+	key, err := kstore.Get("test")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("test_private_key"), key.Body)
+
+	keys, err := kstore.List()
+	require.NoError(t, err)
+	assert.Len(t, keys, 1)
+
+	err = kstore.Delete("test")
+	require.NoError(t, err)
+
+	keys, err = kstore.List()
+	require.NoError(t, err)
+	assert.Len(t, keys, 0)
+}


### PR DESCRIPTION
## Rationale
Libp2p does not provide storage for private keys(Peerstore might be a solution but is on-disk version is flawed), so we need to store them somewhere. The Keystore comes to solve this and allows storing different keys for multiple purposes, including storing p2p keys. Further, we can delegate consensus keys to Keystore as it will evolve through time and get more features/implementations.

## Filling
* Defines interface
* Implements Fs version
* Implements in-memory version

## Other
Closes https://github.com/celestiaorg/celestia-node/issues/65