### PR TITLE
cmd, service/header: rename `genesis` to `trustedHash` to avoid confusion, extract flags to common var for re-use

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,40 @@
+package cmd
+
+import "flag"
+
+var configFlags = []*flag.Flag{
+	loglevelFlag,
+	nodeConfigFlag,
+	trustedHashFlag,
+	trustedPeerFlag,
+	coreRemoteFlag,
+}
+
+var (
+	loglevelFlag = &flag.Flag{
+		Name:     "log.level",
+		Usage:    "DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and\n// their lower-case forms",
+		DefValue: "info",
+	}
+	nodeConfigFlag = &flag.Flag{
+		Name:     "node.config",
+		Usage:    "Path to a customized Config",
+		DefValue: "",
+	}
+	trustedHashFlag = &flag.Flag{
+		Name:     "headers.trusted-hash",
+		Usage:    "Hex encoded block hash. Starting point for header synchronization",
+		DefValue: "",
+	}
+	trustedPeerFlag = &flag.Flag{
+		Name:     "headers.trusted-peer",
+		Usage:    "Multiaddr of a reliable peer to fetch headers from",
+		DefValue: "",
+	}
+	coreRemoteFlag = &flag.Flag{
+		Name: "core.remote",
+		Usage: "Indicates node to connect to the given remote core node. " +
+			"Example: <protocol>://<ip>:<port>, tcp://127.0.0.1:26657",
+		DefValue: "",
+	}
+)

--- a/node/options.go
+++ b/node/options.go
@@ -12,10 +12,10 @@ func WithRemoteCore(protocol string, address string) Option {
 	}
 }
 
-// WithGenesis sets GenesisHash to the Config.
-func WithGenesis(hash string) Option {
+// WithTrustedHash sets TrustedHash to the Config.
+func WithTrustedHash(hash string) Option {
 	return func(cfg *Config) {
-		cfg.Services.GenesisHash = hash
+		cfg.Services.TrustedHash = hash
 	}
 }
 

--- a/node/services/config.go
+++ b/node/services/config.go
@@ -9,19 +9,19 @@ import (
 )
 
 type Config struct {
-	// GenesisHash is the Block/Header hash that Nodes use as starting point for header synchronization.
+	// TrustedHash isg the Block/Header hash that Nodes use as starting point for header synchronization.
 	// Only affects the node once on initial sync.
-	GenesisHash string
+	TrustedHash string
 	// TrustedPeer is the peer we trust to fetch headers from.
 	// Note: The trusted does *not* imply Headers are not verified, but trusted as reliable to fetch headers
 	// at any moment.
 	TrustedPeer string
 }
 
-// TODO(@Wondertan): We need to hardcode genesis hash and one bootstrap peer as trusted.
+// TODO(@Wondertan): We need to hardcode trustedHash hash and one bootstrap peer as trusted.
 func DefaultConfig() Config {
 	return Config{
-		GenesisHash: "",
+		TrustedHash: "",
 		TrustedPeer: "",
 	}
 }
@@ -39,6 +39,6 @@ func (cfg *Config) trustedPeer() (*peer.AddrInfo, error) {
 	return peer.AddrInfoFromP2pAddr(ma)
 }
 
-func (cfg *Config) genesis() (tmbytes.HexBytes, error) {
-	return hex.DecodeString(cfg.GenesisHash)
+func (cfg *Config) trustedHash() (tmbytes.HexBytes, error) {
+	return hex.DecodeString(cfg.TrustedHash)
 }

--- a/node/services/config.go
+++ b/node/services/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Config struct {
-	// TrustedHash isg the Block/Header hash that Nodes use as starting point for header synchronization.
+	// TrustedHash is the Block/Header hash that Nodes use as starting point for header synchronization.
 	// Only affects the node once on initial sync.
 	TrustedHash string
 	// TrustedPeer is the peer we trust to fetch headers from.

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -22,12 +22,12 @@ import (
 // HeaderSyncer creates a new header.Syncer.
 func HeaderSyncer(cfg Config) func(ex header.Exchange, store header.Store) (*header.Syncer, error) {
 	return func(ex header.Exchange, store header.Store) (*header.Syncer, error) {
-		genesis, err := cfg.genesis()
+		trustedHash, err := cfg.trustedHash()
 		if err != nil {
 			return nil, err
 		}
 
-		return header.NewSyncer(ex, store, genesis), nil
+		return header.NewSyncer(ex, store, trustedHash), nil
 	}
 }
 

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -15,9 +15,9 @@ func TestSync(t *testing.T) {
 	defer cancel()
 
 	suite := NewTestSuite(t, 3)
-	genesis := suite.Head()
+	head := suite.Head()
 
-	remoteStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), genesis)
+	remoteStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
 	require.Nil(t, err)
 
 	err = remoteStore.Append(ctx, suite.GenExtendedHeaders(100)...)
@@ -25,11 +25,11 @@ func TestSync(t *testing.T) {
 
 	fakeExchange := NewLocalExchange(remoteStore)
 
-	localStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), genesis)
+	localStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
 	require.Nil(t, err)
 
 	requestSize = 13 // just some random number
-	syncer := NewSyncer(fakeExchange, localStore, genesis.Hash())
+	syncer := NewSyncer(fakeExchange, localStore, head.Hash())
 	syncer.Sync(ctx)
 
 	exp, err := remoteStore.Head(ctx)


### PR DESCRIPTION
 This PR:
* renames `genesis` to `trustedHash` in the codebase to avoid confusion
* extracts flags to common variable for re-use between commands `start` and `init`