### PR TITLE
node: extend init_test with error scenarios

### DIFF
--- a/node/init.go
+++ b/node/init.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -46,6 +47,10 @@ func InitWith(path string, tp Type, cfg *Config) error {
 	err = initDir(dataPath(path))
 	if err != nil {
 		return err
+	}
+
+	if cfg == nil {
+		return errors.New("nil config provided")
 	}
 
 	cfgPath := configPath(path)

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -1,10 +1,13 @@
 package node
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/libs/fslock"
 )
 
 // TODO(@Bidon15): We need more test coverage for Init part
@@ -24,4 +27,60 @@ func TestInitLight(t *testing.T) {
 	require.NoError(t, err)
 	ok := IsInit(dir, Light)
 	assert.True(t, ok)
+}
+
+func TestInitErrForInvalidPath(t *testing.T) {
+	path := "/invalid_path"
+	errLight := Init(path, Light)
+	errFull := Init(path, Full)
+
+	require.Error(t, errLight)
+	require.Error(t, errFull)
+}
+
+func TestInitErrForLockedDir(t *testing.T) {
+	dir := t.TempDir()
+	flock, err := fslock.Lock(lockPath(dir))
+	require.NoError(t, err)
+	defer flock.Unlock() //nolint:errcheck
+
+	errLight := Init(dir, Light)
+	errFull := Init(dir, Full)
+
+	require.Error(t, errLight)
+	require.Error(t, errFull)
+}
+
+func TestIsInitWithBrokenConfig(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.Create(configPath(dir))
+	require.NoError(t, err)
+	defer f.Close()
+
+	//nolint:errcheck
+	f.Write([]byte(`
+		[P2P]
+		  ListenAddresses = [/ip4/0.0.0.0/tcp/2121]
+    `))
+
+	okLight := IsInit(dir, Light)
+	okFull := IsInit(dir, Full)
+
+	assert.False(t, okLight)
+	assert.False(t, okFull)
+}
+
+func TestIsInitForNonExistDir(t *testing.T) {
+	okLight := IsInit("/invalid_path", Light)
+	okFull := IsInit("/invalid_path", Full)
+
+	assert.False(t, okLight)
+	assert.False(t, okFull)
+}
+
+func TestInitWithNilCfg(t *testing.T) {
+	dir := t.TempDir()
+	err := InitWith(dir, Light, nil)
+
+	require.Error(t, err)
 }


### PR DESCRIPTION
Added additional error test cases:
* with invalid path during initing a directory;
* with already locked directory during initing;
* with broken config during IsInit;
* with non exist directory during IsInit;
* with nil config passed to InitWith;
For the last one I have added a small fix because program will panic on encoding or trying to access to struct fields.

Closes #89 