### PR TITLE
fix(node/p2p): ensure  DHT bootrapps itself on Start

### DIFF
--- a/node/p2p/routing.go
+++ b/node/p2p/routing.go
@@ -51,9 +51,14 @@ func PeerRouting(cfg Config) func(routingParams) (routing.PeerRouting, error) {
 		if err != nil {
 			return nil, err
 		}
-		params.Lc.Append(fx.Hook{OnStop: func(context.Context) error {
-			return d.Close()
-		}})
+		params.Lc.Append(fx.Hook{
+			OnStart: func(ctx context.Context) error {
+				return d.Bootstrap(ctx)
+			},
+			OnStop: func(context.Context) error {
+				return d.Close()
+			},
+		})
 
 		return d, nil
 	}


### PR DESCRIPTION
## Background
Basically, this just ensures nodes (both light and full) are connected to bootstrap peers and their DHT table is refreshed, I was imagining something more complex, but this should be fine.

## Ref
Close #201 