### PR TITLE
node: Wrap datastore with mutex to prevent data race

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -32,3 +32,4 @@ Month, DD, YYYY
 - [header] Added missing `err` value in ErrorW logging calls. @jbowen93
 - [service/block, node/p2p] [Fix race conditions in TestExtendedHeaderBroadcast and TestFull_P2P_Streams.](https://github.com/celestiaorg/celestia-node/pull/288) [@jenyasd209](https://github.com/jenyasd209)
 - [ci: increase tokens ratio for dupl to fix false positive scenarios](https://github.com/celestiaorg/celestia-node/pull/314) [@Bidon15](https://github.com/Bidon15)
+- [node: update vanilla datastore with Mutex one](https://github.com/celestiaorg/celestia-node/pull/325) [@Bidon15](https://github.com/Bidon15)

--- a/node/store_mem.go
+++ b/node/store_mem.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
 
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/libs/keystore"
@@ -22,7 +23,7 @@ type memStore struct {
 func NewMemStore() Store {
 	return &memStore{
 		keys: keystore.NewMapKeystore(),
-		data: datastore.NewMapDatastore(),
+		data: ds_sync.MutexWrap(datastore.NewMapDatastore()),
 		core: core.NewMemStore(),
 	}
 }


### PR DESCRIPTION
With current datastore, we bump into the race condition when the datastore is being both read and written to. Changing to mutex wrapped datastore has eliminated the data race error findings.

This case is heavily blocking proper initialisation of node and can cause flakiness in test execution.

Found during work on #262 

Co-authored with @Wondertan 