### PR TITLE
header: hardening syncing logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 abci-cli
 addrbook.json
 artifacts/*
+celestia
+cel-shed
 coverage.txt
 docs/.vuepress/dist
 docs/_build

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -21,6 +21,7 @@ Month, DD, YYYY
 
 ### IMPROVEMENTS
 
+- [header: hardening syncing logic #334](https://github.com/celestiaorg/celestia-node/pull/334) [@Wondertan](https://github.com/Wondertan)
 - [feat(params): add bootstrappers #399](https://github.com/celestiaorg/celestia-node/pull/399) [@Wondertan](https://github.com/Wondertan)
 - [service/header: remove start/stop from P2PExchange](https://github.com/celestiaorg/celestia-node/pull/367) [@Bidon15](https://github.com/Bidon15)
 - [service/share: Implement `FullAvailability`](https://github.com/celestiaorg/celestia-node/pull/333) [@renaynay](https://github.com/renaynay)

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-
 	"github.com/celestiaorg/celestia-node/service/header"
 	"github.com/celestiaorg/celestia-node/service/share"
 )
@@ -18,8 +16,8 @@ func TestDASer(t *testing.T) {
 	randHeader.DataHash = dah.Hash()
 	randHeader.DAH = dah
 
-	sub := &mockHeaderSub{
-		headers: []*header.ExtendedHeader{randHeader},
+	sub := &header.DummySubscriber{
+		Headers: []*header.ExtendedHeader{randHeader},
 	}
 
 	daser := NewDASer(shareServ, sub)
@@ -32,25 +30,3 @@ func TestDASer(t *testing.T) {
 	}(wg)
 	wg.Wait()
 }
-
-type mockHeaderSub struct {
-	headers []*header.ExtendedHeader
-}
-
-func (mhs *mockHeaderSub) Subscribe() (header.Subscription, error) {
-	return mhs, nil
-}
-
-func (mhs *mockHeaderSub) NextHeader(ctx context.Context) (*header.ExtendedHeader, error) {
-	defer func() {
-		mhs.headers = make([]*header.ExtendedHeader, 0)
-	}()
-	if len(mhs.headers) == 0 {
-		return nil, context.Canceled
-	}
-	return mhs.headers[0], nil
-}
-
-func (mhs *mockHeaderSub) Cancel() {}
-
-func (mhs *mockHeaderSub) Topic() *pubsub.Topic { return nil }

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -4,6 +4,7 @@ import logging "github.com/ipfs/go-log/v2"
 
 func SetAllLoggers(level logging.LogLevel) {
 	logging.SetAllLoggers(level)
+	_ = logging.SetLogLevel("bs:sess", "WARN")
 	_ = logging.SetLogLevel("addrutil", "INFO")
 	_ = logging.SetLogLevel("dht", "ERROR")
 	_ = logging.SetLogLevel("swarm2", "WARN")

--- a/node/components.go
+++ b/node/components.go
@@ -7,6 +7,7 @@ import (
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/node/p2p"
 	"github.com/celestiaorg/celestia-node/node/services"
+	"github.com/celestiaorg/celestia-node/service/header"
 )
 
 // lightComponents keeps all the components as DI options required to built a Light Node.
@@ -44,7 +45,7 @@ func baseComponents(cfg *Config, store Store) fxutil.Option {
 		fxutil.Provide(services.HeaderService),
 		fxutil.Provide(services.HeaderStore),
 		fxutil.Provide(services.HeaderSyncer(cfg.Services)),
-		fxutil.Provide(services.P2PSubscriber),
+		fxutil.ProvideAs(services.P2PSubscriber, new(header.Broadcaster), new(header.Subscriber)),
 		fxutil.Provide(services.HeaderP2PExchangeServer),
 		p2p.Components(cfg.P2P),
 	)

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -56,10 +56,10 @@ func Components(cfg Config, loader core.RepoLoader) fxutil.Option {
 func HeaderCoreListener(
 	lc fx.Lifecycle,
 	ex *core.BlockFetcher,
-	p2pSub *header.P2PSubscriber,
+	bcast header.Broadcaster,
 	dag format.DAGService,
 ) *header.CoreListener {
-	cl := header.NewCoreListener(p2pSub, ex, dag)
+	cl := header.NewCoreListener(bcast, ex, dag)
 	lc.Append(fx.Hook{
 		OnStart: cl.Start,
 		OnStop:  cl.Stop,

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -30,7 +30,7 @@ func Components(cfg Config, loader core.RepoLoader) fxutil.Option {
 	return fxutil.Options(
 		fxutil.Provide(core.NewBlockFetcher),
 		fxutil.ProvideAs(header.NewCoreExchange, new(header.Exchange)),
-		fxutil.Provide(HeaderCoreListener),
+		fxutil.Invoke(HeaderCoreListener),
 		fxutil.ProvideIf(cfg.Remote, func() (core.Client, error) {
 			return RemoteClient(cfg)
 		}),

--- a/node/fxutil/options.go
+++ b/node/fxutil/options.go
@@ -30,7 +30,7 @@ func ParseOptions(opts ...Option) (fx.Option, error) {
 	parsed := make([]fx.Option, 0)
 out:
 	for tp, val := range fopts.provides {
-		allAs := make([]interface{}, len(val.as))
+		allAs := make([]fx.Annotation, len(val.as))
 		for i, as := range val.as {
 			ovr, ok := fopts.overrideSupplies[as]
 			if ok && !ovr.used {
@@ -38,7 +38,7 @@ out:
 				continue out
 			}
 
-			allAs[i] = reflect.New(as).Interface()
+			allAs[i] = fx.As(reflect.New(as).Interface())
 		}
 
 		if len(allAs) == 0 {
@@ -53,7 +53,7 @@ out:
 			}
 		}
 
-		parsed = append(parsed, fx.Provide(fx.Annotate(val.target, fx.As(allAs...))))
+		parsed = append(parsed, fx.Provide(fx.Annotate(val.target, allAs...)))
 	}
 
 	for tp, val := range fopts.supplies {

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -46,13 +46,13 @@ func HeaderSyncer(cfg Config) func(
 }
 
 // P2PSubscriber creates a new header.P2PSubscriber.
-func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) *header.P2PSubscriber {
+func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) (*header.P2PSubscriber, header.Subscriber) {
 	p2pSub := header.NewP2PSubscriber(sub)
 	lc.Append(fx.Hook{
 		OnStart: p2pSub.Start,
 		OnStop:  p2pSub.Stop,
 	})
-	return p2pSub
+	return p2pSub, p2pSub
 }
 
 // HeaderService creates a new header.Service.

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -47,13 +47,13 @@ func HeaderSyncer(cfg Config) func(
 }
 
 // P2PSubscriber creates a new header.P2PSubscriber.
-func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) (*header.P2PSubscriber, header.Subscriber) {
+func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) (*header.P2PSubscriber, header.Subscriber, header.Broadcaster) {
 	p2pSub := header.NewP2PSubscriber(sub)
 	lc.Append(fx.Hook{
 		OnStart: p2pSub.Start,
 		OnStop:  p2pSub.Stop,
 	})
-	return p2pSub, p2pSub
+	return p2pSub, p2pSub, p2pSub
 }
 
 // HeaderService creates a new header.Service.

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -39,6 +39,7 @@ func HeaderSyncer(cfg Config) func(
 		syncer := header.NewSyncer(ex, store, sub, trustedHash)
 		lc.Append(fx.Hook{
 			OnStart: syncer.Start,
+			OnStop:  syncer.Stop,
 		})
 
 		return syncer, nil

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -19,14 +19,14 @@ import (
 )
 
 // HeaderSyncer creates a new header.Syncer.
-func HeaderSyncer(cfg Config) func(lc fx.Lifecycle, ex header.Exchange, store header.Store) (*header.Syncer, error) {
-	return func(lc fx.Lifecycle, ex header.Exchange, store header.Store) (*header.Syncer, error) {
+func HeaderSyncer(cfg Config) func(lc fx.Lifecycle, ex header.Exchange, store header.Store, sub *header.P2PSubscriber) (*header.Syncer, error) {
+	return func(lc fx.Lifecycle, ex header.Exchange, store header.Store, sub *header.P2PSubscriber) (*header.Syncer, error) {
 		trustedHash, err := cfg.trustedHash()
 		if err != nil {
 			return nil, err
 		}
 
-		syncer := header.NewSyncer(ex, store, trustedHash)
+		syncer := header.NewSyncer(ex, store, sub, trustedHash)
 		lc.Append(fx.Hook{
 			OnStart: syncer.Start,
 		})
@@ -36,8 +36,8 @@ func HeaderSyncer(cfg Config) func(lc fx.Lifecycle, ex header.Exchange, store he
 }
 
 // P2PSubscriber creates a new header.P2PSubscriber.
-func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub, syncer *header.Syncer) *header.P2PSubscriber {
-	p2pSub := header.NewP2PSubscriber(sub, syncer.Validate)
+func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) *header.P2PSubscriber {
+	p2pSub := header.NewP2PSubscriber(sub)
 	lc.Append(fx.Hook{
 		OnStart: p2pSub.Start,
 		OnStop:  p2pSub.Stop,

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -23,13 +23,13 @@ func HeaderSyncer(cfg Config) func(
 	lc fx.Lifecycle,
 	ex header.Exchange,
 	store header.Store,
-	sub *header.P2PSubscriber,
+	sub header.Subscriber,
 ) (*header.Syncer, error) {
 	return func(
 		lc fx.Lifecycle,
 		ex header.Exchange,
 		store header.Store,
-		sub *header.P2PSubscriber,
+		sub header.Subscriber,
 	) (*header.Syncer, error) {
 		trustedHash, err := cfg.trustedHash()
 		if err != nil {
@@ -47,23 +47,23 @@ func HeaderSyncer(cfg Config) func(
 }
 
 // P2PSubscriber creates a new header.P2PSubscriber.
-func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) (*header.P2PSubscriber, header.Subscriber, header.Broadcaster) {
+func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) (header.Subscriber, header.Broadcaster) {
 	p2pSub := header.NewP2PSubscriber(sub)
 	lc.Append(fx.Hook{
 		OnStart: p2pSub.Start,
 		OnStop:  p2pSub.Stop,
 	})
-	return p2pSub, p2pSub, p2pSub
+	return p2pSub, p2pSub
 }
 
 // HeaderService creates a new header.Service.
 func HeaderService(
 	syncer *header.Syncer,
-	p2pSub *header.P2PSubscriber,
+	sub header.Subscriber,
 	p2pServer *header.P2PExchangeServer,
 	ex header.Exchange,
 ) *header.Service {
-	return header.NewHeaderService(syncer, p2pSub, p2pServer, ex)
+	return header.NewHeaderService(syncer, sub, p2pServer, ex)
 }
 
 // HeaderExchangeP2P constructs new P2PExchange for headers.

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -19,8 +19,18 @@ import (
 )
 
 // HeaderSyncer creates a new header.Syncer.
-func HeaderSyncer(cfg Config) func(lc fx.Lifecycle, ex header.Exchange, store header.Store, sub *header.P2PSubscriber) (*header.Syncer, error) {
-	return func(lc fx.Lifecycle, ex header.Exchange, store header.Store, sub *header.P2PSubscriber) (*header.Syncer, error) {
+func HeaderSyncer(cfg Config) func(
+	lc fx.Lifecycle,
+	ex header.Exchange,
+	store header.Store,
+	sub *header.P2PSubscriber,
+) (*header.Syncer, error) {
+	return func(
+		lc fx.Lifecycle,
+		ex header.Exchange,
+		store header.Store,
+		sub *header.P2PSubscriber,
+	) (*header.Syncer, error) {
 		trustedHash, err := cfg.trustedHash()
 		if err != nil {
 			return nil, err

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -47,13 +47,13 @@ func HeaderSyncer(cfg Config) func(
 }
 
 // P2PSubscriber creates a new header.P2PSubscriber.
-func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) (header.Subscriber, header.Broadcaster) {
+func P2PSubscriber(lc fx.Lifecycle, sub *pubsub.PubSub) *header.P2PSubscriber {
 	p2pSub := header.NewP2PSubscriber(sub)
 	lc.Append(fx.Hook{
 		OnStart: p2pSub.Start,
 		OnStop:  p2pSub.Stop,
 	})
-	return p2pSub, p2pSub
+	return p2pSub
 }
 
 // HeaderService creates a new header.Service.

--- a/service/header/core_exchange.go
+++ b/service/header/core_exchange.go
@@ -31,6 +31,10 @@ func (ce *CoreExchange) RequestHeader(ctx context.Context, height uint64) (*Exte
 }
 
 func (ce *CoreExchange) RequestHeaders(ctx context.Context, from, amount uint64) ([]*ExtendedHeader, error) {
+	if amount == 0 {
+		return nil, nil
+	}
+
 	log.Debugw("core: requesting headers", "from", from, "to", from+amount)
 	headers := make([]*ExtendedHeader, amount)
 	for i := range headers {

--- a/service/header/core_listener.go
+++ b/service/header/core_listener.go
@@ -87,10 +87,8 @@ func (cl *CoreListener) listen(ctx context.Context, sub <-chan *types.Block) {
 			err = cl.p2pSub.Broadcast(ctx, eh)
 			if err != nil {
 				var pserr pubsub.ValidationError
-				if errors.As(err, &pserr) && pserr.Reason == pubsub.RejectValidationIgnored {
-					log.Warnw("core-listener: broadcasting next header", "height", eh.Height,
-						"err", err)
-				} else {
+				// TODO(@Wondertan): Log ValidationIgnore cases as well, once headr duplication issue is fixed
+				if errors.As(err, &pserr) && pserr.Reason != pubsub.RejectValidationIgnored {
 					log.Errorw("core-listener: broadcasting next header", "height", eh.Height,
 						"err", err)
 					return

--- a/service/header/core_listener.go
+++ b/service/header/core_listener.go
@@ -93,9 +93,8 @@ func (cl *CoreListener) listen(ctx context.Context, sub <-chan *types.Block) {
 				} else {
 					log.Errorw("core-listener: broadcasting next header", "height", eh.Height,
 						"err", err)
+					return
 				}
-
-				return
 			}
 		case <-ctx.Done():
 			return

--- a/service/header/core_listener.go
+++ b/service/header/core_listener.go
@@ -20,16 +20,16 @@ import (
 // broadcasts the new `ExtendedHeader` to the header-sub gossipsub
 // network.
 type CoreListener struct {
-	p2pSub  *P2PSubscriber
+	bcast   Broadcaster
 	fetcher *core.BlockFetcher
 	dag     format.DAGService
 
 	cancel context.CancelFunc
 }
 
-func NewCoreListener(p2pSub *P2PSubscriber, fetcher *core.BlockFetcher, dag format.DAGService) *CoreListener {
+func NewCoreListener(bcast Broadcaster, fetcher *core.BlockFetcher, dag format.DAGService) *CoreListener {
 	return &CoreListener{
-		p2pSub:  p2pSub,
+		bcast:   bcast,
 		fetcher: fetcher,
 		dag:     dag,
 	}
@@ -84,7 +84,7 @@ func (cl *CoreListener) listen(ctx context.Context, sub <-chan *types.Block) {
 			}
 
 			// broadcast new ExtendedHeader
-			err = cl.p2pSub.Broadcast(ctx, eh)
+			err = cl.bcast.Broadcast(ctx, eh)
 			if err != nil {
 				var pserr pubsub.ValidationError
 				// TODO(@Wondertan): Log ValidationIgnore cases as well, once headr duplication issue is fixed

--- a/service/header/core_listener_test.go
+++ b/service/header/core_listener_test.go
@@ -67,7 +67,7 @@ func createCoreListener(
 	fetcher *core.BlockFetcher,
 	ps *pubsub.PubSub,
 ) *CoreListener {
-	p2pSub := NewP2PSubscriber(ps, nil)
+	p2pSub := NewP2PSubscriber(ps)
 	err := p2pSub.Start(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/service/header/header_serde.go
+++ b/service/header/header_serde.go
@@ -58,7 +58,7 @@ func UnmarshalExtendedHeader(data []byte) (*ExtendedHeader, error) {
 		return nil, err
 	}
 
-	return out, nil
+	return out, out.ValidateBasic()
 }
 
 func ExtendedHeaderToProto(eh *ExtendedHeader) (*header_pb.ExtendedHeader, error) {

--- a/service/header/header_verify_test.go
+++ b/service/header/header_verify_test.go
@@ -56,7 +56,7 @@ func TestVerifyAdjacent(t *testing.T) {
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			test.prepare()
-			err := VerifyAdjacent(trusted, untrusted)
+			err := trusted.VerifyAdjacent(untrusted)
 			if test.err {
 				assert.Error(t, err)
 			} else {

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -5,14 +5,25 @@ import (
 	"errors"
 	"fmt"
 
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 )
+
+// Validator aliases a func that validates ExtendedHeader.
+type Validator = func(context.Context, *ExtendedHeader) pubsub.ValidationResult
 
 // Subscriber encompasses the behavior necessary to
 // subscribe/unsubscribe from new ExtendedHeader events from the
 // network.
 type Subscriber interface {
+	// Subscribe creates long-living for validated ExtendedHeaders.
+	// Multiple Subscriptions can be created.
 	Subscribe() (Subscription, error)
+	// AddValidator registers a Validator for all Subscriptions.
+	// Registered Validators receive ExtendedHeaders before Subscriptions
+	// and decide whether they will receive ExtendedHeaders or not.
+	// Multiple validators can be registered.
+	AddValidator(Validator) error
 }
 
 // Subscription can retrieve the next ExtendedHeader from the

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -16,7 +16,7 @@ type Validator = func(context.Context, *ExtendedHeader) pubsub.ValidationResult
 // subscribe/unsubscribe from new ExtendedHeader events from the
 // network.
 type Subscriber interface {
-	// Subscribe creates long-living for validated ExtendedHeaders.
+	// Subscribe creates long-living Subscription for validated ExtendedHeaders.
 	// Multiple Subscriptions can be created.
 	Subscribe() (Subscription, error)
 	// AddValidator registers a Validator for all Subscriptions.

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -20,8 +20,8 @@ type Subscriber interface {
 	// Multiple Subscriptions can be created.
 	Subscribe() (Subscription, error)
 	// AddValidator registers a Validator for all Subscriptions.
-	// Registered Validators receive ExtendedHeaders before Subscriptions
-	// and decide whether they will receive ExtendedHeaders or not.
+	// Registered Validators screen ExtendedHeaders for their validity
+	// before they are sent through Subscriptions.
 	// Multiple validators can be registered.
 	AddValidator(Validator) error
 }

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -63,7 +63,7 @@ var (
 	// ErrNotFound is returned when there is no requested header.
 	ErrNotFound = errors.New("header: not found")
 
-	// ErrNoHead is returned when Store does not contain Head of the chain.
+	// ErrNoHead is returned when Store is empty (does not contain any known header).
 	ErrNoHead = fmt.Errorf("header/store: no chain head")
 
 	// ErrNonAdjacent is returned when Store is appended with a header not adjacent to the stored head.

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -52,8 +52,11 @@ var (
 	// ErrNotFound is returned when there is no requested header.
 	ErrNotFound = errors.New("header: not found")
 
-	// ErrNoHead is returned when Store does not contain Head of the chain,
+	// ErrNoHead is returned when Store does not contain Head of the chain.
 	ErrNoHead = fmt.Errorf("header/store: no chain head")
+
+	// ErrNonAdjacent is returned when Store is appended with a header not adjacent to the stored head.
+	ErrNonAdjacent = fmt.Errorf("header/store: non-adjacent")
 )
 
 // Store encompasses the behavior necessary to store and retrieve ExtendedHeaders

--- a/service/header/local_exchange.go
+++ b/service/header/local_exchange.go
@@ -35,6 +35,9 @@ func (l *LocalExchange) RequestHeader(ctx context.Context, height uint64) (*Exte
 }
 
 func (l *LocalExchange) RequestHeaders(ctx context.Context, origin, amount uint64) ([]*ExtendedHeader, error) {
+	if amount == 0 {
+		return nil, nil
+	}
 	return l.store.GetRangeByHeight(ctx, origin, origin+amount)
 }
 

--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -95,6 +95,9 @@ func (ex *P2PExchange) RequestByHash(ctx context.Context, hash tmbytes.HexBytes)
 }
 
 func (ex *P2PExchange) performRequest(ctx context.Context, req *pb.ExtendedHeaderRequest) ([]*ExtendedHeader, error) {
+	if req.Amount == 0 {
+		return make([]*ExtendedHeader, 0), nil
+	}
 	if ex.trustedPeer == "" {
 		return nil, fmt.Errorf("no trusted peer")
 	}

--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -124,12 +124,6 @@ func (ex *P2PExchange) performRequest(ctx context.Context, req *pb.ExtendedHeade
 			stream.Reset() //nolint:errcheck
 			return nil, err
 		}
-		// sanity check the header
-		err = header.ValidateBasic()
-		if err != nil {
-			stream.Reset() //nolint:errcheck
-			return nil, err
-		}
 
 		headers[i] = header
 	}

--- a/service/header/p2p_subscriber.go
+++ b/service/header/p2p_subscriber.go
@@ -16,29 +16,19 @@ const PubSubTopic = "header-sub"
 type P2PSubscriber struct {
 	pubsub *pubsub.PubSub
 	topic  *pubsub.Topic
-
-	validator pubsub.ValidatorEx
 }
 
 // NewP2PSubscriber returns a P2PSubscriber that manages the header Service's
 // relationship with the "header-sub" gossipsub topic.
-func NewP2PSubscriber(ps *pubsub.PubSub, validator pubsub.ValidatorEx) *P2PSubscriber {
+func NewP2PSubscriber(ps *pubsub.PubSub) *P2PSubscriber {
 	return &P2PSubscriber{
 		pubsub:    ps,
-		validator: validator,
 	}
 }
 
 // Start starts the P2PSubscriber, registering a topic validator for the "header-sub"
 // topic and joining it.
 func (p *P2PSubscriber) Start(context.Context) (err error) {
-	if p.validator != nil {
-		err = p.pubsub.RegisterTopicValidator(PubSubTopic, p.validator)
-		if err != nil {
-			return err
-		}
-	}
-
 	p.topic, err = p.pubsub.Join(PubSubTopic)
 	return err
 }
@@ -51,6 +41,12 @@ func (p *P2PSubscriber) Stop(context.Context) error {
 	}
 
 	return p.topic.Close()
+}
+
+// AddValidator applies basic pubsub validator for a topic.
+// Multiple validators can be registered.
+func (p *P2PSubscriber) AddValidator(val pubsub.ValidatorEx) error {
+	return p.pubsub.RegisterTopicValidator(PubSubTopic, val)
 }
 
 // Subscribe returns a new subscription to the P2PSubscriber's

--- a/service/header/p2p_subscriber.go
+++ b/service/header/p2p_subscriber.go
@@ -22,7 +22,7 @@ type P2PSubscriber struct {
 // relationship with the "header-sub" gossipsub topic.
 func NewP2PSubscriber(ps *pubsub.PubSub) *P2PSubscriber {
 	return &P2PSubscriber{
-		pubsub:    ps,
+		pubsub: ps,
 	}
 }
 

--- a/service/header/service.go
+++ b/service/header/service.go
@@ -6,7 +6,7 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
-var log = logging.Logger("header-service")
+var log = logging.Logger("header")
 
 // Service represents the header service that can be started / stopped on a node.
 // Service's main function is to manage its sub-services. Service can contain several

--- a/service/header/service.go
+++ b/service/header/service.go
@@ -14,22 +14,22 @@ var log = logging.Logger("header")
 type Service struct {
 	ex Exchange
 
-	syncer        *Syncer
-	p2pSubscriber *P2PSubscriber
-	p2pServer     *P2PExchangeServer
+	syncer    *Syncer
+	sub       Subscriber
+	p2pServer *P2PExchangeServer
 }
 
 // NewHeaderService creates a new instance of header Service.
 func NewHeaderService(
 	syncer *Syncer,
-	p2pSub *P2PSubscriber,
+	sub Subscriber,
 	p2pServer *P2PExchangeServer,
 	ex Exchange) *Service {
 	return &Service{
-		syncer:        syncer,
-		p2pSubscriber: p2pSub,
-		p2pServer:     p2pServer,
-		ex:            ex,
+		syncer:    syncer,
+		sub:       sub,
+		p2pServer: p2pServer,
+		ex:        ex,
 	}
 }
 

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -195,8 +195,7 @@ func (s *store) Append(ctx context.Context, headers ...*ExtendedHeader) error {
 			continue
 		}
 		// TODO(@Wondertan): Fork choice rule - if two headers are on the same height, but have different hashes
-		//  choose one who has more consensus(power) over it.
-		//  It is not critical to implement this rn, because we can reliably apply the last header who has +2/3.
+		//  halt the node(https://github.com/celestiaorg/celestia-node/issues/365)
 
 		err = VerifyAdjacent(head, h)
 		if err != nil {

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -201,10 +201,10 @@ func (s *store) Append(ctx context.Context, headers ...*ExtendedHeader) error {
 			var verErr *VerifyError
 			if errors.As(err, &verErr) {
 				log.Errorw("invalid header",
-					"current height", head.Height,
 					"height", head.Height,
 					"hash", h.Hash(),
-					"reason", err)
+					"current height", head.Height,
+					"reason", verErr.Reason)
 				break
 			}
 		}

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -192,7 +192,7 @@ func (s *store) Append(ctx context.Context, headers ...*ExtendedHeader) error {
 
 	verified := make([]*ExtendedHeader, 0, lh)
 	for i, h := range headers {
-		err = VerifyAdjacent(head, h)
+		err = head.VerifyAdjacent(h)
 		if err != nil {
 			if i == 0 {
 				return err

--- a/service/header/store_test.go
+++ b/service/header/store_test.go
@@ -32,7 +32,7 @@ func TestStore(t *testing.T) {
 	err = store.Append(ctx, in...)
 	require.NoError(t, err)
 
-	out, err := store.GetRangeByHeight(ctx, 1, 11)
+	out, err := store.GetRangeByHeight(ctx, 2, 12)
 	require.NoError(t, err)
 	for i, h := range in {
 		assert.Equal(t, h.Hash(), out[i].Hash())

--- a/service/header/subscription_test.go
+++ b/service/header/subscription_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p-core/event"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
@@ -28,12 +27,8 @@ func TestSubscriber(t *testing.T) {
 	pubsub1, err := pubsub.NewGossipSub(ctx, net.Hosts()[0], pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign))
 	require.NoError(t, err)
 
-	store1, err := NewStoreWithHead(datastore.NewMapDatastore(), suite.Head())
-	require.NoError(t, err)
-
 	// create sub-service lifecycles for header service 1
 	p2pSub1 := NewP2PSubscriber(pubsub1)
-	syncer1 := NewSyncer(NewLocalExchange(store1), store1, p2pSub1, suite.Head().Hash())
 	err = p2pSub1.Start(context.Background())
 	require.NoError(t, err)
 
@@ -75,11 +70,6 @@ func TestSubscriber(t *testing.T) {
 	expectedHeader := suite.GenExtendedHeaders(1)[0]
 	bin, err := expectedHeader.MarshalBinary()
 	require.NoError(t, err)
-
-	// TODO @renaynay: this is a hack meant to simulate syncing being finished
-	// Topic validation logic should be extracted from the syncer,
-	// ref https://github.com/celestiaorg/celestia-node/issues/318
-	syncer1.finishSync()
 
 	err = p2pSub2.topic.Publish(ctx, bin, pubsub.WithReadiness(pubsub.MinTopicSize(1)))
 	require.NoError(t, err)

--- a/service/header/subscription_test.go
+++ b/service/header/subscription_test.go
@@ -32,8 +32,8 @@ func TestSubscriber(t *testing.T) {
 	require.NoError(t, err)
 
 	// create sub-service lifecycles for header service 1
-	syncer1 := NewSyncer(NewLocalExchange(store1), store1, suite.Head().Hash())
-	p2pSub1 := NewP2PSubscriber(pubsub1, syncer1.Validate)
+	p2pSub1 := NewP2PSubscriber(pubsub1)
+	syncer1 := NewSyncer(NewLocalExchange(store1), store1, p2pSub1, suite.Head().Hash())
 	err = p2pSub1.Start(context.Background())
 	require.NoError(t, err)
 
@@ -42,12 +42,8 @@ func TestSubscriber(t *testing.T) {
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign))
 	require.NoError(t, err)
 
-	store2, err := NewStoreWithHead(datastore.NewMapDatastore(), suite.Head())
-	require.NoError(t, err)
-
 	// create sub-service lifecycles for header service 2
-	syncer2 := NewSyncer(NewLocalExchange(store2), store2, suite.Head().Hash())
-	p2pSub2 := NewP2PSubscriber(pubsub2, syncer2.Validate)
+	p2pSub2 := NewP2PSubscriber(pubsub2)
 	err = p2pSub2.Start(context.Background())
 	require.NoError(t, err)
 

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -12,6 +12,7 @@ import (
 
 // Syncer implements simplest possible synchronization for headers.
 type Syncer struct {
+	sub *P2PSubscriber
 	exchange Exchange
 	store    Store
 	trusted  tmbytes.HexBytes
@@ -23,8 +24,9 @@ type Syncer struct {
 }
 
 // NewSyncer creates a new instance of Syncer.
-func NewSyncer(exchange Exchange, store Store, trusted tmbytes.HexBytes) *Syncer {
+func NewSyncer(exchange Exchange, store Store, sub *P2PSubscriber, trusted tmbytes.HexBytes) *Syncer {
 	return &Syncer{
+		sub: sub,
 		exchange:   exchange,
 		store:      store,
 		trusted:    trusted,
@@ -34,6 +36,13 @@ func NewSyncer(exchange Exchange, store Store, trusted tmbytes.HexBytes) *Syncer
 
 // Start starts the syncing routine.
 func (s *Syncer) Start(context.Context) error {
+	if s.sub != nil {
+		err := s.sub.AddValidator(s.Validate)
+		if err != nil {
+			return err
+		}
+	}
+
 	go s.Sync(context.TODO()) // TODO @Wondertan: leaving this to you to implement in disconnection toleration PR.
 	return nil
 }

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -13,7 +13,7 @@ import (
 
 // Syncer implements simplest possible synchronization for headers.
 type Syncer struct {
-	sub *P2PSubscriber
+	sub      *P2PSubscriber
 	exchange Exchange
 	store    Store
 	trusted  tmbytes.HexBytes
@@ -21,26 +21,26 @@ type Syncer struct {
 	// inProgress is set to 1 once syncing commences and
 	// is set to 0 once syncing is either finished or
 	// not currently in progress
-	inProgress uint64
+	inProgress  uint64
 	triggerSync chan struct{}
 
 	// pending keeps valid headers rcvd from the network awaiting to be appended to store
-	pending map[uint64]*ExtendedHeader
+	pending   map[uint64]*ExtendedHeader
 	pendingLk sync.Mutex
 
-	ctx context.Context
+	ctx    context.Context
 	cancel context.CancelFunc
 }
 
 // NewSyncer creates a new instance of Syncer.
 func NewSyncer(exchange Exchange, store Store, sub *P2PSubscriber, trusted tmbytes.HexBytes) *Syncer {
 	return &Syncer{
-		sub: sub,
-		exchange:   exchange,
-		store:      store,
-		trusted:    trusted,
+		sub:         sub,
+		exchange:    exchange,
+		store:       store,
+		trusted:     trusted,
 		triggerSync: make(chan struct{}), // no buffer needed
-		pending: make(map[uint64]*ExtendedHeader),
+		pending:     make(map[uint64]*ExtendedHeader),
 	}
 }
 

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -296,7 +296,7 @@ func (s *Syncer) getHeaders(ctx context.Context, start, amount uint64) ([]*Exten
 			out = append(out, hs...)
 			start += uint64(len(hs))
 
-			// than, apply cached range
+			// then, apply cached range
 			cached := r.Before(end)
 			out = append(out, cached...)
 			start += uint64(len(cached))

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -71,6 +71,7 @@ func (s *Syncer) Stop(context.Context) error {
 	return nil
 }
 
+// wantSync will trigger the syncing loop (non-blocking).
 func (s *Syncer) wantSync() {
 	select {
 	case s.triggerSync <- struct{}{}:

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -245,6 +245,7 @@ func (s *Syncer) incoming(ctx context.Context, p peer.ID, maybeHead *ExtendedHea
 	}
 
 	// 5. Save verified header to pending cache
+	// NOTE: Pending cache can't be DOSed as we verify above each header against a trusted one.
 	s.pending.Add(maybeHead)
 	// and trigger sync to catch-up
 	s.wantSync()

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -13,15 +13,15 @@ import (
 
 // Syncer implements efficient synchronization for headers.
 //
-// Mainly there are two processes going in Syncer:
-// * Main syncing loop(s.syncLoop)
+// There are two main processes running in Syncer:
+// 1. Main syncing loop(s.syncLoop)
 //    * Performs syncing from the subjective(local chain view) header up to the latest known trusted header
 //    * Syncs by requesting missing headers from Exchange or
 //    * By accessing cache of pending and verified headers
-// * Receives new headers from PubSub subnetwork (s.processIncoming)
-//    * Usually, a new header is adjacent to the trusted head and if so, it is simply appended to the local store
-//    	incrementing the subjective height and making it the new latest known trusted header.
-//    * Or, if farther from future,
+// 2. Receives new headers from PubSub subnetwork (s.processIncoming)
+//    * Usually, a new header is adjacent to the trusted head and if so, it is simply appended to the local store, incrementing the subjective height and 
+// making it the new latest known trusted header.
+//    * Or, if it receives a header further in the future,
 //      * verifies against the latest known trusted header
 //    	* adds the header to pending cache(making it the latest known trusted header)
 //      * and triggers syncing loop to catch up to that point.

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -24,7 +24,7 @@ type Syncer struct {
 	inProgress uint64
 	// signals to start syncing
 	triggerSync chan struct{}
-	// pending keeps ranges of valid headers rcvd from the network awaiting to be appended to store
+	// pending keeps ranges of valid headers received from the network awaiting to be appended to store
 	pending ranges
 
 	cancel context.CancelFunc

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -98,7 +98,7 @@ func (s *Syncer) initStore(ctx context.Context) error {
 	return nil
 }
 
-// trustedHead returns the highest known trusted header which is a valid header with time within the trusting period.
+// trustedHead returns the latest known trusted header that is within the trusting period.
 func (s *Syncer) trustedHead(ctx context.Context) (*ExtendedHeader, error) {
 	// check pending for trusted header and return it if applicable
 	// NOTE: Pending cannot be expired, guaranteed

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -249,7 +249,7 @@ func (s *Syncer) incoming(ctx context.Context, p peer.ID, maybeHead *ExtendedHea
 
 // TODO(@Wondertan): Number of headers that can be requested at once. Either make this configurable or,
 //  find a proper rationale for constant.
-var requestSize uint64 = 256
+var requestSize uint64 = 512
 
 // syncTo requests headers from locally stored head up to the new head.
 func (s *Syncer) syncTo(ctx context.Context, newHead *ExtendedHeader) error {

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -262,7 +262,7 @@ func (s *Syncer) syncTo(ctx context.Context, newHead *ExtendedHeader) error {
 		return nil
 	}
 
-	log.Info("syncing headers", "from", head.Height, "to", newHead.Height)
+	log.Infow("syncing headers", "from", head.Height, "to", newHead.Height)
 	defer log.Info("synced headers")
 
 	start, end := uint64(head.Height)+1, uint64(newHead.Height)

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -177,6 +177,8 @@ func (s *Syncer) incoming(ctx context.Context, maybeHead *ExtendedHeader) pubsub
 	case nil:
 		// a happy case where we append adjacent header correctly
 		return pubsub.ValidationAccept
+	case ErrNonAdjacent:
+		// not adjacent, so try to cache it after verifying
 	default:
 		var verErr *VerifyError
 		if errors.As(err, &verErr) {
@@ -192,8 +194,6 @@ func (s *Syncer) incoming(ctx context.Context, maybeHead *ExtendedHeader) pubsub
 			"hash", maybeHead.Hash().String(),
 			"err", err)
 		// might be a storage error or something else, but we can still try to continue processing 'maybeHead'
-	case ErrNonAdjacent:
-		// not adjacent, so try to cache it after verifying
 	}
 
 	// 2. Get known trusted head, so we can verify maybeHead

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -160,13 +160,11 @@ func (s *Syncer) sync(ctx context.Context) {
 		return
 	}
 
-	log.Info("syncing headers")
 	err = s.syncTo(ctx, trstHead)
 	if err != nil {
 		log.Errorw("syncing headers", "err", err)
 		return
 	}
-	log.Info("synced headers")
 }
 
 // validateMsg implements validation of incoming Headers as PubSub msg validator.
@@ -259,6 +257,13 @@ func (s *Syncer) syncTo(ctx context.Context, newHead *ExtendedHeader) error {
 	if err != nil {
 		return err
 	}
+
+	if head.Height == newHead.Height {
+		return nil
+	}
+
+	log.Info("syncing headers", "from", head.Height, "to", newHead.Height)
+	defer log.Info("synced headers")
 
 	start, end := uint64(head.Height)+1, uint64(newHead.Height)
 	for start <= end {

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -169,7 +169,7 @@ func (s *Syncer) sync(ctx context.Context) {
 	}
 }
 
-// incoming process new incoming Headers, validates them and applies/caches if applicable.
+// incoming processes new incoming Headers, validates them and stores/caches if applicable.
 func (s *Syncer) incoming(ctx context.Context, maybeHead *ExtendedHeader) pubsub.ValidationResult {
 	// 1. Try to append. If header is not adjacent/from future - try it for pending cache below
 	err := s.store.Append(ctx, maybeHead)

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -204,7 +204,7 @@ func (s *Syncer) validate(ctx context.Context, p peer.ID, maybeHead *ExtendedHea
 	return pubsub.ValidationAccept
 }
 
-// subjectiveHead tries to get head locally and if not exists requests by trusted hash.
+// subjectiveHead tries to get head locally and if it does not exist, requests it by trusted hash.
 func (s *Syncer) subjectiveHead(ctx context.Context) (*ExtendedHeader, error) {
 	head, err := s.store.Head(ctx)
 	switch err {

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -79,6 +79,7 @@ func (s *Syncer) wantSync() {
 	}
 }
 
+// mustSync will trigger the syncing loop (blocking).
 func (s *Syncer) mustSync() {
 	select {
 	case s.triggerSync <- struct{}{}:

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -290,7 +290,7 @@ func (s *Syncer) syncTo(ctx context.Context, newHead *ExtendedHeader) error {
 	return nil
 }
 
-// getHeaders gets headers from either remote peers or from local cached of headers rcvd by PubSub
+// getHeaders gets headers from either remote peers or from local cache of headers received by PubSub
 func (s *Syncer) getHeaders(ctx context.Context, start, amount uint64) ([]*ExtendedHeader, error) {
 	// short-circuit if nothing in pending cache to avoid unnecessary allocation below
 	if _, ok := s.pending.FirstRangeWithin(start, start+amount); !ok {

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -138,9 +138,7 @@ func (s *Syncer) trustedHead(ctx context.Context) (*ExtendedHeader, error) {
 		return nil, err
 	}
 
-	if objHead.Height > sbj.Height {
-		s.pending.Add(objHead)
-	}
+	s.pending.Add(objHead)
 	return objHead, nil
 }
 

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -19,8 +19,8 @@ import (
 //    * Syncs by requesting missing headers from Exchange or
 //    * By accessing cache of pending and verified headers
 // 2. Receives new headers from PubSub subnetwork (s.processIncoming)
-//    * Usually, a new header is adjacent to the trusted head and if so, it is simply appended to the local store, incrementing the subjective height and 
-// making it the new latest known trusted header.
+//    * Usually, a new header is adjacent to the trusted head and if so, it is simply appended to the local store,
+//    incrementing the subjective height and making it the new latest known trusted header.
 //    * Or, if it receives a header further in the future,
 //      * verifies against the latest known trusted header
 //    	* adds the header to pending cache(making it the latest known trusted header)

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -171,8 +171,9 @@ func (s *Syncer) sync(ctx context.Context) {
 func (s *Syncer) validateMsg(ctx context.Context, p peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 	maybeHead, err := UnmarshalExtendedHeader(msg.Data)
 	if err != nil {
-		log.Errorw("unmarshalling header received from the PubSub",
-			"err", err, "peer", p.ShortString())
+		log.Errorw("unmarshalling header",
+			"from", p.ShortString(),
+			"err", err)
 		return pubsub.ValidationReject
 	}
 
@@ -191,8 +192,8 @@ func (s *Syncer) incoming(ctx context.Context, p peer.ID, maybeHead *ExtendedHea
 			log.Errorw("invalid header",
 				"height", maybeHead.Height,
 				"hash", maybeHead.Hash(),
-				"reason", verErr.Reason,
-				"from", p.ShortString())
+				"from", p.ShortString(),
+				"reason", verErr.Reason)
 			return pubsub.ValidationReject
 		}
 
@@ -230,8 +231,8 @@ func (s *Syncer) incoming(ctx context.Context, p peer.ID, maybeHead *ExtendedHea
 		log.Errorw("invalid header",
 			"height", maybeHead.Height,
 			"hash", maybeHead.Hash(),
-			"reason", verErr.Reason,
-			"from", p.ShortString())
+			"from", p.ShortString(),
+			"reason", verErr.Reason)
 		return pubsub.ValidationReject
 	}
 

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -10,15 +10,6 @@ import (
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 )
 
-// TODO:
-//  1. Sync protocol for peers to exchange their local heads on connect
-//  2. If we are far from peers but within an unbonding period - trigger sync automatically
-//  3. If we are beyond the unbonding period - request Local Head + 1 header from trusted and hardcoded peer
-//  automatically and continue sync until know head.
-//  4. Limit amount of requests on server side
-//  5. Sync status and till sync is done.
-//  7. Retry requesting headers
-
 // Syncer implements simplest possible synchronization for headers.
 type Syncer struct {
 	sub      *P2PSubscriber

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -111,7 +111,7 @@ func (s *Syncer) trustedHead(ctx context.Context) (*ExtendedHeader, error) {
 	}
 
 	// check if our subjective header is not expired and use it
-	if !IsExpired(sbj) {
+	if !sbj.IsExpired() {
 		return sbj, nil
 	}
 
@@ -225,7 +225,7 @@ func (s *Syncer) incoming(ctx context.Context, p peer.ID, maybeHead *ExtendedHea
 	}
 
 	// 4. Verify maybeHead against trusted
-	err = VerifyNonAdjacent(trstHead, maybeHead)
+	err = trstHead.VerifyNonAdjacent(maybeHead)
 	var verErr *VerifyError
 	if errors.As(err, &verErr) {
 		log.Errorw("invalid header",

--- a/service/header/sync_ranges.go
+++ b/service/header/sync_ranges.go
@@ -2,8 +2,8 @@ package header
 
 import "sync"
 
-// ranges keep non-overlapping and non-adjacent header ranges which used to cache headers
-// Always in ascending heights order
+// ranges keeps non-overlapping and non-adjacent header ranges which are used to cache headers (in ascending order).
+// This prevents unnecessary / duplicate network requests for additional headers during sync.
 type ranges struct {
 	ranges []*_range
 	lk     sync.Mutex // no need for RWMutex as there is only one reader

--- a/service/header/sync_ranges.go
+++ b/service/header/sync_ranges.go
@@ -1,0 +1,164 @@
+package header
+
+import "sync"
+
+// ranges keep non-overlapping and non-adjacent header ranges which used to cache headers
+// Always in ascending heights order
+type ranges struct {
+	ranges []*_range
+	lk     sync.Mutex // no need for RWMutex as there is only one reader
+}
+
+// PopHead pops and returns the highest ExtendedHeader in all ranges if any.
+func (rs *ranges) PopHead() *ExtendedHeader {
+	rs.lk.Lock()
+	defer rs.lk.Unlock()
+
+	ln := len(rs.ranges)
+	if ln == 0 {
+		return nil
+	}
+
+	return rs.ranges[ln-1].PopHead()
+}
+
+// Head returns the highest ExtendedHeader in all ranges if any.
+func (rs *ranges) Head() *ExtendedHeader {
+	rs.lk.Lock()
+	defer rs.lk.Unlock()
+
+	ln := len(rs.ranges)
+	if ln == 0 {
+		return nil
+	}
+
+	head := rs.ranges[ln-1]
+	return head.Head()
+}
+
+// Add appends the new ExtendedHeader to existing range or starts a new one.
+// It starts a new one if the new ExtendedHeader is not adjacent to any of existing ranges.
+func (rs *ranges) Add(h *ExtendedHeader) {
+	head := rs.Head()
+
+	// short-circuit if header is from the past
+	if head != nil && head.Height >= h.Height {
+		// TODO(@Wondertan): Technically, we can still apply the header:
+		//  * Headers here are verified, so we can trust them
+		//  * PubSub does not guarantee the ordering of msgs
+		//    * So there might be a case where ordering is broken
+		//    * Even considering the delay(block time) with which new headers are generated
+		//    * But rarely
+		//  Would be still nice to implement
+		log.Warnf("rcvd headers in wrong order")
+		return
+	}
+
+	rs.lk.Lock()
+	defer rs.lk.Unlock()
+
+	// if the new header is adjacent to head
+	if head != nil && h.Height == head.Height+1 {
+		// append it to the last known range
+		rs.ranges[len(rs.ranges)-1].Append(h)
+	} else {
+		// otherwise, start a new range
+		rs.ranges = append(rs.ranges, newRange(h))
+
+		// it is possible to miss a header or few from PubSub, due to quick disconnects or sleep
+		// once we start rcving them again we save those in new range
+		// so 'Syncer.getHeaders' can fetch what was missed
+	}
+}
+
+// BackWithin searches for a range within a given height span (start:end].
+func (rs *ranges) BackWithin(start, end uint64) (*_range, bool) {
+	r, ok := rs.Back()
+	if !ok {
+		return nil, false
+	}
+
+	if r.Start >= start && r.Start < end {
+		return r, true
+	}
+
+	return nil, false
+}
+
+// Back provides a first non-empty range, while cleaning up empty ones.
+func (rs *ranges) Back() (*_range, bool) {
+	rs.lk.Lock()
+	defer rs.lk.Unlock()
+
+	for {
+		if len(rs.ranges) == 0 {
+			return nil, false
+		}
+
+		out := rs.ranges[0]
+		if !out.Empty() {
+			return out, true
+		}
+
+		rs.ranges = rs.ranges[1:]
+	}
+}
+
+type _range struct {
+	Start uint64
+
+	headers []*ExtendedHeader
+}
+
+func newRange(h *ExtendedHeader) *_range {
+	return &_range{
+		Start:   uint64(h.Height),
+		headers: []*ExtendedHeader{h},
+	}
+}
+
+// Append appends new headers.
+func (r *_range) Append(h ...*ExtendedHeader) {
+	r.headers = append(r.headers, h...)
+}
+
+// Empty reports if range is empty.
+func (r *_range) Empty() bool {
+	return len(r.headers) == 0
+}
+
+// Head reports the head of range if any.
+func (r *_range) Head() *ExtendedHeader {
+	if r.Empty() {
+		return nil
+	}
+	return r.headers[len(r.headers)-1]
+}
+
+// PopHead pops and returns the head of range if any.
+func (r *_range) PopHead() *ExtendedHeader {
+	ln := len(r.headers)
+	if ln == 0 {
+		return nil
+	}
+
+	out := r.headers[ln-1]
+	r.headers = r.headers[:ln-1]
+	return out
+}
+
+// Before cuts off all the headers before height 'end' and returns them.
+func (r *_range) Before(end uint64) []*ExtendedHeader {
+	amnt := uint64(len(r.headers))
+	if r.Start+amnt > end {
+		amnt = end - r.Start
+	}
+
+	out := r.headers[:amnt]
+	r.headers = r.headers[amnt:]
+	if len(r.headers) != 0 {
+		r.Start = uint64(r.headers[0].Height)
+	}
+
+	return out
+}

--- a/service/header/sync_ranges.go
+++ b/service/header/sync_ranges.go
@@ -129,7 +129,7 @@ func (r *_range) Head() *ExtendedHeader {
 	return r.headers[ln-1]
 }
 
-// Before cuts off all the headers before height 'end' and returns them.
+// Before truncates all the headers before height 'end'.
 func (r *_range) Before(end uint64) []*ExtendedHeader {
 	r.lk.Lock()
 	defer r.lk.Unlock()

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -29,7 +29,7 @@ func TestSync(t *testing.T) {
 	require.Nil(t, err)
 
 	requestSize = 13 // just some random number
-	syncer := NewSyncer(fakeExchange, localStore, head.Hash())
+	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
 	syncer.Sync(ctx)
 
 	exp, err := remoteStore.Head(ctx)

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -30,7 +30,7 @@ func TestSync(t *testing.T) {
 
 	requestSize = 13 // just some random number
 	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
-	syncer.Sync(ctx)
+	syncer.sync(ctx)
 
 	exp, err := remoteStore.Head(ctx)
 	require.Nil(t, err)

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -174,7 +174,7 @@ type delayedExchange struct {
 
 func (d *delayedExchange) delay(ctx context.Context) {
 	select {
-	case <-time.After(time.Millisecond*100):
+	case <-time.After(time.Millisecond * 100):
 	case <-ctx.Done():
 	}
 }
@@ -198,4 +198,3 @@ func (d *delayedExchange) RequestByHash(ctx context.Context, hash bytes.HexBytes
 	d.delay(ctx)
 	return d.innner.RequestByHash(ctx, hash)
 }
-

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -10,6 +10,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/bytes"
 )
 
 func TestSyncSimple(t *testing.T) {
@@ -97,7 +98,7 @@ func TestSyncCatchUp(t *testing.T) {
 	require.Nil(t, err)
 
 	// 3. syncer rcvs header from the future and starts catching-up
-	res := syncer.validate(ctx, "", suite.GenExtendedHeaders(1)[0])
+	res := syncer.incoming(ctx, "", suite.GenExtendedHeaders(1)[0])
 	assert.Equal(t, pubsub.ValidationAccept, res)
 
 	// TODO(@Wondertan): Async blocking instead of sleep
@@ -112,3 +113,89 @@ func TestSyncCatchUp(t *testing.T) {
 	// 4. assert syncer caught-up
 	assert.Equal(t, exp.Height+1, have.Height) // plus one as we didn't add last header to remoteStore
 }
+
+func TestSyncPendingRangesWithMisses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	suite := NewTestSuite(t, 3)
+	head := suite.Head()
+
+	remoteStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
+	require.Nil(t, err)
+
+	fakeExchange := NewLocalExchange(remoteStore)
+
+	localStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
+	require.Nil(t, err)
+
+	syncer := NewSyncer(&delayedExchange{fakeExchange}, localStore, nil, head.Hash())
+	err = syncer.Start(ctx)
+	require.Nil(t, err)
+
+	// miss 1
+	err = remoteStore.Append(ctx, suite.GenExtendedHeaders(1)...)
+	require.Nil(t, err)
+
+	range1 := suite.GenExtendedHeaders(15)
+	err = remoteStore.Append(ctx, range1...)
+	require.Nil(t, err)
+
+	// miss 2
+	err = remoteStore.Append(ctx, suite.GenExtendedHeaders(3)...)
+	require.Nil(t, err)
+
+	range2 := suite.GenExtendedHeaders(23)
+	err = remoteStore.Append(ctx, range2...)
+	require.Nil(t, err)
+
+	for _, h := range append(range1, range2...) {
+		res := syncer.incoming(ctx, "", h)
+		assert.Equal(t, pubsub.ValidationAccept, res)
+	}
+
+	// TODO(@Wondertan): Async blocking instead of sleep
+	time.Sleep(time.Second)
+
+	exp, err := remoteStore.Head(ctx)
+	require.Nil(t, err)
+
+	have, err := localStore.Head(ctx)
+	require.Nil(t, err)
+
+	assert.Equal(t, exp.Height, have.Height)
+	assert.Empty(t, syncer.pending.Head())
+}
+
+// delayedExchange prevents sync from finishing instantly
+type delayedExchange struct {
+	innner Exchange
+}
+
+func (d *delayedExchange) delay(ctx context.Context) {
+	select {
+	case <-time.After(time.Millisecond*100):
+	case <-ctx.Done():
+	}
+}
+
+func (d *delayedExchange) RequestHead(ctx context.Context) (*ExtendedHeader, error) {
+	d.delay(ctx)
+	return d.innner.RequestHead(ctx)
+}
+
+func (d *delayedExchange) RequestHeader(ctx context.Context, height uint64) (*ExtendedHeader, error) {
+	d.delay(ctx)
+	return d.innner.RequestHeader(ctx, height)
+}
+
+func (d *delayedExchange) RequestHeaders(ctx context.Context, origin, amount uint64) ([]*ExtendedHeader, error) {
+	d.delay(ctx)
+	return d.innner.RequestHeaders(ctx, origin, amount)
+}
+
+func (d *delayedExchange) RequestByHash(ctx context.Context, hash bytes.HexBytes) (*ExtendedHeader, error) {
+	d.delay(ctx)
+	return d.innner.RequestByHash(ctx, hash)
+}
+

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -35,7 +35,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	// this way we force local head of Syncer to expire, so it requests a new one from trusted peer
 	TrustingPeriod = time.Microsecond
 
-	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
+	syncer := NewSyncer(fakeExchange, localStore, &DummySubscriber{}, head.Hash())
 	err = syncer.Start(ctx)
 	require.Nil(t, err)
 
@@ -73,7 +73,7 @@ func TestSyncerInitStore(t *testing.T) {
 	localStore, err := NewStore(sync.MutexWrap(datastore.NewMapDatastore()))
 	require.Nil(t, err)
 
-	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
+	syncer := NewSyncer(fakeExchange, localStore, &DummySubscriber{}, head.Hash())
 	err = syncer.Start(ctx)
 	require.Nil(t, err)
 
@@ -104,7 +104,7 @@ func TestSyncCatchUp(t *testing.T) {
 	localStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
 	require.Nil(t, err)
 
-	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
+	syncer := NewSyncer(fakeExchange, localStore, &DummySubscriber{}, head.Hash())
 	// 1. Initial sync
 	err = syncer.Start(ctx)
 	require.Nil(t, err)
@@ -114,7 +114,7 @@ func TestSyncCatchUp(t *testing.T) {
 	require.Nil(t, err)
 
 	// 3. syncer rcvs header from the future and starts catching-up
-	res := syncer.incoming(ctx, "", suite.GenExtendedHeaders(1)[0])
+	res := syncer.incoming(ctx, suite.GenExtendedHeaders(1)[0])
 	assert.Equal(t, pubsub.ValidationAccept, res)
 
 	// TODO(@Wondertan): Async blocking instead of sleep
@@ -146,7 +146,7 @@ func TestSyncPendingRangesWithMisses(t *testing.T) {
 	localStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
 	require.Nil(t, err)
 
-	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
+	syncer := NewSyncer(fakeExchange, localStore, &DummySubscriber{}, head.Hash())
 	err = syncer.Start(ctx)
 	require.Nil(t, err)
 

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestSyncSimpleRequestingHead(t *testing.T) {
+	// this way we force local head of Syncer to expire, so it requests a new one from trusted peer
+	TrustingPeriod = time.Microsecond
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -31,9 +34,6 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	require.Nil(t, err)
 
 	requestSize = 13 // just some random number
-
-	// this way we force local head of Syncer to expire, so it requests a new one from trusted peer
-	TrustingPeriod = time.Microsecond
 
 	syncer := NewSyncer(fakeExchange, localStore, &DummySubscriber{}, head.Hash())
 	err = syncer.Start(ctx)
@@ -90,6 +90,9 @@ func TestSyncerInitStore(t *testing.T) {
 }
 
 func TestSyncCatchUp(t *testing.T) {
+	// just set a big enough value, so we trust local header and don't request anything
+	TrustingPeriod = time.Minute
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -132,6 +135,9 @@ func TestSyncCatchUp(t *testing.T) {
 }
 
 func TestSyncPendingRangesWithMisses(t *testing.T) {
+	// just set a big enough value, so we trust local header and don't request anything
+	TrustingPeriod = time.Minute
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -3,14 +3,16 @@ package header
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSync(t *testing.T) {
+func TestSyncSimple(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -30,7 +32,7 @@ func TestSync(t *testing.T) {
 
 	requestSize = 13 // just some random number
 	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
-	syncer.sync(ctx)
+	syncer.sync(ctx) // manually init blocking sync instead of Start
 
 	exp, err := remoteStore.Head(ctx)
 	require.Nil(t, err)
@@ -38,4 +40,75 @@ func TestSync(t *testing.T) {
 	have, err := localStore.Head(ctx)
 	require.Nil(t, err)
 	assert.Equal(t, exp.Height, have.Height)
+}
+
+func TestSyncerInitializeSubjectiveHead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	suite := NewTestSuite(t, 3)
+	head := suite.Head()
+
+	remoteStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
+	require.Nil(t, err)
+
+	err = remoteStore.Append(ctx, suite.GenExtendedHeaders(100)...)
+	require.Nil(t, err)
+
+	fakeExchange := NewLocalExchange(remoteStore)
+
+	// we don't the head here and expect syncer to load it himself
+	localStore, err := NewStore(sync.MutexWrap(datastore.NewMapDatastore()))
+	require.Nil(t, err)
+
+	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
+	syncer.sync(ctx) // manually init blocking sync instead of Start
+
+	exp, err := remoteStore.Head(ctx)
+	require.Nil(t, err)
+
+	have, err := localStore.Head(ctx)
+	require.Nil(t, err)
+	assert.Equal(t, exp.Height, have.Height)
+}
+
+func TestSyncCatchUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	suite := NewTestSuite(t, 3)
+	head := suite.Head()
+
+	remoteStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
+	require.Nil(t, err)
+
+	fakeExchange := NewLocalExchange(remoteStore)
+
+	localStore, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
+	require.Nil(t, err)
+
+	syncer := NewSyncer(fakeExchange, localStore, nil, head.Hash())
+	// 1. Initial sync
+	err = syncer.Start(ctx)
+	require.Nil(t, err)
+
+	// 2. chain grows and syncer misses that
+	err = remoteStore.Append(ctx, suite.GenExtendedHeaders(100)...)
+	require.Nil(t, err)
+
+	// 3. syncer rcvs header from the future and starts catching-up
+	res := syncer.validate(ctx, "", suite.GenExtendedHeaders(1)[0])
+	assert.Equal(t, pubsub.ValidationAccept, res)
+
+	// TODO(@Wondertan): Async blocking instead of sleep
+	time.Sleep(time.Second)
+
+	exp, err := remoteStore.Head(ctx)
+	require.Nil(t, err)
+
+	have, err := localStore.Head(ctx)
+	require.Nil(t, err)
+
+	// 4. assert syncer caught-up
+	assert.Equal(t, exp.Height+1, have.Height) // plus one as we didn't add last header to remoteStore
 }

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -58,7 +58,7 @@ func TestSyncerInitializeSubjectiveHead(t *testing.T) {
 
 	fakeExchange := NewLocalExchange(remoteStore)
 
-	// we don't the head here and expect syncer to load it himself
+	// we don't load the head here and expect syncer to load it himself
 	localStore, err := NewStore(sync.MutexWrap(datastore.NewMapDatastore()))
 	require.Nil(t, err)
 

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -117,7 +117,7 @@ func TestSyncCatchUp(t *testing.T) {
 	require.NoError(t, err)
 
 	// 3. syncer rcvs header from the future and starts catching-up
-	res := syncer.incoming(ctx, suite.GenExtendedHeaders(1)[0])
+	res := syncer.processIncoming(ctx, suite.GenExtendedHeaders(1)[0])
 	assert.Equal(t, pubsub.ValidationAccept, res)
 
 	// TODO(@Wondertan): Async blocking instead of sleep

--- a/service/header/testing.go
+++ b/service/header/testing.go
@@ -126,6 +126,7 @@ func (s *TestSuite) nextProposer() *types.Validator {
 func RandExtendedHeader(t *testing.T) *ExtendedHeader {
 	rh := RandRawHeader(t)
 	valSet, vals := types.RandValidatorSet(5, 1)
+	rh.ValidatorsHash = valSet.Hash()
 	voteSet := types.NewVoteSet(rh.ChainID, rh.Height, 0, tmproto.PrecommitType, valSet)
 	commit, err := types.MakeCommit(RandBlockID(t), rh.Height, 0, voteSet, vals, time.Now())
 	require.NoError(t, err)

--- a/service/header/testing.go
+++ b/service/header/testing.go
@@ -28,7 +28,7 @@ type TestSuite struct {
 	valSet  *types.ValidatorSet
 	valPntr int
 
-	head   *ExtendedHeader
+	head *ExtendedHeader
 }
 
 // NewTestSuite setups a new test suite with a given number of validators.
@@ -51,8 +51,8 @@ func genesis(t *testing.T, valSet *types.ValidatorSet, vals []types.PrivValidato
 	require.NoError(t, err)
 	dah := EmptyDAH()
 	return &ExtendedHeader{
-		RawHeader: *gen,
-		Commit: commit,
+		RawHeader:    *gen,
+		Commit:       commit,
 		ValidatorSet: valSet,
 		DAH:          &dah,
 	}
@@ -72,7 +72,7 @@ func (s *TestSuite) GenExtendedHeaders(num int) []*ExtendedHeader {
 
 func (s *TestSuite) GenExtendedHeader() *ExtendedHeader {
 	dah := da.MinDataAvailabilityHeader()
-	height := s.Head().Height+1
+	height := s.Head().Height + 1
 	rh := s.GenRawHeader(height, s.Head().Hash(), s.Head().Commit.Hash(), dah.Hash())
 	s.head = &ExtendedHeader{
 		RawHeader:    *rh,

--- a/service/header/testing.go
+++ b/service/header/testing.go
@@ -3,6 +3,7 @@
 package header
 
 import (
+	"context"
 	mrand "math/rand"
 	"testing"
 	"time"
@@ -195,3 +196,27 @@ func RandBlockID(t *testing.T) types.BlockID {
 	mrand.Read(bid.PartSetHeader.Hash) //nolint:gosec
 	return bid
 }
+
+type DummySubscriber struct {
+	Headers []*ExtendedHeader
+}
+
+func (mhs *DummySubscriber) AddValidator(Validator) error {
+	return nil
+}
+
+func (mhs *DummySubscriber) Subscribe() (Subscription, error) {
+	return mhs, nil
+}
+
+func (mhs *DummySubscriber) NextHeader(ctx context.Context) (*ExtendedHeader, error) {
+	defer func() {
+		mhs.Headers = make([]*ExtendedHeader, 0)
+	}()
+	if len(mhs.Headers) == 0 {
+		return nil, context.Canceled
+	}
+	return mhs.Headers[0], nil
+}
+
+func (mhs *DummySubscriber) Cancel() {}

--- a/service/header/verify.go
+++ b/service/header/verify.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"time"
+
+	"github.com/tendermint/tendermint/libs/math"
 )
 
 // Verify validates trusted header against untrusted.
@@ -22,12 +24,11 @@ func Verify(trusted, untrusted *ExtendedHeader) error {
 			now)
 	}
 
-	// Ensure that +2/3 of new validators signed correctly.
-	if err := trusted.ValidatorSet.VerifyCommitLight(
+	// Ensure that untrusted commit has 2/3 of trusted commit's power.
+	if err := trusted.ValidatorSet.VerifyCommitLightTrusting(
 		trusted.ChainID,
-		untrusted.Commit.BlockID,
-		untrusted.Height,
 		untrusted.Commit,
+		math.Fraction{Numerator: 2, Denominator: 3},
 	); err != nil {
 		return err
 	}

--- a/service/header/verify.go
+++ b/service/header/verify.go
@@ -102,5 +102,5 @@ type VerifyError struct {
 }
 
 func (vr *VerifyError) Error() string {
-	return vr.Reason.Error()
+	return fmt.Sprintf("header: verify: %s", vr.Reason.Error())
 }

--- a/service/header/verify.go
+++ b/service/header/verify.go
@@ -26,73 +26,81 @@ func IsExpired(eh *ExtendedHeader) bool {
 	return !expirationTime.After(time.Now())
 }
 
-// VerifyNonAdjacent validates non-adjacent 'untrusted' header against 'trusted'.
-func VerifyNonAdjacent(trusted, untrusted *ExtendedHeader) error {
-	if untrusted.ChainID != trusted.ChainID {
-		return fmt.Errorf("header belongs to another chain %q, not %q", untrusted.ChainID, trusted.ChainID)
+// VerifyNonAdjacent validates non-adjacent untrusted header against trusted.
+func VerifyNonAdjacent(trst, untrst *ExtendedHeader) error {
+	if untrst.ChainID != trst.ChainID {
+		return &VerifyError{
+			fmt.Errorf(
+				"header belongs to another chain %q, not %q", untrst.ChainID, trst.ChainID,
+			),
+		}
 	}
 
-	if !untrusted.Time.After(trusted.Time) {
-		return fmt.Errorf("expected new header time %v to be after old header time %v",
-			untrusted.Time,
-			trusted.Time)
+	if !untrst.Time.After(trst.Time) {
+		return &VerifyError{
+			fmt.Errorf("expected new header time %v to be after old header time %v", untrst.Time, trst.Time),
+		}
 	}
 
 	now := time.Now()
-	if !untrusted.Time.Before(now) {
-		return fmt.Errorf("new header has a time from the future %v (now: %v)",
-			untrusted.Time,
-			now)
+	if !untrst.Time.Before(now) {
+		return &VerifyError{
+			fmt.Errorf("new header has a time from the future %v (now: %v)", untrst.Time, now),
+		}
 	}
 
 	// Ensure that untrusted commit has enough of trusted commit's power.
-	if err := trusted.ValidatorSet.VerifyCommitLightTrusting(
-		trusted.ChainID,
-		untrusted.Commit,
-		light.DefaultTrustLevel, // default Tendermint value
-	); err != nil {
-		return err
+	err := trst.ValidatorSet.VerifyCommitLightTrusting(trst.ChainID, untrst.Commit, light.DefaultTrustLevel)
+	if err != nil {
+		return &VerifyError{err}
 	}
 
 	return nil
 }
 
-// VerifyAdjacent validates adjacent 'untrusted' header against 'trusted'.
-func VerifyAdjacent(trusted, untrusted *ExtendedHeader) error {
-	if untrusted.Height != trusted.Height+1 {
-		return fmt.Errorf("headers must be adjacent in height")
+// VerifyAdjacent validates adjacent untrusted header against trusted.
+func VerifyAdjacent(trst, untrst *ExtendedHeader) error {
+	if untrst.Height != trst.Height+1 {
+		return &VerifyError{fmt.Errorf("headers must be adjacent in height")}
 	}
 
-	if untrusted.ChainID != trusted.ChainID {
-		return fmt.Errorf("header belongs to another chain %q, not %q", untrusted.ChainID, trusted.ChainID)
+	if untrst.ChainID != trst.ChainID {
+		return &VerifyError{
+			fmt.Errorf("header belongs to another chain %q, not %q", untrst.ChainID, trst.ChainID),
+		}
 	}
 
-	if !untrusted.Time.After(trusted.Time) {
-		return fmt.Errorf("expected new header time %v to be after old header time %v",
-			untrusted.Time,
-			trusted.Time)
+	if !untrst.Time.After(trst.Time) {
+		return &VerifyError{
+			fmt.Errorf("expected new header time %v to be after old header time %v", untrst.Time, trst.Time),
+		}
 	}
 
 	now := time.Now()
-	if !untrusted.Time.Before(now) {
-		return fmt.Errorf("new header has a time from the future %v (now: %v)",
-			untrusted.Time,
-			now)
+	if !untrst.Time.Before(now) {
+		return &VerifyError{
+			fmt.Errorf("new header has a time from the future %v (now: %v)", untrst.Time, now),
+		}
 	}
 
 	// Check the validator hashes are the same
-	if !bytes.Equal(untrusted.ValidatorsHash, trusted.NextValidatorsHash) {
-		return fmt.Errorf("expected old header next validators (%X) to match those from new header (%X)",
-			trusted.NextValidatorsHash,
-			untrusted.ValidatorsHash,
-		)
+	if !bytes.Equal(untrst.ValidatorsHash, trst.NextValidatorsHash) {
+		return &VerifyError{
+			fmt.Errorf("expected old header next validators (%X) to match those from new header (%X)",
+				trst.NextValidatorsHash,
+				untrst.ValidatorsHash,
+			),
+		}
 	}
 
-	// Ensure that +2/3 of new validators signed correctly.
-	return untrusted.ValidatorSet.VerifyCommitLight(
-		trusted.ChainID,
-		untrusted.Commit.BlockID,
-		untrusted.Height,
-		untrusted.Commit,
-	)
+	return nil
+}
+
+// VerifyError is thrown on during VerifyAdjacent and VerifyNonAdjacent if verification fails.
+type VerifyError struct {
+	Reason error
+}
+
+func (vr *VerifyError) Error() string {
+	return vr.Reason.Error()
 }

--- a/service/header/verify.go
+++ b/service/header/verify.go
@@ -61,7 +61,7 @@ func VerifyNonAdjacent(trst, untrst *ExtendedHeader) error {
 // VerifyAdjacent validates adjacent untrusted header against trusted.
 func VerifyAdjacent(trst, untrst *ExtendedHeader) error {
 	if untrst.Height != trst.Height+1 {
-		return &VerifyError{fmt.Errorf("headers must be adjacent in height")}
+		return ErrNonAdjacent
 	}
 
 	if untrst.ChainID != trst.ChainID {

--- a/service/header/verify_test.go
+++ b/service/header/verify_test.go
@@ -23,12 +23,6 @@ func TestVerifyAdjacent(t *testing.T) {
 		},
 		{
 			prepare: func() {
-				untrusted.Commit.Signatures[0].Signature = nil
-			},
-			err: true,
-		},
-		{
-			prepare: func() {
 				untrusted.ValidatorsHash = tmrand.Bytes(32)
 			},
 			err: true,


### PR DESCRIPTION
Previously, we were syncing only once on `Start` and were catching up the chain by Pubsub topic. This PR changes that we can sync multiple times during runtime and if we missed some new Headers from PubSub topic, that will trigger sync again to catch-up. Also, this PR starts to verify new non-adjacent headers from PubSub and caches them to later be applied adjacently to avoid unnecessary request of already rcvd headers

Also fixes a variety of minor things.

Depends on #327 
Closes: #242 
Closes: #326 