### PR TITLE
service/headers: Fix race in `TestCoreListener`

### DIFF
--- a/service/header/core_listener_test.go
+++ b/service/header/core_listener_test.go
@@ -2,14 +2,14 @@ package header
 
 import (
 	"context"
-	"github.com/libp2p/go-libp2p-core/event"
-	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
 	mdutils "github.com/ipfs/go-merkledag/test"
+	"github.com/libp2p/go-libp2p-core/event"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-node/core"


### PR DESCRIPTION
Attempts fix for #453 

It is not locally reproducible so we will have to run the CI several times, but I applied the same fix as in #342. I am assuming this issue stems from the same issue addressed in that PR.