### PR TITLE
node: start and stop block service by notification from lifecycle

### DIFF
--- a/node/full.go
+++ b/node/full.go
@@ -7,6 +7,7 @@ import (
 	nodecore "github.com/celestiaorg/celestia-node/node/core"
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/node/rpc"
+	"github.com/celestiaorg/celestia-node/node/services"
 	"github.com/celestiaorg/celestia-node/service/block"
 )
 
@@ -20,6 +21,6 @@ func fullComponents(cfg *Config, repo Repository) fx.Option {
 			return core.NewBlockFetcher(client)
 		}),
 		fx.Provide(rpc.NewServer),
-		fx.Provide(block.NewBlockService),
+		services.Components(),
 	)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -96,14 +96,6 @@ func (n *Node) Start(ctx context.Context) error {
 			return err
 		}
 	}
-	// start block service if not Light node
-	if n.Type != Light {
-		err = n.BlockServ.Start(ctx)
-		if err != nil {
-			log.Errorw("starting block service", "err", err)
-			return fmt.Errorf("node: failed to start block service: %w", err)
-		}
-	}
 
 	// TODO(@Wondertan): Print useful information about the node:
 	//  * API address
@@ -153,15 +145,6 @@ func (n *Node) Stop(ctx context.Context) error {
 	if err != nil {
 		log.Errorf("Stopping %s Node: %s", n.Type, err)
 		return err
-	}
-
-	// stop block service if not Light node
-	if n.Type != Light {
-		err = n.BlockServ.Stop(ctx)
-		if err != nil {
-			log.Errorw("stopping block service", "err", err)
-			return fmt.Errorf("node: failed to stop block service: %w", err)
-		}
 	}
 
 	log.Infof("stopped %s Node", n.Type)

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -1,0 +1,22 @@
+package services
+
+import (
+	"github.com/celestiaorg/celestia-node/service/block"
+
+	ipld "github.com/ipfs/go-ipld-format"
+	"go.uber.org/fx"
+)
+
+// Components wraps services creation
+func Components() fx.Option {
+	return fx.Options(
+		fx.Provide(func(lc fx.Lifecycle, fetcher block.Fetcher, store ipld.DAGService) *block.Service {
+			service := block.NewBlockService(fetcher, store)
+			lc.Append(fx.Hook{
+				OnStart: service.Start,
+				OnStop:  service.Stop,
+			})
+			return service
+		}),
+	)
+}


### PR DESCRIPTION
I have added both OnStart and OnStop hooks from block service and now it could not start/stop manually.

Closes #134 