### PR TITLE
node: Node knows of its own Type

### DIFF
--- a/node/full.go
+++ b/node/full.go
@@ -13,6 +13,9 @@ import (
 func fullComponents(cfg *Config, repo Repository) fx.Option {
 	return fx.Options(
 		lightComponents(cfg, repo),
+		fx.Provide(func() Type {
+			return Full
+		}),
 		fxutil.ProvideIf(!cfg.Core.Remote, repo.Core), // provide core repo constructor only in embedded mode.
 		nodecore.Components(cfg.Core),
 		fx.Provide(func(client core.Client) block.Fetcher {

--- a/node/full_test.go
+++ b/node/full_test.go
@@ -19,7 +19,7 @@ func TestNewFull(t *testing.T) {
 	require.NotNil(t, node)
 	require.NotNil(t, node.Config)
 	require.NotNil(t, node.Host)
-	assert.NotZero(t, node.Type)
+	assert.Equal(t, Full, node.Type)
 }
 
 func TestFullLifecycle(t *testing.T) {

--- a/node/light.go
+++ b/node/light.go
@@ -13,9 +13,6 @@ func lightComponents(cfg *Config, repo Repository) fx.Option {
 	return fx.Options(
 		// manual providing
 		fx.Provide(context.Background),
-		fx.Provide(func() Type {
-			return Light
-		}),
 		fx.Provide(func() *Config {
 			return cfg
 		}),

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -14,7 +14,7 @@ func TestNewLight(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, nd)
 	require.NotNil(t, nd.Config)
-	assert.NotZero(t, nd.Type)
+	assert.Equal(t, Light, nd.Type)
 }
 
 func TestLightLifecycle(t *testing.T) {

--- a/node/node.go
+++ b/node/node.go
@@ -60,7 +60,15 @@ func New(tp Type, repo Repository) (*Node, error) {
 	case Full:
 		return newNode(fullComponents(cfg, repo))
 	case Light:
-		return newNode(lightComponents(cfg, repo))
+		// TODO @renaynay @wondertan: hacky, but fx.Provide does not allow two values to be written,
+		// therefore Full node always has Light type since it's provided in lightComponents
+		components := []fx.Option{
+			lightComponents(cfg, repo),
+			fx.Provide(func() Type {
+				return Light
+			}),
+		}
+		return newNode(components...)
 	default:
 		panic("node: unknown Node Type")
 	}


### PR DESCRIPTION
This PR fixes a bug where a `Full` node would have the `Light` type assigned to it during creation.

Resolves #122.