### PR TITLE
refactor(service/header): rework on disk writing strategy of the Store

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -21,7 +21,7 @@ Month, DD, YYYY
 - [swamp: initial structure of the tool](https://github.com/celestiaorg/celestia-node/pull/315) [@Bidon15](https://github.com/Bidon15)
 
 ### IMPROVEMENTS
-
+- [refactor(service/header): rework on disk writing strategy of the Store #431](https://github.com/celestiaorg/celestia-node/pull/431) [@Wondertan](https://github.com/Wondertan)
 - [refactor(service/header): extract store initialization from Syncer #430](https://github.com/celestiaorg/celestia-node/pull/430) [@Wondertan](https://github.com/Wondertan)
 - [header: hardening syncing logic #334](https://github.com/celestiaorg/celestia-node/pull/334) [@Wondertan](https://github.com/Wondertan)
 - [feat(params): add bootstrappers #399](https://github.com/celestiaorg/celestia-node/pull/399) [@Wondertan](https://github.com/Wondertan)

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -78,12 +78,15 @@ func HeaderP2PExchangeServer(lc fx.Lifecycle, host host.Host, store header.Store
 }
 
 // HeaderStore creates and initializes new header.Store.
-func HeaderStore(ds datastore.Batching) (header.Store, error) {
+func HeaderStore(lc fx.Lifecycle, ds datastore.Batching) (header.Store, error) {
 	store, err := header.NewStore(ds)
 	if err != nil {
 		return nil, err
 	}
-
+	lc.Append(fx.Hook{
+		OnStart: store.Start,
+		OnStop:  store.Stop,
+	})
 	return store, nil
 }
 

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -73,6 +73,13 @@ var (
 // Store encompasses the behavior necessary to store and retrieve ExtendedHeaders
 // from a node's local storage.
 type Store interface {
+	// Start starts the store.
+	Start(context.Context) error
+
+	// Stop stops the store by preventing further writes
+	// and waiting till the ongoing ones are done.
+	Stop(context.Context) error
+
 	// Init initializes Store with the given head, meaning it is initialized with the genesis header.
 	Init(context.Context, *ExtendedHeader) error
 

--- a/service/header/p2p_exchange_test.go
+++ b/service/header/p2p_exchange_test.go
@@ -149,6 +149,8 @@ func createStore(t *testing.T, numHeaders int) *mockStore {
 }
 
 func (m *mockStore) Init(context.Context, *ExtendedHeader) error { return nil }
+func (m *mockStore) Start(context.Context) error                 { return nil }
+func (m *mockStore) Stop(context.Context) error                  { return nil }
 
 func (m *mockStore) Head(context.Context) (*ExtendedHeader, error) {
 	return m.headers[m.headHeight], nil

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -25,7 +25,7 @@ var (
 // errStoppedStore is returned for attempted operations on a stopped store
 var errStoppedStore = errors.New("header: stopped store")
 
-// store implement Store interface for ExtendedHeader over Datastore.
+// store implements the Store interface for ExtendedHeaders over Datastore.
 type store struct {
 	// header storing
 	//

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -46,7 +46,7 @@ type store struct {
 	//
 	// queued of header ranges to be written
 	writes chan []*ExtendedHeader
-	// signals writes being done
+	// signals when writes are finished
 	writesDn chan struct{}
 	// pending keeps headers pending to be written in a batch
 	pending []*ExtendedHeader

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -60,13 +60,13 @@ func NewStore(ds datastore.Batching) (Store, error) {
 }
 
 // NewStoreWithHead initiates a new Store and forcefully sets a given trusted header as head.
-func NewStoreWithHead(ds datastore.Batching, head *ExtendedHeader) (Store, error) {
+func NewStoreWithHead(ctx context.Context, ds datastore.Batching, head *ExtendedHeader) (Store, error) {
 	store, err := newStore(ds)
 	if err != nil {
 		return nil, err
 	}
 
-	return store, store.Init(context.TODO(), head)
+	return store, store.Init(ctx, head)
 }
 
 func newStore(ds datastore.Batching) (*store, error) {

--- a/service/header/store.go
+++ b/service/header/store.go
@@ -22,7 +22,7 @@ var (
 	DefaultWriteBatchSize = 2048
 )
 
-// errStoppedStore is returned on operations over stopped store
+// errStoppedStore is returned for attempted operations on a stopped store
 var errStoppedStore = errors.New("header: stopped store")
 
 // store implement Store interface for ExtendedHeader over Datastore.

--- a/service/header/store_height_indexer.go
+++ b/service/header/store_height_indexer.go
@@ -49,14 +49,5 @@ func (hi *heightIndexer) Index(headers ...*ExtendedHeader) error {
 		}
 	}
 
-	err = batch.Commit()
-	if err != nil {
-		return err
-	}
-
-	// update the cache only after indexes are written to the disk
-	for _, h := range headers {
-		hi.cache.Add(h.Height, h.Hash())
-	}
-	return nil
+	return batch.Commit()
 }

--- a/service/header/store_height_indexer.go
+++ b/service/header/store_height_indexer.go
@@ -35,13 +35,8 @@ func (hi *heightIndexer) HashByHeight(h uint64) (tmbytes.HexBytes, error) {
 	return hi.ds.Get(heightKey(h))
 }
 
-// Index saves mapping between header Height and Hash.
-func (hi *heightIndexer) Index(headers ...*ExtendedHeader) error {
-	batch, err := hi.ds.Batch()
-	if err != nil {
-		return err
-	}
-
+// IndexTo saves mapping between header Height and Hash to the given batch.
+func (hi *heightIndexer) IndexTo(batch datastore.Batch, headers ...*ExtendedHeader) error {
 	for _, h := range headers {
 		err := batch.Put(heightKey(uint64(h.Height)), h.Hash())
 		if err != nil {
@@ -49,5 +44,5 @@ func (hi *heightIndexer) Index(headers ...*ExtendedHeader) error {
 		}
 	}
 
-	return batch.Commit()
+	return nil
 }

--- a/service/header/store_heightsub.go
+++ b/service/header/store_heightsub.go
@@ -71,7 +71,7 @@ func (hs *heightSub) Pub(headers ...*ExtendedHeader) {
 	height := hs.Height()
 	from, to := uint64(headers[0].Height), uint64(headers[len(headers)-1].Height)
 	if height+1 != from {
-		log.Fatal("PLEASE REPORT THE BUG: headers given to the heightSub are in the wrong order")
+		log.Fatal("PLEASE FILE A BUG REPORT: headers given to the heightSub are in the wrong order")
 		return
 	}
 	hs.SetHeight(to)

--- a/service/header/store_heightsub_test.go
+++ b/service/header/store_heightsub_test.go
@@ -18,6 +18,7 @@ func TestHeightSub(t *testing.T) {
 	{
 		h := RandExtendedHeader(t)
 		h.Height = 100
+		hs.SetHeight(99)
 		hs.Pub(h)
 
 		h, err := hs.Sub(ctx, 10)

--- a/service/header/store_test.go
+++ b/service/header/store_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,19 +13,17 @@ import (
 
 func TestStore(t *testing.T) {
 	// Alter Cache sizes to read some values from datastore instead of only cache.
-	DefaultStoreCacheSize, DefaultStoreCacheSize = 5, 5
+	// 	DefaultStoreCacheSize, DefaultStoreCacheSize = 5, 5
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	suite := NewTestSuite(t, 3)
-
-	store, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), suite.Head())
-	require.NoError(t, err)
+	store := NewTestStore(ctx, t, suite.Head())
 
 	head, err := store.Head(ctx)
 	require.NoError(t, err)
-	assert.EqualValues(t, suite.Head(), head)
+	assert.EqualValues(t, suite.Head().Hash(), head.Hash())
 
 	in := suite.GenExtendedHeaders(10)
 	err = store.Append(ctx, in...)

--- a/service/header/store_test.go
+++ b/service/header/store_test.go
@@ -20,7 +20,7 @@ func TestStore(t *testing.T) {
 	suite := NewTestSuite(t, 3)
 
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
-	store, err := NewStoreWithHead(ds, suite.Head())
+	store, err := NewStoreWithHead(ctx, ds, suite.Head())
 	require.NoError(t, err)
 
 	err = store.Start(ctx)

--- a/service/header/store_test.go
+++ b/service/header/store_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -12,14 +14,17 @@ import (
 )
 
 func TestStore(t *testing.T) {
-	// Alter Cache sizes to read some values from datastore instead of only cache.
-	// 	DefaultStoreCacheSize, DefaultStoreCacheSize = 5, 5
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
 
 	suite := NewTestSuite(t, 3)
-	store := NewTestStore(ctx, t, suite.Head())
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	store, err := NewStoreWithHead(ds, suite.Head())
+	require.NoError(t, err)
+
+	err = store.Start(ctx)
+	require.NoError(t, err)
 
 	head, err := store.Head(ctx)
 	require.NoError(t, err)
@@ -55,4 +60,26 @@ func TestStore(t *testing.T) {
 	h, err := store.GetByHeight(ctx, 12)
 	require.NoError(t, err)
 	assert.NotNil(t, h)
+
+	err = store.Stop(ctx)
+	require.NoError(t, err)
+
+	// check that the store can be successfully started after previous stop
+	// with all data being flushed.
+	store, err = NewStore(ds)
+	require.NoError(t, err)
+
+	err = store.Start(ctx)
+	require.NoError(t, err)
+
+	head, err = store.Head(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, suite.Head().Hash(), head.Hash())
+
+	out, err = store.GetRangeByHeight(ctx, 1, 13)
+	require.NoError(t, err)
+	assert.Len(t, out, 12)
+
+	err = store.Stop(ctx)
+	require.NoError(t, err)
 }

--- a/service/header/testing.go
+++ b/service/header/testing.go
@@ -24,7 +24,7 @@ import (
 
 // NewTestStore creates initialized and started in memory header Store which is useful for testing.
 func NewTestStore(ctx context.Context, t *testing.T, head *ExtendedHeader) Store {
-	store, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
+	store, err := NewStoreWithHead(ctx, sync.MutexWrap(datastore.NewMapDatastore()), head)
 	require.NoError(t, err)
 
 	err = store.Start(ctx)

--- a/service/header/testing.go
+++ b/service/header/testing.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/crypto/tmhash"
@@ -19,6 +21,21 @@ import (
 	"github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
 )
+
+// NewTestStore creates initialized and started in memory header Store which is useful for testing.
+func NewTestStore(ctx context.Context, t *testing.T, head *ExtendedHeader) Store {
+	store, err := NewStoreWithHead(sync.MutexWrap(datastore.NewMapDatastore()), head)
+	require.NoError(t, err)
+
+	err = store.Start(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := store.Stop(ctx)
+		require.NoError(t, err)
+	})
+	return store
+}
 
 // TestSuite provides everything you need to test chain of Headers.
 // If not, please don't hesitate to extend it for your case.


### PR DESCRIPTION
The PR makes all the writing to Store happen through writeLoop in a separate routine so that
	* Appends are not blocked by long disk IO writes and DB compactions
	* We can batch header writes
	
Also, this PR makes Append writes atomic. Meaning that all the required writes are done in one single batch. Previously, each Append did 3 full io write requests to the disk for:
* Headers themselves
* Highest head reference
* Height indices
Now we make all these writes atomically in one io write additionally to collecting multiple Appends in one big append, leading to a way lesser io writes.
	
Based on #430 
Closes https://github.com/celestiaorg/celestia-node/issues/448

Review commit by commit