### PR TITLE
service/header, service/block: Implements spec'd out types for block and header

### DIFF
--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -16,7 +16,7 @@ var newBlockEventQuery = types.QueryForEvent(types.EventNewBlock).String()
 type BlockFetcher struct {
 	client Client
 
-	newBlockCh chan *block.Raw
+	newBlockCh chan *block.RawBlock
 }
 
 // NewBlockFetcher returns a new `BlockFetcher`.
@@ -27,7 +27,7 @@ func NewBlockFetcher(client Client) *BlockFetcher {
 }
 
 // GetBlock queries Core for a `Block` at the given height.
-func (f *BlockFetcher) GetBlock(ctx context.Context, height *int64) (*block.Raw, error) {
+func (f *BlockFetcher) GetBlock(ctx context.Context, height *int64) (*block.RawBlock, error) {
 	raw, err := f.client.Block(ctx, height)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func (f *BlockFetcher) GetBlock(ctx context.Context, height *int64) (*block.Raw,
 
 // SubscribeNewBlockEvent subscribes to new block events from Core, returning
 // a new block event channel on success.
-func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *block.Raw, error) {
+func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *block.RawBlock, error) {
 	// start the client if not started yet
 	if !f.client.IsRunning() {
 		return nil, fmt.Errorf("client not running")
@@ -52,7 +52,7 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *bloc
 		return nil, fmt.Errorf("new block event channel exists")
 	}
 
-	f.newBlockCh = make(chan *block.Raw)
+	f.newBlockCh = make(chan *block.RawBlock)
 
 	go func() {
 		for {

--- a/service/block/erasure.go
+++ b/service/block/erasure.go
@@ -9,7 +9,7 @@ import (
 
 // extendBlockData erasure codes the given raw block's data and returns the
 // erasure coded block data upon success.
-func extendBlockData(raw *Raw) (*ExtendedBlockData, error) {
+func extendBlockData(raw *RawBlock) (*ExtendedBlockData, error) {
 	namespacedShares, _ := raw.Data.ComputeShares()
 	shares := namespacedShares.RawShares()
 

--- a/service/block/event.go
+++ b/service/block/event.go
@@ -43,7 +43,7 @@ func (s *Service) listenForNewBlocks(ctx context.Context) error {
 // 3. A fraud proof is generated based on whether the generated DataAvailabilityHeader's
 //   root matches the one in the header of the raw block.
 // 4. The Block gets stored.
-func (s *Service) handleRawBlock(raw *Raw) error {
+func (s *Service) handleRawBlock(raw *RawBlock) error {
 	// extend the raw block
 	extendedBlockData, err := extendBlockData(raw)
 	if err != nil {

--- a/service/block/event.go
+++ b/service/block/event.go
@@ -42,7 +42,7 @@ func (s *Service) listenForNewBlocks(ctx context.Context) error {
 // 2. A DataAvailabilityHeader is created from the erasure coded block data.
 // 3. A fraud proof is generated based on whether the generated DataAvailabilityHeader's
 //   root matches the one in the header of the raw block.
-// 4. The ExtendedBlock gets stored.
+// 4. The Block gets stored.
 func (s *Service) handleRawBlock(raw *Raw) error {
 	// extend the raw block
 	extendedBlockData, err := extendBlockData(raw)
@@ -58,8 +58,8 @@ func (s *Service) handleRawBlock(raw *Raw) error {
 			"block hash", raw.Hash().String())
 		return err
 	}
-	// create ExtendedBlock
-	extendedBlock := &ExtendedBlock{
+	// create Block
+	extendedBlock := &Block{
 		data: extendedBlockData,
 	}
 	// check for bad encoding fraud

--- a/service/block/event_test.go
+++ b/service/block/event_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_listenForNewBlocks(t *testing.T) {
 	mockFetcher := &mockFetcher{
-		mockNewBlockCh: make(chan *Raw),
+		mockNewBlockCh: make(chan *RawBlock),
 	}
 	serv := NewBlockService(mockFetcher)
 
@@ -29,14 +29,14 @@ func Test_listenForNewBlocks(t *testing.T) {
 
 // mockFetcher mocks away the `Fetcher` interface.
 type mockFetcher struct {
-	mockNewBlockCh chan *Raw
+	mockNewBlockCh chan *RawBlock
 }
 
-func (m *mockFetcher) GetBlock(ctx context.Context, height *int64) (*Raw, error) {
+func (m *mockFetcher) GetBlock(ctx context.Context, height *int64) (*RawBlock, error) {
 	return nil, nil
 }
 
-func (m *mockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *Raw, error) {
+func (m *mockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *RawBlock, error) {
 	return m.mockNewBlockCh, nil
 }
 
@@ -51,7 +51,7 @@ func (m *mockFetcher) generateBlocks(t *testing.T, num int) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		m.mockNewBlockCh <- &Raw{
+		m.mockNewBlockCh <- &RawBlock{
 			Data: data,
 		}
 	}

--- a/service/block/fraud.go
+++ b/service/block/fraud.go
@@ -7,6 +7,6 @@ import (
 // validateEncoding validates the erasure coding DataRoot in the raw block header against the
 // hash of the generated DataAvailabilityHeader, generating a fraud proof if there is a mismatch.
 // TODO @renaynay: this method is stubbed out for now.
-func (s *Service) validateEncoding(extendedBlock *Block, rawHeader header.Raw) error {
+func (s *Service) validateEncoding(extendedBlock *Block, rawHeader header.RawHeader) error {
 	return nil
 }

--- a/service/block/fraud.go
+++ b/service/block/fraud.go
@@ -7,6 +7,6 @@ import (
 // validateEncoding validates the erasure coding DataRoot in the raw block header against the
 // hash of the generated DataAvailabilityHeader, generating a fraud proof if there is a mismatch.
 // TODO @renaynay: this method is stubbed out for now.
-func (s *Service) validateEncoding(extendedBlock *Block, rawHeader header.RawHeader) error {
+func (s *Service) validateEncoding(extendedBlock *Block, rawHeader header.Raw) error {
 	return nil
 }

--- a/service/block/fraud.go
+++ b/service/block/fraud.go
@@ -1,10 +1,12 @@
 package block
 
-import core "github.com/celestiaorg/celestia-core/types"
+import (
+	"github.com/celestiaorg/celestia-node/service/header"
+)
 
 // validateEncoding validates the erasure coding DataRoot in the raw block header against the
 // hash of the generated DataAvailabilityHeader, generating a fraud proof if there is a mismatch.
 // TODO @renaynay: this method is stubbed out for now.
-func (s *Service) validateEncoding(extendedBlock *ExtendedBlock, rawHeader core.Header) error {
+func (s *Service) validateEncoding(extendedBlock *Block, rawHeader header.RawHeader) error {
 	return nil
 }

--- a/service/block/interface.go
+++ b/service/block/interface.go
@@ -6,7 +6,7 @@ import (
 
 // Fetcher encompasses the behavior necessary to fetch new "raw" blocks.
 type Fetcher interface {
-	GetBlock(ctx context.Context, height *int64) (*Raw, error)
-	SubscribeNewBlockEvent(ctx context.Context) (<-chan *Raw, error)
+	GetBlock(ctx context.Context, height *int64) (*RawBlock, error)
+	SubscribeNewBlockEvent(ctx context.Context) (<-chan *RawBlock, error)
 	UnsubscribeNewBlockEvent(ctx context.Context) error
 }

--- a/service/block/types.go
+++ b/service/block/types.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"github.com/celestiaorg/celestia-node/service/header"
 	"github.com/celestiaorg/rsmt2d"
 
 	core "github.com/celestiaorg/celestia-core/types"
@@ -10,23 +11,33 @@ import (
 // it is still awaiting erasure coding.
 type Raw = core.Block
 
-// ExtendedBlock contains the erasure coded block data as well as its
+// Block represents the entirety of a Block in the Celestia network.
+// It contains the erasure coded block data as well as its
 // ExtendedHeader.
-// TODO @renaynay: ExtendedBlock still needs to be spec'd out.
-type ExtendedBlock struct {
-	// TODO @renaynay: include pointer to ExtendedHeader
-	data *ExtendedBlockData
+type Block struct {
+	header     *header.ExtendedHeader
+	data       *ExtendedBlockData
+	lastCommit *core.Commit
 }
 
 // ExtendedBlockData is an alias to rsmt2d's ExtendedDataSquare type.
-// TODO @renaynay: ExtendedBlockData still needs to be spec'd out.
 type ExtendedBlockData = rsmt2d.ExtendedDataSquare
 
-func (e *ExtendedBlock) Data() *ExtendedBlockData {
-	return e.data
+// Header returns the ExtendedHeader of the Block.
+func (b *Block) Header() *header.ExtendedHeader {
+	return b.header
+}
+
+// Data returns the erasure coded data of the Block.
+func (b *Block) Data() *ExtendedBlockData {
+	return b.data
+}
+
+// LastCommit returns the last commit of the Block.
+func (b *Block) LastCommit() *core.Commit {
+	return b.lastCommit
 }
 
 // BadEncodingError contains all relevant information to
 // generate a BadEncodingFraudProof.
-// TODO @renaynay: BadEncodingError still needs to be spec'd out.
 type BadEncodingError struct{}

--- a/service/block/types.go
+++ b/service/block/types.go
@@ -7,9 +7,9 @@ import (
 	core "github.com/celestiaorg/celestia-core/types"
 )
 
-// Raw is an alias to a "raw" Core block. It is "raw" because
+// RawBlock is an alias to a "raw" Core block. It is "raw" because
 // it is still awaiting erasure coding.
-type Raw = core.Block
+type RawBlock = core.Block
 
 // Block represents the entirety of a Block in the Celestia network.
 // It contains the erasure coded block data as well as its

--- a/service/header/types.go
+++ b/service/header/types.go
@@ -9,11 +9,11 @@ import (
 // information necessary for Celestia Nodes to be notified of new
 // block headers and perform Data Availability Sampling.
 type ExtendedHeader struct {
-	*Raw
+	*RawHeader
 	DAH *da.DataAvailabilityHeader
 }
 
-// Raw is an alias to core.Header. It is
+// RawHeader is an alias to core.Header. It is
 // "raw" because it is not yet wrapped to include
 // the DataAvailabilityHeader.
-type Raw = core.Header
+type RawHeader = core.Header

--- a/service/header/types.go
+++ b/service/header/types.go
@@ -1,0 +1,19 @@
+package header
+
+import (
+	"github.com/celestiaorg/celestia-core/pkg/da"
+	core "github.com/celestiaorg/celestia-core/types"
+)
+
+// ExtendedHeader represents a wrapped "raw" header that includes
+// information necessary for Celestia Nodes to be notified of new
+// block headers and perform Data Availability Sampling.
+type ExtendedHeader struct {
+	*RawHeader
+	DAH *da.DataAvailabilityHeader
+}
+
+// RawHeader is an alias to core.Header. It is
+// "raw" because it is not yet wrapped to include
+// the DataAvailabilityHeader.
+type RawHeader = core.Header

--- a/service/header/types.go
+++ b/service/header/types.go
@@ -9,11 +9,11 @@ import (
 // information necessary for Celestia Nodes to be notified of new
 // block headers and perform Data Availability Sampling.
 type ExtendedHeader struct {
-	*RawHeader
+	*Raw
 	DAH *da.DataAvailabilityHeader
 }
 
-// RawHeader is an alias to core.Header. It is
+// Raw is an alias to core.Header. It is
 // "raw" because it is not yet wrapped to include
 // the DataAvailabilityHeader.
-type RawHeader = core.Header
+type Raw = core.Header


### PR DESCRIPTION
Implements the types defined [here](https://github.com/celestiaorg/celestia-specs/issues/204).

Resolves #87