### PR TITLE
node/services: use genesis if trusted hash is not set

### DIFF
--- a/node/services/config.go
+++ b/node/services/config.go
@@ -6,6 +6,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
+
+	"github.com/celestiaorg/celestia-node/build"
 )
 
 type Config struct {
@@ -40,5 +42,8 @@ func (cfg *Config) trustedPeer() (*peer.AddrInfo, error) {
 }
 
 func (cfg *Config) trustedHash() (tmbytes.HexBytes, error) {
+	if cfg.TrustedHash == "" {
+		return hex.DecodeString(build.Genesis())
+	}
 	return hex.DecodeString(cfg.TrustedHash)
 }


### PR DESCRIPTION
Required for Bridge Node, but also works for Light and in future for Full. This won't be safe for them though, once we stop relying on a trusted peer for the whole syncing, but until then it is safe, as we trust a trusted peer.

Based/depends on #346 
Closes #324 