### PR TITLE
service/block: add Commit from current block in ExtendedHeader

### DIFF
--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/celestiaorg/celestia-core/types"
-
 	"github.com/celestiaorg/celestia-node/service/block"
 )
 
@@ -36,12 +35,24 @@ func (f *BlockFetcher) GetBlock(ctx context.Context, height *int64) (*block.RawB
 	return raw.Block, nil
 }
 
-func (f *BlockFetcher) CommitAtHeight(ctx context.Context, height *int64) (*types.Commit, error) {
+// Commit queries Core for a `Commit` from the block at
+// the given height.
+func (f *BlockFetcher) Commit(ctx context.Context, height *int64) (*types.Commit, error) {
 	commit, err := f.client.Commit(ctx, height)
 	if err != nil {
 		return nil, err
 	}
 	return commit.Commit, nil
+}
+
+// ValidatorSet queries Core for the ValidatorSet from the
+// block at the given height.
+func (f *BlockFetcher) ValidatorSet(ctx context.Context, height *int64) (*types.ValidatorSet, error) {
+	vals, err := f.client.Validators(ctx, height, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return types.NewValidatorSet(vals.Validators), nil
 }
 
 // SubscribeNewBlockEvent subscribes to new block events from Core, returning

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -36,6 +36,14 @@ func (f *BlockFetcher) GetBlock(ctx context.Context, height *int64) (*block.RawB
 	return raw.Block, nil
 }
 
+func (f *BlockFetcher) CommitAtHeight(ctx context.Context, height *int64) (*types.Commit, error) {
+	commit, err := f.client.Commit(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+	return commit.Commit, nil
+}
+
 // SubscribeNewBlockEvent subscribes to new block events from Core, returning
 // a new block event channel on success.
 func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *block.RawBlock, error) {

--- a/core/fetcher_test.go
+++ b/core/fetcher_test.go
@@ -31,3 +31,29 @@ func TestBlockFetcher_GetBlock_and_SubscribeNewBlockEvent(t *testing.T) {
 	require.NoError(t, fetcher.UnsubscribeNewBlockEvent(ctx))
 	require.NoError(t, client.Stop())
 }
+
+func TestBlockFetcher_CommitAtHeight(t *testing.T) {
+	client := MockEmbeddedClient()
+	fetcher := NewBlockFetcher(client)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// generate some blocks
+	newBlockChan, err := fetcher.SubscribeNewBlockEvent(ctx)
+	require.NoError(t, err)
+	// read once from channel to generate next block
+	<-newBlockChan
+	// get Commit from current height
+	commit, err := fetcher.CommitAtHeight(ctx, nil)
+	require.NoError(t, err)
+	// get next block
+	nextBlock := <-newBlockChan
+	// compare LastCommit from next block to Commit from first block height
+	assert.Equal(t, nextBlock.LastCommit.Hash(), commit.Hash())
+	assert.Equal(t, nextBlock.LastCommit.Height, commit.Height)
+	assert.Equal(t, nextBlock.LastCommit.Signatures, commit.Signatures)
+
+	require.NoError(t, fetcher.UnsubscribeNewBlockEvent(ctx))
+	require.NoError(t, client.Stop())
+}

--- a/service/block/event.go
+++ b/service/block/event.go
@@ -61,16 +61,21 @@ func (s *Service) handleRawBlock(raw *RawBlock) error {
 	}
 	log.Debugw("generated DataAvailabilityHeader", "data root", dah.Hash())
 	// create ExtendedHeader
-	commit, err := s.fetcher.CommitAtHeight(context.Background(), &raw.Height)
+	commit, err := s.fetcher.Commit(context.Background(), &raw.Height)
 	if err != nil {
 		log.Errorw("fetching commit", "err", err.Error(), "height", raw.Height)
 		return err
 	}
+	valSet, err := s.fetcher.ValidatorSet(context.Background(), &raw.Height)
+	if err != nil {
+		log.Errorw("fetching validator set", "err", err.Error(), "height", raw.Height)
+		return err
+	}
 	extendedHeader := &header.ExtendedHeader{
-		RawHeader: raw.Header,
-		DAH:       &dah,
-		Commit:    commit,
-		// TODO @renaynay: validator set
+		RawHeader:    raw.Header,
+		DAH:          &dah,
+		Commit:       commit,
+		ValidatorSet: valSet,
 	}
 	// create Block
 	extendedBlock := &Block{

--- a/service/block/event.go
+++ b/service/block/event.go
@@ -60,12 +60,22 @@ func (s *Service) handleRawBlock(raw *RawBlock) error {
 		return err
 	}
 	log.Debugw("generated DataAvailabilityHeader", "data root", dah.Hash())
+	// create ExtendedHeader
+	commit, err := s.fetcher.CommitAtHeight(context.Background(), &raw.Height)
+	if err != nil {
+		log.Errorw("fetching commit", "err", err.Error(), "height", raw.Height)
+		return err
+	}
+	extendedHeader := &header.ExtendedHeader{
+		RawHeader: raw.Header,
+		DAH:       &dah,
+		Commit:    commit,
+		// TODO @renaynay: validator set
+	}
 	// create Block
 	extendedBlock := &Block{
-		header: &header.ExtendedHeader{
-			DAH: &dah,
-		},
-		data: extendedBlockData,
+		header: extendedHeader,
+		data:   extendedBlockData,
 	}
 	// check for bad encoding fraud
 	err = validateEncoding(extendedBlock, raw.Header)

--- a/service/block/event_test.go
+++ b/service/block/event_test.go
@@ -55,7 +55,11 @@ func (m *mockFetcher) GetBlock(ctx context.Context, height *int64) (*RawBlock, e
 	return nil, nil
 }
 
-func (m *mockFetcher) CommitAtHeight(ctx context.Context, height *int64) (*core.Commit, error) {
+func (m *mockFetcher) Commit(ctx context.Context, height *int64) (*core.Commit, error) {
+	return nil, nil
+}
+
+func (m *mockFetcher) ValidatorSet(ctx context.Context, height *int64) (*core.ValidatorSet, error) {
 	return nil, nil
 }
 

--- a/service/block/event_test.go
+++ b/service/block/event_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-core/testutils"
+	core "github.com/celestiaorg/celestia-core/types"
 	"github.com/celestiaorg/celestia-node/service/header"
 )
 
@@ -51,6 +52,10 @@ type mockFetcher struct {
 }
 
 func (m *mockFetcher) GetBlock(ctx context.Context, height *int64) (*RawBlock, error) {
+	return nil, nil
+}
+
+func (m *mockFetcher) CommitAtHeight(ctx context.Context, height *int64) (*core.Commit, error) {
 	return nil, nil
 }
 

--- a/service/block/interface.go
+++ b/service/block/interface.go
@@ -2,11 +2,14 @@ package block
 
 import (
 	"context"
+
+	core "github.com/celestiaorg/celestia-core/types"
 )
 
 // Fetcher encompasses the behavior necessary to fetch new "raw" blocks.
 type Fetcher interface {
 	GetBlock(ctx context.Context, height *int64) (*RawBlock, error)
+	CommitAtHeight(ctx context.Context, height *int64) (*core.Commit, error)
 	SubscribeNewBlockEvent(ctx context.Context) (<-chan *RawBlock, error)
 	UnsubscribeNewBlockEvent(ctx context.Context) error
 }

--- a/service/block/interface.go
+++ b/service/block/interface.go
@@ -9,7 +9,8 @@ import (
 // Fetcher encompasses the behavior necessary to fetch new "raw" blocks.
 type Fetcher interface {
 	GetBlock(ctx context.Context, height *int64) (*RawBlock, error)
-	CommitAtHeight(ctx context.Context, height *int64) (*core.Commit, error)
+	Commit(ctx context.Context, height *int64) (*core.Commit, error)
+	ValidatorSet(ctx context.Context, height *int64) (*core.ValidatorSet, error)
 	SubscribeNewBlockEvent(ctx context.Context) (<-chan *RawBlock, error)
 	UnsubscribeNewBlockEvent(ctx context.Context) error
 }

--- a/service/block/types.go
+++ b/service/block/types.go
@@ -1,11 +1,9 @@
 package block
 
 import (
-	"github.com/celestiaorg/rsmt2d"
-
-	"github.com/celestiaorg/celestia-node/service/header"
-
 	core "github.com/celestiaorg/celestia-core/types"
+	"github.com/celestiaorg/celestia-node/service/header"
+	"github.com/celestiaorg/rsmt2d"
 )
 
 // RawBlock is an alias to a "raw" Core block. It is "raw" because
@@ -16,9 +14,8 @@ type RawBlock = core.Block
 // It contains the erasure coded block data as well as its
 // ExtendedHeader.
 type Block struct {
-	header     *header.ExtendedHeader
-	data       *ExtendedBlockData
-	lastCommit *core.Commit
+	header *header.ExtendedHeader
+	data   *ExtendedBlockData
 }
 
 // ExtendedBlockData is an alias to rsmt2d's ExtendedDataSquare type.
@@ -34,9 +31,9 @@ func (b *Block) Data() *ExtendedBlockData {
 	return b.data
 }
 
-// LastCommit returns the last commit of the Block.
-func (b *Block) LastCommit() *core.Commit {
-	return b.lastCommit
+// Commit returns the commit of the Block.
+func (b *Block) Commit() *core.Commit {
+	return b.header.Commit
 }
 
 // DataSize returns the width of the ExtendedBlockData.


### PR DESCRIPTION
This PR adds the Commit from the current block in the `ExtendedHeader` by extending the `Fetcher` interface to implement another method `CommitAtHeight` to fetch the Commit at the given block height. This is done so that light nodes do not need to request the subsequent header to have the Commit information from the block height of the given `ExtendedHeader`. 

Resolves #161. 