### PR TITLE
feat(cmd):  custom p2p key flag

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -11,7 +11,7 @@ Month, DD, YYYY
 
 ### FEATURES
 
-- [go package] (Link to PR) Description @username
+- [node: enhance DI allowing overriding of dependencies](https://github.com/celestiaorg/celestia-node/pull/290) [@Wondertan](https://github.com/Wondertan)
 
 ### IMPROVEMENTS
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -10,6 +10,7 @@ var configFlags = []*pflag.Flag{
 	trustedHashFlag,
 	trustedPeerFlag,
 	coreRemoteFlag,
+	p2pKeyFlag,
 }
 
 var (
@@ -37,6 +38,11 @@ var (
 		Name: "core.remote",
 		Usage: "Indicates node to connect to the given remote core node. " +
 			"Example: <protocol>://<ip>:<port>, tcp://127.0.0.1:26657",
+		DefValue: "",
+	}
+	p2pKeyFlag = &pflag.Flag{
+		Name:     "p2p.key",
+		Usage:    "Custom p2p Ed25519 private key",
 		DefValue: "",
 	}
 )

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,8 +1,10 @@
 package cmd
 
-import "flag"
+import (
+	"github.com/spf13/pflag"
+)
 
-var configFlags = []*flag.Flag{
+var configFlags = []*pflag.Flag{
 	loglevelFlag,
 	nodeConfigFlag,
 	trustedHashFlag,
@@ -11,27 +13,27 @@ var configFlags = []*flag.Flag{
 }
 
 var (
-	loglevelFlag = &flag.Flag{
+	loglevelFlag = &pflag.Flag{
 		Name:     "log.level",
 		Usage:    "DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and\n// their lower-case forms",
 		DefValue: "info",
 	}
-	nodeConfigFlag = &flag.Flag{
+	nodeConfigFlag = &pflag.Flag{
 		Name:     "node.config",
 		Usage:    "Path to a customized Config",
 		DefValue: "",
 	}
-	trustedHashFlag = &flag.Flag{
+	trustedHashFlag = &pflag.Flag{
 		Name:     "headers.trusted-hash",
 		Usage:    "Hex encoded block hash. Starting point for header synchronization",
 		DefValue: "",
 	}
-	trustedPeerFlag = &flag.Flag{
+	trustedPeerFlag = &pflag.Flag{
 		Name:     "headers.trusted-peer",
 		Usage:    "Multiaddr of a reliable peer to fetch headers from",
 		DefValue: "",
 	}
-	coreRemoteFlag = &flag.Flag{
+	coreRemoteFlag = &pflag.Flag{
 		Name: "core.remote",
 		Usage: "Indicates node to connect to the given remote core node. " +
 			"Example: <protocol>://<ip>:<port>, tcp://127.0.0.1:26657",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -40,6 +40,10 @@ func Init(repoFlagName string, tp node.Type) *cobra.Command {
 
 			var opts []node.Option
 
+			p2pKey := cmd.Flag(p2pKeyFlag.Name).Value.String()
+			if p2pKey != "" {
+				opts = append(opts, node.WithP2PKeyStr(p2pKey))
+			}
 			trustedHash := cmd.Flag(trustedHashFlag.Name).Value.String()
 			if trustedHash != "" {
 				opts = append(opts, node.WithTrustedHash(trustedHash))

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -48,6 +48,10 @@ func Start(repoFlagName string, tp node.Type) *cobra.Command {
 
 			var opts []node.Option
 
+			p2pKey := cmd.Flag(p2pKeyFlag.Name).Value.String()
+			if p2pKey != "" {
+				opts = append(opts, node.WithP2PKeyStr(p2pKey))
+			}
 			trustedHash := cmd.Flag(trustedHashFlag.Name).Value.String()
 			if trustedHash != "" {
 				opts = append(opts, node.WithTrustedHash(trustedHash))

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942
 	github.com/tendermint/tendermint v0.34.14
 	go.uber.org/fx v1.15.0

--- a/node/components.go
+++ b/node/components.go
@@ -3,45 +3,46 @@ package node
 import (
 	"context"
 
-	"go.uber.org/fx"
-
 	nodecore "github.com/celestiaorg/celestia-node/node/core"
+	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/node/p2p"
 	"github.com/celestiaorg/celestia-node/node/services"
 )
 
 // lightComponents keeps all the components as DI options required to built a Light Node.
-func lightComponents(cfg *Config, repo Repository) fx.Option {
-	return fx.Options(
+func lightComponents(cfg *Config, repo Repository) fxutil.Option {
+	return fxutil.Options(
+		fxutil.Supply(Light),
 		baseComponents(cfg, repo),
-		fx.Provide(services.DASer),
-		fx.Provide(services.HeaderExchangeP2P(cfg.Services)),
+		fxutil.Provide(services.DASer),
+		fxutil.Provide(services.HeaderExchangeP2P(cfg.Services)),
 	)
 }
 
 // fullComponents keeps all the components as DI options required to built a Full Node.
-func fullComponents(cfg *Config, repo Repository) fx.Option {
-	return fx.Options(
+func fullComponents(cfg *Config, repo Repository) fxutil.Option {
+	return fxutil.Options(
+		fxutil.Supply(Full),
 		baseComponents(cfg, repo),
 		nodecore.Components(cfg.Core, repo.Core),
-		fx.Provide(services.BlockService),
-		fx.Invoke(services.StartHeaderExchangeP2PServer),
+		fxutil.Provide(services.BlockService),
+		fxutil.Invoke(services.StartHeaderExchangeP2PServer),
 	)
 }
 
 // baseComponents keeps all the common components shared between different Node types.
-func baseComponents(cfg *Config, repo Repository) fx.Option {
-	return fx.Options(
-		fx.Provide(context.Background),
-		fx.Supply(cfg),
-		fx.Supply(repo.Config),
-		fx.Provide(repo.Datastore),
-		fx.Provide(repo.Keystore),
-		fx.Provide(services.ShareService),
-		fx.Provide(services.HeaderService),
-		fx.Provide(services.HeaderStore),
-		fx.Provide(services.HeaderSyncer(cfg.Services)),
-		fx.Provide(services.LightAvailability), // TODO(@Wondertan): Move to light once FullAvailability is implemented
+func baseComponents(cfg *Config, repo Repository) fxutil.Option {
+	return fxutil.Options(
+		fxutil.Provide(context.Background),
+		fxutil.Supply(cfg),
+		fxutil.Supply(repo.Config),
+		fxutil.Provide(repo.Datastore),
+		fxutil.Provide(repo.Keystore),
+		fxutil.Provide(services.ShareService),
+		fxutil.Provide(services.HeaderService),
+		fxutil.Provide(services.HeaderStore),
+		fxutil.Provide(services.HeaderSyncer(cfg.Services)),
+		fxutil.Provide(services.LightAvailability), // TODO(@Wondertan): Move to light once FullAvailability is implemented
 		p2p.Components(cfg.P2P),
 	)
 }

--- a/node/config.go
+++ b/node/config.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/celestiaorg/celestia-node/node/fxutil"
+
 	"github.com/celestiaorg/celestia-node/node/core"
 	"github.com/celestiaorg/celestia-node/node/p2p"
 	"github.com/celestiaorg/celestia-node/node/rpc"
@@ -22,6 +24,8 @@ type Config struct {
 	P2P      p2p.Config
 	RPC      rpc.Config
 	Services services.Config
+
+	overrides []fxutil.Option
 }
 
 // DefaultConfig provides a default Config for a given Node Type 'tp'.

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -1,8 +1,6 @@
 package core
 
 import (
-	"go.uber.org/fx"
-
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/service/header"
@@ -25,9 +23,9 @@ func DefaultConfig() Config {
 }
 
 // Components collects all the components and services related to managing the relationship with the Core node.
-func Components(cfg Config, loader core.RepoLoader) fx.Option {
-	return fx.Options(
-		fx.Provide(core.NewBlockFetcher),
+func Components(cfg Config, loader core.RepoLoader) fxutil.Option {
+	return fxutil.Options(
+		fxutil.Provide(core.NewBlockFetcher),
 		fxutil.ProvideAs(header.NewCoreExchange, new(header.Exchange)),
 		fxutil.ProvideIf(cfg.Remote, func() (core.Client, error) {
 			return RemoteClient(cfg)

--- a/node/fxutil/options.go
+++ b/node/fxutil/options.go
@@ -1,0 +1,196 @@
+package fxutil
+
+import (
+	"fmt"
+	"reflect"
+
+	"go.uber.org/fx"
+)
+
+// Option mimics fx.Option but provides one more OverrideSupply feature.
+type Option func(*fxOptions) error
+
+// ParseOptions parses multiple given instances of Option and coverts them into a fx.Option.
+func ParseOptions(opts ...Option) (fx.Option, error) {
+	fopts := &fxOptions{
+		overrideSupplies: map[reflect.Type]*override{},
+		provides:         map[reflect.Type]interface{}{},
+		supplies:         map[reflect.Type]interface{}{},
+	}
+	for _, opt := range opts {
+		err := opt(fopts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var parsed []fx.Option
+out:
+	for tp, val := range fopts.provides {
+		// exclude provides that are overridden
+		// this has a potentially negative effect for provides with more than one return parameters
+		for i := 0; i < tp.NumOut(); i++ {
+			ovr, ok := fopts.overrideSupplies[tp.Out(i)]
+			if ok && !ovr.used {
+				ovr.used = true
+				continue out
+			}
+		}
+
+		parsed = append(parsed, fx.Provide(val))
+	}
+
+	for tp, val := range fopts.supplies {
+		ovr, ok := fopts.overrideSupplies[tp]
+		if ok && !ovr.used {
+			ovr.used = true
+			continue
+		}
+
+		parsed = append(parsed, fx.Supply(val))
+	}
+
+	for _, val := range fopts.invokes {
+		parsed = append(parsed, fx.Invoke(val))
+	}
+
+	for tp, val := range fopts.overrideSupplies {
+		if !val.used {
+			return nil, fmt.Errorf("fxutil: nothing to override for the given %s", tp)
+		}
+
+		switch tp.Kind() {
+		case reflect.Interface:
+			// if type is an interface - we have to say FX to build the `val` as the interface
+			parsed = append(parsed, fx.Supply(fx.Annotate(
+				val.target,
+				fx.As(reflect.New(tp).Interface()),
+			)))
+		default:
+			parsed = append(parsed, fx.Supply(val.target))
+		}
+	}
+
+	return fx.Options(parsed...), nil
+}
+
+// OverrideSupply overwrites values passed to Provide and Supply.
+// It mimics fx.Supply with one difference - it does not error if there are multiple instances of a type
+// are supplied/provided. Instead, OverrideSupply forces the supply and overrides other Supply and Provide.
+//
+// Only one overriding must exist for a type.
+//
+// Only recvs ptr to a value or an interface.
+// To override an interface a ptr to the interface should be provided:
+//
+//  var r io.Reader
+//  OverrideSupply(&r)
+//
+// and not:
+//
+//  var r io.Reader
+//  OverrideSupply(r)
+//
+// Otherwise, real value of r will be provided, e.g. *bytes.Buffer.
+func OverrideSupply(vals ...interface{}) Option {
+	return func(o *fxOptions) error {
+		for _, val := range vals {
+			refVal := reflect.ValueOf(val)
+			if refVal.Kind() != reflect.Ptr {
+				return fmt.Errorf("fxutil: only ptrs are allowed in OverrideSupply")
+			}
+
+			tp := refVal.Type()
+			if tp.Elem().Kind() == reflect.Interface {
+				// if ptr to an interface is passed - unwrap the interface type and a real value
+				refVal, tp = refVal.Elem().Elem(), tp.Elem()
+			} else if tp.Elem().Kind() != reflect.Struct {
+				// if prt is not pointing at struct, e.g. Slice/String/... - unwrap the value
+				refVal, tp = refVal.Elem(), tp.Elem()
+			}
+
+			_, ok := o.overrideSupplies[tp]
+			if ok {
+				return fmt.Errorf("fxutil: already overridden")
+			}
+			o.overrideSupplies[tp] = &override{target: refVal.Interface()}
+		}
+
+		return nil
+	}
+}
+
+// Supply mimics fx.Supply.
+func Supply(vals ...interface{}) Option {
+	return func(o *fxOptions) error {
+		for _, val := range vals {
+			tp := reflect.TypeOf(val)
+			_, ok := o.supplies[tp]
+			if ok {
+				return fmt.Errorf("fxutil: already supplied")
+			}
+
+			o.supplies[tp] = val
+		}
+
+		return nil
+	}
+}
+
+// Provide mimics fx.Provide.
+// Provided ctors can be overridden by OverrideSupply.
+func Provide(vals ...interface{}) Option {
+	return func(o *fxOptions) error {
+		for _, val := range vals {
+			tp := reflect.TypeOf(val)
+			if tp.Kind() != reflect.Func || tp.NumOut() == 0 {
+				return fmt.Errorf("fxutil: ctor functions passed to Provide must have return params")
+			}
+
+			_, ok := o.provides[tp]
+			if ok {
+				return fmt.Errorf("fxutil: already provided")
+			}
+
+			o.provides[tp] = val
+		}
+
+		return nil
+	}
+}
+
+// Invoke mimics fx.Invoke.
+func Invoke(vals ...interface{}) Option {
+	return func(o *fxOptions) error {
+		for _, val := range vals {
+			o.invokes = append(o.invokes, val)
+		}
+
+		return nil
+	}
+}
+
+// Options combines multiples options into a one Option.
+func Options(opts ...Option) Option {
+	return func(o *fxOptions) error {
+		for _, opt := range opts {
+			err := opt(o)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+type fxOptions struct {
+	overrideSupplies map[reflect.Type]*override
+	provides         map[reflect.Type]interface{}
+	supplies         map[reflect.Type]interface{}
+	invokes          []interface{}
+}
+
+type override struct {
+	target interface{}
+	used   bool
+}

--- a/node/fxutil/options.go
+++ b/node/fxutil/options.go
@@ -24,7 +24,7 @@ func ParseOptions(opts ...Option) (fx.Option, error) {
 		}
 	}
 
-	var parsed []fx.Option
+	parsed := make([]fx.Option, 0)
 out:
 	for tp, val := range fopts.provides {
 		allAs := make([]interface{}, len(val.as))
@@ -195,10 +195,7 @@ func ProvideAs(val interface{}, as ...interface{}) Option {
 // Invoke mimics fx.Invoke.
 func Invoke(vals ...interface{}) Option {
 	return func(o *fxOptions) error {
-		for _, val := range vals {
-			o.invokes = append(o.invokes, val)
-		}
-
+		o.invokes = append(o.invokes, vals...)
 		return nil
 	}
 }

--- a/node/fxutil/options_test.go
+++ b/node/fxutil/options_test.go
@@ -45,3 +45,23 @@ func TestOverride(t *testing.T) {
 	assert.Equal(t, ovr, tt.R)
 	assert.Equal(t, ovrS, tt.S)
 }
+
+func TestProvideAs(t *testing.T) {
+	tt := struct {
+		fx.In
+		R io.Reader
+	}{}
+
+	fopt, err := ParseOptions(
+		ProvideAs(
+			func() *bytes.Buffer {
+				return bytes.NewBuffer([]byte("xyz"))
+			},
+			new(io.Reader),
+		),
+	)
+	require.NoError(t, err)
+
+	fxtest.New(t, fopt, fx.Populate(&tt), fx.NopLogger)
+	assert.NotNil(t, tt.R)
+}

--- a/node/fxutil/options_test.go
+++ b/node/fxutil/options_test.go
@@ -65,3 +65,18 @@ func TestProvideAs(t *testing.T) {
 	fxtest.New(t, fopt, fx.Populate(&tt), fx.NopLogger)
 	assert.NotNil(t, tt.R)
 }
+
+func TestSupplyAs(t *testing.T) {
+	tt := struct {
+		fx.In
+		R io.Reader
+	}{}
+
+	fopt, err := ParseOptions(
+		SupplyAs(bytes.NewBuffer([]byte("xyz")), new(io.Reader)),
+	)
+	require.NoError(t, err)
+
+	fxtest.New(t, fopt, fx.Populate(&tt), fx.NopLogger)
+	assert.NotNil(t, tt.R)
+}

--- a/node/fxutil/options_test.go
+++ b/node/fxutil/options_test.go
@@ -1,0 +1,47 @@
+package fxutil
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestOverride(t *testing.T) {
+	tt := struct {
+		fx.In
+		Buf *bytes.Buffer
+		R   io.Reader
+		S   string
+	}{}
+
+	ovrS := "override"
+	prv := bytes.NewBuffer(nil)
+	ovr := bytes.NewBuffer([]byte("xyz"))
+
+	var prvR io.Reader = prv
+	var ovrR io.Reader = ovr
+
+	fopt, err := ParseOptions(
+		Supply("supplied"),
+		Provide(func() *bytes.Buffer {
+			return prv
+		}),
+		Provide(func() io.Reader {
+			return prvR
+		}),
+		OverrideSupply(&ovrS),
+		OverrideSupply(ovr),
+		OverrideSupply(&ovrR),
+	)
+	require.NoError(t, err)
+
+	fxtest.New(t, fopt, fx.Populate(&tt), fx.NopLogger)
+	assert.Equal(t, ovr, tt.Buf)
+	assert.Equal(t, ovr, tt.R)
+	assert.Equal(t, ovrS, tt.S)
+}

--- a/node/fxutil/util.go
+++ b/node/fxutil/util.go
@@ -18,12 +18,6 @@ func WithLifecycle(ctx context.Context, lc fx.Lifecycle) context.Context {
 	return ctx
 }
 
-// ProvideAs provides the first argument as types of the second.
-// TODO(@Wondertan): Support overriding
-func ProvideAs(prv interface{}, as ...interface{}) Option {
-	return Provide(fx.Annotate(prv, fx.As(as...)))
-}
-
 // SupplyIf supplies DI if a condition is met.
 func SupplyIf(cond bool, val ...interface{}) Option {
 	if cond {

--- a/node/fxutil/util.go
+++ b/node/fxutil/util.go
@@ -19,31 +19,32 @@ func WithLifecycle(ctx context.Context, lc fx.Lifecycle) context.Context {
 }
 
 // ProvideAs provides the first argument as types of the second.
-func ProvideAs(prv interface{}, as ...interface{}) fx.Option {
-	return fx.Provide(fx.Annotate(prv, fx.As(as...)))
+// TODO(@Wondertan): Support overriding
+func ProvideAs(prv interface{}, as ...interface{}) Option {
+	return Provide(fx.Annotate(prv, fx.As(as...)))
 }
 
 // SupplyIf supplies DI if a condition is met.
-func SupplyIf(cond bool, val ...interface{}) fx.Option {
+func SupplyIf(cond bool, val ...interface{}) Option {
 	if cond {
-		return fx.Supply(val...)
+		return Supply(val...)
 	}
-	return fx.Options()
+	return Options()
 }
 
 // ProvideIf provides a given constructor if a condition is met.
-func ProvideIf(cond bool, ctor ...interface{}) fx.Option {
+func ProvideIf(cond bool, ctor ...interface{}) Option {
 	if cond {
-		return fx.Provide(ctor...)
+		return Provide(ctor...)
 	}
 
-	return fx.Options()
+	return Options()
 }
 
 // InvokeIf invokes a given function if a condition is met.
-func InvokeIf(cond bool, function interface{}) fx.Option {
+func InvokeIf(cond bool, function interface{}) Option {
 	if cond {
-		return fx.Invoke(function)
+		return Invoke(function)
 	}
-	return fx.Options()
+	return Options()
 }

--- a/node/init.go
+++ b/node/init.go
@@ -16,7 +16,10 @@ func Init(path string, tp Type, options ...Option) error {
 	cfg := DefaultConfig(tp)
 	for _, option := range options {
 		if option != nil {
-			option(cfg)
+			err := option(cfg)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -44,7 +47,7 @@ func InitWith(path string, tp Type, cfg *Config) error {
 		}
 		return err
 	}
-	defer flock.Unlock() //nolint: errcheck
+	defer flock.Unlock() // nolint: errcheck
 
 	err = initDir(keysPath(path))
 	if err != nil {

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -2,8 +2,10 @@ package node
 
 import (
 	"context"
+	"crypto/rand"
 	"testing"
 
+	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,4 +38,14 @@ func TestLightLifecycle(t *testing.T) {
 
 	err = nd.Stop(stopCtx)
 	require.NoError(t, err)
+}
+
+func TestNewLightWithP2PKey(t *testing.T) {
+	key, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+
+	repo := MockRepository(t, DefaultConfig(Light))
+	node, err := New(Light, repo, WithP2PKey(key))
+	require.NoError(t, err)
+	assert.True(t, node.Host.ID().MatchesPrivateKey(key))
 }

--- a/node/node.go
+++ b/node/node.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/das"
+	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/node/rpc"
 	"github.com/celestiaorg/celestia-node/service/block"
 	"github.com/celestiaorg/celestia-node/service/header"
@@ -36,9 +37,6 @@ var log = logging.Logger("node")
 type Node struct {
 	Type   Type
 	Config *Config
-
-	// the Node keeps a reference to the DI App that controls the lifecycles of services registered on the Node.
-	app *fx.App
 
 	// CoreClient provides access to a Core node process.
 	CoreClient core.Client `optional:"true"`
@@ -64,6 +62,9 @@ type Node struct {
 	HeaderServ *header.Service // not optional
 
 	DASer *das.DASer `optional:"true"`
+
+	// start and stop control ref internal fx.App lifecycle funcs to be called from Start and Stop
+	start, stop lifecycleFunc
 }
 
 // New assembles a new Node with the given type 'tp' over Repository 'repo'.
@@ -72,17 +73,21 @@ func New(tp Type, repo Repository, options ...Option) (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	for _, option := range options {
 		if option != nil {
-			option(cfg)
+			err := option(cfg)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	switch tp {
 	case Full:
-		return newNode(tp, fullComponents(cfg, repo))
+		return newNode(fullComponents(cfg, repo), fxutil.Options(cfg.overrides...))
 	case Light:
-		return newNode(tp, lightComponents(cfg, repo))
+		return newNode(lightComponents(cfg, repo), fxutil.Options(cfg.overrides...))
 	default:
 		panic("node: unknown Node Type")
 	}
@@ -93,7 +98,7 @@ func (n *Node) Start(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, Timeout)
 	defer cancel()
 
-	err := n.app.Start(ctx)
+	err := n.start(ctx)
 	if err != nil {
 		log.Errorf("starting %s Node: %s", n.Type, err)
 		return fmt.Errorf("node: failed to start: %w", err)
@@ -142,7 +147,7 @@ func (n *Node) Stop(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, Timeout)
 	defer cancel()
 
-	err := n.app.Stop(ctx)
+	err := n.stop(ctx)
 	if err != nil {
 		log.Errorf("Stopping %s Node: %s", n.Type, err)
 		return err
@@ -156,13 +161,25 @@ func (n *Node) Stop(ctx context.Context) error {
 // DI options allow initializing the Node with a customized set of components and services.
 // NOTE: newNode is currently meant to be used privately to create various custom Node types e.g. full, unless we
 // decide to give package users the ability to create custom node types themselves.
-func newNode(tp Type, opts ...fx.Option) (*Node, error) {
+func newNode(opts ...fxutil.Option) (*Node, error) {
+	fopt, err := fxutil.ParseOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	node := new(Node)
-	node.app = fx.New(
+	app := fx.New(
 		fx.NopLogger,
 		fx.Extract(node),
-		fx.Options(opts...),
-		fx.Supply(tp),
+		fopt,
 	)
-	return node, node.app.Err()
+	if err := app.Err(); err != nil {
+		return nil, err
+	}
+
+	node.start, node.stop = app.Start, app.Stop
+	return node, nil
 }
+
+// lifecycleFunc defines a type for common lifecycle funcs.
+type lifecycleFunc func(context.Context) error

--- a/node/options.go
+++ b/node/options.go
@@ -1,34 +1,72 @@
 package node
 
+import (
+	"encoding/hex"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+
+	"github.com/celestiaorg/celestia-node/node/fxutil"
+)
+
 // Option for Node's Config.
-type Option func(*Config)
+type Option func(*Config) error
 
 // WithRemoteCore configures Node to start with remote Core.
 func WithRemoteCore(protocol string, address string) Option {
-	return func(cfg *Config) {
+	return func(cfg *Config) (_ error) {
 		cfg.Core.Remote = true
 		cfg.Core.RemoteConfig.Protocol = protocol
 		cfg.Core.RemoteConfig.RemoteAddr = address
+		return
 	}
 }
 
 // WithTrustedHash sets TrustedHash to the Config.
 func WithTrustedHash(hash string) Option {
-	return func(cfg *Config) {
+	return func(cfg *Config) (_ error) {
 		cfg.Services.TrustedHash = hash
+		return
 	}
 }
 
 // WithTrustedPeer sets TrustedPeer to the Config.
 func WithTrustedPeer(addr string) Option {
-	return func(cfg *Config) {
+	return func(cfg *Config) (_ error) {
 		cfg.Services.TrustedPeer = addr
+		return
 	}
 }
 
 // WithConfig sets the entire custom config.
 func WithConfig(custom *Config) Option {
-	return func(cfg *Config) {
+	return func(cfg *Config) (_ error) {
 		*cfg = *custom
+		return
+	}
+}
+
+// WithP2PKey sets custom Ed25519 private key for p2p networking.
+func WithP2PKey(key crypto.PrivKey) Option {
+	return func(cfg *Config) (_ error) {
+		cfg.overrides = append(cfg.overrides, fxutil.OverrideSupply(&key))
+		return
+	}
+}
+
+// WithP2PKeyStr sets custom hex encoded Ed25519 private key for p2p networking.
+func WithP2PKeyStr(key string) Option {
+	return func(cfg *Config) (_ error) {
+		decKey, err := hex.DecodeString(key)
+		if err != nil {
+			return err
+		}
+
+		key, err := crypto.UnmarshalEd25519PrivateKey(decKey)
+		if err != nil {
+			return err
+		}
+
+		cfg.overrides = append(cfg.overrides, fxutil.OverrideSupply(&key))
+		return
 	}
 }

--- a/node/p2p/p2p.go
+++ b/node/p2p/p2p.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
-	"go.uber.org/fx"
+
+	"github.com/celestiaorg/celestia-node/node/fxutil"
 )
 
 // Config combines all configuration fields for P2P subsystem.
@@ -59,21 +60,22 @@ func DefaultConfig() Config {
 }
 
 // Components collects all the components and services related to p2p.
-func Components(cfg Config) fx.Option {
-	return fx.Options(
-		fx.Provide(Identity),
-		fx.Provide(PeerStore),
-		fx.Provide(ConnectionManager(cfg)),
-		fx.Provide(ConnectionGater),
-		fx.Provide(Host(cfg)),
-		fx.Provide(RoutedHost),
-		fx.Provide(PubSub(cfg)),
-		fx.Provide(DataExchange(cfg)),
-		fx.Provide(DAG),
-		fx.Provide(PeerRouting(cfg)),
-		fx.Provide(ContentRouting),
-		fx.Provide(AddrsFactory(cfg.AnnounceAddresses, cfg.NoAnnounceAddresses)),
-		fx.Invoke(Listen(cfg.ListenAddresses)),
+func Components(cfg Config) fxutil.Option {
+	return fxutil.Options(
+		fxutil.Provide(Key),
+		fxutil.Provide(ID),
+		fxutil.Provide(PeerStore),
+		fxutil.Provide(ConnectionManager(cfg)),
+		fxutil.Provide(ConnectionGater),
+		fxutil.Provide(Host(cfg)),
+		fxutil.Provide(RoutedHost),
+		fxutil.Provide(PubSub(cfg)),
+		fxutil.Provide(DataExchange(cfg)),
+		fxutil.Provide(DAG),
+		fxutil.Provide(PeerRouting(cfg)),
+		fxutil.Provide(ContentRouting),
+		fxutil.Provide(AddrsFactory(cfg.AnnounceAddresses, cfg.NoAnnounceAddresses)),
+		fxutil.Invoke(Listen(cfg.ListenAddresses)),
 	)
 }
 


### PR DESCRIPTION
## About
Currently, only `start` cmd works with a custom private key.  To make `init` work #291 and #292 have to be merged. 

Closes #284 