### PR TITLE
swamp: Add store method to node creation

### DIFF
--- a/node/tests/swamp/config.go
+++ b/node/tests/swamp/config.go
@@ -9,19 +9,19 @@ import (
 	"github.com/celestiaorg/celestia-node/core"
 )
 
-// InfraComponents struct represents a set of pre-requisite attributes from the test scenario
-type InfraComponents struct {
+// Components struct represents a set of pre-requisite attributes from the test scenario
+type Components struct {
 	App     types.Application
 	CoreCfg *tn.Config
 }
 
-// DefaultInfraComponents creates a KvStore with a block retention of 200
+// DefaultComponents creates a KvStore with a block retention of 200
 // In addition, the empty block interval is set to 200ms
-func DefaultInfraComponents() *InfraComponents {
+func DefaultComponents() *Components {
 	app := core.CreateKvStore(200)
 	tnCfg := tn.TestConfig()
 	tnCfg.Consensus.CreateEmptyBlocksInterval = 200 * time.Millisecond
-	return &InfraComponents{
+	return &Components{
 		App:     app,
 		CoreCfg: tnCfg,
 	}

--- a/node/tests/swamp/config.go
+++ b/node/tests/swamp/config.go
@@ -9,19 +9,19 @@ import (
 	"github.com/celestiaorg/celestia-node/core"
 )
 
-// Config struct represents a set of pre-requisite attributes from the test scenario
-type Config struct {
+// InfraComps struct represents a set of pre-requisite attributes from the test scenario
+type InfraComps struct {
 	App     types.Application
 	CoreCfg *tn.Config
 }
 
-// DefaultConfig creates a KvStore with a block retention of 200
+// DefaultInfraComps creates a KvStore with a block retention of 200
 // In addition, the empty block interval is set to 200ms
-func DefaultConfig() *Config {
+func DefaultInfraComps() *InfraComps {
 	app := core.CreateKvStore(200)
 	tnCfg := tn.TestConfig()
 	tnCfg.Consensus.CreateEmptyBlocksInterval = 200 * time.Millisecond
-	return &Config{
+	return &InfraComps{
 		App:     app,
 		CoreCfg: tnCfg,
 	}

--- a/node/tests/swamp/config.go
+++ b/node/tests/swamp/config.go
@@ -9,19 +9,19 @@ import (
 	"github.com/celestiaorg/celestia-node/core"
 )
 
-// InfraComps struct represents a set of pre-requisite attributes from the test scenario
-type InfraComps struct {
+// InfraComponents struct represents a set of pre-requisite attributes from the test scenario
+type InfraComponents struct {
 	App     types.Application
 	CoreCfg *tn.Config
 }
 
-// DefaultInfraComps creates a KvStore with a block retention of 200
+// DefaultInfraComponents creates a KvStore with a block retention of 200
 // In addition, the empty block interval is set to 200ms
-func DefaultInfraComps() *InfraComps {
+func DefaultInfraComponents() *InfraComponents {
 	app := core.CreateKvStore(200)
 	tnCfg := tn.TestConfig()
 	tnCfg.Consensus.CreateEmptyBlocksInterval = 200 * time.Millisecond
-	return &InfraComps{
+	return &InfraComponents{
 		App:     app,
 		CoreCfg: tnCfg,
 	}

--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -43,7 +43,7 @@ type Swamp struct {
 }
 
 // NewSwamp creates a new instance of Swamp.
-func NewSwamp(t *testing.T, ic *InfraComponents) *Swamp {
+func NewSwamp(t *testing.T, ic *Components) *Swamp {
 	if testing.Verbose() {
 		log.SetDebugLogging()
 	}
@@ -76,14 +76,14 @@ func NewSwamp(t *testing.T, ic *InfraComponents) *Swamp {
 // instead we are assigning all created BNs to 1 Core from the swamp
 
 // newTendermintCoreNode creates a new instance of Tendermint Core with a kvStore
-func newTendermintCoreNode(ic *InfraComponents) (*tn.Node, error) {
+func newTendermintCoreNode(c *Components) (*tn.Node, error) {
 	var opt rpctest.Options
 	rpctest.RecreateConfig(&opt)
 
-	tn := rpctest.NewTendermint(ic.App, &opt)
+	tn := rpctest.NewTendermint(c.App, &opt)
 
 	// rewriting the created config with test's one
-	tn.Config().Consensus = ic.CoreCfg.Consensus
+	tn.Config().Consensus = c.CoreCfg.Consensus
 
 	return tn, tn.Start()
 }

--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -43,7 +43,7 @@ type Swamp struct {
 }
 
 // NewSwamp creates a new instance of Swamp.
-func NewSwamp(t *testing.T, ic *InfraComps) *Swamp {
+func NewSwamp(t *testing.T, ic *InfraComponents) *Swamp {
 	if testing.Verbose() {
 		log.SetDebugLogging()
 	}
@@ -76,7 +76,7 @@ func NewSwamp(t *testing.T, ic *InfraComps) *Swamp {
 // instead we are assigning all created BNs to 1 Core from the swamp
 
 // newTendermintCoreNode creates a new instance of Tendermint Core with a kvStore
-func newTendermintCoreNode(ic *InfraComps) (*tn.Node, error) {
+func newTendermintCoreNode(ic *InfraComponents) (*tn.Node, error) {
 	var opt rpctest.Options
 	rpctest.RecreateConfig(&opt)
 

--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -186,7 +186,7 @@ func (s *Swamp) NewLightNode(options ...node.Option) *node.Node {
 }
 
 // NewBridgeNodeWithStore creates a new instance of BridgeNodes with predefined Store.
-// Afterwards, the instance is store in the swamp's BridgeNodes slice.
+// Afterwards, the instance is stored in the swamp's BridgeNodes slice.
 func (s *Swamp) NewBridgeNodeWithStore(store node.Store, options ...node.Option) *node.Node {
 	ks, err := store.Keystore()
 	require.NoError(s.t, err)
@@ -207,7 +207,7 @@ func (s *Swamp) NewBridgeNodeWithStore(store node.Store, options ...node.Option)
 }
 
 // NewLightNodeWithStore creates a new instance of LightNode with predefined Store.
-// Afterwards, the instance is store in the swamp's LightNodes slice
+// Afterwards, the instance is stored in the swamp's LightNodes slice
 func (s *Swamp) NewLightNodeWithStore(store node.Store, options ...node.Option) *node.Node {
 	ks, err := store.Keystore()
 	require.NoError(s.t, err)

--- a/node/tests/sync_test.go
+++ b/node/tests/sync_test.go
@@ -25,7 +25,7 @@ Steps:
 6. Check LN is synced with BN
 */
 func TestSyncLightWithBridge(t *testing.T) {
-	sw := swamp.NewSwamp(t, swamp.DefaultConfig())
+	sw := swamp.NewSwamp(t, swamp.DefaultInfraComps())
 
 	bridge := sw.NewBridgeNode()
 

--- a/node/tests/sync_test.go
+++ b/node/tests/sync_test.go
@@ -25,7 +25,7 @@ Steps:
 6. Check LN is synced with BN
 */
 func TestSyncLightWithBridge(t *testing.T) {
-	sw := swamp.NewSwamp(t, swamp.DefaultInfraComponents())
+	sw := swamp.NewSwamp(t, swamp.DefaultComponents())
 
 	bridge := sw.NewBridgeNode()
 

--- a/node/tests/sync_test.go
+++ b/node/tests/sync_test.go
@@ -25,7 +25,7 @@ Steps:
 6. Check LN is synced with BN
 */
 func TestSyncLightWithBridge(t *testing.T) {
-	sw := swamp.NewSwamp(t, swamp.DefaultInfraComps())
+	sw := swamp.NewSwamp(t, swamp.DefaultInfraComponents())
 
 	bridge := sw.NewBridgeNode()
 


### PR DESCRIPTION
- move test from swamp to tests dir
  - adapt makefile to new changes in dir test placement
- rename config to infracomps
- use coreclient with swamp subscription id instead of blockfetcher

We need store to successfully save the state of node in order to start/stop the existing node

Relates to #370 