### PR TITLE
node, client: use `require` instead of `assert` for consistency.

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +20,7 @@ func TestEmbeddedClient_Status(t *testing.T) {
 
 	status, err := client.Status(ctx)
 	require.NoError(t, err)
-	assert.NotNil(t, status)
+	require.NotNil(t, status)
 
 	require.NoError(t, client.Stop())
 }
@@ -70,7 +69,7 @@ func TestRemoteClient_Status(t *testing.T) {
 
 	status, err := client.Status(ctx)
 	require.NoError(t, err)
-	assert.NotNil(t, status)
+	require.NotNil(t, status)
 
 	require.NoError(t, client.Stop())
 	require.NoError(t, remote.Stop())

--- a/node/full_test.go
+++ b/node/full_test.go
@@ -23,10 +23,10 @@ func TestNewFull(t *testing.T) {
 	})
 
 	node, err := NewFull(cfg)
-	assert.NoError(t, err)
-	assert.NotNil(t, node)
-	assert.NotNil(t, node.Config)
-	assert.NotNil(t, node.Host)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	require.NotNil(t, node.Config)
+	require.NotNil(t, node.Host)
 	assert.NotZero(t, node.Type)
 }
 
@@ -56,7 +56,7 @@ func TestFullLifecycle(t *testing.T) {
 	t.Cleanup(cancel)
 
 	err = node.Stop(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // TestFull_P2P_Streams tests the ability for Full nodes to communicate
@@ -74,7 +74,7 @@ func TestFull_P2P_Streams(t *testing.T) {
 	nodeConf.Core.EmbeddedConfig = nodeEmbeddedConfig
 	nodeConf.P2P = p2p.DefaultConfig()
 	node, err := NewFull(nodeConf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Host)
 	// make peer node
@@ -86,7 +86,7 @@ func TestFull_P2P_Streams(t *testing.T) {
 		"/ip6/::/tcp/2124",
 	}
 	peer, err := NewFull(peerConf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, peer)
 	require.NotNil(t, node.Host)
 

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestNewLight(t *testing.T) {
 	nd, err := NewLight(DefaultConfig())
-	assert.NoError(t, err)
-	assert.NotNil(t, nd)
-	assert.NotNil(t, nd.Config)
+	require.NoError(t, err)
+	require.NotNil(t, nd)
+	require.NotNil(t, nd.Config)
 	assert.NotZero(t, nd.Type)
 }
 


### PR DESCRIPTION
This PR changes tests in `node` and `client` pkg to use `require` instead of `assert` for consistency.