### PR TITLE
Fix start order of mocknet

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -29,6 +29,7 @@ Month, DD, YYYY
 - [docker] Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script. 
 - [chore(share): handle rows concurrently in GetSharesByNamespace #241](https://github.com/celestiaorg/celestia-node/pull/241) [@vgonkivs](https://github.com/vgonkivs)
 - [ci: adding data race detector action](https://github.com/celestiaorg/celestia-node/pull/289) [@Bidon15](https://github.com/Bidon15)
+- [services/header: Fix order of mocknet start](https://github.com/celestiaorg/celestia-node/pull/342) [@atoulme](https://github.com/atoulme)
 
 ### BUG FIXES
 

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -29,7 +29,6 @@ Month, DD, YYYY
 - [docker] Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script. 
 - [chore(share): handle rows concurrently in GetSharesByNamespace #241](https://github.com/celestiaorg/celestia-node/pull/241) [@vgonkivs](https://github.com/vgonkivs)
 - [ci: adding data race detector action](https://github.com/celestiaorg/celestia-node/pull/289) [@Bidon15](https://github.com/Bidon15)
-- [services/header: Fix order of mocknet start](https://github.com/celestiaorg/celestia-node/pull/342) [@atoulme](https://github.com/atoulme)
 
 ### BUG FIXES
 

--- a/service/header/subscription_test.go
+++ b/service/header/subscription_test.go
@@ -18,7 +18,7 @@ func TestSubscriber(t *testing.T) {
 	defer cancel()
 
 	// create mock network
-	net, err := mocknet.FullMeshConnected(ctx, 2)
+	net, err := mocknet.FullMeshLinked(ctx, 2)
 	require.NoError(t, err)
 
 	suite := NewTestSuite(t, 3)
@@ -36,9 +36,6 @@ func TestSubscriber(t *testing.T) {
 	err = p2pSub1.Start(context.Background())
 	require.NoError(t, err)
 
-	// subscribe
-	subscription, err := p2pSub1.Subscribe()
-	require.NoError(t, err)
 
 	// get mock host and create new gossipsub on it
 	pubsub2, err := pubsub.NewGossipSub(ctx, net.Hosts()[1],
@@ -54,7 +51,14 @@ func TestSubscriber(t *testing.T) {
 	err = p2pSub2.Start(context.Background())
 	require.NoError(t, err)
 
+	err = net.ConnectAllButSelf()
+	time.Sleep(400 * time.Millisecond) // wait for peers to finish their connection.
+
+	// subscribe
 	_, err = p2pSub2.Subscribe()
+	require.NoError(t, err)
+
+	subscription, err := p2pSub1.Subscribe()
 	require.NoError(t, err)
 
 	expectedHeader := suite.GenExtendedHeaders(1)[0]


### PR DESCRIPTION
Fixes #173 by separating the creation of the hosts from connecting them, allowing that we configure the gossip protocol on them, otherwise the host doesn't know to gossip with the other host.