### PR TITLE
feat(service/header): update Store.Append to return amount of applied/valid headers 

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -21,6 +21,7 @@ Month, DD, YYYY
 - [swamp: initial structure of the tool](https://github.com/celestiaorg/celestia-node/pull/315) [@Bidon15](https://github.com/Bidon15)
 
 ### IMPROVEMENTS
+- [feat(service/header): update Store.Append to return amount of applied/valid headers #434](https://github.com/celestiaorg/celestia-node/pull/434) [@Wondertan](https://github.com/Wondertan)
 - [refactor(service/header): rework on disk writing strategy of the Store #431](https://github.com/celestiaorg/celestia-node/pull/431) [@Wondertan](https://github.com/Wondertan)
 - [refactor(service/header): extract store initialization from Syncer #430](https://github.com/celestiaorg/celestia-node/pull/430) [@Wondertan](https://github.com/Wondertan)
 - [header: hardening syncing logic #334](https://github.com/celestiaorg/celestia-node/pull/334) [@Wondertan](https://github.com/Wondertan)

--- a/service/header/interface.go
+++ b/service/header/interface.go
@@ -99,6 +99,9 @@ type Store interface {
 	Has(context.Context, tmbytes.HexBytes) (bool, error)
 
 	// Append stores and verifies the given ExtendedHeader(s).
-	// It requires them to be adjacent and in ascending order.
-	Append(context.Context, ...*ExtendedHeader) error
+	// It requires them to be adjacent and in ascending order,
+	// as it applies them contiguously on top of the current head height.
+	// It returns the amount of successfully applied headers,
+	// so caller can understand what given header was invalid, if any.
+	Append(context.Context, ...*ExtendedHeader) (int, error)
 }

--- a/service/header/p2p_exchange_test.go
+++ b/service/header/p2p_exchange_test.go
@@ -182,7 +182,7 @@ func (m *mockStore) Has(context.Context, tmbytes.HexBytes) (bool, error) {
 	return false, nil
 }
 
-func (m *mockStore) Append(ctx context.Context, headers ...*ExtendedHeader) error {
+func (m *mockStore) Append(ctx context.Context, headers ...*ExtendedHeader) (int, error) {
 	for _, header := range headers {
 		m.headers[header.Height] = header
 		// set head
@@ -190,5 +190,5 @@ func (m *mockStore) Append(ctx context.Context, headers ...*ExtendedHeader) erro
 			m.headHeight = header.Height
 		}
 	}
-	return nil
+	return len(headers), nil
 }

--- a/service/header/store_test.go
+++ b/service/header/store_test.go
@@ -31,8 +31,9 @@ func TestStore(t *testing.T) {
 	assert.EqualValues(t, suite.Head().Hash(), head.Hash())
 
 	in := suite.GenExtendedHeaders(10)
-	err = store.Append(ctx, in...)
+	ln, err := store.Append(ctx, in...)
 	require.NoError(t, err)
+	assert.Equal(t, 10, ln)
 
 	out, err := store.GetRangeByHeight(ctx, 2, 12)
 	require.NoError(t, err)
@@ -53,8 +54,9 @@ func TestStore(t *testing.T) {
 	assert.False(t, ok)
 
 	go func() {
-		err := store.Append(ctx, suite.GenExtendedHeaders(1)...)
+		ln, err := store.Append(ctx, suite.GenExtendedHeaders(1)...)
 		require.NoError(t, err)
+		assert.Equal(t, 1, ln)
 	}()
 
 	h, err := store.GetByHeight(ctx, 12)

--- a/service/header/sync.go
+++ b/service/header/sync.go
@@ -152,7 +152,7 @@ func (s *Syncer) sync(ctx context.Context) {
 // processIncoming processes new processIncoming Headers, validates them and stores/caches if applicable.
 func (s *Syncer) processIncoming(ctx context.Context, maybeHead *ExtendedHeader) pubsub.ValidationResult {
 	// 1. Try to append. If header is not adjacent/from future - try it for pending cache below
-	err := s.store.Append(ctx, maybeHead)
+	_, err := s.store.Append(ctx, maybeHead)
 	switch err {
 	case nil:
 		// a happy case where we append adjacent header correctly
@@ -243,12 +243,12 @@ func (s *Syncer) syncTo(ctx context.Context, newHead *ExtendedHeader) error {
 			return err
 		}
 
-		err = s.store.Append(ctx, headers...)
+		ln, err := s.store.Append(ctx, headers...)
 		if err != nil {
 			return err
 		}
 
-		start += uint64(len(headers))
+		start += uint64(ln)
 	}
 
 	return nil

--- a/service/header/sync_test.go
+++ b/service/header/sync_test.go
@@ -22,7 +22,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	head := suite.Head()
 
 	remoteStore := NewTestStore(ctx, t, head)
-	err := remoteStore.Append(ctx, suite.GenExtendedHeaders(100)...)
+	_, err := remoteStore.Append(ctx, suite.GenExtendedHeaders(100)...)
 	require.NoError(t, err)
 
 	localStore := NewTestStore(ctx, t, head)
@@ -60,7 +60,7 @@ func TestSyncCatchUp(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. chain grows and syncer misses that
-	err = remoteStore.Append(ctx, suite.GenExtendedHeaders(100)...)
+	_, err = remoteStore.Append(ctx, suite.GenExtendedHeaders(100)...)
 	require.NoError(t, err)
 
 	// 3. syncer rcvs header from the future and starts catching-up
@@ -98,19 +98,19 @@ func TestSyncPendingRangesWithMisses(t *testing.T) {
 	require.NoError(t, err)
 
 	// miss 1 (helps to test that Syncer properly requests missed Headers from Exchange)
-	err = remoteStore.Append(ctx, suite.GenExtendedHeaders(1)...)
+	_, err = remoteStore.Append(ctx, suite.GenExtendedHeaders(1)...)
 	require.NoError(t, err)
 
 	range1 := suite.GenExtendedHeaders(15)
-	err = remoteStore.Append(ctx, range1...)
+	_, err = remoteStore.Append(ctx, range1...)
 	require.NoError(t, err)
 
 	// miss 2
-	err = remoteStore.Append(ctx, suite.GenExtendedHeaders(3)...)
+	_, err = remoteStore.Append(ctx, suite.GenExtendedHeaders(3)...)
 	require.NoError(t, err)
 
 	range2 := suite.GenExtendedHeaders(23)
-	err = remoteStore.Append(ctx, range2...)
+	_, err = remoteStore.Append(ctx, range2...)
 	require.NoError(t, err)
 
 	// manually add to pending


### PR DESCRIPTION
Currently, Store allows passing via Append partially valid header ranges, but it doesn't report back how many headers were applied, so the caller can react accordingly. This PR provides this by changing the Append method.

Based on #431 
Closes https://github.com/celestiaorg/celestia-node/issues/451

Review commit by commit