### PR TITLE
Include the error in P2PExchange.handleRequestByHash error logging

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -19,3 +19,5 @@ Month, DD, YYYY
 ### BUG FIXES
 
 - [go package] (Link to PR) Description @username
+
+- [header] Added missing `err` value in ErrorW logging calls. @jbowen93

--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -101,19 +101,19 @@ func (ex *P2PExchange) handleRequestByHash(hash []byte, stream network.Stream) {
 
 	header, err := ex.store.Get(ex.ctx, hash)
 	if err != nil {
-		log.Errorw("getting header by hash", "hash", tmbytes.HexBytes(hash).String(), "err")
+		log.Errorw("getting header by hash", "hash", tmbytes.HexBytes(hash).String(), "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
 	resp, err := ExtendedHeaderToProto(header)
 	if err != nil {
-		log.Errorw("marshaling header to proto", "hash", tmbytes.HexBytes(hash).String(), "err")
+		log.Errorw("marshaling header to proto", "hash", tmbytes.HexBytes(hash).String(), "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
 	_, err = serde.Write(stream, resp)
 	if err != nil {
-		log.Errorw("writing header to stream", "hash", tmbytes.HexBytes(hash).String(), "err")
+		log.Errorw("writing header to stream", "hash", tmbytes.HexBytes(hash).String(), "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}


### PR DESCRIPTION
The existing implementation of `P2PExchange.handleRequestByHash` doesn't include the actual `err` value in the `ErrorW` logging call. 