### PR TITLE
lint: fix locale by adding UK English to US one

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,6 @@ linters-settings:
   maligned:
     suggest-new: true
   misspell:
-    locale: US
+    locale: US, UK
   goimports:
     local-prefixes: github.com/celestiaorg


### PR DESCRIPTION
Now, we can use both English variants

Fixes linter errors for #148 