### PR TITLE
Pass trusted peers to config

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -6,6 +6,7 @@ Month, DD, YYYY
 
 ### BREAKING CHANGES
 
+- [node: Light node can be initialised with multiple trusted peers](https://github.com/celestiaorg/celestia-node/pull/455) [@vgonkivs](https://github.com/vgonkivs)
 - [chore: rename Repository to Store #296](https://github.com/celestiaorg/celestia-node/pull/296) [@Wondertan](https://github.com/Wondertan)
 - [chore: rename Full node to Bridge node #294](https://github.com/celestiaorg/celestia-node/pull/294) [@Wondertan](https://github.com/Wondertan)
 - [node: remove InitWith #291](https://github.com/celestiaorg/celestia-node/pull/291) [@Wondertan](https://github.com/Wondertan)
@@ -36,7 +37,6 @@ Month, DD, YYYY
 - [docker: Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script](https://github.com/celestiaorg/celestia-node/pull/295) [@jbowen93](https://github.com/jbowen93)
 - [chore(share): handle rows concurrently in GetSharesByNamespace #241](https://github.com/celestiaorg/celestia-node/pull/241) [@vgonkivs](https://github.com/vgonkivs)
 - [ci: adding data race detector action](https://github.com/celestiaorg/celestia-node/pull/289) [@Bidon15](https://github.com/Bidon15)
-- [node: Light node can be initialised with multiple trusted peers](https://github.com/celestiaorg/celestia-node/pull/455) [@vgonkivs](https://github.com/vgonkivs)
 
 ### BUG FIXES
 

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -36,6 +36,7 @@ Month, DD, YYYY
 - [docker: Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script](https://github.com/celestiaorg/celestia-node/pull/295) [@jbowen93](https://github.com/jbowen93)
 - [chore(share): handle rows concurrently in GetSharesByNamespace #241](https://github.com/celestiaorg/celestia-node/pull/241) [@vgonkivs](https://github.com/vgonkivs)
 - [ci: adding data race detector action](https://github.com/celestiaorg/celestia-node/pull/289) [@Bidon15](https://github.com/Bidon15)
+-[node: Light node can be initialised with multiple trusted peers](https://github.com/celestiaorg/celestia-node/pull/455) [@vgonkivs](https://github.com/vgonkivs)
 
 ### BUG FIXES
 

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -6,7 +6,7 @@ Month, DD, YYYY
 
 ### BREAKING CHANGES
 
-- [node: Light node can be initialised with multiple trusted peers](https://github.com/celestiaorg/celestia-node/pull/455) [@vgonkivs](https://github.com/vgonkivs)
+- [node: Light node can be initialised with multiple trusted peers #455](https://github.com/celestiaorg/celestia-node/pull/455) [@vgonkivs](https://github.com/vgonkivs)
 - [chore: rename Repository to Store #296](https://github.com/celestiaorg/celestia-node/pull/296) [@Wondertan](https://github.com/Wondertan)
 - [chore: rename Full node to Bridge node #294](https://github.com/celestiaorg/celestia-node/pull/294) [@Wondertan](https://github.com/Wondertan)
 - [node: remove InitWith #291](https://github.com/celestiaorg/celestia-node/pull/291) [@Wondertan](https://github.com/Wondertan)

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -36,7 +36,7 @@ Month, DD, YYYY
 - [docker: Created `docker/` dir with `Dockerfile` and `entrypoint.sh` script](https://github.com/celestiaorg/celestia-node/pull/295) [@jbowen93](https://github.com/jbowen93)
 - [chore(share): handle rows concurrently in GetSharesByNamespace #241](https://github.com/celestiaorg/celestia-node/pull/241) [@vgonkivs](https://github.com/vgonkivs)
 - [ci: adding data race detector action](https://github.com/celestiaorg/celestia-node/pull/289) [@Bidon15](https://github.com/Bidon15)
--[node: Light node can be initialised with multiple trusted peers](https://github.com/celestiaorg/celestia-node/pull/455) [@vgonkivs](https://github.com/vgonkivs)
+- [node: Light node can be initialised with multiple trusted peers](https://github.com/celestiaorg/celestia-node/pull/455) [@vgonkivs](https://github.com/vgonkivs)
 
 ### BUG FIXES
 

--- a/cmd/flags_header.go
+++ b/cmd/flags_header.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	headersTrustedHashFlag = "headers.trusted-hash"
-	headersTrustedPeerFlag = "headers.trusted-peer"
+	headersTrustedHashFlag  = "headers.trusted-hash"
+	headersTrustedPeersFlag = "headers.trusted-peers"
 )
 
 // HeadersFlags gives a set of hardcoded Header package flags.
@@ -27,7 +27,7 @@ func HeadersFlags() *flag.FlagSet {
 	)
 
 	flags.StringSlice(
-		headersTrustedPeerFlag,
+		headersTrustedPeersFlag,
 		make([]string, 0),
 		"Multiaddr of a reliable peer to fetch headers from. (Format: multiformats.io/multiaddr)",
 	)
@@ -47,7 +47,7 @@ func ParseHeadersFlags(cmd *cobra.Command, env *Env) error {
 		env.AddOptions(node.WithTrustedHash(hash))
 	}
 
-	tpeers, err := cmd.Flags().GetStringSlice(headersTrustedPeerFlag)
+	tpeers, err := cmd.Flags().GetStringSlice(headersTrustedPeersFlag)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func ParseHeadersFlags(cmd *cobra.Command, env *Env) error {
 		for _, tpeer := range tpeers {
 			_, err := multiaddr.NewMultiaddr(tpeer)
 			if err != nil {
-				return fmt.Errorf("cmd: while parsing '%s' with peer addr '%s': %w", headersTrustedPeerFlag, tpeer, err)
+				return fmt.Errorf("cmd: while parsing '%s' with peer addr '%s': %w", headersTrustedPeersFlag, tpeer, err)
 			}
 			env.AddOptions(node.WithTrustedPeer(tpeer))
 		}

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -18,10 +18,10 @@ func WithTrustedHash(hash string) Option {
 	}
 }
 
-// WithTrustedPeer sets TrustedPeer to the Config.
+// WithTrustedPeers appends TrustedPeer to the Config.
 func WithTrustedPeer(addr string) Option {
 	return func(cfg *Config, _ *settings) (_ error) {
-		cfg.Services.TrustedPeer = addr
+		cfg.Services.TrustedPeers = append(cfg.Services.TrustedPeers, addr)
 		return
 	}
 }

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -18,7 +18,7 @@ func WithTrustedHash(hash string) Option {
 	}
 }
 
-// WithTrustedPeers appends TrustedPeer to the Config.
+// WithTrustedPeer appends TrustedPeer to the Config.
 func WithTrustedPeer(addr string) Option {
 	return func(cfg *Config, _ *settings) (_ error) {
 		cfg.Services.TrustedPeers = append(cfg.Services.TrustedPeers, addr)

--- a/node/services/config.go
+++ b/node/services/config.go
@@ -33,6 +33,7 @@ func DefaultConfig() Config {
 
 func (cfg *Config) trustedPeers() ([]*peer.AddrInfo, error) {
 	if len(cfg.TrustedPeers) == 0 {
+		log.Info("No trusted peers given, initializing with default bootstrappers as trusted peers")
 		cfg.TrustedPeers = params.Bootstrappers()
 	}
 

--- a/node/services/config.go
+++ b/node/services/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	// TrustedHash is the Block/Header hash that Nodes use as starting point for header synchronization.
 	// Only affects the node once on initial sync.
 	TrustedHash string
-	// TrustedPeers is the peer we trust to fetch headers from.
+	// TrustedPeers are the peers we trust to fetch headers from.
 	// Note: The trusted does *not* imply Headers are not verified, but trusted as reliable to fetch headers
 	// at any moment.
 	TrustedPeers []string
@@ -33,7 +33,6 @@ func DefaultConfig() Config {
 
 func (cfg *Config) trustedPeers() ([]*peer.AddrInfo, error) {
 	if len(cfg.TrustedPeers) == 0 {
-		log.Warn("No Trusted Peers provided. Get default.")
 		cfg.TrustedPeers = params.Bootstrappers()
 	}
 

--- a/node/services/config.go
+++ b/node/services/config.go
@@ -33,8 +33,8 @@ func DefaultConfig() Config {
 
 func (cfg *Config) trustedPeers() ([]*peer.AddrInfo, error) {
 	if len(cfg.TrustedPeers) == 0 {
-		log.Warn("No Trusted Peers provided. Headers won't be synced accordingly")
-		return make([]*peer.AddrInfo, 0), nil
+		log.Warn("No Trusted Peers provided. Get default.")
+		cfg.TrustedPeers = params.Bootstrappers()
 	}
 
 	addrInfos := make([]*peer.AddrInfo, len(cfg.TrustedPeers))

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -3,11 +3,6 @@ package services
 import (
 	"context"
 
-	"github.com/celestiaorg/celestia-node/das"
-	"github.com/celestiaorg/celestia-node/node/fxutil"
-	"github.com/celestiaorg/celestia-node/service/block"
-	"github.com/celestiaorg/celestia-node/service/header"
-	"github.com/celestiaorg/celestia-node/service/share"
 	"github.com/ipfs/go-datastore"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
@@ -16,6 +11,12 @@ import (
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"go.uber.org/fx"
+
+	"github.com/celestiaorg/celestia-node/das"
+	"github.com/celestiaorg/celestia-node/node/fxutil"
+	"github.com/celestiaorg/celestia-node/service/block"
+	"github.com/celestiaorg/celestia-node/service/header"
+	"github.com/celestiaorg/celestia-node/service/share"
 )
 
 // HeaderSyncer creates a new header.Syncer.

--- a/node/tests/README.md
+++ b/node/tests/README.md
@@ -30,7 +30,7 @@ For example, you will need to know the host of the first Celestia node to be abl
 ```go
 addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(sw.Network.Host(bridge.Host.ID())))
 require.NoError(t, err)
-light := sw.NewLightClient(node.WithTrustedPeers(addrs[0].String()))
+light := sw.NewLightClient(node.WithTrustedPeer(addrs[0].String()))
 ```
 
 ## Concenptual overview

--- a/node/tests/README.md
+++ b/node/tests/README.md
@@ -30,7 +30,7 @@ For example, you will need to know the host of the first Celestia node to be abl
 ```go
 addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(sw.Network.Host(bridge.Host.ID())))
 require.NoError(t, err)
-light := sw.NewLightClient(node.WithTrustedPeer(addrs[0].String()))
+light := sw.NewLightClient(node.WithTrustedPeers(addrs[0].String()))
 ```
 
 ## Concenptual overview

--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/rand"
 
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -24,13 +25,13 @@ type P2PExchange struct {
 
 	// TODO @renaynay: post-Devnet, we need to remove reliance of Exchange on one bootstrap peer
 	// Ref https://github.com/celestiaorg/celestia-node/issues/172#issuecomment-964306823.
-	trustedPeer peer.ID
+	trustedPeers peer.IDSlice
 }
 
-func NewP2PExchange(host host.Host, peer peer.ID) *P2PExchange {
+func NewP2PExchange(host host.Host, peer peer.IDSlice) *P2PExchange {
 	return &P2PExchange{
-		host:        host,
-		trustedPeer: peer,
+		host:         host,
+		trustedPeers: peer,
 	}
 }
 
@@ -98,11 +99,12 @@ func (ex *P2PExchange) performRequest(ctx context.Context, req *pb.ExtendedHeade
 	if req.Amount == 0 {
 		return make([]*ExtendedHeader, 0), nil
 	}
-	if ex.trustedPeer == "" {
+	if len(ex.trustedPeers) == 0 {
 		return nil, fmt.Errorf("no trusted peer")
 	}
 
-	stream, err := ex.host.NewStream(ctx, ex.trustedPeer, exchangeProtocolID)
+	index := rand.Intn(len(ex.trustedPeers))
+	stream, err := ex.host.NewStream(ctx, ex.trustedPeers[index], exchangeProtocolID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -103,6 +103,7 @@ func (ex *P2PExchange) performRequest(ctx context.Context, req *pb.ExtendedHeade
 		return nil, fmt.Errorf("no trusted peer")
 	}
 
+	// nolint:gosec // G404: Use of weak random number generator
 	index := rand.Intn(len(ex.trustedPeers))
 	stream, err := ex.host.NewStream(ctx, ex.trustedPeers[index], exchangeProtocolID)
 	if err != nil {

--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -99,7 +99,7 @@ func (ex *P2PExchange) performRequest(ctx context.Context, req *pb.ExtendedHeade
 	}
 
 	if len(ex.trustedPeers) == 0 {
-		return nil, fmt.Errorf("no trusted peer")
+		return nil, fmt.Errorf("no trusted peers")
 	}
 
 	// nolint:gosec // G404: Use of weak random number generator

--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -23,8 +23,6 @@ var exchangeProtocolID = protocol.ID("/header-ex/v0.0.1")
 type P2PExchange struct {
 	host host.Host
 
-	// TODO @renaynay: post-Devnet, we need to remove reliance of Exchange on one bootstrap peer
-	// Ref https://github.com/celestiaorg/celestia-node/issues/172#issuecomment-964306823.
 	trustedPeers peer.IDSlice
 }
 
@@ -98,6 +96,10 @@ func (ex *P2PExchange) RequestByHash(ctx context.Context, hash tmbytes.HexBytes)
 func (ex *P2PExchange) performRequest(ctx context.Context, req *pb.ExtendedHeaderRequest) ([]*ExtendedHeader, error) {
 	if req.Amount == 0 {
 		return make([]*ExtendedHeader, 0), nil
+	}
+
+	if len(ex.trustedPeers) == 0 {
+		return nil, fmt.Errorf("no trusted peer")
 	}
 
 	// nolint:gosec // G404: Use of weak random number generator

--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -28,10 +28,10 @@ type P2PExchange struct {
 	trustedPeers peer.IDSlice
 }
 
-func NewP2PExchange(host host.Host, peer peer.IDSlice) *P2PExchange {
+func NewP2PExchange(host host.Host, peers peer.IDSlice) *P2PExchange {
 	return &P2PExchange{
 		host:         host,
-		trustedPeers: peer,
+		trustedPeers: peers,
 	}
 }
 
@@ -98,9 +98,6 @@ func (ex *P2PExchange) RequestByHash(ctx context.Context, hash tmbytes.HexBytes)
 func (ex *P2PExchange) performRequest(ctx context.Context, req *pb.ExtendedHeaderRequest) ([]*ExtendedHeader, error) {
 	if req.Amount == 0 {
 		return make([]*ExtendedHeader, 0), nil
-	}
-	if len(ex.trustedPeers) == 0 {
-		return nil, fmt.Errorf("no trusted peer")
 	}
 
 	// nolint:gosec // G404: Use of weak random number generator

--- a/service/header/p2p_exchange_test.go
+++ b/service/header/p2p_exchange_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	libhost "github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,17 +110,17 @@ func createMocknet(ctx context.Context, t *testing.T) (libhost.Host, libhost.Hos
 }
 
 // createP2PExAndServer creates a P2PExchange with 5 headers already in its store.
-func createP2PExAndServer(t *testing.T, host, peer libhost.Host) (Exchange, *mockStore) {
+func createP2PExAndServer(t *testing.T, host, tpeer libhost.Host) (Exchange, *mockStore) {
 	store := createStore(t, 5)
-	serverSideEx := NewP2PExchangeServer(peer, store)
+	serverSideEx := NewP2PExchangeServer(tpeer, store)
 	err := serverSideEx.Start(context.Background())
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		serverSideEx.Stop(context.Background()) //nolint:errcheck
 	})
-
-	return NewP2PExchange(host, peer.ID()), store
+	ids := []peer.ID{tpeer.ID()}
+	return NewP2PExchange(host, ids), store
 }
 
 type mockStore struct {

--- a/service/header/p2p_exchange_test.go
+++ b/service/header/p2p_exchange_test.go
@@ -119,8 +119,8 @@ func createP2PExAndServer(t *testing.T, host, tpeer libhost.Host) (Exchange, *mo
 	t.Cleanup(func() {
 		serverSideEx.Stop(context.Background()) //nolint:errcheck
 	})
-	ids := []peer.ID{tpeer.ID()}
-	return NewP2PExchange(host, ids), store
+
+	return NewP2PExchange(host, []peer.ID{tpeer.ID()}), store
 }
 
 type mockStore struct {


### PR DESCRIPTION
Fixes #364 

Chages:
* multiple trusted peers can be passed on node initialisation;
* trusted peer will be taken randomly on `performRequest`;