### PR TITLE
libs/fslock: change build directive to be compatible w/ earlier Go versions

### DIFF
--- a/libs/fslock/lock_unix.go
+++ b/libs/fslock/lock_unix.go
@@ -1,4 +1,5 @@
 //go:build darwin || freebsd || linux
+// +build darwin freebsd linux
 
 package fslock
 


### PR DESCRIPTION
Resolves #139.