### PR TITLE
Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 #!/usr/bin/make -f
 PROJECTNAME=$(shell basename "$(PWD)")
+BUILD_DATE=$(shell date)
+LAST_COMMIT=$(shell git rev-parse HEAD)
+# Replace with the current version
+CELESTIA_VERSION="0.1.0"
 
 ## help: Get more info on make commands.
 help: Makefile
@@ -10,7 +14,7 @@ help: Makefile
 ## build: Build celesita-node binary.
 build:
 	@echo "--> Building Celestia"
-	@go build ./cmd/celestia
+	@go build -ldflags "-X 'main.buildTime=$(BUILD_DATE)' -X 'main.lastCommit=$(LAST_COMMIT)' -X 'main.semanticVersion=$(CELESTIA_VERSION)'" ./cmd/celestia 
 
 ## fmt: Formats only *.go (excluding *.pb.go *pb_test.go). Runs `gofmt & goimports` internally.
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PROJECTNAME=$(shell basename "$(PWD)")
 BUILD_DATE=$(shell date)
 LAST_COMMIT=$(shell git rev-parse HEAD)
-# Replace with the current version
+# TODO (@OrlandoRomo) get version from git tags
 CELESTIA_VERSION="0.1.0"
 
 ## help: Get more info on make commands.

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -12,6 +12,7 @@ func init() {
 		fullCmd,
 		lightCmd,
 		devCmd,
+		versionCmd,
 	)
 }
 

--- a/cmd/celestia/version.go
+++ b/cmd/celestia/version.go
@@ -13,10 +13,6 @@ var (
 	semanticVersion string
 )
 
-func init() {
-	versionCmd.AddCommand()
-}
-
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show information about the current binary build",

--- a/cmd/celestia/version.go
+++ b/cmd/celestia/version.go
@@ -21,10 +21,10 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show information about the current binary build",
 	Args:  cobra.NoArgs,
-	Run:   getBinaryInfo,
+	Run:   getBuildInfo,
 }
 
-func getBinaryInfo(cmd *cobra.Command, args []string) {
+func getBuildInfo(cmd *cobra.Command, args []string) {
 	fmt.Printf("Semantic version: %s\n", semanticVersion)
 	fmt.Printf("Commit: %s\n", lastCommit)
 	fmt.Printf("Build Date: %s\n", buildTime)

--- a/cmd/celestia/version.go
+++ b/cmd/celestia/version.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	buildTime       string
+	lastCommit      string
+	semanticVersion string
+)
+
+func init() {
+	versionCmd.AddCommand()
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show information about the current binary build",
+	Args:  cobra.NoArgs,
+	Run:   getBinaryInfo,
+}
+
+func getBinaryInfo(cmd *cobra.Command, args []string) {
+	fmt.Printf("Semantic version: %s\n", semanticVersion)
+	fmt.Printf("Commit: %s\n", lastCommit)
+	fmt.Printf("Build Date: %s\n", buildTime)
+	fmt.Printf("System version: %s/%s\n", runtime.GOARCH, runtime.GOOS)
+	fmt.Printf("Golang version: %s\n", runtime.Version())
+}


### PR DESCRIPTION
The goal for this PR is to add the `version` subcommand of `celestia` command to get more information about the build binary. The new subcommand closes [#155](https://github.com/celestiaorg/celestia-node/issues/155).

### version command in action
- On Linux environment (Zorin OS 16)
<img width="550" alt="Screen Shot 2021-10-28 at 16 21 53" src="https://user-images.githubusercontent.com/34588445/139338366-265800a9-07f9-480b-bf78-8b1df518bee8.png">


