### PR TITLE
swamp: separate tendermint node creation from the swamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,13 @@ test-unit-race:
 ## test-swamp: Running swamp tests located in node/tests
 test-swamp:
 	@echo "--> Running swamp tests"
-	@go test -v ./node/tests/swamp
+	@go test -v ./node/tests
 .PHONY: test-swamp
 
 ## test-swamp: Running swamp tests with data race detector located in node/tests
 test-swamp-race:
 	@echo "--> Running swamp tests with data race detector"
-	@go test -v -race ./node/tests/swamp
+	@go test -v -race ./node/tests
 .PHONY: test-swamp-race
 
 ## test-all: Running both unit and swamp tests

--- a/node/tests/swamp/config.go
+++ b/node/tests/swamp/config.go
@@ -16,11 +16,11 @@ type Config struct {
 }
 
 // DefaultConfig creates a KvStore with a block retention of 200
-// In addition, the empty block interval is set to 100ms
+// In addition, the empty block interval is set to 200ms
 func DefaultConfig() *Config {
 	app := core.CreateKvStore(200)
 	tnCfg := tn.TestConfig()
-	tnCfg.Consensus.CreateEmptyBlocksInterval = 100 * time.Millisecond
+	tnCfg.Consensus.CreateEmptyBlocksInterval = 200 * time.Millisecond
 	return &Config{
 		App:     app,
 		CoreCfg: tnCfg,

--- a/node/tests/swamp/config.go
+++ b/node/tests/swamp/config.go
@@ -3,9 +3,10 @@ package swamp
 import (
 	"time"
 
-	"github.com/celestiaorg/celestia-node/core"
 	"github.com/tendermint/tendermint/abci/types"
 	tn "github.com/tendermint/tendermint/config"
+
+	"github.com/celestiaorg/celestia-node/core"
 )
 
 // Config struct represents a set of pre-requisite attributes from the test scenario

--- a/node/tests/swamp/config.go
+++ b/node/tests/swamp/config.go
@@ -1,0 +1,24 @@
+package swamp
+
+import (
+	"time"
+
+	"github.com/celestiaorg/celestia-node/core"
+	"github.com/tendermint/tendermint/abci/types"
+	tn "github.com/tendermint/tendermint/config"
+)
+
+type Config struct {
+	App     types.Application
+	CoreCfg *tn.Config
+}
+
+func DefaultConfig() *Config {
+	app := core.CreateKvStore(200)
+	tnCfg := tn.TestConfig()
+	tnCfg.Consensus.CreateEmptyBlocksInterval = 100 * time.Millisecond
+	return &Config{
+		App:     app,
+		CoreCfg: tnCfg,
+	}
+}

--- a/node/tests/swamp/config.go
+++ b/node/tests/swamp/config.go
@@ -8,11 +8,14 @@ import (
 	tn "github.com/tendermint/tendermint/config"
 )
 
+// Config struct represents a set of pre-requisite attributes from the test scenario
 type Config struct {
 	App     types.Application
 	CoreCfg *tn.Config
 }
 
+// DefaultConfig creates a KvStore with a block retention of 200
+// In addition, the empty block interval is set to 100ms
 func DefaultConfig() *Config {
 	app := core.CreateKvStore(200)
 	tnCfg := tn.TestConfig()

--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -80,9 +80,7 @@ func newTendermintCoreNode(cfg *Config) (*tn.Node, error) {
 	// rewriting the created config with test's one
 	tn.Config().Consensus = cfg.CoreCfg.Consensus
 
-	err := tn.Start()
-
-	return tn, err
+	return tn, tn.Start()
 }
 
 // stopAllNodes goes through all received slices of Nodes and stops one-by-one

--- a/node/tests/swamp/sync_test.go
+++ b/node/tests/swamp/sync_test.go
@@ -24,7 +24,11 @@ Steps:
 6. Check LN is synced with BN
 */
 func TestSyncLightWithBridge(t *testing.T) {
-	sw := NewSwamp(t)
+	tendermint, err1 := NewTendermintCoreNode(100, 100*time.Millisecond)
+	require.NoError(t, err1)
+
+	sw := NewSwamp(t, tendermint)
+
 	bridge := sw.NewBridgeNode()
 
 	ctx := context.Background()

--- a/node/tests/sync_test.go
+++ b/node/tests/sync_test.go
@@ -1,4 +1,4 @@
-package swamp
+package tests
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-node/node"
+	"github.com/celestiaorg/celestia-node/node/tests/swamp"
 )
 
 /*
@@ -24,10 +25,7 @@ Steps:
 6. Check LN is synced with BN
 */
 func TestSyncLightWithBridge(t *testing.T) {
-	tendermint, err1 := NewTendermintCoreNode(100, 100*time.Millisecond)
-	require.NoError(t, err1)
-
-	sw := NewSwamp(t, tendermint)
+	sw := swamp.NewSwamp(t, swamp.DefaultConfig())
 
 	bridge := sw.NewBridgeNode()
 


### PR DESCRIPTION
Adapting the sync test to this change

Resolves #371 #392 