### PR TITLE
service/block: add basic encoding validation in `BlockService`

### DIFF
--- a/service/block/event.go
+++ b/service/block/event.go
@@ -52,7 +52,7 @@ func (s *Service) handleRawBlock(raw *RawBlock) error {
 		return err
 	}
 	// generate DAH using extended block
-	_, err = header.DataAvailabilityHeaderFromExtendedData(extendedBlockData)
+	dah, err := header.DataAvailabilityHeaderFromExtendedData(extendedBlockData)
 	if err != nil {
 		log.Errorw("computing DataAvailabilityHeader", "err msg", err, "block height", raw.Height,
 			"block hash", raw.Hash().String())
@@ -60,10 +60,13 @@ func (s *Service) handleRawBlock(raw *RawBlock) error {
 	}
 	// create Block
 	extendedBlock := &Block{
+		header: &header.ExtendedHeader{
+			DAH: &dah,
+		},
 		data: extendedBlockData,
 	}
 	// check for bad encoding fraud
-	err = s.validateEncoding(extendedBlock, raw.Header)
+	err = validateEncoding(extendedBlock, raw.Header)
 	if err != nil {
 		log.Errorw("checking for bad encoding", "err msg", err, "block height", raw.Height,
 			"block hash", raw.Hash().String())

--- a/service/block/event_test.go
+++ b/service/block/event_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/celestiaorg/celestia-core/testutils"
-
+	"github.com/celestiaorg/celestia-node/service/header"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,8 +51,21 @@ func (m *mockFetcher) generateBlocks(t *testing.T, num int) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		m.mockNewBlockCh <- &RawBlock{
+		rawBlock := &RawBlock{
 			Data: data,
 		}
+		// extend the data to get the data hash
+		extendedData, err := extendBlockData(rawBlock)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dah, err := header.DataAvailabilityHeaderFromExtendedData(extendedData)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rawBlock.Header = header.RawHeader{
+			DataHash: dah.Hash(),
+		}
+		m.mockNewBlockCh <- rawBlock
 	}
 }

--- a/service/block/fraud.go
+++ b/service/block/fraud.go
@@ -1,12 +1,19 @@
 package block
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/celestiaorg/celestia-node/service/header"
 )
 
 // validateEncoding validates the erasure coding DataRoot in the raw block header against the
 // hash of the generated DataAvailabilityHeader, generating a fraud proof if there is a mismatch.
-// TODO @renaynay: this method is stubbed out for now.
-func (s *Service) validateEncoding(extendedBlock *Block, rawHeader header.RawHeader) error {
+// TODO @renaynay: this method is stubbed out for now. It only performs a basic validation to check
+// whether the hash of the DAH equals the data root in the raw header.
+func validateEncoding(block *Block, rawHeader header.RawHeader) error {
+	if w, g := block.header.DAH.Hash(), rawHeader.DataHash; !bytes.Equal(w, g) {
+		return fmt.Errorf("wrong DataHash in RawHeader. Expected %X, got %X", w, g)
+	}
 	return nil
 }

--- a/service/block/fraud_test.go
+++ b/service/block/fraud_test.go
@@ -1,0 +1,44 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-core/testutils"
+	"github.com/celestiaorg/celestia-node/service/header"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateEncoding_Successful(t *testing.T) {
+	data, err := testutils.GenerateRandomBlockData(1, 1, 1, 1, 40)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// create raw block for extending
+	rawBlock := &RawBlock{
+		Data: data,
+	}
+	// extend the raw block to be able to generate the DAH
+	extendedData, err := extendBlockData(rawBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// generate the DAH from the extended block data
+	dah, err := header.DataAvailabilityHeaderFromExtendedData(extendedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// use DAH hash for raw block header
+	rawBlock.Header = header.RawHeader{
+		DataHash: dah.Hash(),
+	}
+	// create the full extended block with the extended data and extended header
+	block := &Block{
+		header: &header.ExtendedHeader{
+			DAH: &dah,
+		},
+		data: extendedData,
+	}
+	// validate the encoding of the block against the data hash in the raw block header
+	err = validateEncoding(block, rawBlock.Header)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR relies on #87 being merged first.

Resolves #92. 