### PR TITLE
node/config: add WithBootstrapPeers option

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -12,7 +12,6 @@ Month, DD, YYYY
 
 ### FEATURES
 
-- [node/config: add WithBootstrapPeers option #375](https://github.com/celestiaorg/celestia-node/pull/375) [@Bidon15](https://github.com/Bidon15)
 - [feat(cmd): give a birth to cel-shed and p2p key utilities #281](https://github.com/celestiaorg/celestia-node/pull/281) [@Wondertan](https://github.com/Wondertan)
 - [feat(cmd|node): MutualPeers Node option and CLI flag #280](https://github.com/celestiaorg/celestia-node/pull/280) [@Wondertan](https://github.com/Wondertan)
 - [node: enhance DI allowing overriding of dependencies](https://github.com/celestiaorg/celestia-node/pull/290) [@Wondertan](https://github.com/Wondertan)

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -12,6 +12,7 @@ Month, DD, YYYY
 
 ### FEATURES
 
+- [node/config: add WithBootstrapPeers option #375](https://github.com/celestiaorg/celestia-node/pull/375) [@Bidon15](https://github.com/Bidon15)
 - [feat(cmd): give a birth to cel-shed and p2p key utilities #281](https://github.com/celestiaorg/celestia-node/pull/281) [@Wondertan](https://github.com/Wondertan)
 - [feat(cmd|node): MutualPeers Node option and CLI flag #280](https://github.com/celestiaorg/celestia-node/pull/280) [@Wondertan](https://github.com/Wondertan)
 - [node: enhance DI allowing overriding of dependencies](https://github.com/celestiaorg/celestia-node/pull/290) [@Wondertan](https://github.com/Wondertan)

--- a/node/bridge_test.go
+++ b/node/bridge_test.go
@@ -151,9 +151,32 @@ func TestBridge_WithMockedCoreClient(t *testing.T) {
 	err = node.Start(ctx)
 	require.NoError(t, err)
 
-	ctx, cancel = context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
 	err = node.Stop(ctx)
 	require.NoError(t, err)
+}
+
+func TestBridge_WithMutualPeers(t *testing.T) {
+	repo := MockStore(t, DefaultConfig(Bridge))
+	peers := []string{
+		"/ip6/100:0:114b:abc5:e13a:c32f:7a9e:f00a/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
+		"/ip4/192.168.1.10/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
+	}
+	node, err := New(Bridge, repo, WithMutualPeers(peers))
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	assert.Equal(t, node.Config.P2P.MutualPeers, peers)
+}
+
+func TestBridge_WithBootstrapPeers(t *testing.T) {
+	repo := MockStore(t, DefaultConfig(Bridge))
+	peers := []string{
+		"/ip6/100:0:114b:abc5:e13a:c32f:7a9e:f00a/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
+		"/ip4/192.168.1.10/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
+	}
+	node, err := New(Bridge, repo, WithBootstrapPeers(peers))
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	assert.Equal(t, node.Config.P2P.BootstrapPeers, peers)
 }

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -34,9 +34,18 @@ func WithConfig(custom *Config) Option {
 	}
 }
 
+// WithMutualPeers sets MutualPeers[] config.
 func WithMutualPeers(addrs []string) Option {
 	return func(cfg *Config, _ *settings) (_ error) {
 		cfg.P2P.MutualPeers = addrs
+		return nil
+	}
+}
+
+// WithBootstrapPeers sets BootstrapPeers[] config.
+func WithBootstrapPeers(addrs []string) Option {
+	return func(cfg *Config, _ *settings) (_ error) {
+		cfg.P2P.BootstrapPeers = addrs
 		return nil
 	}
 }

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -34,7 +34,7 @@ func WithConfig(custom *Config) Option {
 	}
 }
 
-// WithMutualPeers sets MutualPeers[] config.
+// WithMutualPeers sets the `MutualPeers` field in the config.
 func WithMutualPeers(addrs []string) Option {
 	return func(cfg *Config, _ *settings) (_ error) {
 		cfg.P2P.MutualPeers = addrs
@@ -42,7 +42,7 @@ func WithMutualPeers(addrs []string) Option {
 	}
 }
 
-// WithBootstrapPeers sets BootstrapPeers[] config.
+// WithBootstrapPeers sets the `BootstrapPeers` field in the config.
 func WithBootstrapPeers(addrs []string) Option {
 	return func(cfg *Config, _ *settings) (_ error) {
 		cfg.P2P.BootstrapPeers = addrs

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -62,3 +62,16 @@ func TestNewLightWithHost(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, node.Host.ID(), nw.Peers()[0])
 }
+
+func TestLight_WithBootstrapPeers(t *testing.T) {
+	repo := MockStore(t, DefaultConfig(Light))
+	peers := []string{
+		"/ip6/100:0:114b:abc5:e13a:c32f:7a9e:f00a/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
+		"/ip4/192.168.1.10/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
+	}
+	node, err := New(Light, repo, WithBootstrapPeers(peers))
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	assert.Equal(t, node.Config.P2P.BootstrapPeers, peers)
+}

--- a/node/light_test.go
+++ b/node/light_test.go
@@ -63,6 +63,19 @@ func TestNewLightWithHost(t *testing.T) {
 	assert.Equal(t, node.Host.ID(), nw.Peers()[0])
 }
 
+func TestLight_WithMutualPeers(t *testing.T) {
+	repo := MockStore(t, DefaultConfig(Light))
+	peers := []string{
+		"/ip6/100:0:114b:abc5:e13a:c32f:7a9e:f00a/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
+		"/ip4/192.168.1.10/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
+	}
+	node, err := New(Light, repo, WithMutualPeers(peers))
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	assert.Equal(t, node.Config.P2P.MutualPeers, peers)
+}
+
 func TestLight_WithBootstrapPeers(t *testing.T) {
 	repo := MockStore(t, DefaultConfig(Light))
 	peers := []string{


### PR DESCRIPTION
Add tests for WithMutualPeers and WithBootstrapPeers for both bridge/light types
Remove redundancy in WithMockClient test

This is needed for the swamp to initialise the light node with 2+ connections to bridge nodes
Resolves #372  