### PR TITLE
feat(node): unified node constructor

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -21,30 +21,21 @@ type Config struct {
 }
 
 // DefaultConfig provides a default Config for a given Node Type 'tp'.
+// NOTE: Currently, configs are identical, but this will change.
 func DefaultConfig(tp Type) *Config {
 	switch tp {
 	case Full:
-		return DefaultFullConfig()
+		return &Config{
+			P2P:  p2p.DefaultConfig(),
+			Core: core.DefaultConfig(),
+		}
 	case Light:
-		return DefaultLightConfig()
+		return &Config{
+			P2P:  p2p.DefaultConfig(),
+			Core: core.DefaultConfig(),
+		}
 	default:
 		panic("node: unknown Node Type")
-	}
-}
-
-// DefaultFullConfig provides DefaultConfig for Full Node
-func DefaultFullConfig() *Config {
-	return &Config{
-		P2P:  p2p.DefaultConfig(),
-		Core: core.DefaultConfig(),
-	}
-}
-
-// DefaultLightConfig provides a default Light Node Config.
-func DefaultLightConfig() *Config {
-	return &Config{
-		P2P:  p2p.DefaultConfig(),
-		Core: core.DefaultConfig(),
 	}
 }
 

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestConfigWriteRead(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	in := DefaultFullConfig()
+	in := DefaultConfig(Full)
 
 	err := in.Encode(buf)
 	require.NoError(t, err)

--- a/node/full.go
+++ b/node/full.go
@@ -9,16 +9,6 @@ import (
 	"github.com/celestiaorg/celestia-node/service/block"
 )
 
-// NewFull assembles a new Full Node from required components.
-func NewFull(repo Repository) (*Node, error) {
-	cfg, err := repo.Config()
-	if err != nil {
-		return nil, err
-	}
-
-	return newNode(fullComponents(cfg, repo))
-}
-
 // fullComponents keeps all the components as DI options required to built a Full Node.
 func fullComponents(cfg *Config, repo Repository) fx.Option {
 	return fx.Options(

--- a/node/full_test.go
+++ b/node/full_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNewFull(t *testing.T) {
 	repo := MockRepository(t, DefaultFullConfig())
-	node, err := NewFull(repo)
+	node, err := New(Full, repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Config)
@@ -24,7 +24,7 @@ func TestNewFull(t *testing.T) {
 
 func TestFullLifecycle(t *testing.T) {
 	repo := MockRepository(t, DefaultFullConfig())
-	node, err := NewFull(repo)
+	node, err := New(Full, repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Config)
@@ -50,7 +50,7 @@ func TestFullLifecycle(t *testing.T) {
 // directly with each other via libp2p streams.
 func TestFull_P2P_Streams(t *testing.T) {
 	repo := MockRepository(t, DefaultFullConfig())
-	node, err := NewFull(repo)
+	node, err := New(Full, repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Host)
@@ -62,7 +62,7 @@ func TestFull_P2P_Streams(t *testing.T) {
 		"/ip6/::/tcp/2124",
 	}
 	repo = MockRepository(t, peerConf)
-	peer, err := NewFull(repo)
+	peer, err := New(Full, repo)
 	require.NoError(t, err)
 	require.NotNil(t, peer)
 	require.NotNil(t, node.Host)

--- a/node/full_test.go
+++ b/node/full_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewFull(t *testing.T) {
-	repo := MockRepository(t, DefaultFullConfig())
+	repo := MockRepository(t, DefaultConfig(Full))
 	node, err := New(Full, repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
@@ -23,7 +23,7 @@ func TestNewFull(t *testing.T) {
 }
 
 func TestFullLifecycle(t *testing.T) {
-	repo := MockRepository(t, DefaultFullConfig())
+	repo := MockRepository(t, DefaultConfig(Full))
 	node, err := New(Full, repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
@@ -49,13 +49,13 @@ func TestFullLifecycle(t *testing.T) {
 // TestFull_P2P_Streams tests the ability for Full nodes to communicate
 // directly with each other via libp2p streams.
 func TestFull_P2P_Streams(t *testing.T) {
-	repo := MockRepository(t, DefaultFullConfig())
+	repo := MockRepository(t, DefaultConfig(Full))
 	node, err := New(Full, repo)
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.NotNil(t, node.Host)
 
-	peerConf := DefaultFullConfig()
+	peerConf := DefaultConfig(Full)
 	// modify address to be different
 	peerConf.P2P.ListenAddresses = []string{
 		"/ip4/0.0.0.0/tcp/2124",

--- a/node/light.go
+++ b/node/light.go
@@ -8,16 +8,6 @@ import (
 	"github.com/celestiaorg/celestia-node/node/p2p"
 )
 
-// NewLight assembles a new Light Node from required components.
-func NewLight(repo Repository) (*Node, error) {
-	cfg, err := repo.Config()
-	if err != nil {
-		return nil, err
-	}
-
-	return newNode(lightComponents(cfg, repo))
-}
-
 // lightComponents keeps all the components as DI options required to built a Light Node.
 func lightComponents(cfg *Config, repo Repository) fx.Option {
 	return fx.Options(

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewLight(t *testing.T) {
-	repo := MockRepository(t, DefaultLightConfig())
+	repo := MockRepository(t, DefaultConfig(Light))
 	nd, err := New(Light, repo)
 	require.NoError(t, err)
 	require.NotNil(t, nd)
@@ -18,7 +18,7 @@ func TestNewLight(t *testing.T) {
 }
 
 func TestLightLifecycle(t *testing.T) {
-	repo := MockRepository(t, DefaultLightConfig())
+	repo := MockRepository(t, DefaultConfig(Light))
 	nd, err := New(Light, repo)
 	require.NoError(t, err)
 

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewLight(t *testing.T) {
 	repo := MockRepository(t, DefaultLightConfig())
-	nd, err := NewLight(repo)
+	nd, err := New(Light, repo)
 	require.NoError(t, err)
 	require.NotNil(t, nd)
 	require.NotNil(t, nd.Config)
@@ -19,7 +19,7 @@ func TestNewLight(t *testing.T) {
 
 func TestLightLifecycle(t *testing.T) {
 	repo := MockRepository(t, DefaultLightConfig())
-	nd, err := NewLight(repo)
+	nd, err := New(Light, repo)
 	require.NoError(t, err)
 
 	startCtx, cancel := context.WithCancel(context.Background())

--- a/node/node.go
+++ b/node/node.go
@@ -49,18 +49,16 @@ type Node struct {
 	BlockServ *block.Service `optional:"true"`
 }
 
-// newNode creates a new Node from given DI options.
-// DI options allow initializing the Node with a customized set of components and services.
-// NOTE: newNode is currently meant to be used privately to create various custom Node types e.g. full, unless we
-// decide to give package users the ability to create custom node types themselves.
-func newNode(opts ...fx.Option) (*Node, error) {
-	node := new(Node)
-	node.app = fx.New(
-		fx.NopLogger,
-		fx.Extract(node),
-		fx.Options(opts...),
-	)
-	return node, node.app.Err()
+// New assembles a new Node with the given type 'tp' over Repository 'repo'.
+func New(tp Type, repo Repository) (*Node, error) {
+	switch tp {
+	case Full:
+		return NewFull(repo)
+	case Light:
+		return NewLight(repo)
+	default:
+		panic("node: unknown Node Type")
+	}
 }
 
 // Start launches the Node and all the referenced components and services.
@@ -92,4 +90,18 @@ func (n *Node) Stop(ctx context.Context) error {
 
 	log.Infof("%s Node is stopped", n.Type)
 	return nil
+}
+
+// newNode creates a new Node from given DI options.
+// DI options allow initializing the Node with a customized set of components and services.
+// NOTE: newNode is currently meant to be used privately to create various custom Node types e.g. full, unless we
+// decide to give package users the ability to create custom node types themselves.
+func newNode(opts ...fx.Option) (*Node, error) {
+	node := new(Node)
+	node.app = fx.New(
+		fx.NopLogger,
+		fx.Extract(node),
+		fx.Options(opts...),
+	)
+	return node, node.app.Err()
 }

--- a/node/node.go
+++ b/node/node.go
@@ -67,8 +67,6 @@ func New(tp Type, repo Repository) (*Node, error) {
 }
 
 // Start launches the Node and all its components and services.
-// It blocks until the given context 'ctx' is canceled. If canceled, the Node is still in the running state
-// and should be gracefully stopped via Stop.
 func (n *Node) Start(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, n.app.StartTimeout())
 	defer cancel()
@@ -86,6 +84,17 @@ func (n *Node) Start(ctx context.Context) error {
 	//  * API address
 	//  * Pubkey/PeerID
 	//  * Host listening address
+
+	return nil
+}
+
+// Run is a Start which blocks on the given context 'ctx' until it is canceled.
+// If canceled, the Node is still in the running state and should be gracefully stopped via Stop.
+func (n *Node) Run(ctx context.Context) error {
+	err := n.Start(ctx)
+	if err != nil {
+		return err
+	}
 
 	<-ctx.Done()
 	return ctx.Err()

--- a/node/node.go
+++ b/node/node.go
@@ -51,11 +51,16 @@ type Node struct {
 
 // New assembles a new Node with the given type 'tp' over Repository 'repo'.
 func New(tp Type, repo Repository) (*Node, error) {
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil, err
+	}
+
 	switch tp {
 	case Full:
-		return NewFull(repo)
+		return newNode(fullComponents(cfg, repo))
 	case Light:
-		return NewLight(repo)
+		return newNode(lightComponents(cfg, repo))
 	default:
 		panic("node: unknown Node Type")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -104,7 +104,7 @@ func (n *Node) Run(ctx context.Context) error {
 // Canceling the given context earlier 'ctx' unblocks the Stop and aborts graceful shutdown forcing remaining
 // Components/Services to close immediately.
 func (n *Node) Stop(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(context.Background(), n.app.StopTimeout())
+	ctx, cancel := context.WithTimeout(ctx, n.app.StopTimeout())
 	defer cancel()
 
 	log.Debugf("Stopping %s Node...", n.Type)


### PR DESCRIPTION
## Context 
In #86 we moved `Open/Init/IsInit` functions over the unified pattern where they receive Node Type as param. Now, it makes total sense to introduce a `New` Node constructor to would instantiate a Node for a given type. For now, old constructors(NewFull/NewLight) are preserved, same as with `DefaultLight(Full)Config` but we can make them private and/or remove them if we find a reason for that in future