### PR TITLE
perf(services/header): increase Store caches sizes

### DIFF
--- a/service/header/store.go
+++ b/service/header/store.go
@@ -16,9 +16,9 @@ import (
 // TODO(@Wondertan): Those values must be configurable and proper defaults should be set for specific node type.
 var (
 	// DefaultStoreCacheSize defines the amount of max entries allowed in the Header Store cache.
-	DefaultStoreCacheSize = 1024
+	DefaultStoreCacheSize = 10240
 	// DefaultIndexCacheSize defines the amount of max entries allowed in the Height to Hash index cache.
-	DefaultIndexCacheSize = 256
+	DefaultIndexCacheSize = 2048
 )
 
 type store struct {


### PR DESCRIPTION
Note that I have no idea how to calculate a universal value for cache sizes in our case, so this is mostly playing around and experimenting based on a feeling that the initial values are too conservative.