### PR TITLE
ipld: retrieve data starting from root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/tendermint/tendermint v0.34.14
 	go.uber.org/fx v1.16.0
 	go.uber.org/zap v1.21.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,6 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/tendermint/tendermint v0.34.14
 	go.uber.org/fx v1.16.0
 	go.uber.org/zap v1.21.0
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 require (

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -3,8 +3,6 @@ package ipld
 import (
 	"context"
 	"errors"
-	"fmt"
-	"math/rand"
 
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -20,285 +18,130 @@ import (
 
 var ErrRetrieveTimeout = errors.New("retrieve data timeout")
 
+type totalShares struct {
+	data [][]byte
+	err  chan error
+}
+
 // RetrieveData asynchronously fetches block data using the minimum number
 // of requests to IPFS. It fails if one of the random samples sampled is not available.
 func RetrieveData(
-	ctx context.Context,
+	parentCtx context.Context,
 	dah *da.DataAvailabilityHeader,
 	dag ipld.NodeGetter,
 	codec rsmt2d.Codec,
 ) (*rsmt2d.ExtendedDataSquare, error) {
 	edsWidth := len(dah.RowsRoots)
-	sc := newshareCounter(ctx, uint32(edsWidth))
-	// convert the row and col roots into Cids
 	rowRoots := dah.RowsRoots
 	colRoots := dah.ColumnRoots
-	// sample 1/4 of the total extended square by sampling half of the leaves in
-	// half of the rows.
-	// Sampling is done randomly here in an effort to increase
-	// resilience when the downloading node is also serving the shares back to
-	// the network. // TODO @renaynay: this should probably eventually change to
-	// just downloading the first half.
-	for _, row := range uniqueRandNumbers(edsWidth/2, edsWidth) {
-		for _, col := range uniqueRandNumbers(edsWidth/2, edsWidth) {
-			rootCid, err := plugin.CidFromNamespacedSha256(rowRoots[row])
+	shares := &totalShares{
+		data: make([][]byte, edsWidth*edsWidth),
+		err:  make(chan error),
+	}
+
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	go fillBlockWithData(ctx, rowRoots, dag, true, shares)
+	go fillBlockWithData(ctx, colRoots, dag, false, shares)
+
+	for i := 0; i < len(dah.RowsRoots); i++ {
+		select {
+		case err := <-shares.err:
 			if err != nil {
 				return nil, err
 			}
-			go sc.retrieveShare(rootCid, true, row, col, dag)
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
-	// wait until enough data has been collected, too many errors encountered,
-	// or the timeout is reached
-	err := sc.wait()
-	if err != nil {
-		return nil, err
-	}
-	// flatten the square
-	flattened := sc.flatten()
-	// repair the square
+
 	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(edsWidth) / 2)
-	return rsmt2d.RepairExtendedDataSquare(rowRoots, colRoots, flattened, codec, tree.Constructor)
+	return rsmt2d.RepairExtendedDataSquare(rowRoots, colRoots, shares.data, codec, tree.Constructor)
 }
 
-func RetrieveDataExt(
+// fillBlockWithData fetches 1/4 of shares for the given root
+func fillBlockWithData(
 	ctx context.Context,
-	dah *da.DataAvailabilityHeader,
-	dag ipld.NodeGetter,
-	codec rsmt2d.Codec,
-) (*rsmt2d.ExtendedDataSquare, error) {
-	edsWidth := len(dah.RowsRoots)
-	rowRoots := dah.RowsRoots
-	colRoots := dah.ColumnRoots
+	data [][]byte, dag ipld.NodeGetter,
+	isRow bool,
+	f *totalShares,
+) {
+	for i := 0; i < len(data)/2; i++ {
+		go func(i int) {
+			rootHash, err := plugin.CidFromNamespacedSha256(data[i])
+			if err != nil {
+				f.err <- err
+				return
+			}
+			subtreeRootHash, err := getHalfTreeNodeHash(ctx, rootHash, dag, true)
+			if err != nil {
+				f.err <- err
+				return
+			}
 
-	sc := newshareCounter(ctx, uint32(edsWidth))
-	go fillTheBlock(ctx, colRoots, false, dag, sc)
-	go fillTheBlock(ctx, rowRoots, true, dag, sc)
-	err := sc.wait()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	// flatten the square
-	flattened := sc.flatten()
-	fmt.Println(len(flattened))
-	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(edsWidth) / 2)
-	return rsmt2d.RepairExtendedDataSquare(rowRoots, colRoots, flattened, codec, tree.Constructor)
-}
-
-func fillTheBlock(ctx context.Context, data [][]byte, isRow bool, dag ipld.NodeGetter, sc *shareCounter) {
-	numbers := make([]uint32, 0)
-	if isRow {
-		numbers = uniqueRandNumbers(int(sc.edsWidth/4), int(sc.edsWidth))
-	} else {
-		numbers = uniqueNumbersInRange(int(sc.edsWidth/2), int(sc.edsWidth), int(sc.edsWidth/4))
-	}
-	for _, number := range numbers {
-		go func(number uint32) {
-			rootCid, _ := plugin.CidFromNamespacedSha256(data[number])
-			leafs, _ := GetLeafsExt(ctx, dag, rootCid, int(sc.edsWidth/4))
-			for leafIndex, l := range leafs {
-				data := l.RawData()[1:]
+			leafs, err := GetLeafs(ctx, dag, *subtreeRootHash)
+			if err != nil {
+				f.err <- err
+				return
+			}
+			for leafIdx, leaf := range leafs {
+				shareData := leaf.RawData()[1:]
+				// it's not needed to store data for cols
+				// as we are fetching data from the same share for rows and cols
 				if isRow {
-					sc.shareChan <- indexedShare{data: data[NamespaceSize:], index: index{row: uint32(number), col: uint32(leafIndex)}}
-				} else {
-					sc.shareChan <- indexedShare{data: data[NamespaceSize:], index: index{row: uint32(leafIndex), col: uint32(number)}}
+					f.data[(i*len(data))+leafIdx] = shareData[NamespaceSize:]
 				}
 			}
-		}(number)
+			f.err <- nil
+		}(i)
 	}
 }
 
-func GetLeafsExt(
-	ctx context.Context,
-	dag ipld.NodeGetter,
-	root cid.Cid,
-	maxDepth int,
-) (leafs []ipld.Node, err error) {
+// getHalfTreeNodeHash returns only one subtree - left or right
+func getHalfTreeNodeHash(ctx context.Context, root cid.Cid, dag ipld.NodeGetter, isLeftSubtree bool) (*cid.Cid, error) {
 	nd, err := dag.Get(ctx, root)
 	if err != nil {
 		return nil, err
 	}
-	if maxDepth == 0 {
-		leafs = append(leafs, nd)
-		return
-	}
 	links := nd.Links()
-	if len(links) == 1 {
+	if isLeftSubtree || len(links) == 1 {
+		return &links[0].Cid, nil
+	}
+
+	return &links[1].Cid, nil
+}
+
+// GetLeafs recursively starts going down to find all leafs from the given root
+func GetLeafs(ctx context.Context, dag ipld.NodeGetter, root cid.Cid) (leafs []ipld.Node, err error) {
+	// request the node
+	nd, err := dag.Get(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	// look for links
+	lnks := nd.Links()
+	if len(lnks) == 1 {
+		// in case there is only one we reached tree's bottom, so finally request the leaf.
+		nd, err = dag.Get(ctx, lnks[0].Cid)
+		if err != nil {
+			return nil, err
+		}
 		leafs = append(leafs, nd)
 		return
 	}
-	newDep := maxDepth / 2
-	for _, leaf := range links {
-		l, err := GetLeafsExt(ctx, dag, leaf.Cid, newDep)
+
+	for _, node := range lnks {
+		// recursively walk down through selected children to get the leafs
+		l, err := GetLeafs(ctx, dag, node.Cid)
 		if err != nil {
 			return nil, err
 		}
 
 		leafs = append(leafs, l...)
 	}
-	return leafs, nil
-}
-
-func uniqueNumbersInRange(from, to, count int) []uint32 {
-	samples := make(map[uint32]struct{}, count)
-	for i := 0; i < count; {
-		sample := uint32(rand.Intn(to-from) + from)
-		if _, has := samples[sample]; has {
-			continue
-		}
-		samples[sample] = struct{}{}
-		i++
-	}
-	out := make([]uint32, count)
-	counter := 0
-	for s := range samples {
-		out[counter] = s
-		counter++
-	}
-	return out
-}
-
-// uniqueRandNumbers generates count unique random numbers with a max of max
-func uniqueRandNumbers(count, max int) []uint32 {
-	if count > max {
-		panic(fmt.Sprintf("cannot create %d unique samples from a max of %d", count, max))
-	}
-	samples := make(map[uint32]struct{}, count)
-	for i := 0; i < count; {
-		// nolint:gosec // G404: Use of weak random number generator
-		sample := uint32(rand.Intn(max))
-		if _, has := samples[sample]; has {
-			continue
-		}
-		samples[sample] = struct{}{}
-		i++
-	}
-	out := make([]uint32, count)
-	counter := 0
-	for s := range samples {
-		out[counter] = s
-		counter++
-	}
-	return out
-}
-
-type index struct {
-	row uint32
-	col uint32
-}
-
-type indexedShare struct {
-	data []byte
-	index
-}
-
-// shareCounter is a thread safe tallying mechanism for share retrieval
-type shareCounter struct {
-	// all shares
-	shares map[index][]byte
-	// number of shares successfully collected
-	counter uint32
-	// the width of the extended data square
-	edsWidth uint32
-	// the minimum shares needed to repair the extended data square
-	minSharesNeeded uint32
-
-	shareChan chan indexedShare
-	ctx       context.Context
-	cancel    context.CancelFunc
-	// any errors encountered when attempting to retrieve shares
-	errc chan error
-}
-
-func newshareCounter(parentCtx context.Context, edsWidth uint32) *shareCounter {
-	ctx, cancel := context.WithCancel(parentCtx)
-
-	// calculate the min number of shares needed to repair the square
-	minSharesNeeded := edsWidth * edsWidth / 4
-
-	return &shareCounter{
-		shares:          make(map[index][]byte),
-		edsWidth:        edsWidth,
-		minSharesNeeded: minSharesNeeded,
-		shareChan:       make(chan indexedShare, 512),
-		errc:            make(chan error, 1),
-		ctx:             ctx,
-		cancel:          cancel,
-	}
-}
-
-// retrieveLeaf uses GetLeafData to fetch a single leaf and counts that leaf
-func (sc *shareCounter) retrieveShare(
-	rootCid cid.Cid,
-	isRow bool,
-	axisIdx uint32,
-	idx uint32,
-	dag ipld.NodeGetter,
-) {
-	data, err := GetLeafData(sc.ctx, rootCid, idx, sc.edsWidth, dag)
-	if err != nil {
-		select {
-		case <-sc.ctx.Done():
-		case sc.errc <- err:
-		}
-	}
-
-	if len(data) < plugin.ShareSize {
-		return
-	}
-
-	// switch the row and col indexes if needed
-	rowIdx := idx
-	colIdx := axisIdx
-	if isRow {
-		rowIdx = axisIdx
-		colIdx = idx
-	}
-
-	select {
-	case <-sc.ctx.Done():
-	case sc.shareChan <- indexedShare{data: data[NamespaceSize:], index: index{row: rowIdx, col: colIdx}}:
-	}
-}
-
-// wait until enough data has been collected, the timeout has been reached, or
-// too many errors are encountered
-func (sc *shareCounter) wait() error {
-	defer sc.cancel()
-
-	for {
-		select {
-		case <-sc.ctx.Done():
-			err := sc.ctx.Err()
-			if err == context.DeadlineExceeded {
-				return ErrRetrieveTimeout
-			}
-			return err
-		case share := <-sc.shareChan:
-			_, has := sc.shares[share.index]
-			// add iff it does not already exists
-			if !has {
-				sc.shares[share.index] = share.data
-				sc.counter++
-				// check finishing condition
-				if sc.counter >= sc.minSharesNeeded {
-					return nil
-				}
-			}
-
-		case err := <-sc.errc:
-			return fmt.Errorf("failure to retrieve data square: %w", err)
-		}
-	}
-}
-
-func (sc *shareCounter) flatten() [][]byte {
-	flattended := make([][]byte, sc.edsWidth*sc.edsWidth)
-	for index, data := range sc.shares {
-		flattended[(index.row*sc.edsWidth)+index.col] = data
-	}
-	return flattended
+	return
 }
 
 // GetLeafData fetches and returns the data for leaf leafIndex of root rootCid.

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -115,7 +115,9 @@ func fillQuadrant(
 					leafIdx += len(leaves)
 				}
 				shareData := leaf.RawData()[1:]
-				dataSquare[((i+roots.from)*length*2)+leafIdx] = shareData[NamespaceSize:]
+                                 // position is calculated by < insert explanation>
+                                 position := ((i+roots.from)*length*2)+leafIdx
+				dataSquare[position] = shareData[NamespaceSize:]
 
 			}
 			return err

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -59,7 +59,7 @@ type quadrant struct {
 func pickRandomQuadrant(roots [][]byte) (*quadrant, error) {
 	edsWidth := len(roots)
 	// get the random number from 1 to 4.
-	q := rand.Intn(4) + 1
+	q := rand.Intn(4) + 1 //nolint:gosec
 	quadrant := &quadrant{rootCids: make([]cid.Cid, edsWidth/2)}
 	// quadrants 1 and 3 corresponds to left subtree,
 	// 2 and 4 to the right subtree
@@ -122,16 +122,18 @@ func fillQuadrant(
 }
 
 // GetSubtreeLeaves returns only one subtree - left or right
-func GetSubtreeLeaves(ctx context.Context, root cid.Cid, dag ipld.NodeGetter, isLeftSubtree bool, treeSize uint32) ([]ipld.Node, error) {
+func GetSubtreeLeaves(
+	ctx context.Context,
+	root cid.Cid,
+	dag ipld.NodeGetter,
+	isLeftSubtree bool, treeSize uint32) ([]ipld.Node, error) {
 	nd, err := dag.Get(ctx, root)
 	if err != nil {
 		return nil, err
 	}
 	links := nd.Links()
-	subtreeRootHash := cid.Cid{}
-	if isLeftSubtree || len(links) == 1 {
-		subtreeRootHash = links[0].Cid
-	} else {
+	subtreeRootHash := links[0].Cid
+	if !isLeftSubtree && len(links) > 1 {
 		subtreeRootHash = links[1].Cid
 	}
 

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -103,7 +103,7 @@ func fillQuadrant(
 	for i := 0; i < len(quadrant.rootCids); i++ {
 		i := i
 		errGroup.Go(func() error {
-			leaves, err := GetSubtreeLeaves(
+			leaves, err := getSubtreeLeaves(
 				ctx,
 				quadrant.rootCids[i],
 				dag,
@@ -135,8 +135,8 @@ func fillQuadrant(
 	return errGroup.Wait()
 }
 
-// GetSubtreeLeaves returns only one subtree - left or right
-func GetSubtreeLeaves(
+// getSubtreeLeaves returns only one subtree - left or right
+func getSubtreeLeaves(
 	ctx context.Context,
 	root cid.Cid,
 	dag ipld.NodeGetter,
@@ -154,10 +154,6 @@ func GetSubtreeLeaves(
 	}
 
 	return getLeaves(ctx, dag, subtreeRootHash, make([]ipld.Node, 0, treeSize))
-}
-
-func GetLeaves(ctx context.Context, dag ipld.NodeGetter, root cid.Cid, size uint32) ([]ipld.Node, error) {
-	return getLeaves(ctx, dag, root, make([]ipld.Node, 0, size))
 }
 
 // getLeaves recursively starts going down to find all leafs from the given root

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -137,20 +137,11 @@ func GetSubtreeLeaves(
 		subtreeRootHash = links[1].Cid
 	}
 
-	leaves, err := GetLeaves(ctx, dag, subtreeRootHash, treeSize)
-	if err != nil {
-		return nil, err
-	}
-	return leaves, nil
+	return getLeaves(ctx, dag, subtreeRootHash, make([]ipld.Node, 0, treeSize))
 }
 
 func GetLeaves(ctx context.Context, dag ipld.NodeGetter, root cid.Cid, size uint32) ([]ipld.Node, error) {
-	leaves, err := getLeaves(ctx, dag, root, make([]ipld.Node, 0, size))
-	if err != nil {
-		return nil, err
-	}
-
-	return leaves, nil
+	return getLeaves(ctx, dag, root, make([]ipld.Node, 0, size))
 }
 
 // getLeaves recursively starts going down to find all leafs from the given root

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -95,7 +95,8 @@ func pickRandomQuadrant(roots [][]byte) (*quadrant, error) {
 // fillQuadrant fetches 1/4 of shares for the given root
 func fillQuadrant(
 	ctx context.Context,
-	roots *quadrant, dag ipld.NodeGetter,
+	roots *quadrant, 
+	dag ipld.NodeGetter,
 	dataSquare [][]byte,
 ) error {
 	errGroup, ctx := errgroup.WithContext(ctx)

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -39,7 +39,7 @@ func RetrieveData(
 		return nil, err
 	}
 
-	batchAdder := NewNmtNodeAdder(parentCtx, ipld.NewBatch(parentCtx, dag, ipld.MaxSizeBatchOption(BatchSize)))
+	batchAdder := NewNmtNodeAdder(parentCtx, ipld.NewBatch(parentCtx, dag, ipld.MaxSizeBatchOption(batchSize(edsWidth))))
 	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(edsWidth)/2, nmt.NodeVisitor(batchAdder.Visit))
 	extended, err := rsmt2d.RepairExtendedDataSquare(dah.RowsRoots, dah.ColumnRoots, dataSquare, codec, tree.Constructor)
 	if err != nil {

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -128,7 +128,9 @@ func GetSubtreeLeaves(
 	ctx context.Context,
 	root cid.Cid,
 	dag ipld.NodeGetter,
-	isLeftSubtree bool, treeSize uint32) ([]ipld.Node, error) {
+	isLeftSubtree bool, 
+	treeSize uint32,
+	) ([]ipld.Node, error) {
 	nd, err := dag.Get(ctx, root)
 	if err != nil {
 		return nil, err

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -53,6 +53,7 @@ func RetrieveData(
 type quadrant struct {
 	isLeftSubtree bool
 	from          int
+	to            int
 	rootCids      []cid.Cid
 }
 
@@ -63,24 +64,25 @@ func pickRandomQuadrant(roots [][]byte) (*quadrant, error) {
 	quadrant := &quadrant{rootCids: make([]cid.Cid, edsWidth/2)}
 	// quadrants 1 and 3 corresponds to left subtree,
 	// 2 and 4 to the right subtree
-	/* | 1 | 2 |
-	   | 3 | 4 |
+	/*
+		| 1 | 2 |
+		| 3 | 4 |
 	*/
 	// choose subtree
 	if q%2 == 1 {
 		quadrant.isLeftSubtree = true
 	}
-	to := 0
+
 	// define range of shares for sampling
 	if q > 2 {
 		quadrant.from = edsWidth / 2
-		to = edsWidth
+		quadrant.to = edsWidth
 	} else {
-		to = edsWidth / 2
+		quadrant.to = edsWidth / 2
 	}
 
 	var err error
-	for index, counter := quadrant.from, 0; index < to; index++ {
+	for index, counter := quadrant.from, 0; index < quadrant.to; index++ {
 		quadrant.rootCids[counter], err = plugin.CidFromNamespacedSha256(roots[index])
 		if err != nil {
 			return nil, err

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -128,9 +128,9 @@ func GetSubtreeLeaves(
 	ctx context.Context,
 	root cid.Cid,
 	dag ipld.NodeGetter,
-	isLeftSubtree bool, 
+	isLeftSubtree bool,
 	treeSize uint32,
-	) ([]ipld.Node, error) {
+) ([]ipld.Node, error) {
 	nd, err := dag.Get(ctx, root)
 	if err != nil {
 		return nil, err

--- a/ipld/read_test.go
+++ b/ipld/read_test.go
@@ -129,9 +129,6 @@ func TestRetrieveBlockData(t *testing.T) {
 		{"128x128(max)", MaxSquareSize},
 	}
 	for _, tc := range tests {
-		if tc.squareSize == MaxSquareSize {
-			t.Skip("skipping as it spawns too many goroutines")
-		}
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// generate EDS
@@ -147,14 +144,9 @@ func TestRetrieveBlockData(t *testing.T) {
 			defer cancel()
 
 			dah := da.NewDataAvailabilityHeader(in)
-
 			out, err := RetrieveData(ctx, &dah, dag, rsmt2d.NewRSGF8Codec())
 			require.NoError(t, err)
 			assert.True(t, EqualEDS(in, out))
-
-			out2, err1 := RetrieveDataExt(ctx, &dah, dag, rsmt2d.NewRSGF8Codec())
-			require.NoError(t, err1)
-			assert.True(t, EqualEDS(in, out2))
 		})
 	}
 }

--- a/ipld/read_test.go
+++ b/ipld/read_test.go
@@ -151,6 +151,10 @@ func TestRetrieveBlockData(t *testing.T) {
 			out, err := RetrieveData(ctx, &dah, dag, rsmt2d.NewRSGF8Codec())
 			require.NoError(t, err)
 			assert.True(t, EqualEDS(in, out))
+
+			out2, err1 := RetrieveDataExt(ctx, &dah, dag, rsmt2d.NewRSGF8Codec())
+			require.NoError(t, err1)
+			assert.True(t, EqualEDS(in, out2))
 		})
 	}
 }

--- a/ipld/read_test.go
+++ b/ipld/read_test.go
@@ -164,7 +164,7 @@ func TestRetrieveMaxBlockData(t *testing.T) {
 	require.NoError(t, err)
 
 	// limit with deadline, specifically retrieval
-	ctx, cancel := context.WithTimeout(parentCtx, time.Second*2)
+	ctx, cancel := context.WithTimeout(parentCtx, time.Second*50)
 	defer cancel()
 
 	dah := da.NewDataAvailabilityHeader(in)

--- a/ipld/read_test.go
+++ b/ipld/read_test.go
@@ -126,7 +126,6 @@ func TestRetrieveBlockData(t *testing.T) {
 	tests := []test{
 		{"1x1(min)", 1},
 		{"32x32(med)", 32},
-		{"128x128(max)", MaxSquareSize},
 	}
 	for _, tc := range tests {
 		tc := tc
@@ -149,6 +148,29 @@ func TestRetrieveBlockData(t *testing.T) {
 			assert.True(t, EqualEDS(in, out))
 		})
 	}
+}
+
+func TestRetrieveMaxBlockData(t *testing.T) {
+	parentCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dag := mdutils.Mock()
+
+	// generate EDS
+	eds := generateRandEDS(t, MaxSquareSize)
+
+	shares := ExtractODSShares(eds)
+
+	in, err := PutData(parentCtx, shares, dag)
+	require.NoError(t, err)
+
+	// limit with deadline, specifically retrieval
+	ctx, cancel := context.WithTimeout(parentCtx, time.Second*2)
+	defer cancel()
+
+	dah := da.NewDataAvailabilityHeader(in)
+	out, err := RetrieveData(ctx, &dah, dag, rsmt2d.NewRSGF8Codec())
+	require.NoError(t, err)
+	assert.True(t, EqualEDS(in, out))
 }
 
 func Test_ConvertEDStoShares(t *testing.T) {

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -154,6 +154,6 @@ func LightAvailability(ctx context.Context, lc fx.Lifecycle, dag ipld.DAGService
 	return share.NewLightAvailability(merkledag.NewSession(fxutil.WithLifecycle(ctx, lc), dag))
 }
 
-func FullAvailability(ctx context.Context, lc fx.Lifecycle, dag ipld.DAGService) share.Availability {
-	return share.NewFullAvailability(merkledag.NewSession(fxutil.WithLifecycle(ctx, lc), dag))
+func FullAvailability(dag ipld.DAGService) share.Availability {
+	return share.NewFullAvailability(dag)
 }

--- a/service/share/full_availability.go
+++ b/service/share/full_availability.go
@@ -13,19 +13,19 @@ import (
 // recovery technique. It is considered "full" because it is required
 // to download enough shares to fully reconstruct the data square.
 type fullAvailability struct {
-	getter format.NodeGetter
+	service format.DAGService
 }
 
 // NewFullAvailability creates a new full Availability.
-func NewFullAvailability(get format.NodeGetter) Availability {
+func NewFullAvailability(service format.DAGService) Availability {
 	return &fullAvailability{
-		getter: get,
+		service: service,
 	}
 }
 
 // SharesAvailable reconstructs the data committed to the given Root by requesting
 // enough Shares from the network.
 func (fa *fullAvailability) SharesAvailable(ctx context.Context, root *Root) error {
-	_, err := ipld.RetrieveData(ctx, root, fa.getter, rsmt2d.NewRSGF8Codec())
+	_, err := ipld.RetrieveData(ctx, root, fa.service, rsmt2d.NewRSGF8Codec())
 	return err
 }


### PR DESCRIPTION
Fixes #247

* fetching data from root instead of particular share;
* removed share counter;

Time duration from start fetching till the end of fetching:
```
=== RUN   TestRetrieveBlockData
=== RUN   TestRetrieveBlockData/1x1(min)
374.436µs
=== RUN   TestRetrieveBlockData/32x32(med)
52.936894ms
=== RUN   TestRetrieveBlockData/128x128(max)
1.298028147s
```

Unfortunately, test  TestRetrieveBlockData/128x128(max) failed by timeout. I guess bottleneck could be [here](https://github.com/celestiaorg/rsmt2d/blob/ac0f1e1a51bf7b5420965fb7c35fa32a56e02292/extendeddatacrossword.go#L77). In the worst case we are  iterating over a slice of 65k of elements and making a pretty heavy operation of copying.