### PR TITLE
service/header: Implement basic header `Service` structure and interfaces

### DIFF
--- a/service/header/header.go
+++ b/service/header/header.go
@@ -3,6 +3,7 @@ package header
 import (
 	"fmt"
 
+	tmbytes "github.com/celestiaorg/celestia-core/libs/bytes"
 	"github.com/celestiaorg/celestia-core/pkg/da"
 	core "github.com/celestiaorg/celestia-core/types"
 )
@@ -41,3 +42,14 @@ func (eh *ExtendedHeader) UnmarshalBinary(data []byte) error {
 	*eh = *out
 	return nil
 }
+
+// ExtendedHeaderRequest represents a request for one or more
+// ExtendedHeaders from the Celestia network.
+type ExtendedHeaderRequest struct {
+	Origin int64 // block height from which to begin retrieving headers (in descending order)
+	Amount int   // quantity of headers to be requested
+}
+
+// Hash is an alias to HexBytes which enables HEX-encoding for
+// json/encoding.
+type Hash = tmbytes.HexBytes

--- a/service/header/header.go
+++ b/service/header/header.go
@@ -3,7 +3,6 @@ package header
 import (
 	"fmt"
 
-	tmbytes "github.com/celestiaorg/celestia-core/libs/bytes"
 	"github.com/celestiaorg/celestia-core/pkg/da"
 	core "github.com/celestiaorg/celestia-core/types"
 )
@@ -42,14 +41,3 @@ func (eh *ExtendedHeader) UnmarshalBinary(data []byte) error {
 	*eh = *out
 	return nil
 }
-
-// ExtendedHeaderRequest represents a request for one or more
-// ExtendedHeaders from the Celestia network.
-type ExtendedHeaderRequest struct {
-	Origin int64 // block height from which to begin retrieving headers (in descending order)
-	Amount int   // quantity of headers to be requested
-}
-
-// Hash is an alias to HexBytes which enables HEX-encoding for
-// json/encoding.
-type Hash = tmbytes.HexBytes

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -21,10 +21,10 @@ type Subscription interface {
 }
 
 // Exchange encompasses the behavior necessary to request ExtendedHeaders
-// and respond to ExtendedHeader requests from the network.
+// from the network.
 type Exchange interface {
-	RequestHeaders(ctx context.Context, request *ExtendedHeaderRequest) ([]*ExtendedHeader, error)
-	RespondToHeadersRequest(ctx context.Context, request *ExtendedHeaderRequest) error
+	RequestHeader(ctx context.Context, height int64) (*ExtendedHeader, error)
+	RequestBatchedHeaders(ctx context.Context, from, to int64) ([]*ExtendedHeader, error)
 }
 
 // Store encompasses the behavior necessary to store and retrieve ExtendedHeaders

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -1,0 +1,39 @@
+package header
+
+import (
+	"context"
+
+	tmbytes "github.com/celestiaorg/celestia-core/libs/bytes"
+)
+
+// Subscriber encompasses the behavior necessary to
+// subscribe/unsubscribe from new ExtendedHeader events from the
+// network.
+type Subscriber interface {
+	Subscribe() (Subscription, error)
+}
+
+// Subscription can retrieve the next ExtendedHeader from the
+// network.
+type Subscription interface {
+	NextHeader(ctx context.Context) (*ExtendedHeader, error)
+	Cancel()
+}
+
+// Exchange encompasses the behavior necessary to request ExtendedHeaders
+// and respond to ExtendedHeader requests from the network.
+type Exchange interface {
+	RequestHeaders(ctx context.Context, request *ExtendedHeaderRequest) ([]*ExtendedHeader, error)
+	RespondToHeadersRequest(ctx context.Context, request *ExtendedHeaderRequest) error
+}
+
+// Store encompasses the behavior necessary to store and retrieve ExtendedHeaders
+// from a node's local storage.
+type Store interface {
+	Get(ctx context.Context, hash tmbytes.HexBytes) (*ExtendedHeader, error)
+	GetMany(ctx context.Context, hashes []tmbytes.HexBytes) ([]*ExtendedHeader, error)
+	GetByHeight(ctx context.Context, height int64) (*ExtendedHeader, error)
+	GetRangeByHeight(ctx context.Context, from, to int64) ([]*ExtendedHeader, error)
+	Put(ctx context.Context, header *ExtendedHeader) error
+	PutMany(ctx context.Context, headers []*ExtendedHeader) error
+}

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -16,24 +16,43 @@ type Subscriber interface {
 // Subscription can retrieve the next ExtendedHeader from the
 // network.
 type Subscription interface {
+	// NextHeader returns the newest verified and valid ExtendedHeader
+	// in the network.
 	NextHeader(ctx context.Context) (*ExtendedHeader, error)
+	// Cancel cancels the subscription.
 	Cancel()
 }
 
 // Exchange encompasses the behavior necessary to request ExtendedHeaders
 // from the network.
 type Exchange interface {
+	// RequestHeader performs a request for the ExtendedHeader at the given
+	// height to the network. Note that the ExtendedHeader must be verified
+	// thereafter.
 	RequestHeader(ctx context.Context, height int64) (*ExtendedHeader, error)
-	RequestBatchedHeaders(ctx context.Context, from, to int64) ([]*ExtendedHeader, error)
+	// RequestHeaders performs a request for the given range of ExtendedHeaders
+	// to the network. Note that the ExtendedHeaders must be verified thereafter.
+	RequestHeaders(ctx context.Context, from, to int64) ([]*ExtendedHeader, error)
 }
 
 // Store encompasses the behavior necessary to store and retrieve ExtendedHeaders
 // from a node's local storage.
 type Store interface {
+	// Head returns the ExtendedHeader of the chain head.
+	Head() (*ExtendedHeader, error)
+
+	// Get returns the ExtendedHeader corresponding to the given hash.
 	Get(ctx context.Context, hash tmbytes.HexBytes) (*ExtendedHeader, error)
+	// GetMany returns the ExtendedHeaders corresponding to the given hashes.
 	GetMany(ctx context.Context, hashes []tmbytes.HexBytes) ([]*ExtendedHeader, error)
+
+	// GetByHeight returns the ExtendedHeader corresponding to the given block height.
 	GetByHeight(ctx context.Context, height int64) (*ExtendedHeader, error)
+	// GetRangeByHeight returns the given range of ExtendedHeaders.
 	GetRangeByHeight(ctx context.Context, from, to int64) ([]*ExtendedHeader, error)
+
+	// Put stores the given ExtendedHeader.
 	Put(ctx context.Context, header *ExtendedHeader) error
+	// PutMany stores the given ExtendedHeaders.
 	PutMany(ctx context.Context, headers []*ExtendedHeader) error
 }

--- a/service/header/service.go
+++ b/service/header/service.go
@@ -1,0 +1,39 @@
+package header
+
+import (
+	"context"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+// Service represents the Header service that can be started / stopped on a node.
+// Service contains 3 main functionalities:
+// 		1. Listening for/requesting new ExtendedHeaders from the network.
+// 		2. Verifying and serving ExtendedHeaders to the network.
+// 		3. Storing/caching ExtendedHeaders.
+type Service struct {
+	exchange Exchange
+	store    Store
+}
+
+var log = logging.Logger("header-service")
+
+// NewHeaderService creates a new instance of header Service.
+func NewHeaderService(exchange Exchange, store Store) *Service {
+	return &Service{
+		exchange: exchange,
+		store:    store,
+	}
+}
+
+// Start starts the header Service.
+func (s *Service) Start(ctx context.Context) error {
+	log.Info("starting header service")
+	return nil
+}
+
+// Stop stops the header Service.
+func (s *Service) Stop(ctx context.Context) error {
+	log.Info("stopping header service")
+	return nil
+}


### PR DESCRIPTION
This PR implements header `Service` as well as adds two interfaces: `Exchange` and `Store` that cover the behaviours necessary for a node to retrieve/provide `ExtendedHeader`s from/to the network, as well as store/retrieve those `ExtendedHeader`s from the node's local storage.

Related to #24 