### PR TITLE
service/block, service/header: `BlockService` broadcasts generated `ExtendedHeader`s to network

### DIFF
--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+
 	"github.com/celestiaorg/celestia-node/service/header"
 	"github.com/celestiaorg/celestia-node/service/share"
 )
@@ -50,3 +52,5 @@ func (mhs *mockHeaderSub) NextHeader(ctx context.Context) (*header.ExtendedHeade
 }
 
 func (mhs *mockHeaderSub) Cancel() {}
+
+func (mhs *mockHeaderSub) Topic() *pubsub.Topic { return nil }

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -3,31 +3,36 @@ package services
 import (
 	"context"
 
+	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/service/block"
 	"github.com/celestiaorg/celestia-node/service/header"
 	"github.com/celestiaorg/celestia-node/service/share"
-
-	ipld "github.com/ipfs/go-ipld-format"
-	"go.uber.org/fx"
 )
 
-func Header(lc fx.Lifecycle, ps *pubsub.PubSub) *header.Service {
+// Header constructs a new header.Service.
+func Header(lc fx.Lifecycle, ps *pubsub.PubSub) (*header.Service, header.Broadcaster) {
 	service := header.NewHeaderService(nil, nil, ps)
 	lc.Append(fx.Hook{
 		OnStart: service.Start,
 		OnStop:  service.Stop,
 	})
-	return service
+	return service, service
 }
 
 // Block constructs new block.Service.
-func Block(lc fx.Lifecycle, fetcher block.Fetcher, store ipld.DAGService) *block.Service {
-	service := block.NewBlockService(fetcher, store)
+func Block(
+	lc fx.Lifecycle,
+	fetcher block.Fetcher,
+	store ipld.DAGService,
+	broadcaster header.Broadcaster,
+) *block.Service {
+	service := block.NewBlockService(fetcher, store, broadcaster)
 	lc.Append(fx.Hook{
 		OnStart: service.Start,
 		OnStop:  service.Stop,

--- a/service/block/event.go
+++ b/service/block/event.go
@@ -77,6 +77,11 @@ func (s *Service) handleRawBlock(raw *RawBlock) error {
 		Commit:       commit,
 		ValidatorSet: valSet,
 	}
+	// broadcast ExtendedHeader
+	if err := s.broadcaster.Broadcast(context.Background(), extendedHeader); err != nil {
+		log.Errorw("broadcasting new ExtendedHeader to network", "err", err)
+		return err
+	}
 	// create Block
 	extendedBlock := &Block{
 		header: extendedHeader,

--- a/service/block/event_test.go
+++ b/service/block/event_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-datastore"
 	md "github.com/ipfs/go-merkledag/test"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,7 +24,7 @@ func TestEventLoop(t *testing.T) {
 	mockFetcher := &mockFetcher{
 		mockNewBlockCh: make(chan *RawBlock),
 	}
-	serv := NewBlockService(mockFetcher, md.Mock())
+	serv := NewBlockService(mockFetcher, md.Mock(), new(mockBroadcaster))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -47,8 +50,62 @@ func TestEventLoop(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestExtendedHeaderBroadcast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	suite := header.NewTestSuite(t, 3)
+
+	mockFetcher := &mockFetcher{
+		suite:          suite,
+		commits:        make(map[int64]*core.Commit),
+		valSets:        make(map[int64]*core.ValidatorSet),
+		mockNewBlockCh: make(chan *RawBlock),
+	}
+
+	// create mock network w/ new pubsub
+	net, err := mocknet.FullMeshConnected(context.Background(), 2)
+	require.NoError(t, err)
+
+	pub, err := pubsub.NewGossipSub(context.Background(), net.Hosts()[1],
+		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign))
+	require.NoError(t, err)
+
+	store1, err := header.NewStoreWithHead(datastore.NewMapDatastore(), suite.Head())
+	require.NoError(t, err)
+
+	// also create subscription to topic to listen on the other side
+	headerServ := header.NewHeaderService(header.NewLocalExchange(store1), store1, pub)
+	require.NoError(t, err)
+	err = headerServ.Start(ctx)
+	require.NoError(t, err)
+
+	sub, err := headerServ.Subscribe()
+	require.NoError(t, err)
+
+	serv := NewBlockService(mockFetcher, md.Mock(), headerServ)
+
+	err = serv.Start(ctx)
+	require.NoError(t, err)
+
+	numBlocks := 3
+	validRawBlocks := mockFetcher.generateBlocksWithValidHeaders(t, numBlocks)
+
+	i := 0
+	for i < numBlocks {
+		got, err := sub.NextHeader(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, validRawBlocks[i].Header.Height, got.Height)
+		assert.Equal(t, validRawBlocks[i].Header.DataHash.Bytes(), got.DAH.Hash())
+		i++
+	}
+}
+
 // mockFetcher mocks away the `Fetcher` interface.
 type mockFetcher struct {
+	suite          *header.TestSuite
+	valSets        map[int64]*core.ValidatorSet
+	commits        map[int64]*core.Commit
 	mockNewBlockCh chan *RawBlock
 }
 
@@ -57,11 +114,11 @@ func (m *mockFetcher) GetBlock(ctx context.Context, height *int64) (*RawBlock, e
 }
 
 func (m *mockFetcher) Commit(ctx context.Context, height *int64) (*core.Commit, error) {
-	return nil, nil
+	return m.commits[*height], nil
 }
 
 func (m *mockFetcher) ValidatorSet(ctx context.Context, height *int64) (*core.ValidatorSet, error) {
-	return nil, nil
+	return m.valSets[*height], nil
 }
 
 func (m *mockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan *RawBlock, error) {
@@ -73,6 +130,31 @@ func (m *mockFetcher) UnsubscribeNewBlockEvent(ctx context.Context) error {
 	return nil
 }
 
+func (m *mockFetcher) generateBlocksWithValidHeaders(t *testing.T, num int) []*RawBlock {
+	rawBlocks := make([]*RawBlock, num)
+
+	prevEH := m.suite.Head()
+
+	for i := range rawBlocks {
+		eh := m.suite.GenExtendedHeader()
+		b := &RawBlock{
+			Header:     eh.RawHeader,
+			LastCommit: prevEH.Commit,
+		}
+		require.NoError(t, b.ValidateBasic())
+		require.NoError(t, b.Header.ValidateBasic())
+
+		rawBlocks[i] = b
+		// store commit and valset at height
+		m.commits[b.Height] = eh.Commit
+		m.valSets[b.Height] = eh.ValidatorSet
+
+		m.mockNewBlockCh <- b
+		prevEH = eh
+	}
+	return rawBlocks
+}
+
 // generateBlocks generates new raw blocks and sends them to the mock fetcher,
 // returning the extended blocks generated from the process to compare against.
 func (m *mockFetcher) generateBlocks(t *testing.T, num int) []Block {
@@ -82,6 +164,7 @@ func (m *mockFetcher) generateBlocks(t *testing.T, num int) []Block {
 
 	for i := 0; i < num; i++ {
 		rawBlock, block := generateRawAndExtendedBlock(t)
+
 		extendedBlocks[i] = *block
 		m.mockNewBlockCh <- rawBlock
 	}
@@ -117,4 +200,21 @@ func generateRawAndExtendedBlock(t *testing.T) (*RawBlock, *Block) {
 		},
 		data: extendedData,
 	}
+}
+
+type mockBroadcaster struct {
+	topic *pubsub.Topic
+}
+
+func (mb *mockBroadcaster) Broadcast(ctx context.Context, header *header.ExtendedHeader) error {
+	if mb.topic != nil {
+		bin, err := header.MarshalBinary()
+		if err != nil {
+			return err
+		}
+		if err := mb.topic.Publish(ctx, bin); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/service/block/service.go
+++ b/service/block/service.go
@@ -5,6 +5,8 @@ import (
 
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/celestiaorg/celestia-node/service/header"
 )
 
 // Service represents the Block service that can be started / stopped on a `Full` node.
@@ -13,18 +15,21 @@ import (
 // 		2. Erasure coding the "raw" blocks and producing a DataAvailabilityHeader + verifying the Data root.
 // 		3. Storing erasure coded blocks.
 // 		4. Serving erasure coded blocks to other `Full` node peers.
+// TODO @renaynay: add docs about broadcaster
 type Service struct {
-	fetcher Fetcher
-	store   ipld.DAGService
+	fetcher     Fetcher
+	store       ipld.DAGService
+	broadcaster header.Broadcaster
 }
 
 var log = logging.Logger("block-service")
 
 // NewBlockService creates a new instance of block Service.
-func NewBlockService(fetcher Fetcher, store ipld.DAGService) *Service {
+func NewBlockService(fetcher Fetcher, store ipld.DAGService, broadcaster header.Broadcaster) *Service {
 	return &Service{
-		fetcher: fetcher,
-		store:   store,
+		fetcher:     fetcher,
+		store:       store,
+		broadcaster: broadcaster,
 	}
 }
 

--- a/service/block/store_test.go
+++ b/service/block/store_test.go
@@ -12,7 +12,7 @@ import (
 func TestService_BlockStore(t *testing.T) {
 	// create mock block service (fetcher is not necessary here)
 	mockStore := md.Mock()
-	serv := NewBlockService(nil, mockStore)
+	serv := NewBlockService(nil, mockStore, new(mockBroadcaster))
 
 	_, block := generateRawAndExtendedBlock(t)
 

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -25,6 +25,11 @@ type Subscription interface {
 	Cancel()
 }
 
+// Broadcaster broadcasts an ExtendedHeader to the network.
+type Broadcaster interface {
+	Broadcast(ctx context.Context, header *ExtendedHeader) error
+}
+
 // Exchange encompasses the behavior necessary to request ExtendedHeaders
 // from the network.
 type Exchange interface {

--- a/service/header/service.go
+++ b/service/header/service.go
@@ -92,3 +92,12 @@ func (s *Service) Subscribe() (Subscription, error) {
 
 	return newSubscription(s.topic)
 }
+
+func (s *Service) Broadcast(ctx context.Context, header *ExtendedHeader) error {
+	bin, err := header.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	return s.topic.Publish(ctx, bin)
+}

--- a/service/header/subscription_test.go
+++ b/service/header/subscription_test.go
@@ -53,6 +53,9 @@ func TestSubscriber(t *testing.T) {
 	err = headerServ2.Start(ctx)
 	require.NoError(t, err)
 
+	_, err = headerServ2.Subscribe()
+	require.NoError(t, err)
+
 	time.Sleep(2 * time.Second)
 
 	expectedHeader := suite.GenExtendedHeaders(1)[0]

--- a/service/header/testing.go
+++ b/service/header/testing.go
@@ -11,13 +11,12 @@ import (
 
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	"github.com/tendermint/tendermint/libs/bytes"
-	"github.com/tendermint/tendermint/pkg/da"
-	"github.com/tendermint/tendermint/types"
-	tmtime "github.com/tendermint/tendermint/types/time"
-
 	tmrand "github.com/tendermint/tendermint/libs/rand"
+	"github.com/tendermint/tendermint/pkg/da"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/proto/tendermint/version"
+	"github.com/tendermint/tendermint/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
 // TestSuite provides everything you need to test chain of Headers.


### PR DESCRIPTION
`block.Service` now receives a `Broadcaster` from the `header.Service` so that it can `Broadcast()` new `ExtendedHeader`s to the network as they are created during the block handling process.