### PR TITLE
libs/fslock: a simple utility to lock directories

### DIFF
--- a/libs/fslock/lock_unix.go
+++ b/libs/fslock/lock_unix.go
@@ -12,12 +12,12 @@ import (
 func (l *Locker) lock() (err error) {
 	l.file, err = os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {
-		return fmt.Errorf("fslock: error opening file: %v", err)
+		return fmt.Errorf("fslock: error opening file: %w", err)
 	}
 
 	_, err = l.file.WriteString(strconv.Itoa(os.Getpid()))
 	if err != nil {
-		return fmt.Errorf("fslock: error writing process id: %v", err)
+		return fmt.Errorf("fslock: error writing process id: %w", err)
 	}
 
 	err = syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
@@ -25,23 +25,23 @@ func (l *Locker) lock() (err error) {
 		return ErrLocked
 	}
 	if err != nil {
-		return fmt.Errorf("fslock: flocking error: %v", err)
+		return fmt.Errorf("fslock: flocking error: %w", err)
 	}
 
-	return nil
+	return
 }
 
 func (l *Locker) unlock() error {
 	err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN|syscall.LOCK_NB)
 	if err != nil {
-		return fmt.Errorf("fslock: unflocking error: %v", err)
+		return fmt.Errorf("fslock: unflocking error: %w", err)
 	}
 
 	file := l.file
 	l.file = nil
 	err = file.Close()
 	if err != nil {
-		return fmt.Errorf("fslock: while closing file: %v", err)
+		return fmt.Errorf("fslock: while closing file: %w", err)
 	}
 
 	return os.Remove(l.path)

--- a/libs/fslock/lock_unix.go
+++ b/libs/fslock/lock_unix.go
@@ -22,7 +22,7 @@ func (l *Locker) lock() (err error) {
 
 	err = syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 	if err != nil && err.Error() == "resource temporarily unavailable" {
-		return ErrLocked
+		return ErrLocked // we have to check here for a string in err, as there is no error types defined for this case.
 	}
 	if err != nil {
 		return fmt.Errorf("fslock: flocking error: %w", err)

--- a/libs/fslock/lock_unix.go
+++ b/libs/fslock/lock_unix.go
@@ -1,0 +1,48 @@
+//go:build darwin || freebsd || linux
+
+package fslock
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func (l *Locker) lock() (err error) {
+	l.file, err = os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		return fmt.Errorf("fslock: error opening file: %v", err)
+	}
+
+	_, err = l.file.WriteString(strconv.Itoa(os.Getpid()))
+	if err != nil {
+		return fmt.Errorf("fslock: error writing process id: %v", err)
+	}
+
+	err = syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil && err.Error() == "resource temporarily unavailable" {
+		return ErrLocked
+	}
+	if err != nil {
+		return fmt.Errorf("fslock: flocking error: %v", err)
+	}
+
+	return nil
+}
+
+func (l *Locker) unlock() error {
+	err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN|syscall.LOCK_NB)
+	if err != nil {
+		return fmt.Errorf("fslock: unflocking error: %v", err)
+	}
+
+	file := l.file
+	l.file = nil
+	err = file.Close()
+	if err != nil {
+		return fmt.Errorf("fslock: while closing file: %v", err)
+	}
+
+	return os.Remove(l.path)
+}

--- a/libs/fslock/locker.go
+++ b/libs/fslock/locker.go
@@ -1,0 +1,42 @@
+package fslock
+
+import (
+	"errors"
+	"os"
+)
+
+var (
+	ErrLocked = errors.New("fslock: directory is locked")
+)
+
+func Lock(path string) (*Locker, error) {
+	l := New(path)
+	err := l.Lock()
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+// TODO Add windows support
+type Locker struct {
+	file *os.File
+	path string
+}
+
+func New(path string) *Locker {
+	return &Locker{path: path}
+}
+
+func (l *Locker) Lock() error {
+	return l.lock()
+}
+
+func (l *Locker) Unlock() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	return l.unlock()
+}

--- a/libs/fslock/locker.go
+++ b/libs/fslock/locker.go
@@ -5,8 +5,11 @@ import (
 	"os"
 )
 
+// ErrLocked is signaled when someone tries to lock an already locked file.
 var ErrLocked = errors.New("fslock: directory is locked")
 
+// Lock creates a new Locker under the given 'path'
+// and immediately does Lock on it.
 func Lock(path string) (*Locker, error) {
 	l := New(path)
 	err := l.Lock()
@@ -17,19 +20,26 @@ func Lock(path string) (*Locker, error) {
 	return l, nil
 }
 
+// Locker is a simple utility meant to create lock files.
+// This is to prevent multiple processes from managing the same working directory by purpose or accident.
+// NOTE: Windows is not supported.
 type Locker struct {
 	file *os.File
 	path string
 }
 
+// New creates a new Locker with a File pointing to the given 'path'.
 func New(path string) *Locker {
 	return &Locker{path: path}
 }
 
+// Lock locks the file.
+// Subsequent calls will error with ErrLocked on any Locker instance looking to the same path.
 func (l *Locker) Lock() error {
 	return l.lock()
 }
 
+// Unlock frees up the lock.
 func (l *Locker) Unlock() error {
 	if l == nil || l.file == nil {
 		return nil

--- a/libs/fslock/locker.go
+++ b/libs/fslock/locker.go
@@ -5,9 +5,7 @@ import (
 	"os"
 )
 
-var (
-	ErrLocked = errors.New("fslock: directory is locked")
-)
+var ErrLocked = errors.New("fslock: directory is locked")
 
 func Lock(path string) (*Locker, error) {
 	l := New(path)

--- a/libs/fslock/locker.go
+++ b/libs/fslock/locker.go
@@ -17,7 +17,6 @@ func Lock(path string) (*Locker, error) {
 	return l, nil
 }
 
-// TODO Add windows support
 type Locker struct {
 	file *os.File
 	path string

--- a/libs/fslock/locker_test.go
+++ b/libs/fslock/locker_test.go
@@ -1,0 +1,40 @@
+package fslock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocker(t *testing.T) {
+	path := filepath.Join(os.TempDir(), ".lock")
+	defer os.Remove(path)
+
+	locker := New(path)
+	locker2 := New(path)
+
+	err := locker.Lock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = locker2.Lock()
+	if err != ErrLocked {
+		t.Fatal("No locking")
+	}
+
+	err = locker.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = locker2.Lock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = locker2.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Context
Over the weekend in my spare time, I was playing around syscalls and wanted to implement something. The idea fell to do something useful to our current tasks and so I decided to make a locking library, as we need to lock our [Repo](https://github.com/celestiaorg/celestia-node/issues/30) from simultaneous usage. I am aware there are existing libraries solving that, but this one is especially minimal.

## Filling
* Implemented and tested on Linux/MacOS
* Windows support? Maybe...