### PR TITLE
feat(cmd/cel-shed): new header category and store-init cmd

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -12,6 +12,7 @@ Month, DD, YYYY
 
 ### FEATURES
 
+- [feat(cmd/cel-shed): new header category and store-init cmd #462](https://github.com/celestiaorg/celestia-node/pull/462) [@Wondertan](https://github.com/Wondertan)
 - [service/header: SyncState #397](https://github.com/celestiaorg/celestia-node/pull/397) [@Wondertan](https://github.com/Wondertan)
 - [feat(service/header): HeightSub #428](https://github.com/celestiaorg/celestia-node/pull/428) [@Wondertan](https://github.com/Wondertan)
 - [params: Define Network Types #346](https://github.com/celestiaorg/celestia-node/pull/346) [@Wondertan](https://github.com/Wondertan)

--- a/cmd/cel-shed/header.go
+++ b/cmd/cel-shed/header.go
@@ -36,6 +36,11 @@ Custom store path is not supported yet.`,
 			return fmt.Errorf("invalid node-type")
 		}
 
+		height, err := strconv.Atoi(args[1])
+		if err != nil {
+			return fmt.Errorf("invalid height: %w", err)
+		}
+
 		store, err := node.OpenStore(fmt.Sprintf("~/.celestia-%s", strings.ToLower(tp.String())), tp)
 		if err != nil {
 			return err
@@ -49,11 +54,6 @@ Custom store path is not supported yet.`,
 		hstore, err := header.NewStore(ds)
 		if err != nil {
 			return err
-		}
-
-		height, err := strconv.Atoi(args[1])
-		if err != nil {
-			return fmt.Errorf("ivalid height: %w", err)
 		}
 
 		newHead, err := hstore.GetByHeight(cmd.Context(), uint64(height))

--- a/cmd/cel-shed/header.go
+++ b/cmd/cel-shed/header.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/celestiaorg/celestia-node/service/header"
+
+	"github.com/celestiaorg/celestia-node/node"
+)
+
+func init() {
+	headerCmd.AddCommand(headerStoreInit)
+}
+
+var headerCmd = &cobra.Command{
+	Use:   "header [subcommand]",
+	Short: "Collection of header module related utilities",
+}
+
+var headerStoreInit = &cobra.Command{
+	Use: "store-init [node-type] [height]",
+	Short: `Forcefully initialize header store head to be of the given height. Requires the node being stopped. 
+Custom store path is not supported yet.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return fmt.Errorf("not enough arguments")
+		}
+
+		tp := node.ParseType(args[0])
+		if !tp.IsValid() {
+			return fmt.Errorf("invalid node-type")
+		}
+
+		store, err := node.OpenStore(fmt.Sprintf("~/.celestia-%s", strings.ToLower(tp.String())), tp)
+		if err != nil {
+			return err
+		}
+
+		ds, err := store.Datastore()
+		if err != nil {
+			return err
+		}
+
+		hstore, err := header.NewStore(ds)
+		if err != nil {
+			return err
+		}
+
+		height, err := strconv.Atoi(args[1])
+		if err != nil {
+			return fmt.Errorf("ivalid height: %w", err)
+		}
+
+		newHead, err := hstore.GetByHeight(cmd.Context(), uint64(height))
+		if err != nil {
+			return err
+		}
+
+		return hstore.Init(cmd.Context(), newHead)
+	},
+}

--- a/cmd/cel-shed/main.go
+++ b/cmd/cel-shed/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(p2pCmd)
+	rootCmd.AddCommand(p2pCmd, headerCmd)
 }
 
 var rootCmd = &cobra.Command{

--- a/service/header/store_heightsub.go
+++ b/service/header/store_heightsub.go
@@ -40,7 +40,7 @@ func (hs *heightSub) SetHeight(height uint64) {
 // It can return errElapsedHeight, which means a requested header was already provided
 // and caller should get it elsewhere.
 func (hs *heightSub) Sub(ctx context.Context, height uint64) (*ExtendedHeader, error) {
-	if hs.Height() >= height {
+	if hs.Height() >= height || hs.Height() == 0 { // if height is zero - intentionally avoid subscribing
 		return nil, errElapsedHeight
 	}
 


### PR DESCRIPTION
Implements a utility to force the store to change it is head. Was useful to recover from bug #457.
Very low priority to review