### PR TITLE
service/header: remove start/stop from P2PExchange

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -18,6 +18,7 @@ Month, DD, YYYY
 
 ### IMPROVEMENTS
 
+- [service/header: remove start/stop from P2PExchange](https://github.com/celestiaorg/celestia-node/pull/367) [@Bidon15](https://github.com/Bidon15)
 - [service/share: Implement `FullAvailability`](https://github.com/celestiaorg/celestia-node/pull/333) [@renaynay](https://github.com/renaynay)
 - [services/header: Refactor `HeaderService` to be responsible for broadcasting new `ExtendedHeader`s to the gossipsub network](https://github.com/celestiaorg/celestia-node/pull/327) [@renaynay](https://github.com/renaynay)
 - [cmd: introduce Env - an Environment for CLI commands #313](https://github.com/celestiaorg/celestia-node/pull/313) [@Wondertan](https://github.com/Wondertan)

--- a/node/services/config.go
+++ b/node/services/config.go
@@ -3,10 +3,13 @@ package services
 import (
 	"encoding/hex"
 
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 )
+
+var log = logging.Logger("node/services")
 
 type Config struct {
 	// TrustedHash is the Block/Header hash that Nodes use as starting point for header synchronization.
@@ -28,6 +31,7 @@ func DefaultConfig() Config {
 
 func (cfg *Config) trustedPeer() (*peer.AddrInfo, error) {
 	if cfg.TrustedPeer == "" {
+		log.Warn("No Trusted Peer provided. Headers won't be synced accordingly")
 		return &peer.AddrInfo{}, nil
 	}
 

--- a/service/header/p2p_exchange_test.go
+++ b/service/header/p2p_exchange_test.go
@@ -115,17 +115,11 @@ func createP2PExAndServer(t *testing.T, host, peer libhost.Host) (Exchange, *moc
 	err := serverSideEx.Start(context.Background())
 	require.NoError(t, err)
 
-	// create new exchange
-	clientSideEx := NewP2PExchange(host, libhost.InfoFromHost(peer), nil) // we don't need the store on the requesting side
-	err = clientSideEx.Start(context.Background())
-	require.NoError(t, err)
-
 	t.Cleanup(func() {
 		serverSideEx.Stop(context.Background()) //nolint:errcheck
-		clientSideEx.Stop(context.Background()) //nolint:errcheck
 	})
 
-	return clientSideEx, store
+	return NewP2PExchange(host, peer.ID()), store
 }
 
 type mockStore struct {


### PR DESCRIPTION
Change config to log warnings with missing trusted peer
In HeaderExchangeP2P func we are creating an addr for the host instead of making it in the removed connect
Removed store in p2pExchange

Now, instead of handling connection ourselves, we are delegating this to libp2p itself and only creating NewStream in `performRequest` func in `p2p_exchange.go`


Solves the issue `panic of closing a closed channel` #350 

Co-authored-by: @Wondertan 