### PR TITLE
service/header: Header Exchange implemented over Core Node

### DIFF
--- a/core/header_fetcher.go
+++ b/core/header_fetcher.go
@@ -1,0 +1,2 @@
+package core
+

--- a/core/header_fetcher.go
+++ b/core/header_fetcher.go
@@ -1,2 +1,0 @@
-package core
-

--- a/ipld/read_test.go
+++ b/ipld/read_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/tendermint/tendermint/pkg/wrapper"
 
 	"github.com/celestiaorg/celestia-node/ipld/plugin"
-	"github.com/celestiaorg/celestia-node/service/header"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/celestiaorg/rsmt2d"
@@ -139,8 +138,7 @@ func TestRetrieveBlockData(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*2)
 			defer cancel()
 
-			dah, err := header.DataAvailabilityHeaderFromExtendedData(in)
-			require.NoError(t, err)
+			dah := da.NewDataAvailabilityHeader(in)
 
 			out, err := RetrieveData(ctx, &dah, dag, rsmt2d.NewRSGF8Codec())
 			require.NoError(t, err)

--- a/service/header/core_exchange.go
+++ b/service/header/core_exchange.go
@@ -1,3 +1,122 @@
 package header
 
+import (
+	"context"
+	"math"
 
+	format "github.com/ipfs/go-ipld-format"
+
+	"github.com/tendermint/tendermint/pkg/da"
+	"github.com/tendermint/tendermint/pkg/wrapper"
+	"github.com/tendermint/tendermint/types"
+
+	"github.com/celestiaorg/celestia-node/core"
+	"github.com/celestiaorg/celestia-node/ipld"
+	"github.com/celestiaorg/nmt"
+	"github.com/celestiaorg/rsmt2d"
+)
+
+type CoreExchange struct {
+	fetcher    *core.BlockFetcher
+	shareStore format.DAGService
+}
+
+func NewCoreExchange(fetcher *core.BlockFetcher, dag format.DAGService) *CoreExchange {
+	return &CoreExchange{
+		fetcher:    fetcher,
+		shareStore: dag,
+	}
+}
+
+func (ce *CoreExchange) RequestHeader(ctx context.Context, height uint64) (*ExtendedHeader, error) {
+	intHeight := int64(height) + 1
+	block, err := ce.fetcher.GetBlock(ctx, &intHeight)
+	if err != nil {
+		return nil, err
+	}
+	return ce.generateExtendedHeaderFromBlock(block)
+}
+
+func (ce *CoreExchange) RequestHeaders(ctx context.Context, origin, amount uint64) ([]*ExtendedHeader, error) {
+	headers := make([]*ExtendedHeader, amount)
+	for i := range headers {
+		extHeader, err := ce.RequestHeader(ctx, origin+uint64(i))
+		if err != nil {
+			return nil, err
+		}
+
+		headers[i] = extHeader
+	}
+
+	return headers, nil
+}
+
+func (ce *CoreExchange) RequestByHash(ctx context.Context, hash []byte) (*ExtendedHeader, error) {
+	block, err := ce.fetcher.GetBlockByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	return ce.generateExtendedHeaderFromBlock(block)
+}
+
+func (ce *CoreExchange) RequestHead(ctx context.Context) (*ExtendedHeader, error) {
+	chainHead, err := ce.fetcher.GetBlock(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return ce.generateExtendedHeaderFromBlock(chainHead)
+}
+
+func (ce *CoreExchange) generateExtendedHeaderFromBlock(block *types.Block) (*ExtendedHeader, error) {
+	extended, err := ce.extendBlockData(block)
+	if err != nil {
+		log.Errorw("computing extended data square", "err msg", err, "block height",
+			block.Height, "block hash", block.Hash().String())
+		return nil, err
+	}
+	// write block data to store
+	dah := da.NewDataAvailabilityHeader(extended)
+	log.Debugw("generated DataAvailabilityHeader", "data root", dah.Hash())
+	// create ExtendedHeader
+	commit, err := ce.fetcher.Commit(context.Background(), &block.Height)
+	if err != nil {
+		log.Errorw("fetching commit", "err", err.Error(), "height", block.Height)
+		return nil, err
+	}
+	valSet, err := ce.fetcher.ValidatorSet(context.Background(), &block.Height)
+	if err != nil {
+		log.Errorw("fetching validator set", "err", err.Error(), "height", block.Height)
+		return nil, err
+	}
+	return &ExtendedHeader{
+		RawHeader:    block.Header,
+		DAH:          &dah,
+		Commit:       commit,
+		ValidatorSet: valSet,
+	}, nil
+}
+
+// extendBlockData erasure codes the given raw block's data and returns the
+// erasure coded block data upon success.
+// TODO @renaynay: this is duplicate code for purpose of DEVNET, delete post devnet
+func (ce *CoreExchange) extendBlockData(raw *types.Block) (*rsmt2d.ExtendedDataSquare, error) {
+	namespacedShares, _ := raw.Data.ComputeShares()
+	shares := namespacedShares.RawShares()
+
+	// create nmt adder wrapping batch adder
+	batchAdder := ipld.NewNmtNodeAdder(context.Background(), format.NewBatch(context.Background(), ce.shareStore))
+
+	// create the nmt wrapper to generate row and col commitments
+	squareSize := squareSize64(len(namespacedShares))
+	tree := wrapper.NewErasuredNamespacedMerkleTree(squareSize, nmt.NodeVisitor(batchAdder.Visit))
+
+	// compute extended square
+	return rsmt2d.ComputeExtendedDataSquare(shares, rsmt2d.NewRSGF8Codec(), tree.Constructor)
+}
+
+// squareSize64 computes the square size as a uint64 from
+// the given length of shares.
+// TODO @renaynay: this is duplicate code for purpose of DEVNET, delete post devnet
+func squareSize64(length int) uint64 {
+	return uint64(math.Sqrt(float64(length)))
+}

--- a/service/header/core_exchange.go
+++ b/service/header/core_exchange.go
@@ -1,0 +1,3 @@
+package header
+
+

--- a/service/header/core_exchange_test.go
+++ b/service/header/core_exchange_test.go
@@ -1,0 +1,40 @@
+package header
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mdutils "github.com/ipfs/go-merkledag/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/core"
+)
+
+func TestCoreExchange_RequestHeaders(t *testing.T) {
+	fetcher := createCoreFetcher()
+	store := mdutils.Mock()
+
+	// generate 10 blocks
+	generateBlocks(t, fetcher)
+
+	ce := NewCoreExchange(fetcher, store)
+	headers, err := ce.RequestHeaders(context.Background(), 0, 10)
+	require.NoError(t, err)
+
+	fmt.Println(len(headers))
+}
+
+func createCoreFetcher() *core.BlockFetcher {
+	mock := core.MockEmbeddedClient()
+	return core.NewBlockFetcher(mock)
+}
+
+func generateBlocks(t *testing.T, fetcher *core.BlockFetcher) {
+	sub, err := fetcher.SubscribeNewBlockEvent(context.Background())
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		<-sub
+	}
+}

--- a/service/header/dah.go
+++ b/service/header/dah.go
@@ -5,6 +5,7 @@ import (
 )
 
 // DataAvailabilityHeaderFromExtendedData generates a DataAvailabilityHeader from the given data square.
+// TODO @renaynay: use da.NewDataAvailabilityHeader
 func DataAvailabilityHeaderFromExtendedData(data *rsmt2d.ExtendedDataSquare) (DataAvailabilityHeader, error) {
 	// generate the row and col roots using the EDS
 	dah := DataAvailabilityHeader{


### PR DESCRIPTION
This PR will allow header service to sync headers from the core node in order to sync up to the chain. This is necessary for bootstrap peers.