### PR TITLE
node: initialization and Repository

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -38,7 +38,7 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 	defer f.Close()
-	var cfg config.Config
+	var cfg Config
 	_, err = toml.DecodeReader(f, &cfg)
 	return &cfg, err
 }

--- a/core/config.go
+++ b/core/config.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"os"
-	"testing"
 
 	"github.com/BurntSushi/toml"
 
@@ -17,14 +16,6 @@ type Config = config.Config
 func DefaultConfig() *Config {
 	cfg := config.DefaultConfig()
 	updateDefaults(cfg)
-	return cfg
-}
-
-func TestConfig(t *testing.T) *Config {
-	cfg := config.ResetTestRoot(t.Name())
-	t.Cleanup(func() {
-		os.RemoveAll(cfg.RootDir)
-	})
 	return cfg
 }
 

--- a/core/init.go
+++ b/core/init.go
@@ -23,7 +23,9 @@ const defaultValKeyType = types.ABCIPubKeyTypeSecp256k1
 // * P2P comms private key
 // * Stub genesis doc file
 func Init(path string) (err error) {
-	log.Info("Initializing repository over '%s'", path)
+	log.Info("Initializing Repository over '%s'", path)
+	defer log.Info("Repository initialized")
+
 	// 1 - ensure config
 	cfg := DefaultConfig()
 	cfg.SetRoot(path)
@@ -33,18 +35,23 @@ func Init(path string) (err error) {
 		if err != nil {
 			return fmt.Errorf("core: can't write config: %w", err)
 		}
+		log.Info("New config is generated")
+	} else {
+		log.Info("Config already exists")
 	}
 	// 2 - ensure private validator key
 	var pv *privval.FilePV
 	keyPath := cfg.PrivValidatorKeyFile()
-	if utils.Exists(keyPath) {
-		pv = privval.LoadFilePV(keyPath, cfg.PrivValidatorStateFile())
-	} else {
+	if !utils.Exists(keyPath) {
 		pv, err = privval.GenFilePV(keyPath, cfg.PrivValidatorStateFile(), defaultValKeyType)
 		if err != nil {
 			return
 		}
 		pv.Save()
+		log.Info("New consensus private key is generated")
+	} else {
+		pv = privval.LoadFilePV(keyPath, cfg.PrivValidatorStateFile())
+		log.Info("Consensus private key already exists")
 	}
 	// 3 - ensure private p2p key
 	_, err = p2p.LoadOrGenNodeKey(cfg.NodeKeyFile())
@@ -54,7 +61,8 @@ func Init(path string) (err error) {
 	// 4 - ensure genesis
 	genPath := cfg.GenesisFile()
 	if !utils.Exists(genPath) {
-		log.Warn("Genesis file is not found - generating a stub")
+		log.Info("New stub genesis document is generated")
+		log.Warn("Stub genesis document must not be used in production environment!")
 		pubKey, err := pv.GetPubKey()
 		if err != nil {
 			return fmt.Errorf("can't get pubkey: %w", err)
@@ -73,7 +81,12 @@ func Init(path string) (err error) {
 			}},
 		}
 
-		return genDoc.SaveAs(genPath)
+		err = genDoc.SaveAs(genPath)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Info("Genesis document already exists")
 	}
 
 	return nil

--- a/core/repo.go
+++ b/core/repo.go
@@ -10,7 +10,7 @@ import (
 var ErrNotInited = errors.New("core: repository is not initialized")
 
 // TODO(@Wondertan):
-//  * This should expose GenesisDoc and others. We can add ad-hoc
+//  * This should expose GenesisDoc and others. We can add them ad-hoc.
 //  * Ideally, add private keys to Keystore to unify access pattern.
 type Repository interface {
 	// Config loads a Config.

--- a/core/testing.go
+++ b/core/testing.go
@@ -1,17 +1,29 @@
 package core
 
 import (
+	"os"
 	"testing"
 
 	"github.com/celestiaorg/celestia-core/abci/example/kvstore"
+	"github.com/celestiaorg/celestia-core/config"
 	"github.com/celestiaorg/celestia-core/node"
 	rpctest "github.com/celestiaorg/celestia-core/rpc/test"
 )
 
+// MockRepo provides a mock Repository that is intended for use in test scenarios.
 func MockRepo(t *testing.T) Repository {
 	repo := NewMemRepository()
-	repo.PutConfig(TestConfig(t)) //nolint: errcheck
+	repo.PutConfig(MockConfig(t)) //nolint: errcheck
 	return repo
+}
+
+// MockConfig provides a testing configuration for embedded Core Client.
+func MockConfig(t *testing.T) *Config {
+	cfg := config.ResetTestRoot(t.Name())
+	t.Cleanup(func() {
+		os.RemoveAll(cfg.RootDir)
+	})
+	return cfg
 }
 
 // StartMockNode starts a mock Core node background process and returns it.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/libp2p/go-libp2p-peerstore v0.2.8
 	github.com/libp2p/go-libp2p-pubsub v0.5.4
 	github.com/libp2p/go-libp2p-routing-helpers v0.2.3
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-base32 v0.0.4
 	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/celestiaorg/celestia-core v0.0.1-mvp-das-lightclient.0.20210831102741-321cdc4f8dc4
 	github.com/ipfs/go-bitswap v0.4.0
 	github.com/ipfs/go-datastore v0.4.6
+	github.com/ipfs/go-ds-badger2 v0.1.1
 	github.com/ipfs/go-ipfs-blockstore v0.1.6
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1
 	github.com/ipfs/go-log/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -180,9 +180,12 @@ github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6ps
 github.com/dgraph-io/badger v1.6.1/go.mod h1:FRmFw3uxvcpa8zG3Rxs0th+hCLIuaQg8HlNV5bjgnuU=
 github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
 github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=
+github.com/dgraph-io/badger/v2 v2.2007.3 h1:Sl9tQWz92WCbVSe8pj04Tkqlm2boW+KAxd+XSs58SQI=
+github.com/dgraph-io/badger/v2 v2.2007.3/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/badger/v3 v3.2011.1 h1:Hmyof0WMEF/QtutX5SQHzIMnJQxb/IrSzhjckV2SD6g=
 github.com/dgraph-io/badger/v3 v3.2011.1/go.mod h1:0rLLrQpKVQAL0or/lBLMQznhr6dWWX7h5AKnmnqx268=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d h1:eQYOG6A4td1tht0NdJB9Ls6DsXRGb2Ft6X9REU/MbbE=
 github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -441,6 +444,8 @@ github.com/ipfs/go-ds-badger v0.0.7/go.mod h1:qt0/fWzZDoPW6jpQeqUjR5kBfhDNB65jd9
 github.com/ipfs/go-ds-badger v0.2.1/go.mod h1:Tx7l3aTph3FMFrRS838dcSJh+jjA7cX9DrGVwx/NOwE=
 github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
 github.com/ipfs/go-ds-badger v0.2.7/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
+github.com/ipfs/go-ds-badger2 v0.1.1 h1:fAg+isaefjuYCZnxSL5G9WrxhZR00wu46+O4mv5HuCc=
+github.com/ipfs/go-ds-badger2 v0.1.1/go.mod h1:iwo4rt4HyFbGzi9gUacbMQnCQDuX91hsVssNEQU4BW0=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=

--- a/go.sum
+++ b/go.sum
@@ -845,6 +845,7 @@ github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=

--- a/node/config.go
+++ b/node/config.go
@@ -20,7 +20,19 @@ type Config struct {
 	Core core.Config
 }
 
-// DefaultFullConfig provides a default Full Node Config.
+// DefaultConfig provides a default Config for a given Node Type 'tp'.
+func DefaultConfig(tp Type) *Config {
+	switch tp {
+	case Full:
+		return DefaultFullConfig()
+	case Light:
+		return DefaultLightConfig()
+	default:
+		panic("node: unknown Node Type")
+	}
+}
+
+// DefaultFullConfig provides DefaultConfig
 func DefaultFullConfig() *Config {
 	return &Config{
 		P2P:  p2p.DefaultConfig(),

--- a/node/config.go
+++ b/node/config.go
@@ -32,7 +32,7 @@ func DefaultConfig(tp Type) *Config {
 	}
 }
 
-// DefaultFullConfig provides DefaultConfig
+// DefaultFullConfig provides DefaultConfig for Full Node
 func DefaultFullConfig() *Config {
 	return &Config{
 		P2P:  p2p.DefaultConfig(),

--- a/node/config.go
+++ b/node/config.go
@@ -10,6 +10,9 @@ import (
 	"github.com/celestiaorg/celestia-node/node/p2p"
 )
 
+// ConfigLoader defines a function that loads a config from any source.
+type ConfigLoader func() (*Config, error)
+
 // Config is main configuration structure for a Node.
 // It combines configuration units for all Node subsystems.
 type Config struct {
@@ -17,14 +20,23 @@ type Config struct {
 	Core core.Config
 }
 
-// DefaultConfig provides a default Node Config.
-func DefaultConfig() *Config {
+// DefaultFullConfig provides a default Full Node Config.
+func DefaultFullConfig() *Config {
 	return &Config{
 		P2P:  p2p.DefaultConfig(),
 		Core: core.DefaultConfig(),
 	}
 }
 
+// DefaultLightConfig provides a default Light Node Config.
+func DefaultLightConfig() *Config {
+	return &Config{
+		P2P:  p2p.DefaultConfig(),
+		Core: core.DefaultConfig(),
+	}
+}
+
+// SaveConfig saves Config 'cfg' under the given 'path'.
 func SaveConfig(path string, cfg *Config) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -35,6 +47,7 @@ func SaveConfig(path string, cfg *Config) error {
 	return cfg.Encode(f)
 }
 
+// LoadConfig loads Config from the given 'path'.
 func LoadConfig(path string) (*Config, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestConfigWriteRead(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	in := DefaultConfig()
+	in := DefaultFullConfig()
 
 	err := in.Encode(buf)
 	require.NoError(t, err)

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -12,10 +12,11 @@ func TestConfigWriteRead(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	in := DefaultConfig()
 
-	err := WriteTo(in, buf)
+	err := in.Encode(buf)
 	require.NoError(t, err)
 
-	out, err := ReadFrom(buf)
+	var out Config
+	err = out.Decode(buf)
 	require.NoError(t, err)
-	assert.EqualValues(t, in, out)
+	assert.EqualValues(t, in, &out)
 }

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -27,7 +27,14 @@ func DefaultConfig() Config {
 func Components(cfg Config) fx.Option {
 	return fx.Options(
 		fxutil.ProvideIf(cfg.Remote, RemoteClient),
-		fxutil.ProvideIf(!cfg.Remote, core.NewEmbedded),
+		fxutil.ProvideIf(!cfg.Remote, func(repo core.Repository) (core.Client, error) {
+			cfg, err := repo.Config()
+			if err != nil {
+				return nil, err
+			}
+
+			return core.NewEmbedded(cfg)
+		}),
 	)
 }
 

--- a/node/full.go
+++ b/node/full.go
@@ -10,18 +10,20 @@ import (
 )
 
 // NewFull assembles a new Full Node from required components.
-func NewFull(cfg *Config, corecfg *core.Config) (*Node, error) {
-	return newNode(fullComponents(cfg, corecfg))
+func NewFull(repo Repository) (*Node, error) {
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	return newNode(fullComponents(cfg, repo))
 }
 
 // fullComponents keeps all the components as DI options required to built a Full Node.
-func fullComponents(cfg *Config, corecfg *core.Config) fx.Option {
+func fullComponents(cfg *Config, repo Repository) fx.Option {
 	return fx.Options(
-		lightComponents(cfg),
-		fxutil.ProvideIf(!cfg.Core.Remote, func() *core.Config {
-			return corecfg
-		}),
-		// components
+		lightComponents(cfg, repo),
+		fxutil.ProvideIf(!cfg.Core.Remote, repo.Core), // provide core repo constructor only in embedded mode.
 		nodecore.Components(cfg.Core),
 		fx.Provide(func(client core.Client) block.Fetcher {
 			return core.NewBlockFetcher(client)

--- a/node/full_test.go
+++ b/node/full_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/protocol"
-
-	"github.com/celestiaorg/celestia-node/core"
 )
 
 func TestNewFull(t *testing.T) {
-	node, err := NewFull(DefaultConfig(), core.TestConfig(t))
+	repo := MockRepository(t, DefaultFullConfig())
+	node, err := NewFull(repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Config)
@@ -24,7 +23,8 @@ func TestNewFull(t *testing.T) {
 }
 
 func TestFullLifecycle(t *testing.T) {
-	node, err := NewFull(DefaultConfig(), core.TestConfig(t))
+	repo := MockRepository(t, DefaultFullConfig())
+	node, err := NewFull(repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Config)
@@ -49,18 +49,20 @@ func TestFullLifecycle(t *testing.T) {
 // TestFull_P2P_Streams tests the ability for Full nodes to communicate
 // directly with each other via libp2p streams.
 func TestFull_P2P_Streams(t *testing.T) {
-	node, err := NewFull(DefaultConfig(), core.TestConfig(t))
+	repo := MockRepository(t, DefaultFullConfig())
+	node, err := NewFull(repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Host)
 
-	peerConf := DefaultConfig()
+	peerConf := DefaultFullConfig()
 	// modify address to be different
 	peerConf.P2P.ListenAddresses = []string{
 		"/ip4/0.0.0.0/tcp/2124",
 		"/ip6/::/tcp/2124",
 	}
-	peer, err := NewFull(peerConf, core.TestConfig(t))
+	repo = MockRepository(t, peerConf)
+	peer, err := NewFull(repo)
 	require.NoError(t, err)
 	require.NotNil(t, peer)
 	require.NotNil(t, node.Host)

--- a/node/init.go
+++ b/node/init.go
@@ -1,0 +1,1 @@
+package node

--- a/node/init.go
+++ b/node/init.go
@@ -1,1 +1,102 @@
 package node
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/celestiaorg/celestia-node/libs/fslock"
+	"github.com/celestiaorg/celestia-node/libs/utils"
+)
+
+// Init initializes the Node FS Repository in the dir under 'path' with given Config 'cfg'.
+func Init(path string, cfg *Config) error {
+	path, err := repoPath(path)
+	if err != nil {
+		return err
+	}
+
+	flock, err := fslock.Lock(lockPath(path))
+	if err != nil {
+		if err == fslock.ErrLocked {
+			return ErrOpened
+		}
+		return err
+	}
+	defer flock.Unlock() //nolint: errcheck
+
+	err = initRoot(path)
+	if err != nil {
+		return err
+	}
+
+	err = initSub(keysPath(path))
+	if err != nil {
+		return err
+	}
+
+	err = initSub(dataPath(path))
+	if err != nil {
+		return err
+	}
+
+	err = initSub(corePath(path))
+	if err != nil {
+		return err
+	}
+
+	cfgPath := configPath(path)
+	if !utils.Exists(cfgPath) {
+		return SaveConfig(cfgPath, cfg)
+	}
+
+	return nil
+}
+
+// IsInit checks whether FS Repository was setup under given 'path'.
+// If any required file/subdirectory does not exist, then false is reported.
+func IsInit(path string) (bool, error) {
+	path, err := repoPath(path)
+	if err != nil {
+		return false, err
+	}
+
+	if utils.Exists(corePath(path)) &&
+		utils.Exists(keysPath(path)) &&
+		utils.Exists(dataPath(path)) &&
+		utils.Exists(configPath(path)) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+const perms = 0755
+
+func initRoot(path string) error {
+	if !utils.Exists(path) {
+		err := os.MkdirAll(path, perms)
+		if err != nil {
+			return err
+		}
+	}
+
+	// check for writing permissions
+	f, err := os.Create(filepath.Join(path, ".check"))
+	if err != nil {
+		return err
+	}
+
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(f.Name())
+}
+
+func initSub(path string) error {
+	if !utils.Exists(path) {
+		return os.Mkdir(path, perms)
+	}
+	return nil
+}

--- a/node/init.go
+++ b/node/init.go
@@ -9,8 +9,9 @@ import (
 	"github.com/celestiaorg/celestia-node/libs/utils"
 )
 
-// Init initializes the Node FileSystem(FS) Repository in the directory under 'path' with the given Config.
-func Init(path string, cfg *Config) error {
+// Init initializes the Node FileSystem(FS) Repository for th given Node Type 'tp' in the directory under 'path' with
+// the given Config.
+func Init(path string, cfg *Config, tp Type) error {
 	path, err := repoPath(path)
 	if err != nil {
 		return err
@@ -56,7 +57,7 @@ func Init(path string, cfg *Config) error {
 	// TODO(@Wondertan): This is a lazy hack which prevents Core Repository to be generated for all case, and generates
 	//  only for a Full Node with embedded Core Node. Ideally, we should a have global map Node Type/Mode -> Custom
 	//  Init Func, so Init would run initialization for specific Mode/Type.
-	if !cfg.Core.Remote {
+	if !cfg.Core.Remote && tp == Full {
 		corePath := corePath(path)
 		err = initDir(corePath)
 		if err != nil {

--- a/node/init.go
+++ b/node/init.go
@@ -79,7 +79,7 @@ func IsInit(path string, tp Type) bool {
 		return false
 	}
 
-cfg, err := LoadConfig(configPath(path)) // load the Config and implicitly check for its existence
+	cfg, err := LoadConfig(configPath(path)) // load the Config and implicitly check for its existence
 	if err != nil {
 		return false
 	}

--- a/node/init.go
+++ b/node/init.go
@@ -15,6 +15,8 @@ func Init(path string, cfg *Config) error {
 	if err != nil {
 		return err
 	}
+	log.Info("Initializing Repository for the Node over '%s'", path)
+	defer log.Info("Repository initialized")
 
 	flock, err := fslock.Lock(lockPath(path))
 	if err != nil {

--- a/node/init.go
+++ b/node/init.go
@@ -9,7 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-node/libs/utils"
 )
 
-// Init initializes the Node FS Repository in the dir under 'path' with given Config 'cfg'.
+// Init initializes the Node FS Repository in the directory under 'path' with the given Config.
 func Init(path string, cfg *Config) error {
 	path, err := repoPath(path)
 	if err != nil {

--- a/node/init.go
+++ b/node/init.go
@@ -53,16 +53,20 @@ func Init(path string, cfg *Config) error {
 		log.Info("Config already exists")
 	}
 
-	corePath := corePath(path)
-	err = initDir(corePath)
-	if err != nil {
-		return err
+	// TODO(@Wondertan): This is a lazy hack which prevents Core Repository to be generated for all case, and generates
+	//  only for a Full Node with embedded Core Node. Ideally, we should a have global map Node Type/Mode -> Custom
+	//  Init Func, so Init would run initialization for specific Mode/Type.
+	if !cfg.Core.Remote {
+		corePath := corePath(path)
+		err = initDir(corePath)
+		if err != nil {
+			return err
+		}
+
+		return core.Init(corePath)
 	}
 
-	// TODO(@Wondertan): This is a lazy hack which causes Core Repository to be generated for all case,
-	//  even when its not needed. Ideally, we should a have global map Node Type/Mode -> Custom Init Func, so Init would
-	//  run initialization for specific Mode/Type, but there are some caveats with such approach.
-	return core.Init(corePath)
+	return nil
 }
 
 // IsInit checks whether FS Repository was setup under given 'path'.

--- a/node/init.go
+++ b/node/init.go
@@ -40,35 +40,42 @@ func Init(path string, cfg *Config) error {
 		return err
 	}
 
-	err = initSub(corePath(path))
+	cfgPath := configPath(path)
+	if !utils.Exists(cfgPath) {
+		err = SaveConfig(cfgPath, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	corePath := corePath(path)
+	err = initSub(corePath)
 	if err != nil {
 		return err
 	}
 
-	cfgPath := configPath(path)
-	if !utils.Exists(cfgPath) {
-		return SaveConfig(cfgPath, cfg)
-	}
-
-	return nil
+	// TODO(@Wondertan): This is a lazy hack which causes Core Repository to be generated for all case,
+	//  even when its not needed. Ideally, we should a have global map Node Type/Mode -> Custom Init Func, so Init would
+	//  run initialization for specific Mode/Type, but there are some caveats with such approach.
+	return core.Init(corePath)
 }
 
 // IsInit checks whether FS Repository was setup under given 'path'.
 // If any required file/subdirectory does not exist, then false is reported.
-func IsInit(path string) (bool, error) {
+func IsInit(path string) bool {
 	path, err := repoPath(path)
 	if err != nil {
-		return false, err
+		return false
 	}
 
 	if utils.Exists(corePath(path)) &&
 		utils.Exists(keysPath(path)) &&
 		utils.Exists(dataPath(path)) &&
 		utils.Exists(configPath(path)) {
-		return true, nil
+		return true
 	}
 
-	return false, nil
+	return false
 }
 
 const perms = 0755

--- a/node/init.go
+++ b/node/init.go
@@ -79,7 +79,7 @@ func IsInit(path string, tp Type) bool {
 		return false
 	}
 
-	cfg, err := LoadConfig(configPath(path)) // this way we load Config  andimplicitly check it existence
+cfg, err := LoadConfig(configPath(path)) // load the Config and implicitly check for its existence
 	if err != nil {
 		return false
 	}

--- a/node/init.go
+++ b/node/init.go
@@ -9,7 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-node/libs/utils"
 )
 
-// Init initializes the Node FS Repository in the directory under 'path' with the given Config.
+// Init initializes the Node FileSystem(FS) Repository in the directory under 'path' with the given Config.
 func Init(path string, cfg *Config) error {
 	path, err := repoPath(path)
 	if err != nil {

--- a/node/init.go
+++ b/node/init.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/libs/fslock"
 	"github.com/celestiaorg/celestia-node/libs/utils"
 )

--- a/node/init.go
+++ b/node/init.go
@@ -32,12 +32,12 @@ func Init(path string, cfg *Config) error {
 		return err
 	}
 
-	err = initSub(keysPath(path))
+	err = initDir(keysPath(path))
 	if err != nil {
 		return err
 	}
 
-	err = initSub(dataPath(path))
+	err = initDir(dataPath(path))
 	if err != nil {
 		return err
 	}
@@ -48,10 +48,13 @@ func Init(path string, cfg *Config) error {
 		if err != nil {
 			return err
 		}
+		log.Info("New config is generated")
+	} else {
+		log.Info("Config already exists")
 	}
 
 	corePath := corePath(path)
-	err = initSub(corePath)
+	err = initDir(corePath)
 	if err != nil {
 		return err
 	}
@@ -82,12 +85,11 @@ func IsInit(path string) bool {
 
 const perms = 0755
 
+// initRoot initializes(creates) directory if not created and check if it is writable
 func initRoot(path string) error {
-	if !utils.Exists(path) {
-		err := os.MkdirAll(path, perms)
-		if err != nil {
-			return err
-		}
+	err := initDir(path)
+	if err != nil {
+		return err
 	}
 
 	// check for writing permissions
@@ -104,9 +106,10 @@ func initRoot(path string) error {
 	return os.Remove(f.Name())
 }
 
-func initSub(path string) error {
-	if !utils.Exists(path) {
-		return os.Mkdir(path, perms)
+// initDir creates a dir if not exist
+func initDir(path string) error {
+	if utils.Exists(path) {
+		return nil
 	}
-	return nil
+	return os.Mkdir(path, perms)
 }

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -1,0 +1,1 @@
+package node

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO(@Bidon15): We need more test coverage for Init part
+// Tests could include invalid paths/configs and custom ones
+// For more info visit #89 
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
 	err := Init(dir, DefaultFullConfig(), Full)

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -9,11 +9,19 @@ import (
 
 // TODO(@Bidon15): We need more test coverage for Init part
 // Tests could include invalid paths/configs and custom ones
-// For more info visit #89 
-func TestInit(t *testing.T) {
+// For more info visit #89
+func TestInitFull(t *testing.T) {
 	dir := t.TempDir()
-	err := Init(dir, DefaultFullConfig(), Full)
+	err := Init(dir, Full)
 	require.NoError(t, err)
-	ok := IsInit(dir)
+	ok := IsInit(dir, Full)
+	assert.True(t, ok)
+}
+
+func TestInitLight(t *testing.T) {
+	dir := t.TempDir()
+	err := Init(dir, Light)
+	require.NoError(t, err)
+	ok := IsInit(dir, Light)
 	assert.True(t, ok)
 }

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
-	err := Init(dir, DefaultConfig())
+	err := Init(dir, DefaultFullConfig())
 	require.NoError(t, err)
 	ok := IsInit(dir)
 	assert.True(t, ok)

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
-	err := Init(dir, DefaultFullConfig())
+	err := Init(dir, DefaultFullConfig(), Full)
 	require.NoError(t, err)
 	ok := IsInit(dir)
 	assert.True(t, ok)

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -1,1 +1,17 @@
 package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	dir := t.TempDir()
+	err := Init(dir, DefaultConfig())
+	require.NoError(t, err)
+	ok, err := IsInit(dir)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -11,7 +11,6 @@ func TestInit(t *testing.T) {
 	dir := t.TempDir()
 	err := Init(dir, DefaultConfig())
 	require.NoError(t, err)
-	ok, err := IsInit(dir)
-	require.NoError(t, err)
+	ok := IsInit(dir)
 	assert.True(t, ok)
 }

--- a/node/light.go
+++ b/node/light.go
@@ -9,12 +9,17 @@ import (
 )
 
 // NewLight assembles a new Light Node from required components.
-func NewLight(cfg *Config) (*Node, error) {
-	return newNode(lightComponents(cfg))
+func NewLight(repo Repository) (*Node, error) {
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	return newNode(lightComponents(cfg, repo))
 }
 
 // lightComponents keeps all the components as DI options required to built a Light Node.
-func lightComponents(cfg *Config) fx.Option {
+func lightComponents(cfg *Config, repo Repository) fx.Option {
 	return fx.Options(
 		// manual providing
 		fx.Provide(context.Background),
@@ -24,6 +29,11 @@ func lightComponents(cfg *Config) fx.Option {
 		fx.Provide(func() *Config {
 			return cfg
 		}),
+		fx.Provide(func() ConfigLoader {
+			return repo.Config
+		}),
+		fx.Provide(repo.Datastore),
+		fx.Provide(repo.Keystore),
 		// components
 		p2p.Components(cfg.P2P),
 	)

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestNewLight(t *testing.T) {
-	nd, err := NewLight(DefaultConfig())
+	repo := MockRepository(t, DefaultLightConfig())
+	nd, err := NewLight(repo)
 	require.NoError(t, err)
 	require.NotNil(t, nd)
 	require.NotNil(t, nd.Config)
@@ -17,7 +18,8 @@ func TestNewLight(t *testing.T) {
 }
 
 func TestLightLifecycle(t *testing.T) {
-	nd, err := NewLight(DefaultConfig())
+	repo := MockRepository(t, DefaultLightConfig())
+	nd, err := NewLight(repo)
 	require.NoError(t, err)
 
 	startCtx, cancel := context.WithCancel(context.Background())

--- a/node/p2p/p2p.go
+++ b/node/p2p/p2p.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"fmt"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 	"go.uber.org/fx"
@@ -62,11 +61,6 @@ func DefaultConfig() Config {
 // Components collects all the components and services related to p2p.
 func Components(cfg Config) fx.Option {
 	return fx.Options(
-		// TODO(@Wondertan): This shouldn't be here, but it is required until we start using real datastore
-		fx.Provide(func() datastore.Batching {
-			return datastore.NewMapDatastore()
-		}),
-
 		fx.Provide(Identity),
 		fx.Provide(PeerStore),
 		fx.Provide(ConnectionManager(cfg)),

--- a/node/repo.go
+++ b/node/repo.go
@@ -52,11 +52,7 @@ func Open(path string) (Repository, error) {
 		return nil, err
 	}
 
-	ok, err := IsInit(path)
-	if err != nil {
-		flock.Unlock() //nolint: errcheck
-		return nil, err
-	}
+	ok := IsInit(path)
 	if !ok {
 		flock.Unlock() //nolint: errcheck
 		return nil, ErrNotInited

--- a/node/repo.go
+++ b/node/repo.go
@@ -1,0 +1,248 @@
+package node
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/ipfs/go-datastore"
+	dsbadger "github.com/ipfs/go-ds-badger2"
+	"github.com/mitchellh/go-homedir"
+
+	"github.com/celestiaorg/celestia-node/core"
+	"github.com/celestiaorg/celestia-node/libs/fslock"
+	"github.com/celestiaorg/celestia-node/libs/keystore"
+)
+
+var (
+	ErrOpened   = errors.New("node: repository is in use")
+	ErrNotInited = errors.New("node: repository is not set up")
+)
+
+type Repository interface {
+	Keystore() (keystore.Keystore, error)
+	Datastore() (datastore.Batching, error)
+	Core() (core.Repository, error)
+
+	Config() (*Config, error)
+	PutConfig(*Config) error
+
+	Path() string
+	Close() error
+
+	DiskUsage() (uint64, error)
+}
+
+// TODO: Nice error wrappings
+// TODO: Repo for light node
+// TODO: Memory repo
+type fsRepository struct {
+	path string
+
+	data    datastore.Batching
+	keys    keystore.Keystore
+	core    core.Repository
+
+	lock sync.RWMutex // protects all the fields
+	dirLock *fslock.Locker // protects directory
+}
+
+// Open creates new FS Repository under the given 'path'.
+// The Repository must be initialized first.
+func Open(path string) (Repository, error) {
+	path, err := repoPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	flock, err := fslock.Lock(lockPath(path))
+	if err != nil {
+		if err == fslock.ErrLocked {
+			return nil, ErrOpened
+		}
+		return nil, err
+	}
+
+	ok, err := IsInit(path)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNotInited
+	}
+
+	return &fsRepository{
+		path:    path,
+		dirLock: flock,
+	}, nil
+}
+
+func (f *fsRepository) Path() string {
+	return f.path
+}
+
+func (f *fsRepository) Config() (*Config, error) {
+	return readConfig(f.path)
+}
+
+func (f *fsRepository) PutConfig(config *Config) error {
+	return writeConfig(f.path, config, true)
+}
+
+func (f *fsRepository) Keystore() (_ keystore.Keystore, err error) {
+	f.lock.RLock()
+	if f.keys != nil {
+		f.lock.RUnlock()
+		return f.keys, nil
+	}
+	f.lock.RUnlock()
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	f.keys, err = keystore.NewFSKeystore(keysPath(f.path))
+	if err != nil {
+		return nil, err
+	}
+
+	return f.keys, nil
+}
+
+func (f *fsRepository) Datastore() (_ datastore.Batching, err error) {
+	f.lock.RLock()
+	if f.data != nil {
+		f.lock.RUnlock()
+		return f.data, nil
+	}
+	f.lock.RUnlock()
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	// TODO(@Wondertan): Study badger code and review available options to fine tune it for our use-cases.
+	opts := dsbadger.DefaultOptions // this should be copied
+	f.data, err = dsbadger.NewDatastore(dataPath(f.path), &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return f.data, nil
+}
+
+func (f *fsRepository) Core() (_ core.Repository, err error) {
+	f.lock.RLock()
+	if f.core != nil {
+		f.lock.RUnlock()
+		return f.core, nil
+	}
+	f.lock.RUnlock()
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	f.core, err = core.Open(corePath(f.path))
+	if err != nil {
+		return nil, err
+	}
+
+	return f.core, nil
+}
+
+func (f *fsRepository) Close() error {
+	defer f.dirLock.Unlock()
+	return f.data.Close()
+}
+
+func (f *fsRepository) DiskUsage() (uint64, error) {
+	panic("implement me")
+}
+
+func writeConfig(path string, cfg *Config, force bool) error {
+	exist, err := isSetUp(configPath(path))
+	if err != nil {
+		return err
+	}
+	if exist && !force {
+		return nil
+	}
+
+	f, err := os.Create(configPath(path))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return config.WriteTo(cfg, f)
+}
+
+func readConfig(path string) (*Config, error) {
+	f, err := os.Open(configPath(path))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return config.ReadFrom(f)
+}
+
+
+func setUpRepo(path string) error {
+	err := os.MkdirAll(path, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	// check permissions to write into it
+	f, err := os.Create(filepath.Join(path, ".check"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return os.Remove(f.Name())
+}
+
+func setUpSubDir(path string) error {
+	err := os.Mkdir(path, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
+}
+
+func isSetUp(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func repoPath(path string) (string, error) {
+	return homedir.Expand(filepath.Clean(path))
+}
+
+func configPath(base string) string {
+	return filepath.Join(base, "config.toml")
+}
+
+func lockPath(base string) string {
+	return filepath.Join(base, "lock")
+}
+
+func keysPath(base string) string {
+	return filepath.Join(base, "keys")
+}
+
+func dataPath(base string) string {
+	return filepath.Join(base, "data")
+}
+
+func corePath(base string) string {
+	return filepath.Join(base, "core")
+}

--- a/node/repo.go
+++ b/node/repo.go
@@ -51,7 +51,7 @@ type Repository interface {
 // To be opened the Repository must be initialized first, otherwise ErrNotInited is thrown.
 // Open takes a file Lock on directory, hence only one Repository can be opened at a time under the given 'path',
 // otherwise ErrOpened is thrown.
-func Open(path string) (Repository, error) {
+func Open(path string, tp Type) (Repository, error) {
 	path, err := repoPath(path)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func Open(path string) (Repository, error) {
 		return nil, err
 	}
 
-	ok := IsInit(path)
+	ok := IsInit(path, tp)
 	if !ok {
 		flock.Unlock() //nolint: errcheck
 		return nil, ErrNotInited

--- a/node/repo.go
+++ b/node/repo.go
@@ -31,7 +31,7 @@ type Repository interface {
 	// Keystore provides a Keystore to access keys.
 	Keystore() (keystore.Keystore, error)
 
-	// Datastore provides a Datastore - a KV store for arbitrary data to be stored on disk
+	// Datastore provides a Datastore - a KV store for arbitrary data to be stored on disk.
 	Datastore() (datastore.Batching, error)
 
 	// Core provides an access to Core's Repository.

--- a/node/repo.go
+++ b/node/repo.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// ErrOpened is thrown on attempt to open already open/in-use Repository.
-	ErrOpened    = errors.New("node: repository is in use")
+	ErrOpened = errors.New("node: repository is in use")
 	// ErrNotInited is thrown on attempt to open Repository without initialization.
 	ErrNotInited = errors.New("node: repository is not initialized")
 )

--- a/node/repo.go
+++ b/node/repo.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 
@@ -81,11 +82,21 @@ func (f *fsRepository) Path() string {
 }
 
 func (f *fsRepository) Config() (*Config, error) {
-	return LoadConfig(f.path)
+	cfg, err := LoadConfig(f.path)
+	if err != nil {
+		return nil, fmt.Errorf("node: can't load Config: %w", err)
+	}
+
+	return cfg, nil
 }
 
 func (f *fsRepository) PutConfig(cfg *Config) error {
-	return SaveConfig(f.path, cfg)
+	err := SaveConfig(f.path, cfg)
+	if err != nil {
+		return fmt.Errorf("node: can't save Config: %w", err)
+	}
+
+	return nil
 }
 
 func (f *fsRepository) Keystore() (_ keystore.Keystore, err error) {
@@ -101,7 +112,7 @@ func (f *fsRepository) Keystore() (_ keystore.Keystore, err error) {
 
 	f.keys, err = keystore.NewFSKeystore(keysPath(f.path))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("node: can't open Keystore: %w", err)
 	}
 
 	return f.keys, nil
@@ -122,7 +133,7 @@ func (f *fsRepository) Datastore() (_ datastore.Batching, err error) {
 	opts := dsbadger.DefaultOptions // this should be copied
 	f.data, err = dsbadger.NewDatastore(dataPath(f.path), &opts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("node: can't open Badger Datastore: %w", err)
 	}
 
 	return f.data, nil
@@ -141,7 +152,7 @@ func (f *fsRepository) Core() (_ core.Repository, err error) {
 
 	f.core, err = core.Open(corePath(f.path))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("node: can't open Core Repository: %w", err)
 	}
 
 	return f.core, nil

--- a/node/repo.go
+++ b/node/repo.go
@@ -23,7 +23,7 @@ var (
 )
 
 // Repository encapsulates storage for the Node.
-// Tt provides access and manages for the Node data stored in root directory e.g. '~/.celestia'.
+// It provides access for the Node data stored in root directory e.g. '~/.celestia'.
 type Repository interface {
 	// Path reports the FileSystem path of Repository.
 	Path() string

--- a/node/repo.go
+++ b/node/repo.go
@@ -15,22 +15,34 @@ import (
 )
 
 var (
+	// ErrOpened is thrown on attempt to open already open/in-use Repository.
 	ErrOpened    = errors.New("node: repository is in use")
+	// ErrNotInited is thrown on attempt to open Repository without initialization.
 	ErrNotInited = errors.New("node: repository is not initialized")
 )
 
-// TODO: Nice error wrappings
-// TODO: Memory repo
-
+// Repository encapsulates storage for the Node.
+// Tt provides access and manages for the Node data stored in root directory e.g. '~/.celestia'.
 type Repository interface {
+	// Path reports the FileSystem path of Repository.
+	Path() string
+
+	// Keystore provides a Keystore to access keys.
 	Keystore() (keystore.Keystore, error)
+
+	// Datastore provides a Datastore - a KV store for arbitrary data to be stored on disk
 	Datastore() (datastore.Batching, error)
+
+	// Core provides an access to Core's Repository.
 	Core() (core.Repository, error)
 
+	// Config loads the stored Node config.
 	Config() (*Config, error)
+
+	// PutConfig alters the stored Node config.
 	PutConfig(*Config) error
 
-	Path() string
+	// Close closes the Repository freeing up acquired resources and locks.
 	Close() error
 }
 

--- a/node/repo_mem.go
+++ b/node/repo_mem.go
@@ -24,7 +24,7 @@ func NewMemRepository(cfg *Config) Repository {
 		keys: keystore.NewMapKeystore(),
 		data: datastore.NewMapDatastore(),
 		core: core.NewMemRepository(),
-		cfg: cfg,
+		cfg:  cfg,
 	}
 }
 
@@ -60,4 +60,3 @@ func (m *memRepository) Path() string {
 func (m *memRepository) Close() error {
 	return nil
 }
-

--- a/node/repo_mem.go
+++ b/node/repo_mem.go
@@ -1,0 +1,63 @@
+package node
+
+import (
+	"sync"
+
+	"github.com/ipfs/go-datastore"
+
+	"github.com/celestiaorg/celestia-node/core"
+	"github.com/celestiaorg/celestia-node/libs/keystore"
+)
+
+type memRepository struct {
+	keys keystore.Keystore
+	data datastore.Batching
+	core core.Repository
+	cfg  *Config
+	cfgL sync.Mutex
+}
+
+// NewMemRepository creates an in-memory Repository for Node.
+// Useful for testing.
+func NewMemRepository(cfg *Config) Repository {
+	return &memRepository{
+		keys: keystore.NewMapKeystore(),
+		data: datastore.NewMapDatastore(),
+		core: core.NewMemRepository(),
+		cfg: cfg,
+	}
+}
+
+func (m *memRepository) Keystore() (keystore.Keystore, error) {
+	return m.keys, nil
+}
+
+func (m *memRepository) Datastore() (datastore.Batching, error) {
+	return m.data, nil
+}
+
+func (m *memRepository) Core() (core.Repository, error) {
+	return m.core, nil
+}
+
+func (m *memRepository) Config() (*Config, error) {
+	m.cfgL.Lock()
+	defer m.cfgL.Unlock()
+	return m.cfg, nil
+}
+
+func (m *memRepository) PutConfig(cfg *Config) error {
+	m.cfgL.Lock()
+	defer m.cfgL.Unlock()
+	m.cfg = cfg
+	return nil
+}
+
+func (m *memRepository) Path() string {
+	return ""
+}
+
+func (m *memRepository) Close() error {
+	return nil
+}
+

--- a/node/repo_mem.go
+++ b/node/repo_mem.go
@@ -19,12 +19,11 @@ type memRepository struct {
 
 // NewMemRepository creates an in-memory Repository for Node.
 // Useful for testing.
-func NewMemRepository(cfg *Config) Repository {
+func NewMemRepository() Repository {
 	return &memRepository{
 		keys: keystore.NewMapKeystore(),
 		data: datastore.NewMapDatastore(),
 		core: core.NewMemRepository(),
-		cfg:  cfg,
 	}
 }
 

--- a/node/repo_test.go
+++ b/node/repo_test.go
@@ -1,0 +1,1 @@
+package node

--- a/node/repo_test.go
+++ b/node/repo_test.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/celestiaorg/celestia-node/core"
 )
 
 func TestRepo(t *testing.T) {
@@ -33,13 +31,6 @@ func TestRepo(t *testing.T) {
 	assert.NotNil(t, data)
 
 	crepo, err := repo.Core()
-	assert.ErrorIs(t, err, core.ErrNotInited)
-	assert.Nil(t, crepo)
-
-	err = core.Init(corePath(dir))
-	require.NoError(t, err)
-
-	crepo, err = repo.Core()
 	assert.NoError(t, err)
 	assert.NotNil(t, crepo)
 }

--- a/node/repo_test.go
+++ b/node/repo_test.go
@@ -13,7 +13,7 @@ func TestRepo(t *testing.T) {
 	_, err := Open(dir)
 	assert.ErrorIs(t, err, ErrNotInited)
 
-	err = Init(dir, DefaultConfig())
+	err = Init(dir, DefaultFullConfig())
 	require.NoError(t, err)
 
 	repo, err := Open(dir)

--- a/node/repo_test.go
+++ b/node/repo_test.go
@@ -7,19 +7,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRepo(t *testing.T) {
+func TestRepoFull(t *testing.T) {
 	dir := t.TempDir()
 
-	_, err := Open(dir)
+	_, err := Open(dir, Full)
 	assert.ErrorIs(t, err, ErrNotInited)
 
-	err = Init(dir, DefaultFullConfig(), Full)
+	err = Init(dir, Full)
 	require.NoError(t, err)
 
-	repo, err := Open(dir)
+	repo, err := Open(dir, Full)
 	require.NoError(t, err)
 
-	_, err = Open(dir)
+	_, err = Open(dir, Full)
 	assert.ErrorIs(t, err, ErrOpened)
 
 	ks, err := repo.Keystore()
@@ -33,4 +33,32 @@ func TestRepo(t *testing.T) {
 	crepo, err := repo.Core()
 	assert.NoError(t, err)
 	assert.NotNil(t, crepo)
+}
+
+func TestRepoLight(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Open(dir, Light)
+	assert.ErrorIs(t, err, ErrNotInited)
+
+	err = Init(dir, Light)
+	require.NoError(t, err)
+
+	repo, err := Open(dir, Light)
+	require.NoError(t, err)
+
+	_, err = Open(dir, Light)
+	assert.ErrorIs(t, err, ErrOpened)
+
+	ks, err := repo.Keystore()
+	assert.NoError(t, err)
+	assert.NotNil(t, ks)
+
+	data, err := repo.Datastore()
+	assert.NoError(t, err)
+	assert.NotNil(t, data)
+
+	crepo, err := repo.Core()
+	assert.Error(t, err)
+	assert.Nil(t, crepo)
 }

--- a/node/repo_test.go
+++ b/node/repo_test.go
@@ -13,7 +13,7 @@ func TestRepo(t *testing.T) {
 	_, err := Open(dir)
 	assert.ErrorIs(t, err, ErrNotInited)
 
-	err = Init(dir, DefaultFullConfig())
+	err = Init(dir, DefaultFullConfig(), Full)
 	require.NoError(t, err)
 
 	repo, err := Open(dir)

--- a/node/repo_test.go
+++ b/node/repo_test.go
@@ -1,1 +1,45 @@
 package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/core"
+)
+
+func TestRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Open(dir)
+	assert.ErrorIs(t, err, ErrNotInited)
+
+	err = Init(dir, DefaultConfig())
+	require.NoError(t, err)
+
+	repo, err := Open(dir)
+	require.NoError(t, err)
+
+	_, err = Open(dir)
+	assert.ErrorIs(t, err, ErrOpened)
+
+	ks, err := repo.Keystore()
+	assert.NoError(t, err)
+	assert.NotNil(t, ks)
+
+	data, err := repo.Datastore()
+	assert.NoError(t, err)
+	assert.NotNil(t, data)
+
+	crepo, err := repo.Core()
+	assert.ErrorIs(t, err, core.ErrNotInited)
+	assert.Nil(t, crepo)
+
+	err = core.Init(corePath(dir))
+	require.NoError(t, err)
+
+	crepo, err = repo.Core()
+	assert.NoError(t, err)
+	assert.NotNil(t, crepo)
+}

--- a/node/testing.go
+++ b/node/testing.go
@@ -1,0 +1,22 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/core"
+)
+
+// MockRepository provides mock in memory Repository for testing purposes.
+func MockRepository(t *testing.T, cfg *Config) Repository {
+	t.Helper()
+	repo := NewMemRepository()
+	err := repo.PutConfig(cfg)
+	require.NoError(t, err)
+	crepo, err := repo.Core()
+	require.NoError(t, err)
+	err = crepo.PutConfig(core.MockConfig(t))
+	require.NoError(t, err)
+	return repo
+}


### PR DESCRIPTION
## Context
The final piece for #30. Although, there are some other non-priority things left that can be done later on.
> It took me a while to land this, even the feature is more or less simple. The main complexity comes from the fact that we have multiple Node Types/Mode and Core Repository, that are not used in some types and used in others. Also, we discussed dynamic mode switchability. All this required a flexible Repository to meet such requirements and originally I went towards an over-engineered approach that was not reasonable, so here we are. The current approach has one downside - shared initialization logic. That is, the LightNode and FullNode with remote Core will also initialize Repo for the Core, but won't use it. We can fix that by attaching custom initialization logic to each Mode/Type, but that is not critical for now.

## Changes
* Utility functions to Save/Load Node's Config from disk
* Provides Init, IsInit functions for the Node to initialize and check initialization of root directory or in other words Repository for the Node.
* The node's Repository itself with lazyloading of subcomponents, including Repository for Core(#81)

## TO DO
- [x] Mem Repo
- [x] Actually use the Repo on the Node.

## Refs
Depends on celestiaorg/celestia-node#81 and contains commits from it
Closes #30, but with some leftovers that should go into follow-up issue after this PR.