### PR TITLE
service/header: SyncState

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -12,6 +12,7 @@ Month, DD, YYYY
 
 ### FEATURES
 
+- [service/header: SyncState #397](https://github.com/celestiaorg/celestia-node/pull/397) [@Wondertan](https://github.com/Wondertan)
 - [feat(service/header): HeightSub #428](https://github.com/celestiaorg/celestia-node/pull/428) [@Wondertan](https://github.com/Wondertan)
 - [params: Define Network Types #346](https://github.com/celestiaorg/celestia-node/pull/346) [@Wondertan](https://github.com/Wondertan)
 - [feat(cmd): give a birth to cel-shed and p2p key utilities #281](https://github.com/celestiaorg/celestia-node/pull/281) [@Wondertan](https://github.com/Wondertan)

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -83,6 +83,9 @@ type Store interface {
 	// Init initializes Store with the given head, meaning it is initialized with the genesis header.
 	Init(context.Context, *ExtendedHeader) error
 
+	// Height reports current height of the chain head.
+	Height() uint64
+
 	// Head returns the ExtendedHeader of the chain head.
 	Head(context.Context) (*ExtendedHeader, error)
 

--- a/service/header/p2p_exchange_test.go
+++ b/service/header/p2p_exchange_test.go
@@ -152,6 +152,10 @@ func (m *mockStore) Init(context.Context, *ExtendedHeader) error { return nil }
 func (m *mockStore) Start(context.Context) error                 { return nil }
 func (m *mockStore) Stop(context.Context) error                  { return nil }
 
+func (m *mockStore) Height() uint64 {
+	return uint64(m.headHeight)
+}
+
 func (m *mockStore) Head(context.Context) (*ExtendedHeader, error) {
 	return m.headers[m.headHeight], nil
 }

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -266,9 +266,13 @@ func (s *store) Append(ctx context.Context, headers ...*ExtendedHeader) (int, er
 		// it is important to do Pub after updating caches
 		// so cache is consistent with atomic Height counter on the heightSub
 		s.heightSub.Pub(verified...)
+
+		ln := len(verified)
+		head := verified[ln-1]
+		log.Infow("new head", "height", head.Height, "hash", head.Hash())
 		// we return an error here after writing,
 		// as there might be an invalid header in between of a given range
-		return len(verified), err
+		return ln, err
 	case <-s.writesDn:
 		return 0, errStoppedStore
 	case <-ctx.Done():

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -300,6 +300,7 @@ func (s *store) flushLoop() {
 			// TODO(@Wondertan): Should this be a fatal error case with os.Exit?
 			from, to := uint64(headers[0].Height), uint64(headers[len(headers)-1].Height)
 			log.Errorw("writing header batch", "from", from, "to", to)
+			continue
 		}
 		// reset pending
 		s.pending = s.pending[:0]

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -128,6 +128,10 @@ func (s *store) Stop(ctx context.Context) error {
 	return nil
 }
 
+func (s *store) Height() uint64 {
+	return s.heightSub.Height()
+}
+
 func (s *store) Head(ctx context.Context) (*ExtendedHeader, error) {
 	head, err := s.GetByHeight(ctx, s.heightSub.Height())
 	if err == nil {

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -294,7 +294,7 @@ func (s *Syncer) doSync(ctx context.Context, oldHead, newHead *ExtendedHeader) (
 	s.state.Start = time.Now()
 	s.stateLk.Unlock()
 
-	for processed := uint64(0); from < to; from += processed {
+	for processed := 0; from < to; from += uint64(processed) {
 		processed, err = s.processHeaders(ctx, from, to)
 		if err != nil && processed == 0 {
 			break
@@ -309,14 +309,13 @@ func (s *Syncer) doSync(ctx context.Context, oldHead, newHead *ExtendedHeader) (
 }
 
 // processHeaders gets and stores headers starting at the given 'from' height up to 'to' height - [from:to]
-func (s *Syncer) processHeaders(ctx context.Context, from, to uint64) (uint64, error) {
+func (s *Syncer) processHeaders(ctx context.Context, from, to uint64) (int, error) {
 	headers, err := s.findHeaders(ctx, from, to)
 	if err != nil {
 		return 0, err
 	}
 
-	ln, err := s.store.Append(ctx, headers...)
-	return uint64(ln), err
+	return s.store.Append(ctx, headers...)
 }
 
 // TODO(@Wondertan): Number of headers that can be requested at once. Either make this configurable or,

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -75,12 +75,10 @@ func (s *Syncer) Start(context.Context) error {
 }
 
 // Stop stops Syncer.
-func (s *Syncer) Stop(ctx context.Context) error {
-	defer func() {
-		s.cancel()
-		s.cancel = nil
-	}()
-	return s.WaitSync(ctx)
+func (s *Syncer) Stop(context.Context) error {
+	s.cancel()
+	s.cancel = nil
+	return nil
 }
 
 // IsSyncing returns the current sync status of the Syncer.

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -204,10 +204,6 @@ func (s *Syncer) processIncoming(ctx context.Context, maybeHead *ExtendedHeader)
 	default:
 		var verErr *VerifyError
 		if errors.As(err, &verErr) {
-			log.Errorw("invalid header",
-				"height", maybeHead.Height,
-				"hash", maybeHead.Hash(),
-				"reason", verErr.Reason)
 			return pubsub.ValidationReject
 		}
 

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -281,10 +281,10 @@ func (s *Syncer) syncTo(ctx context.Context, newHead *ExtendedHeader) {
 		return
 	}
 
-	log.Infow("synced headers",
+	log.Infow("finished syncing",
 		"from", head.Height,
 		"to", newHead.Height,
-		"took", s.state.End.Sub(s.state.Start))
+		"elapsed time", s.state.End.Sub(s.state.Start))
 }
 
 // doSync performs actual syncing updating the internal SyncState

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -88,14 +88,22 @@ func (s *Syncer) IsSyncing() bool {
 
 // SyncState collects all the information about o sync.
 type SyncState struct {
-	ID                           uint64
-	FromHeight, ToHeight, Height uint64
-	FromHash, ToHash             tmbytes.HexBytes
-	Start, End                   time.Time
-	Error                        error
+	ID                   uint64 // incrementing ID of a sync
+	Height               uint64 // height at the moment when State is requested for a sync
+	FromHeight, ToHeight uint64 // the starting and the ending point of a sync
+	FromHash, ToHash     tmbytes.HexBytes
+	Start, End           time.Time
+	Error                error // the error that might happen within a sync
+}
+
+// Finished is true whether a sync is done.
+func (s SyncState) Finished() bool {
+	return s.ToHeight == s.Height
 }
 
 // State reports state of current, if in progress, or last sync, if finished.
+// Note that throughout the whole Syncer lifetime there might an initial sync and multiple catch-ups.
+// All of them are treated as different syncs with different state IDs and other information.
 func (s *Syncer) State() SyncState {
 	s.stateLk.RLock()
 	defer s.stateLk.RUnlock()

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -115,7 +115,7 @@ func (s SyncState) Finished() bool {
 	return s.ToHeight == s.Height
 }
 
-// State reports state of current, if in progress, or last sync, if finished.
+// State reports state of the current (if in progress), or last sync (if finished).
 // Note that throughout the whole Syncer lifetime there might an initial sync and multiple catch-ups.
 // All of them are treated as different syncs with different state IDs and other information.
 func (s *Syncer) State() SyncState {

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -281,7 +281,7 @@ func (s *Syncer) syncTo(ctx context.Context, newHead *ExtendedHeader) {
 		return
 	}
 
-	log.Info("synced headers",
+	log.Infow("synced headers",
 		"from", head.Height,
 		"to", newHead.Height,
 		"took", s.state.End.Sub(s.state.Start))

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -90,6 +90,11 @@ func (s *Syncer) IsSyncing() bool {
 
 // WaitSync blocks until ongoing sync is done.
 func (s *Syncer) WaitSync(ctx context.Context) error {
+	state := s.State()
+	if state.Finished() {
+		return nil
+	}
+
 	// this store method blocks until header is available
 	_, err := s.store.GetByHeight(ctx, s.State().ToHeight)
 	return err

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -326,7 +326,7 @@ func (s *Syncer) doSync(ctx context.Context, oldHead, newHead *ExtendedHeader) (
 	return err
 }
 
-// processHeaders gets and stores the 'amount' number of headers going from the 'start' height.
+// processHeaders gets and stores the given 'amount' of headers starting at the given 'from' height.
 func (s *Syncer) processHeaders(ctx context.Context, from, amount uint64) (uint64, error) {
 	headers, err := s.getHeaders(ctx, from, amount)
 	if err != nil {

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -110,7 +110,7 @@ type SyncState struct {
 	Error                error // the error that might happen within a sync
 }
 
-// Finished is true whether a sync is done.
+// Finished returns true if sync is done, false otherwise.
 func (s SyncState) Finished() bool {
 	return s.ToHeight == s.Height
 }

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -266,6 +266,11 @@ func (s *Syncer) syncTo(ctx context.Context, newHead *ExtendedHeader) {
 		"to", newHead.Height)
 	err = s.doSync(ctx, head, newHead)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			// don't log this error as it is normal case of Syncer being stopped
+			return
+		}
+
 		log.Errorw("syncing headers",
 			"from", head.Height,
 			"to", newHead.Height,

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -100,7 +100,7 @@ func (s *Syncer) WaitSync(ctx context.Context) error {
 	return err
 }
 
-// SyncState collects all the information about o sync.
+// SyncState collects all the information about a sync.
 type SyncState struct {
 	ID                   uint64 // incrementing ID of a sync
 	Height               uint64 // height at the moment when State is requested for a sync

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -317,8 +317,9 @@ func (s *Syncer) doSync(ctx context.Context, oldHead, newHead *ExtendedHeader) (
 		s.stateLk.Unlock()
 	}
 
+	finHeight := from - 1 // minus one as we add one to the 'amount' in the loop above
 	s.stateLk.Lock()
-	s.state.Height = from - 1 // minus one as we add one to the amount above
+	s.state.Height = finHeight
 	s.state.End = time.Now()
 	s.state.Error = err
 	s.stateLk.Unlock()

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -43,6 +43,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	assert.Equal(t, uint64(exp.Height), syncer.State().Height)
 	assert.Equal(t, uint64(2), syncer.State().FromHeight)
 	assert.Equal(t, uint64(exp.Height), syncer.State().ToHeight)
+	assert.True(t, syncer.State().Finished())
 }
 
 func TestSyncCatchUp(t *testing.T) {
@@ -85,6 +86,7 @@ func TestSyncCatchUp(t *testing.T) {
 	assert.Equal(t, uint64(exp.Height+1), syncer.State().Height)
 	assert.Equal(t, uint64(2), syncer.State().FromHeight)
 	assert.Equal(t, uint64(exp.Height+1), syncer.State().ToHeight)
+	assert.True(t, syncer.State().Finished())
 }
 
 func TestSyncPendingRangesWithMisses(t *testing.T) {

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -40,6 +40,9 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, exp.Height, have.Height)
 	assert.Empty(t, syncer.pending.Head())
+	assert.Equal(t, uint64(exp.Height), syncer.State().Height)
+	assert.Equal(t, uint64(2), syncer.State().FromHeight)
+	assert.Equal(t, uint64(exp.Height), syncer.State().ToHeight)
 }
 
 func TestSyncCatchUp(t *testing.T) {
@@ -79,6 +82,9 @@ func TestSyncCatchUp(t *testing.T) {
 	// 4. assert syncer caught-up
 	assert.Equal(t, exp.Height+1, have.Height) // plus one as we didn't add last header to remoteStore
 	assert.Empty(t, syncer.pending.Head())
+	assert.Equal(t, uint64(exp.Height+1), syncer.State().Height)
+	assert.Equal(t, uint64(2), syncer.State().FromHeight)
+	assert.Equal(t, uint64(exp.Height+1), syncer.State().ToHeight)
 }
 
 func TestSyncPendingRangesWithMisses(t *testing.T) {


### PR DESCRIPTION
Mainly this PR provides an API to have a visibility of what is happening inside Syncer, via
* `State()` which shows detailed information of an ongoing sync
* `WaitSync` which allows waiting for an ongoing sync to finish
* Changes `Stop()` to wait for an ongoing sync to finish, before stopping the syncing.

Depends on #434
Closes: https://github.com/celestiaorg/celestia-node/issues/450, https://github.com/celestiaorg/celestia-node/issues/405