### PR TITLE
docker: Create a single Dockerfile that works for full and light `celestia-node`s

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.42
+          version: v1.43

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -18,8 +18,6 @@ Month, DD, YYYY
 
 - [docker] Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script. 
 
-- [docker] Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script. 
-
 ### BUG FIXES
 
 - [go package] (Link to PR) Description @username

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -16,6 +16,8 @@ Month, DD, YYYY
 - [chore: bump deps #297](https://github.com/celestiaorg/celestia-node/pull/297) [@Wondertan](https://github.com/Wondertan)
 - [workflows/lint: update golangci-lint to v1.43 #308](https://github.com/celestiaorg/celestia-node/pull/308) [@Wondertan](https://github.com/Wondertan)
 
+- [docker] Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script. 
+
 ### BUG FIXES
 
 - [go package] (Link to PR) Description @username

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -18,6 +18,8 @@ Month, DD, YYYY
 
 - [docker] Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script. 
 
+- [docker] Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script. 
+
 ### BUG FIXES
 
 - [go package] (Link to PR) Description @username

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -14,6 +14,7 @@ Month, DD, YYYY
 ### IMPROVEMENTS
 
 - [chore: bump deps #297](https://github.com/celestiaorg/celestia-node/pull/297) [@Wondertan](https://github.com/Wondertan)
+- [workflows/lint: update golangci-lint to v1.43 #308](https://github.com/celestiaorg/celestia-node/pull/308) [@Wondertan](https://github.com/Wondertan)
 
 ### BUG FIXES
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.17 as builder
+RUN apt update && \
+    apt install make bash
+ENV HOME /celestia-node
+COPY / ${HOME}
+WORKDIR ${HOME}
+RUN make build 
+
+FROM ubuntu
+ENV NODE_TYPE full
+ENV SLEEP 0s
+
+WORKDIR $APP
+
+# COPY docker/entrypoint.sh script/entrypoint.sh
+COPY docker/entrypoint.sh /
+
+# Copy in the binary
+COPY --from=builder /celestia-node/celestia /
+
+EXPOSE 2121
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["celestia"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,16 +4,11 @@ RUN apt update && \
 ENV HOME /celestia-node
 COPY / ${HOME}
 WORKDIR ${HOME}
-RUN make build 
+RUN env GOOS=linux GOARCH=amd64 make build
 
 FROM ubuntu
 ENV NODE_TYPE full
-# Issue/bug #279 
-ENV SLEEP 0s
 
-WORKDIR $APP
-
-# COPY docker/entrypoint.sh script/entrypoint.sh
 COPY docker/entrypoint.sh /
 
 # Copy in the binary

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN make build
 
 FROM ubuntu
 ENV NODE_TYPE full
+# Issue/bug #279 
 ENV SLEEP 0s
 
 WORKDIR $APP

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e 
+
+if [ "$1" = 'celestia' ]; then
+    ./celestia "${NODE_TYPE}" --repo.path /celestia-"${NODE_TYPE}" init
+
+    sleep "${SLEEP}"
+
+    exec ./"$@" "--"
+fi
+
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,8 +5,6 @@ set -e
 if [ "$1" = 'celestia' ]; then
     ./celestia "${NODE_TYPE}" --repo.path /celestia-"${NODE_TYPE}" init
 
-    sleep "${SLEEP}"
-
     exec ./"$@" "--"
 fi
 


### PR DESCRIPTION
Create a new `Dockerfile` that works for both celestia-node full and light nodes while matching the expectations of both the docker-compose and k8s cluster setups. 

At runtime the a `NODE_TYPE` environment variable matching either `full` or `light` is expected. 

If not provided it defaults to `full`. 

For examples see the [docker-compose config](https://github.com/celestiaorg/devops-test/blob/main/devnet/docker/docker-compose.yml#L84) and the [k8s config](https://github.com/celestiaorg/devops-test/blob/main/devnet/k8s/core-nodes/0/core0-deployment.yaml#L76).

This has been manually tested by building the Docker image
```
docker build -f docker/Dockerfile -t jbowen93/celestia-node:multi
``` 
and then testing it with docker-compose
```
cd devnet
./start-docker.sh
```
and with kubernetes
```
cd devnet
kubectl create -f k8s/core-nodes -R && \
sleep 45s && \
kubectl create -f k8s/light-nodes -R
```