### PR TITLE
Makefile: a few updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ help: Makefile
 	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
 .PHONY: help
 
-## format: Formats only *.go (excluding *.pb.go *pb_test.go). Runs `gofmt & goimports` internally.
-format:
-	find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s
-	find . -name '*.go' -type f -not -path "*.git*"  -not -name '*.pb.go' -not -name '*pb_test.go' | xargs goimports -w -local github.com/celestiaorg/celestia-node
-.PHONY: format
+## fmt: Formats only *.go (excluding *.pb.go *pb_test.go). Runs `gofmt & goimports` internally.
+fmt:
+	@find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s
+	@find . -name '*.go' -type f -not -path "*.git*"  -not -name '*.pb.go' -not -name '*pb_test.go' | xargs goimports -w -local github.com/celestiaorg/celestia-node
+	@go mod tidy
+.PHONY: fmt
 
 ## lint: Linting *.go files using golangci-lint. Look for .golangci.yml for the list of linters.
 lint:


### PR DESCRIPTION
## Changes and motivation
* make format -> make fmt
	* Make it Golang idiomatic following `go fmt`. I am a bit tired of misspelling it.
* invisible execution for format with `@`
	* There is no gain in seeing `find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s` everytime you do formatting.
* extend formatting with go mod tidy
	* so we don't need to do it in a separate command eash time