### PR TITLE
node: use Repository on the Node and slightly improve testing utilites

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"os"
-	"testing"
 
 	"github.com/BurntSushi/toml"
 
@@ -17,14 +16,6 @@ type Config = config.Config
 func DefaultConfig() *Config {
 	cfg := config.DefaultConfig()
 	updateDefaults(cfg)
-	return cfg
-}
-
-func TestConfig(t *testing.T) *Config {
-	cfg := config.ResetTestRoot(t.Name())
-	t.Cleanup(func() {
-		os.RemoveAll(cfg.RootDir)
-	})
 	return cfg
 }
 

--- a/core/repo.go
+++ b/core/repo.go
@@ -10,7 +10,7 @@ import (
 var ErrNotInited = errors.New("core: repository is not initialized")
 
 // TODO(@Wondertan):
-//  * This should expose GenesisDoc and others. We can add ad-hoc
+//  * This should expose GenesisDoc and others. We can add them ad-hoc.
 //  * Ideally, add private keys to Keystore to unify access pattern.
 type Repository interface {
 	// Config loads a Config.

--- a/core/testing.go
+++ b/core/testing.go
@@ -10,7 +10,7 @@ import (
 	rpctest "github.com/celestiaorg/celestia-core/rpc/test"
 )
 
-// MockRepo provides a testing Repository.
+// MockRepo provides a mock Repository that is intended for use in test scenarios.
 func MockRepo(t *testing.T) Repository {
 	repo := NewMemRepository()
 	repo.PutConfig(MockConfig(t)) //nolint: errcheck

--- a/core/testing.go
+++ b/core/testing.go
@@ -1,17 +1,29 @@
 package core
 
 import (
+	"os"
 	"testing"
 
 	"github.com/celestiaorg/celestia-core/abci/example/kvstore"
+	"github.com/celestiaorg/celestia-core/config"
 	"github.com/celestiaorg/celestia-core/node"
 	rpctest "github.com/celestiaorg/celestia-core/rpc/test"
 )
 
+// MockRepo provides a testing Repository.
 func MockRepo(t *testing.T) Repository {
 	repo := NewMemRepository()
-	repo.PutConfig(TestConfig(t)) //nolint: errcheck
+	repo.PutConfig(MockConfig(t)) //nolint: errcheck
 	return repo
+}
+
+// MockConfig provides a testing configuration for embedded Core Client.
+func MockConfig(t *testing.T) *Config {
+	cfg := config.ResetTestRoot(t.Name())
+	t.Cleanup(func() {
+		os.RemoveAll(cfg.RootDir)
+	})
+	return cfg
 }
 
 // StartMockNode starts a mock Core node background process and returns it.

--- a/node/config.go
+++ b/node/config.go
@@ -10,6 +10,9 @@ import (
 	"github.com/celestiaorg/celestia-node/node/p2p"
 )
 
+// ConfigLoader defines a function that loads a config from any source.
+type ConfigLoader func() (*Config, error)
+
 // Config is main configuration structure for a Node.
 // It combines configuration units for all Node subsystems.
 type Config struct {
@@ -17,14 +20,23 @@ type Config struct {
 	Core core.Config
 }
 
-// DefaultConfig provides a default Node Config.
-func DefaultConfig() *Config {
+// DefaultFullConfig provides a default Full Node Config.
+func DefaultFullConfig() *Config {
 	return &Config{
 		P2P:  p2p.DefaultConfig(),
 		Core: core.DefaultConfig(),
 	}
 }
 
+// DefaultLightConfig provides a default Light Node Config.
+func DefaultLightConfig() *Config {
+	return &Config{
+		P2P:  p2p.DefaultConfig(),
+		Core: core.DefaultConfig(),
+	}
+}
+
+// SaveConfig saves Config 'cfg' under the given 'path'.
 func SaveConfig(path string, cfg *Config) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -35,6 +47,7 @@ func SaveConfig(path string, cfg *Config) error {
 	return cfg.Encode(f)
 }
 
+// LoadConfig loads Config from the given 'path'.
 func LoadConfig(path string) (*Config, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestConfigWriteRead(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	in := DefaultConfig()
+	in := DefaultFullConfig()
 
 	err := in.Encode(buf)
 	require.NoError(t, err)

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -27,7 +27,14 @@ func DefaultConfig() Config {
 func Components(cfg Config) fx.Option {
 	return fx.Options(
 		fxutil.ProvideIf(cfg.Remote, RemoteClient),
-		fxutil.ProvideIf(!cfg.Remote, core.NewEmbedded),
+		fxutil.ProvideIf(!cfg.Remote, func(repo core.Repository) (core.Client, error) {
+			cfg, err := repo.Config()
+			if err != nil {
+				return nil, err
+			}
+
+			return core.NewEmbedded(cfg)
+		}),
 	)
 }
 

--- a/node/full.go
+++ b/node/full.go
@@ -10,18 +10,20 @@ import (
 )
 
 // NewFull assembles a new Full Node from required components.
-func NewFull(cfg *Config, corecfg *core.Config) (*Node, error) {
-	return newNode(fullComponents(cfg, corecfg))
+func NewFull(repo Repository) (*Node, error) {
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	return newNode(fullComponents(cfg, repo))
 }
 
 // fullComponents keeps all the components as DI options required to built a Full Node.
-func fullComponents(cfg *Config, corecfg *core.Config) fx.Option {
+func fullComponents(cfg *Config, repo Repository) fx.Option {
 	return fx.Options(
-		lightComponents(cfg),
-		fxutil.ProvideIf(!cfg.Core.Remote, func() *core.Config {
-			return corecfg
-		}),
-		// components
+		lightComponents(cfg, repo),
+		fxutil.ProvideIf(!cfg.Core.Remote, repo.Core), // provide core repo constructor only in embedded mode.
 		nodecore.Components(cfg.Core),
 		fx.Provide(func(client core.Client) block.Fetcher {
 			return core.NewBlockFetcher(client)

--- a/node/full_test.go
+++ b/node/full_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/protocol"
-
-	"github.com/celestiaorg/celestia-node/core"
 )
 
 func TestNewFull(t *testing.T) {
-	node, err := NewFull(DefaultConfig(), core.TestConfig(t))
+	repo := MockRepository(t, DefaultFullConfig())
+	node, err := NewFull(repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Config)
@@ -24,7 +23,8 @@ func TestNewFull(t *testing.T) {
 }
 
 func TestFullLifecycle(t *testing.T) {
-	node, err := NewFull(DefaultConfig(), core.TestConfig(t))
+	repo := MockRepository(t, DefaultFullConfig())
+	node, err := NewFull(repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Config)
@@ -49,18 +49,20 @@ func TestFullLifecycle(t *testing.T) {
 // TestFull_P2P_Streams tests the ability for Full nodes to communicate
 // directly with each other via libp2p streams.
 func TestFull_P2P_Streams(t *testing.T) {
-	node, err := NewFull(DefaultConfig(), core.TestConfig(t))
+	repo := MockRepository(t, DefaultFullConfig())
+	node, err := NewFull(repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Host)
 
-	peerConf := DefaultConfig()
+	peerConf := DefaultFullConfig()
 	// modify address to be different
 	peerConf.P2P.ListenAddresses = []string{
 		"/ip4/0.0.0.0/tcp/2124",
 		"/ip6/::/tcp/2124",
 	}
-	peer, err := NewFull(peerConf, core.TestConfig(t))
+	repo = MockRepository(t, peerConf)
+	peer, err := NewFull(repo)
 	require.NoError(t, err)
 	require.NotNil(t, peer)
 	require.NotNil(t, node.Host)

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
-	err := Init(dir, DefaultConfig())
+	err := Init(dir, DefaultFullConfig())
 	require.NoError(t, err)
 	ok := IsInit(dir)
 	assert.True(t, ok)

--- a/node/light.go
+++ b/node/light.go
@@ -9,21 +9,28 @@ import (
 )
 
 // NewLight assembles a new Light Node from required components.
-func NewLight(cfg *Config) (*Node, error) {
-	return newNode(lightComponents(cfg))
+func NewLight(repo Repository) (*Node, error) {
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	return newNode(lightComponents(cfg, repo))
 }
 
 // lightComponents keeps all the components as DI options required to built a Light Node.
-func lightComponents(cfg *Config) fx.Option {
+func lightComponents(cfg *Config, repo Repository) fx.Option {
 	return fx.Options(
 		// manual providing
 		fx.Provide(context.Background),
 		fx.Provide(func() Type {
 			return Light
 		}),
-		fx.Provide(func() *Config {
-			return cfg
+		fx.Provide(func() ConfigLoader {
+			return repo.Config
 		}),
+		fx.Provide(repo.Datastore),
+		fx.Provide(repo.Keystore),
 		// components
 		p2p.Components(cfg.P2P),
 	)

--- a/node/light.go
+++ b/node/light.go
@@ -26,6 +26,9 @@ func lightComponents(cfg *Config, repo Repository) fx.Option {
 		fx.Provide(func() Type {
 			return Light
 		}),
+		fx.Provide(func() *Config {
+			return cfg
+		}),
 		fx.Provide(func() ConfigLoader {
 			return repo.Config
 		}),

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestNewLight(t *testing.T) {
-	nd, err := NewLight(DefaultConfig())
+	repo := MockRepository(t, DefaultLightConfig())
+	nd, err := NewLight(repo)
 	require.NoError(t, err)
 	require.NotNil(t, nd)
 	require.NotNil(t, nd.Config)
@@ -17,7 +18,8 @@ func TestNewLight(t *testing.T) {
 }
 
 func TestLightLifecycle(t *testing.T) {
-	nd, err := NewLight(DefaultConfig())
+	repo := MockRepository(t, DefaultLightConfig())
+	nd, err := NewLight(repo)
 	require.NoError(t, err)
 
 	startCtx, cancel := context.WithCancel(context.Background())

--- a/node/node.go
+++ b/node/node.go
@@ -24,7 +24,7 @@ var log = logging.Logger("node")
 // * Light
 type Node struct {
 	Type   Type
-	Config ConfigLoader
+	Config *Config
 
 	// the Node keeps a reference to the DI App that controls the lifecycles of services registered on the Node.
 	app *fx.App

--- a/node/node.go
+++ b/node/node.go
@@ -24,7 +24,7 @@ var log = logging.Logger("node")
 // * Light
 type Node struct {
 	Type   Type
-	Config *Config
+	Config ConfigLoader
 
 	// the Node keeps a reference to the DI App that controls the lifecycles of services registered on the Node.
 	app *fx.App

--- a/node/p2p/p2p.go
+++ b/node/p2p/p2p.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"fmt"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 	"go.uber.org/fx"
@@ -62,11 +61,6 @@ func DefaultConfig() Config {
 // Components collects all the components and services related to p2p.
 func Components(cfg Config) fx.Option {
 	return fx.Options(
-		// TODO(@Wondertan): This shouldn't be here, but it is required until we start using real datastore
-		fx.Provide(func() datastore.Batching {
-			return datastore.NewMapDatastore()
-		}),
-
 		fx.Provide(Identity),
 		fx.Provide(PeerStore),
 		fx.Provide(ConnectionManager(cfg)),

--- a/node/repo_mem.go
+++ b/node/repo_mem.go
@@ -19,12 +19,11 @@ type memRepository struct {
 
 // NewMemRepository creates an in-memory Repository for Node.
 // Useful for testing.
-func NewMemRepository(cfg *Config) Repository {
+func NewMemRepository() Repository {
 	return &memRepository{
 		keys: keystore.NewMapKeystore(),
 		data: datastore.NewMapDatastore(),
 		core: core.NewMemRepository(),
-		cfg:  cfg,
 	}
 }
 

--- a/node/repo_test.go
+++ b/node/repo_test.go
@@ -13,7 +13,7 @@ func TestRepo(t *testing.T) {
 	_, err := Open(dir)
 	assert.ErrorIs(t, err, ErrNotInited)
 
-	err = Init(dir, DefaultConfig())
+	err = Init(dir, DefaultFullConfig())
 	require.NoError(t, err)
 
 	repo, err := Open(dir)

--- a/node/testing.go
+++ b/node/testing.go
@@ -1,0 +1,21 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/core"
+)
+
+func MockRepository(t *testing.T) Repository {
+	t.Helper()
+	repo := NewMemRepository()
+	err := repo.PutConfig(DefaultConfig())
+	require.NoError(t, err)
+	crepo, err := repo.Core()
+	require.NoError(t, err)
+	err = crepo.PutConfig(core.MockConfig(t))
+	require.NoError(t, err)
+	return repo
+}

--- a/node/testing.go
+++ b/node/testing.go
@@ -8,10 +8,11 @@ import (
 	"github.com/celestiaorg/celestia-node/core"
 )
 
-func MockRepository(t *testing.T) Repository {
+// MockRepository provides mock in memory Repository for testing purposes.
+func MockRepository(t *testing.T, cfg *Config) Repository {
 	t.Helper()
 	repo := NewMemRepository()
-	err := repo.PutConfig(DefaultConfig())
+	err := repo.PutConfig(cfg)
 	require.NoError(t, err)
 	crepo, err := repo.Core()
 	require.NoError(t, err)


### PR DESCRIPTION
## Context
This is the last TODO of #86.

## Changes
* MockRepository for Node
* Group mocks in `node` and `core` packages into testing.go
* Split DefaultConfig into default for Light and Full. We don't have a difference right now that will change soon.
* Actually use Repository on the node and tests update