### PR TITLE
service/header: implement HeaderSub

### DIFF
--- a/service/header/service.go
+++ b/service/header/service.go
@@ -2,8 +2,10 @@ package header
 
 import (
 	"context"
+	"fmt"
 
 	logging "github.com/ipfs/go-log/v2"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
 // Service represents the Header service that can be started / stopped on a node.
@@ -14,26 +16,48 @@ import (
 type Service struct {
 	exchange Exchange
 	store    Store
+
+	topic  *pubsub.Topic // instantiated header-sub topic
+	pubsub *pubsub.PubSub
 }
 
 var log = logging.Logger("header-service")
 
 // NewHeaderService creates a new instance of header Service.
-func NewHeaderService(exchange Exchange, store Store) *Service {
+func NewHeaderService(exchange Exchange, store Store, pubsub *pubsub.PubSub) *Service {
 	return &Service{
 		exchange: exchange,
 		store:    store,
+		pubsub:   pubsub,
 	}
 }
 
 // Start starts the header Service.
 func (s *Service) Start(ctx context.Context) error {
 	log.Info("starting header service")
+
+	topic, err := s.pubsub.Join(ExtendedHeaderSubTopic)
+	if err != nil {
+		return err
+	}
+	s.topic = topic
+
+	// TODO @renaynay: start internal header service processes
 	return nil
+}
+
+// Subscribe returns a new subscription to the header pubsub topic
+func (s *Service) Subscribe() (Subscription, error) {
+	if s.topic == nil {
+		return nil, fmt.Errorf("header topic is not instantiated, service must be started before subscribing")
+	}
+
+	return newSubscription(s.topic)
 }
 
 // Stop stops the header Service.
 func (s *Service) Stop(ctx context.Context) error {
 	log.Info("stopping header service")
-	return nil
+
+	return s.topic.Close()
 }

--- a/service/header/subscription.go
+++ b/service/header/subscription.go
@@ -1,0 +1,56 @@
+package header
+
+import (
+	"context"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+// ExtendedHeaderSubTopic hardcodes the name of the ExtendedHeader
+// gossipsub topic.
+const ExtendedHeaderSubTopic = "header-sub"
+
+// subscription handles retrieving ExtendedHeaders from the header pubsub topic.
+type subscription struct {
+	topic        *pubsub.Topic
+	subscription *pubsub.Subscription
+}
+
+// newSubscription creates a new ExtendedHeader event subscription
+// on the given host.
+func newSubscription(topic *pubsub.Topic) (*subscription, error) {
+	sub, err := topic.Subscribe()
+	if err != nil {
+		return nil, err
+	}
+
+	return &subscription{
+		topic:        topic,
+		subscription: sub,
+	}, nil
+}
+
+// NextHeader returns the next (latest) verified ExtendedHeader from the network.
+func (s *subscription) NextHeader(ctx context.Context) (*ExtendedHeader, error) {
+	msg, err := s.subscription.Next(ctx)
+	if err != nil {
+		log.Errorw("reading next message from subscription", "err", err.Error())
+		return nil, err
+	}
+	log.Debugw("received message", "topic", msg.Message.GetTopic(), "sender", msg.ReceivedFrom)
+
+	var header ExtendedHeader
+	err = header.UnmarshalBinary(msg.Data)
+	if err != nil {
+		log.Errorw("unmarshaling data from message", "err", err.Error())
+		return nil, err
+	}
+
+	log.Debugw("received new ExtendedHeader", "height", header.Height, "hash", header.Hash())
+	return &header, nil
+}
+
+// Cancel cancels the subscription to new ExtendedHeaders from the network.
+func (s *subscription) Cancel() {
+	s.subscription.Cancel()
+}

--- a/service/header/subscription_test.go
+++ b/service/header/subscription_test.go
@@ -1,0 +1,56 @@
+package header
+
+import (
+	"context"
+	"testing"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubscriber tests the header Service's implementation of Subscriber.
+func TestSubscriber(t *testing.T) {
+	// create mock network
+	net, err := mocknet.FullMeshConnected(context.Background(), 2)
+	require.NoError(t, err)
+
+	// get mock host and create new gossipsub on it
+	peer1 := net.Hosts()[0]
+	gossub1, err := pubsub.NewGossipSub(context.Background(), peer1,
+		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign))
+	require.NoError(t, err)
+
+	// create header Service
+	headerServ := NewHeaderService(nil, nil, gossub1)
+	err = headerServ.Start(context.Background())
+	require.NoError(t, err)
+
+	// subscribe
+	subscription, err := headerServ.Subscribe()
+	require.NoError(t, err)
+
+	// publish ExtendedHeader to topic
+	peer2 := net.Hosts()[1]
+	gossub2, err := pubsub.NewGossipSub(context.Background(), peer2,
+		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign))
+	require.NoError(t, err)
+	topic, err := gossub2.Join(ExtendedHeaderSubTopic)
+	require.NoError(t, err)
+
+	expectedHeader := RandExtendedHeader(t)
+	bin, err := expectedHeader.MarshalBinary()
+	require.NoError(t, err)
+
+	err = topic.Publish(context.Background(), bin)
+	require.NoError(t, err)
+
+	// get next ExtendedHeader from network
+	header, err := subscription.NextHeader(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedHeader.Height, header.Height)
+	assert.Equal(t, expectedHeader.Hash(), header.Hash())
+	assert.Equal(t, expectedHeader.DAH.Hash(), header.DAH.Hash())
+}


### PR DESCRIPTION
This PR implements a structure for HeaderSub, exposing an interface for any service / component that needs access to new `ExtendedHeader`s to be able to subscribe to new `ExtendedHeader` events.

Resolves #164. 
Related to #24. 