### PR TITLE
node: remove InitWith

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -8,6 +8,7 @@ Month, DD, YYYY
 
 - [chore: rename Repository to Store #296](https://github.com/celestiaorg/celestia-node/pull/296) [@Wondertan](https://github.com/Wondertan)
 - [chore: rename Full node to Bridge node #294](https://github.com/celestiaorg/celestia-node/pull/294) [@Wondertan](https://github.com/Wondertan)
+- [node: remove InitWith #291](https://github.com/celestiaorg/celestia-node/pull/291) [@Wondertan](https://github.com/Wondertan)
 
 ### FEATURES
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,6 +29,8 @@ func Init(storeFlagName string, tp node.Type) *cobra.Command {
 				return fmt.Errorf("store path must be specified")
 			}
 
+			var opts []node.Option
+
 			nodeConfig := cmd.Flag(nodeConfigFlag.Name).Value.String()
 			if nodeConfig != "" {
 				cfg, err := node.LoadConfig(nodeConfig)
@@ -36,10 +38,8 @@ func Init(storeFlagName string, tp node.Type) *cobra.Command {
 					return err
 				}
 
-				return node.InitWith(storePath, tp, cfg)
+				opts = append(opts, node.WithConfig(cfg))
 			}
-
-			var opts []node.Option
 
 			trustedHash := cmd.Flag(trustedHashFlag.Name).Value.String()
 			if trustedHash != "" {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -48,7 +48,14 @@ func Start(storeFlagName string, tp node.Type) *cobra.Command {
 			logs.SetAllLoggers(level)
 
 			var opts []node.Option
-
+			nodeConfig := cmd.Flag(nodeConfigFlag.Name).Value.String()
+			if nodeConfig != "" {
+				cfg, err := node.LoadConfig(nodeConfig)
+				if err != nil {
+					return err
+				}
+				opts = append(opts, node.WithConfig(cfg))
+			}
 			trustedHash := cmd.Flag(trustedHashFlag.Name).Value.String()
 			if trustedHash != "" {
 				opts = append(opts, node.WithTrustedHash(trustedHash))
@@ -65,15 +72,6 @@ func Start(storeFlagName string, tp node.Type) *cobra.Command {
 				}
 				opts = append(opts, node.WithRemoteCore(protocol, ip))
 			}
-			nodeConfig := cmd.Flag(nodeConfigFlag.Name).Value.String()
-			if nodeConfig != "" {
-				cfg, err := node.LoadConfig(nodeConfig)
-				if err != nil {
-					return err
-				}
-				opts = append(opts, node.WithConfig(cfg))
-			}
-
 			mutualPeersStr := cmd.Flag(mutualPeersFlag.Name).Value.String()
 			if mutualPeersStr != "" {
 				mutualPeers := strings.Split(mutualPeersStr, ",")

--- a/node/init.go
+++ b/node/init.go
@@ -20,12 +20,6 @@ func Init(path string, tp Type, options ...Option) error {
 		}
 	}
 
-	return InitWith(path, tp, cfg)
-}
-
-// InitWith initializes the Node FileSystem Store for the given Node Type 'tp' in the directory under 'path'
-// with the given Config 'cfg'.
-func InitWith(path string, tp Type, cfg *Config) error {
 	path, err := storePath(path)
 	if err != nil {
 		return err

--- a/node/init_test.go
+++ b/node/init_test.go
@@ -29,15 +29,6 @@ func TestInitErrForInvalidPath(t *testing.T) {
 	}
 }
 
-func TestInitWithNilConfig(t *testing.T) {
-	dir := t.TempDir()
-	nodes := []Type{Light, Bridge}
-
-	for _, node := range nodes {
-		require.Error(t, InitWith(dir, node, nil))
-	}
-}
-
 func TestIsInitWithBrokenConfig(t *testing.T) {
 	dir := t.TempDir()
 	f, err := os.Create(configPath(dir))


### PR DESCRIPTION
## About 
This PR removes redundant `node.InitWith` as we have a separate option to pass a Config, so to have similar functionality, one should use `node.Init(node.WithConfig())`.