### PR TITLE
node: fix naming of the test from full to bridge

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -36,3 +36,4 @@ Month, DD, YYYY
 - [service/block, node/p2p] [Fix race conditions in TestExtendedHeaderBroadcast and TestFull_P2P_Streams.](https://github.com/celestiaorg/celestia-node/pull/288) [@jenyasd209](https://github.com/jenyasd209)
 - [ci: increase tokens ratio for dupl to fix false positive scenarios](https://github.com/celestiaorg/celestia-node/pull/314) [@Bidon15](https://github.com/Bidon15)
 - [node: update vanilla datastore with Mutex one](https://github.com/celestiaorg/celestia-node/pull/325) [@Bidon15](https://github.com/Bidon15)
+- [node: fix naming of the test from full to bridge](https://github.com/celestiaorg/celestia-node/pull/341) [@Bidon15](https://github.com/Bidon15)

--- a/node/bridge_test.go
+++ b/node/bridge_test.go
@@ -138,7 +138,7 @@ func TestBridge_NotPanicWithNilOpts(t *testing.T) {
 	require.NotNil(t, node)
 }
 
-func TestFull_WithMockedCoreClient(t *testing.T) {
+func TestBridge_WithMockedCoreClient(t *testing.T) {
 	repo := MockStore(t, DefaultConfig(Bridge))
 	node, err := New(Bridge, repo, WithCoreClient(core.MockEmbeddedClient()))
 	require.NoError(t, err)


### PR DESCRIPTION
Found this nit during testing. Small name change to be compliant with new naming schema