### PR TITLE
Persist generated key to keystore and reuse existing key if present

### DIFF
--- a/libs/keystore/fs_keystore.go
+++ b/libs/keystore/fs_keystore.go
@@ -2,11 +2,14 @@ package keystore
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 )
+
+var ErrNotFound = errors.New("keystore: key not found")
 
 // fsKeystore implements persistent Keystore over OS filesystem.
 type fsKeystore struct {
@@ -51,7 +54,7 @@ func (f *fsKeystore) Get(n KeyName) (PrivKey, error) {
 	st, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return PrivKey{}, fmt.Errorf("keystore: key '%s' not found", n)
+			return PrivKey{}, fmt.Errorf("%w: %s", ErrNotFound, n)
 		}
 
 		return PrivKey{}, fmt.Errorf("keystore: check before reading key '%s' failed: %w", n, err)

--- a/libs/keystore/fs_keystore.go
+++ b/libs/keystore/fs_keystore.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 )
 
+// ErrNotFound is returned when the key does not exist.
 var ErrNotFound = errors.New("keystore: key not found")
 
 // fsKeystore implements persistent Keystore over OS filesystem.

--- a/libs/keystore/map_keystore.go
+++ b/libs/keystore/map_keystore.go
@@ -35,7 +35,7 @@ func (m *mapKeystore) Get(n KeyName) (PrivKey, error) {
 
 	k, ok := m.keys[n]
 	if !ok {
-		return PrivKey{}, fmt.Errorf("keystore: key '%s' not found", n)
+		return PrivKey{}, fmt.Errorf("%w: %s", ErrNotFound, n)
 	}
 
 	return k, nil

--- a/node/p2p/identity.go
+++ b/node/p2p/identity.go
@@ -4,10 +4,11 @@ import (
 	"crypto/rand"
 	"errors"
 
-	"github.com/celestiaorg/celestia-node/libs/keystore"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
+
+	"github.com/celestiaorg/celestia-node/libs/keystore"
 )
 
 // TODO(Josh): What should the real name for this be?

--- a/node/p2p/identity.go
+++ b/node/p2p/identity.go
@@ -11,8 +11,7 @@ import (
 	"github.com/celestiaorg/celestia-node/libs/keystore"
 )
 
-// TODO(Josh): What should the real name for this be?
-const keyName = "test-key"
+const keyName = "p2p-key"
 
 // TODO(@Wondertan): Should also receive a KeyStore to save generated key and reuse if exists.
 // Identity provides a networking private key and PeerID of the node.

--- a/node/p2p/identity.go
+++ b/node/p2p/identity.go
@@ -2,21 +2,48 @@ package p2p
 
 import (
 	"crypto/rand"
+	"errors"
 
+	"github.com/celestiaorg/celestia-node/libs/keystore"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
 )
 
+// TODO(Josh): What should the real name for this be?
+const keyName = "test-key"
+
 // TODO(@Wondertan): Should also receive a KeyStore to save generated key and reuse if exists.
 // Identity provides a networking private key and PeerID of the node.
-func Identity(pstore peerstore.Peerstore) (crypto.PrivKey, peer.ID, error) {
-	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
+func Identity(pstore peerstore.Peerstore, ks keystore.Keystore) (priv crypto.PrivKey, id peer.ID, err error) {
+	ksPriv, err := ks.Get(keyName)
 	if err != nil {
-		return nil, "", err
+		if errors.Is(err, keystore.ErrNotFound) {
+			// No existing private key in the keystore so generate a new one
+			priv, _, err = crypto.GenerateEd25519Key(rand.Reader)
+			if err != nil {
+				return nil, "", err
+			}
+			bytes, err := crypto.MarshalPrivateKey(priv)
+			if err != nil {
+				return nil, "", err
+			}
+			// Store the new private key in the keystore
+			err = ks.Put(keyName, keystore.PrivKey{Body: bytes})
+			if err != nil {
+				return nil, "", err
+			}
+		} else {
+			return nil, "", err
+		}
+	} else {
+		priv, err = crypto.UnmarshalPrivateKey(ksPriv.Body)
+		if err != nil {
+			return nil, "", err
+		}
 	}
 
-	id, err := peer.IDFromPrivateKey(priv)
+	id, err = peer.IDFromPrivateKey(priv)
 	if err != nil {
 		return nil, "", err
 	}
@@ -26,5 +53,5 @@ func Identity(pstore peerstore.Peerstore) (crypto.PrivKey, peer.ID, error) {
 		return nil, "", err
 	}
 
-	return priv, id, pstore.AddPubKey(id, pub)
+	return priv, id, pstore.AddPubKey(id, priv.GetPublic())
 }


### PR DESCRIPTION
identity.go previously created a new key on every run of `celestia full init` resulting in new PeerIDs each time. Persisting the keys allows us to have persistent PeerIDs. 