### PR TITLE
fix(cmd): fix repository path handling for Init and Start commands

### DIFF
--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -12,7 +12,8 @@ func init() {
 		cmd.Init(repoFlagName, node.Full),
 		cmd.Start(repoFlagName, node.Full),
 	)
-	fullCmd.PersistentFlags().StringP(repoFlagName,
+	fullCmd.PersistentFlags().StringP(
+		repoFlagName,
 		repoFlagShort,
 		"~/.celestia-full",
 		"The root/home directory of your Celestial Full Node",

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -8,13 +8,12 @@ import (
 )
 
 func init() {
-	const repoName = "repository"
 	fullCmd.AddCommand(
-		cmd.Init(repoName, node.Full),
-		cmd.Start(repoName, node.Full),
+		cmd.Init(repoFlagName, node.Full),
+		cmd.Start(repoFlagName, node.Full),
 	)
-	fullCmd.PersistentFlags().StringP(repoName,
-		"r",
+	fullCmd.PersistentFlags().StringP(repoFlagName,
+		repoFlagShort,
 		"~/.celestia-full",
 		"The root/home directory of your Celestial Full Node",
 	)

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -8,14 +8,13 @@ import (
 )
 
 func init() {
-	const repoName = "repository"
 	lightCmd.AddCommand(
-		cmd.Init(repoName, node.Light),
-		cmd.Start(repoName, node.Light),
+		cmd.Init(repoFlagName, node.Light),
+		cmd.Start(repoFlagName, node.Light),
 	)
 	lightCmd.PersistentFlags().StringP(
-		repoName,
-		"r",
+		repoFlagName,
+		repoFlagShort,
 		"~/.celestia-light",
 		"The root/home directory of your Celestial Light Node",
 	)

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -6,6 +6,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	repoFlagName  = "repo.path"
+	repoFlagShort = "r"
+)
+
 func init() {
 	rootCmd.AddCommand(
 		fullCmd,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -17,11 +17,11 @@ import (
 
 // Start constructs a CLI command to start Celestia Node daemon of the given type 'tp'.
 // It is meant to be used a subcommand and also receive persistent flag name for repository path.
-func Start(repoName string, tp node.Type) *cobra.Command {
+func Start(repoFlagName string, tp node.Type) *cobra.Command {
 	if !tp.IsValid() {
 		panic("cmd: Start: invalid Node Type")
 	}
-	if len(repoName) == 0 && tp != node.Dev { // repository path not necessary for **DEV MODE**
+	if len(repoFlagName) == 0 && tp != node.Dev { // repository path not necessary for **DEV MODE**
 		panic("parent command must specify a persistent flag name for repository path")
 	}
 
@@ -35,6 +35,11 @@ func Start(repoName string, tp node.Type) *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			repoPath := cmd.Flag(repoFlagName).Value.String()
+			if repoPath == "" {
+				return fmt.Errorf("repository path must be speficied")
+			}
+
 			level, err := logging.LevelFromString(cmd.Flag(loglevelFlag.Name).Value.String())
 			if err != nil {
 				return fmt.Errorf("while setting log level: %w", err)
@@ -79,7 +84,7 @@ func Start(repoName string, tp node.Type) *cobra.Command {
 				opts = append(opts, node.WithConfig(cfg))
 			}
 
-			repo, err := node.Open(repoName, tp)
+			repo, err := node.Open(repoPath, tp)
 			if err != nil {
 				return err
 			}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -37,7 +37,7 @@ func Start(repoFlagName string, tp node.Type) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			repoPath := cmd.Flag(repoFlagName).Value.String()
 			if repoPath == "" {
-				return fmt.Errorf("repository path must be speficied")
+				return fmt.Errorf("repository path must be specified")
 			}
 
 			level, err := logging.LevelFromString(cmd.Flag(loglevelFlag.Name).Value.String())


### PR DESCRIPTION
Fixes bug introduced in #229, without the fix `start` does not work.