### PR TITLE
core: initialization and Repository

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -9,8 +9,11 @@ import (
 	"github.com/celestiaorg/celestia-core/config"
 )
 
+// Config is an alias for Core config.
+// It have to be used throughout celestia-node codebase to simplify future config changes and etc.
 type Config = config.Config
 
+// DefaultConfig gives slightly update default config of Core node.
 func DefaultConfig() *Config {
 	cfg := config.DefaultConfig()
 	updateDefaults(cfg)

--- a/core/config.go
+++ b/core/config.go
@@ -28,7 +28,7 @@ func TestConfig(t *testing.T) *Config {
 	return cfg
 }
 
-// LoadConfig config from the file under the given 'path'.
+// LoadConfig loads the config from the file under the given 'path'.
 // NOTE: Unfortunately, Core(Tendermint) does not provide us with convenient function to load the Config,
 // so we have to do our own. Furthermore, we have to make own SaveConfig, as the one the Core provides has
 // incompatibility issues with our toml parser version.

--- a/core/config.go
+++ b/core/config.go
@@ -36,7 +36,7 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	defer f.Close()
 	var cfg config.Config
-	_, err = toml.NewDecoder(f).Decode(&cfg)
+	_, err = toml.DecodeReader(f, &cfg)
 	return &cfg, err
 }
 

--- a/core/config.go
+++ b/core/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Config is an alias for Core config.
-// It have to be used throughout celestia-node codebase to simplify future config changes and etc.
+// It has to be used throughout celestia-node codebase to simplify future config changes and etc.
 type Config = config.Config
 
 // DefaultConfig gives slightly update default config of Core node.

--- a/core/config.go
+++ b/core/config.go
@@ -4,13 +4,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/BurntSushi/toml"
+
 	"github.com/celestiaorg/celestia-core/config"
 )
 
 type Config = config.Config
 
 func DefaultConfig() *Config {
-	return config.DefaultConfig()
+	cfg := config.DefaultConfig()
+	updateDefaults(cfg)
+	return cfg
 }
 
 func TestConfig(t *testing.T) *Config {
@@ -19,4 +23,39 @@ func TestConfig(t *testing.T) *Config {
 		os.RemoveAll(cfg.RootDir)
 	})
 	return cfg
+}
+
+// LoadConfig config from the file under the given 'path'.
+// NOTE: Unfortunately, Core(Tendermint) does not provide us with convenient function to load the Config,
+// so we have to do our own. Furthermore, we have to make own SaveConfig, as the one the Core provides has
+// incompatibility issues with our toml parser version.
+func LoadConfig(path string) (*Config, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var cfg config.Config
+	_, err = toml.NewDecoder(f).Decode(&cfg)
+	return &cfg, err
+}
+
+// SaveConfig saves config in a file under the given 'path'.
+func SaveConfig(path string, cfg *Config) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return toml.NewEncoder(f).Encode(cfg)
+}
+
+// change default paths to remove unneeded 'config' sub dir
+func updateDefaults(cfg *Config) {
+	cfg.Genesis = "genesis.json"
+	cfg.PrivValidatorKey = "priv_validator_key.json"
+	cfg.PrivValidatorState = "priv_validator_state.json"
+	cfg.NodeKey = "p2p_key.json"
+	cfg.P2P.AddrBook = "addr_book.json"
 }

--- a/core/config.go
+++ b/core/config.go
@@ -13,7 +13,7 @@ import (
 // It has to be used throughout celestia-node codebase to simplify future config changes and etc.
 type Config = config.Config
 
-// DefaultConfig gives slightly update default config of Core node.
+// DefaultConfig returns a modified default config of Core node.
 func DefaultConfig() *Config {
 	cfg := config.DefaultConfig()
 	updateDefaults(cfg)

--- a/core/init.go
+++ b/core/init.go
@@ -14,7 +14,6 @@ import (
 )
 
 // defaultValKeyType is default crypto algo for consensus in core
-// TODO(@Wondertan): Should we make this configurable
 const defaultValKeyType = types.ABCIPubKeyTypeSecp256k1
 
 // Init initializes the Core repository under the given 'path'.

--- a/core/init.go
+++ b/core/init.go
@@ -17,6 +17,12 @@ import (
 // TODO(@Wondertan): Should we make this configurable
 const defaultValKeyType = types.ABCIPubKeyTypeSecp256k1
 
+// Init initializes the Core repository under the given 'path'.
+// It checks and creates the default if not exist:
+// * Config
+// * Private validator key
+// * P2P comms private key
+// * Stub genesis doc file
 func Init(path string) (err error) {
 	log.Info("Initializing repository over '%s'", path)
 	// 1 - ensure config
@@ -74,6 +80,8 @@ func Init(path string) (err error) {
 	return nil
 }
 
+// IsInit checks whether the Core is initialized under the given 'path'.
+// It requires Config, Private Validator Key, Private P2P Key and genesis doc.
 func IsInit(path string) bool {
 	cfgPath := configPath(path)
 	if !utils.Exists(cfgPath) {

--- a/core/init.go
+++ b/core/init.go
@@ -1,0 +1,102 @@
+package core
+
+import (
+	"fmt"
+	"path/filepath"
+
+	tmrand "github.com/celestiaorg/celestia-core/libs/rand"
+	"github.com/celestiaorg/celestia-core/p2p"
+	"github.com/celestiaorg/celestia-core/privval"
+	"github.com/celestiaorg/celestia-core/types"
+	tmtime "github.com/celestiaorg/celestia-core/types/time"
+
+	"github.com/celestiaorg/celestia-node/libs/utils"
+)
+
+// defaultValKeyType is default crypto algo for consensus in core
+// TODO(@Wondertan): Should we make this configurable
+const defaultValKeyType = types.ABCIPubKeyTypeSecp256k1
+
+func Init(path string) (err error) {
+	log.Info("Initializing repository over '%s'", path)
+	// 1 - ensure config
+	cfg := DefaultConfig()
+	cfg.SetRoot(path)
+	cfgPath := configPath(path)
+	if !utils.Exists(cfgPath) {
+		err = SaveConfig(cfgPath, cfg)
+		if err != nil {
+			return fmt.Errorf("core: can't write config: %w", err)
+		}
+	}
+	// 2 - ensure private validator key
+	keyPath, pv := cfg.PrivValidatorKeyFile(), new(privval.FilePV)
+	if utils.Exists(keyPath) {
+		pv = privval.LoadFilePV(keyPath, cfg.PrivValidatorStateFile())
+	} else {
+		pv, err = privval.GenFilePV(keyPath, cfg.PrivValidatorStateFile(), defaultValKeyType)
+		if err != nil {
+			return
+		}
+		pv.Save()
+	}
+	// 3 - ensure private p2p key
+	_, err = p2p.LoadOrGenNodeKey(cfg.NodeKeyFile())
+	if err != nil {
+		return
+	}
+	// 4 - ensure genesis
+	genPath := cfg.GenesisFile()
+	if !utils.Exists(genPath) {
+		log.Warn("Genesis file is not found - generating a stub")
+		pubKey, err := pv.GetPubKey()
+		if err != nil {
+			return fmt.Errorf("can't get pubkey: %w", err)
+		}
+
+		params := types.DefaultConsensusParams()
+		params.Validator.PubKeyTypes = []string{defaultValKeyType}
+		genDoc := types.GenesisDoc{
+			ChainID:         fmt.Sprintf("localnet-%v", tmrand.Str(6)),
+			GenesisTime:     tmtime.Now(),
+			ConsensusParams: params,
+			Validators: []types.GenesisValidator{{
+				Address: pubKey.Address(),
+				PubKey:  pubKey,
+				Power:   10,
+			}},
+		}
+
+		err = genDoc.SaveAs(genPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}
+
+func IsInit(path string) bool {
+	cfgPath := configPath(path)
+	if !utils.Exists(cfgPath) {
+		return false
+	}
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil{
+		log.Errorf("loading config: %s", err)
+		return false
+	}
+
+	if !utils.Exists(cfg.PrivValidatorKeyFile()) ||
+		!utils.Exists(cfg.NodeKeyFile()) ||
+		!utils.Exists(cfg.GenesisFile()) {
+		return false
+	}
+
+	return true
+}
+
+func configPath(base string) string {
+	return filepath.Join(base, "config.toml")
+}

--- a/core/init.go
+++ b/core/init.go
@@ -30,7 +30,8 @@ func Init(path string) (err error) {
 		}
 	}
 	// 2 - ensure private validator key
-	keyPath, pv := cfg.PrivValidatorKeyFile(), new(privval.FilePV)
+	var pv *privval.FilePV
+	keyPath := cfg.PrivValidatorKeyFile()
 	if utils.Exists(keyPath) {
 		pv = privval.LoadFilePV(keyPath, cfg.PrivValidatorStateFile())
 	} else {
@@ -67,13 +68,10 @@ func Init(path string) (err error) {
 			}},
 		}
 
-		err = genDoc.SaveAs(genPath)
-		if err != nil {
-			return err
-		}
+		return genDoc.SaveAs(genPath)
 	}
 
-	return
+	return nil
 }
 
 func IsInit(path string) bool {
@@ -83,7 +81,7 @@ func IsInit(path string) bool {
 	}
 
 	cfg, err := LoadConfig(cfgPath)
-	if err != nil{
+	if err != nil {
 		log.Errorf("loading config: %s", err)
 		return false
 	}

--- a/core/init_test.go
+++ b/core/init_test.go
@@ -1,0 +1,16 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsInit(t *testing.T) {
+	dir := t.TempDir()
+	err := Init(dir)
+	require.NoError(t, err)
+	ok := IsInit(dir)
+	assert.True(t, ok)
+}

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -10,7 +10,7 @@ import (
 
 func MockRepo(t *testing.T) Repository {
 	repo := NewMemRepository()
-	repo.PutConfig(TestConfig(t))
+	repo.PutConfig(TestConfig(t)) //nolint: errcheck
 	return repo
 }
 

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -1,10 +1,18 @@
 package core
 
 import (
+	"testing"
+
 	"github.com/celestiaorg/celestia-core/abci/example/kvstore"
 	"github.com/celestiaorg/celestia-core/node"
 	rpctest "github.com/celestiaorg/celestia-core/rpc/test"
 )
+
+func MockRepo(t *testing.T) Repository {
+	repo := NewMemRepository()
+	repo.PutConfig(TestConfig(t))
+	return repo
+}
 
 // StartMockNode starts a mock Core node background process and returns it.
 func StartMockNode() *node.Node {

--- a/core/repo.go
+++ b/core/repo.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"errors"
+
+	"github.com/celestiaorg/celestia-core/config"
+)
+
+// ErrNotInited is used to signal when core is intended to be started without being initialized.
+var ErrNotInited = errors.New("core: repository is not initialized")
+
+// TODO(@Wondertan):
+//  * This should expose GenesisDoc and others. We can add ad-hoc
+//  * Ideally, add private keys to Keystore to unify access pattern.
+type Repository interface {
+	// Config loads a Config.
+	Config() (*Config, error)
+	// PutConfig saves given config.
+	PutConfig(*Config) error
+}
+
+// Open instantiates FS Repository from a given 'path'.
+func Open(path string) (Repository, error) {
+	if !IsInit(path) {
+		return nil, ErrNotInited
+	}
+
+	return &fsRepository{path}, nil
+}
+
+func (f *fsRepository) Config() (*Config, error) {
+	return LoadConfig(configPath(f.path))
+}
+
+func (f *fsRepository) PutConfig(cfg *Config) error {
+	cfg.SetRoot(f.path) // not allowed to change root in runtime
+	updateDefaults(cfg) // ensure stability over path fields
+	config.WriteConfigFile(configPath(f.path), cfg)
+	return nil
+}
+
+type fsRepository struct {
+	path string
+}

--- a/core/repo_mem.go
+++ b/core/repo_mem.go
@@ -1,0 +1,29 @@
+package core
+
+import "sync"
+
+// NewMemRepository creates in memory implementation of Repository
+func NewMemRepository() Repository {
+	return &memRepository{}
+}
+
+type memRepository struct {
+	cfg *Config
+	lock sync.Mutex
+}
+
+func (m *memRepository) Config() (*Config, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.cfg, nil
+}
+
+func (m *memRepository) PutConfig(cfg *Config) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.cfg = cfg
+	return nil
+}
+
+// not to accidentally forget to update mem implementation when Repository will be extended.
+var _ = (Repository)(&memRepository{})

--- a/core/repo_mem.go
+++ b/core/repo_mem.go
@@ -8,7 +8,7 @@ func NewMemRepository() Repository {
 }
 
 type memRepository struct {
-	cfg *Config
+	cfg  *Config
 	lock sync.Mutex
 }
 

--- a/libs/utils/fs.go
+++ b/libs/utils/fs.go
@@ -1,0 +1,9 @@
+package utils
+
+import "os"
+
+// Exists checks whether file or directory exists under the given 'path' on the system.
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}


### PR DESCRIPTION
## Context
The penultimate piece for #30. It introduces initialization flow for the embedded Core node along with repository to access Core' stored data. Basically, it implements some of the important functionality for future `init` command.

## Others
* Implements custom serialization for `core.Config`(rationale is in the code)
* Starts own collection of utilities
* Provides FS, InMem and Mock repositories


## Refs
Depends on #71 and #74
Moves towards done #30
