### PR TITLE
Properly fetch Validators from Core and two more fixes

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -28,8 +28,7 @@ Month, DD, YYYY
 
 ### BUG FIXES
 
-- [go package] (Link to PR) Description @username
-
+- [Bunch of fixes](https://github.com/celestiaorg/celestia-node/pull/328) [@Wondertan](https://github.com/Wondertan)
 - [header] Added missing `err` value in ErrorW logging calls. @jbowen93
 - [service/block, node/p2p] [Fix race conditions in TestExtendedHeaderBroadcast and TestFull_P2P_Streams.](https://github.com/celestiaorg/celestia-node/pull/288) [@jenyasd209](https://github.com/jenyasd209)
 - [ci: increase tokens ratio for dupl to fix false positive scenarios](https://github.com/celestiaorg/celestia-node/pull/314) [@Bidon15](https://github.com/Bidon15)

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -28,7 +28,7 @@ Month, DD, YYYY
 
 ### BUG FIXES
 
-- [Bunch of fixes](https://github.com/celestiaorg/celestia-node/pull/328) [@Wondertan](https://github.com/Wondertan)
+- [Properly fetch Validators from Core and two more fixes #328](https://github.com/celestiaorg/celestia-node/pull/328) [@Wondertan](https://github.com/Wondertan)
 - [header] Added missing `err` value in ErrorW logging calls. @jbowen93
 - [service/block, node/p2p] [Fix race conditions in TestExtendedHeaderBroadcast and TestFull_P2P_Streams.](https://github.com/celestiaorg/celestia-node/pull/288) [@jenyasd209](https://github.com/jenyasd209)
 - [ci: increase tokens ratio for dupl to fix false positive scenarios](https://github.com/celestiaorg/celestia-node/pull/314) [@Bidon15](https://github.com/Bidon15)

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -68,10 +68,16 @@ func (f *BlockFetcher) Commit(ctx context.Context, height *int64) (*types.Commit
 	return res.Commit, nil
 }
 
+// maxValidators is a maximum amount of validators
+// Should be in sync with network params and paging provided by Client
+const maxValidators = 100
+
 // ValidatorSet queries Core for the ValidatorSet from the
 // block at the given height.
 func (f *BlockFetcher) ValidatorSet(ctx context.Context, height *int64) (*types.ValidatorSet, error) {
-	res, err := f.client.Validators(ctx, height, nil, nil)
+	// FIXME: The ugliness of passing pointers for integers in this case can't be explained with words
+	maxVals := maxValidators
+	res, err := f.client.Validators(ctx, height, nil, &maxVals)
 	if err != nil {
 		return nil, err
 	}

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -3,10 +3,11 @@ package core
 import (
 	"context"
 
+	"go.uber.org/fx"
+
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/service/header"
-	"go.uber.org/fx"
 )
 
 // Config combines all configuration fields for managing the relationship with a Core node.


### PR DESCRIPTION
Includes critical fix for #319 and two minor findings. Commit names are descriptive enough so check those

Closes #319