### PR TITLE
das: DASing of past headers

### DIFF
--- a/das/checkpoint_store.go
+++ b/das/checkpoint_store.go
@@ -1,0 +1,51 @@
+package das
+
+import (
+	"encoding/binary"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+)
+
+var (
+	storePrefix   = datastore.NewKey("das")
+	checkpointKey = datastore.NewKey("checkpoint")
+)
+
+// NewCheckpointStore wraps the given datastore.Datastore with
+// the `das` prefix.
+func NewCheckpointStore(ds datastore.Datastore) datastore.Datastore {
+	return namespace.Wrap(ds, storePrefix)
+
+}
+
+// loadCheckpoint // TODO @renaynay: document
+//
+// 1. gets checkpoint from disk
+// 1a. if there is no checkpoint, you start from `GetByHeight` of 1
+// 1b. if there is a checkpoint, continue
+func loadCheckpoint(ds datastore.Datastore) (int64, error) {
+	checkpoint, err := ds.Get(checkpointKey)
+	if err != nil {
+		// if no checkpoint was found, return checkpoint as
+		// 0 since DASer begins sampling on checkpoint+1
+		if err == datastore.ErrNotFound {
+			log.Debug("checkpoint not found, starting sampling at block height 1")
+			return 0, nil
+		}
+
+		return 0, err
+	}
+	return int64(binary.BigEndian.Uint64(checkpoint)), err
+}
+
+// TODO @renaynay: document
+
+// storeCheckpoint stores the given DAS checkpoint to disk.
+func storeCheckpoint(ds datastore.Datastore, checkpoint int64) error {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(checkpoint))
+
+	return ds.Put(checkpointKey, buf)
+}
+

--- a/das/checkpoint_store.go
+++ b/das/checkpoint_store.go
@@ -16,7 +16,6 @@ var (
 // the `das` prefix.
 func NewCheckpointStore(ds datastore.Datastore) datastore.Datastore {
 	return namespace.Wrap(ds, storePrefix)
-
 }
 
 // loadCheckpoint loads the DAS checkpoint from disk and returns it.

--- a/das/checkpoint_store.go
+++ b/das/checkpoint_store.go
@@ -12,9 +12,11 @@ var (
 	checkpointKey = datastore.NewKey("checkpoint")
 )
 
-// NewCheckpointStore wraps the given datastore.Datastore with
-// the `das` prefix.
-func NewCheckpointStore(ds datastore.Datastore) datastore.Datastore {
+// wrapCheckpointStore wraps the given datastore.Datastore with the `das`
+// prefix. The checkpoint store stores/loads the DASer's checkpoint to/from
+// disk using the checkpointKey. The checkpoint is stored as a uint64
+// representation of the height of the latest successfully DASed header.
+func wrapCheckpointStore(ds datastore.Datastore) datastore.Datastore {
 	return namespace.Wrap(ds, storePrefix)
 }
 

--- a/das/checkpoint_store.go
+++ b/das/checkpoint_store.go
@@ -2,7 +2,6 @@ package das
 
 import (
 	"encoding/binary"
-
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 )
@@ -39,8 +38,6 @@ func loadCheckpoint(ds datastore.Datastore) (int64, error) {
 	return int64(binary.BigEndian.Uint64(checkpoint)), err
 }
 
-// TODO @renaynay: document
-
 // storeCheckpoint stores the given DAS checkpoint to disk.
 func storeCheckpoint(ds datastore.Datastore, checkpoint int64) error {
 	buf := make([]byte, 8)
@@ -48,4 +45,3 @@ func storeCheckpoint(ds datastore.Datastore, checkpoint int64) error {
 
 	return ds.Put(checkpointKey, buf)
 }
-

--- a/das/checkpoint_store.go
+++ b/das/checkpoint_store.go
@@ -20,7 +20,7 @@ func wrapCheckpointStore(ds datastore.Datastore) datastore.Datastore {
 	return namespace.Wrap(ds, storePrefix)
 }
 
-// loadCheckpoint loads the DAS checkpoint from disk and returns it.
+// loadCheckpoint loads the DAS checkpoint height from disk and returns it.
 // If there is no known checkpoint, it returns height 0.
 func loadCheckpoint(ds datastore.Datastore) (int64, error) {
 	checkpoint, err := ds.Get(checkpointKey)

--- a/das/checkpoint_store.go
+++ b/das/checkpoint_store.go
@@ -19,11 +19,8 @@ func NewCheckpointStore(ds datastore.Datastore) datastore.Datastore {
 
 }
 
-// loadCheckpoint // TODO @renaynay: document
-//
-// 1. gets checkpoint from disk
-// 1a. if there is no checkpoint, you start from `GetByHeight` of 1
-// 1b. if there is a checkpoint, continue
+// loadCheckpoint loads the DAS checkpoint from disk and returns it.
+// If there is no known checkpoint, it returns height 0.
 func loadCheckpoint(ds datastore.Datastore) (int64, error) {
 	checkpoint, err := ds.Get(checkpointKey)
 	if err != nil {

--- a/das/checkpoint_store.go
+++ b/das/checkpoint_store.go
@@ -2,6 +2,7 @@ package das
 
 import (
 	"encoding/binary"
+
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 )

--- a/das/checkpoint_store_test.go
+++ b/das/checkpoint_store_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCheckpointStore(t *testing.T) {
-	ds := NewCheckpointStore(sync.MutexWrap(datastore.NewMapDatastore()))
+	ds := wrapCheckpointStore(sync.MutexWrap(datastore.NewMapDatastore()))
 	checkpoint := int64(5)
 	err := storeCheckpoint(ds, checkpoint)
 	require.NoError(t, err)

--- a/das/checkpoint_store_test.go
+++ b/das/checkpoint_store_test.go
@@ -1,0 +1,21 @@
+package das
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckpointStore(t *testing.T) {
+	ds := NewCheckpointStore(sync.MutexWrap(datastore.NewMapDatastore()))
+	checkpoint := int64(5)
+	err := storeCheckpoint(ds, checkpoint)
+	require.NoError(t, err)
+	got, err := loadCheckpoint(ds)
+	require.NoError(t, err)
+
+	assert.Equal(t, checkpoint, got)
+}

--- a/das/daser.go
+++ b/das/daser.go
@@ -122,7 +122,7 @@ func (d *DASer) sample(ctx context.Context, sub header.Subscription, checkpoint 
 		// to our last DASed header, kick off routine to DAS all headers
 		// between last DASed header and h. This situation could occur
 		// either on start or due to network latency/disconnection.
-		if h.Height > (height + 1) { // TODO @renaynay: what if height = 7 and h.Height = 9 (so only need to catch up on 8
+		if h.Height > (height + 1) {
 			// DAS headers between last DASed height up to the current
 			// header
 			go d.catchUp(ctx, height, h.Height-1)

--- a/das/daser.go
+++ b/das/daser.go
@@ -176,11 +176,11 @@ func (d *DASer) catchUpScheduler(ctx context.Context, checkpoint int64) {
 		if err := storeCheckpoint(d.cstore, checkpoint); err != nil {
 			log.Errorw("storing checkpoint to disk", "height", checkpoint, "err", err)
 		}
-		// signal that all catchUp routines have finished
-		close(d.catchUpDn)
 		// close out jobs channel
 		close(d.jobsCh)
 		d.jobsCh = nil
+		// signal that all catchUp routines have finished
+		close(d.catchUpDn)
 	}()
 
 	for {

--- a/das/daser.go
+++ b/das/daser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 
 	"github.com/celestiaorg/celestia-node/service/header"
@@ -18,21 +19,35 @@ type DASer struct {
 	da   share.Availability
 	hsub header.Subscriber
 
+	// getter allows the DASer to fetch a header at a certain height
+	// and blocks until it becomes available.
+	getter HeaderGetter
+	// checkpoint from disk -- DASStore stores checkpoint w/ DASCheckpoint key
+	// checkpoint = latest successfully DASed header (reference to it, not the header)
+	ds datastore.Datastore
+
 	cancel context.CancelFunc
 	done   chan struct{}
 }
 
 // NewDASer creates a new DASer.
-func NewDASer(da share.Availability, hsub header.Subscriber) *DASer {
+func NewDASer(
+	da share.Availability,
+	hsub header.Subscriber,
+	getter HeaderGetter,
+	ds datastore.Datastore,
+) *DASer {
 	return &DASer{
-		da:   da,
-		hsub: hsub,
-		done: make(chan struct{}),
+		da:     da,
+		hsub:   hsub,
+		getter: getter,
+		ds:     ds,
+		done:   make(chan struct{}),
 	}
 }
 
 // Start initiates subscription for new ExtendedHeaders and spawns a sampling routine.
-func (d *DASer) Start(context.Context) error {
+func (d *DASer) Start(ctx context.Context) error {
 	if d.cancel != nil {
 		return fmt.Errorf("da: DASer already started")
 	}
@@ -42,8 +57,30 @@ func (d *DASer) Start(context.Context) error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go d.sampling(ctx, sub)
+	// load latest DASed checkpoint
+	checkpoint, err := loadCheckpoint(d.ds)
+	if err != nil {
+		return err
+	}
+	log.Infow("loaded latest DASed checkpoint", "height", checkpoint)
+
+	// load current network head // TODO @renaynay: do we have to sample over netHead as well or will that be handled by sampleLatest via hsub?
+	netHead, err := d.getter.Head(ctx)
+	if err != nil {
+		return err
+	}
+
+	dasCtx, cancel := context.WithCancel(context.Background())
+
+	// start two separate routines:
+	// 1. samples headers from the latest DASed header to the
+	//    current network head (samples headers from the past)
+	// 2. samples new headers coming through the ExtendedHeader
+	//    gossipsub topic (samples new inbound headers in the
+	//    network)
+	go d.sampleFromCheckpoint(dasCtx, checkpoint, netHead.Height)
+	go d.sampleLatest(dasCtx, sub)
+
 	d.cancel = cancel
 	return nil
 }
@@ -52,6 +89,7 @@ func (d *DASer) Start(context.Context) error {
 func (d *DASer) Stop(ctx context.Context) error {
 	d.cancel()
 	select {
+	// TODO @renaynay: add done case for sampleCheckpoint
 	case <-d.done:
 		d.cancel = nil
 		return nil
@@ -60,8 +98,55 @@ func (d *DASer) Stop(ctx context.Context) error {
 	}
 }
 
-// sampling validates availability for each Header received from header subscription.
-func (d *DASer) sampling(ctx context.Context, sub header.Subscription) {
+// sampleFromCheckpoint starts sampling headers from the last known
+// `checkpoint` (latest/heighest DASed header), and breaks the loop
+// once network head `netHead` is reached, leaving only the `sampleLatest`
+// loop running.
+//
+// 2. Loop:
+// 2a. request by height (checkpoint+1)
+// 2b. DAS on that height
+// 2c. stop when height == network height
+func (d *DASer) sampleFromCheckpoint(ctx context.Context, checkpoint, netHead int64) {
+	// immediately break if DASer is up to speed with network head
+	if checkpoint+1 == netHead { // TODO @renaynay: test this scenario
+		log.Debugw("caught up to network head", "net head", netHead)
+		return
+	}
+
+	// start sampling from the next header after the checkpoint as the
+	// checkpoint has already been successfully DASed.
+	for height := checkpoint + 1; height < netHead; height++ {
+		h, err := d.getter.GetByHeight(ctx, uint64(height))
+		if err != nil {
+			if err == context.Canceled {
+				return
+			}
+
+			log.Errorw("failed to get next header", "height", height, "err", err)
+			continue // TODO @renaynay: should we really continue in this case?
+		}
+
+		startTime := time.Now()
+
+		err = d.da.SharesAvailable(ctx, h.DAH)
+		if err != nil {
+			if err == context.Canceled {
+				return
+			}
+			log.Errorw("sampling failed", "height", h.Height, "hash", h.Hash(),
+				"square width", len(h.DAH.RowsRoots), "data root", h.DAH.Hash(), "err", err)
+			// continue sampling
+		}
+
+		sampleTime := time.Since(startTime)
+		log.Infow("sampling successful", "height", h.Height, "hash", h.Hash(),
+			"square width", len(h.DAH.RowsRoots), "finished (s)", sampleTime.Seconds())
+	}
+}
+
+// sampleLatest validates availability for each Header received from header subscription. // TODO renaynay: rename to sampleLatest
+func (d *DASer) sampleLatest(ctx context.Context, sub header.Subscription) {
 	defer sub.Cancel()
 	defer close(d.done)
 	for {

--- a/das/daser.go
+++ b/das/daser.go
@@ -122,7 +122,7 @@ func (d *DASer) sample(ctx context.Context, sub header.Subscription, checkpoint 
 		// to our last DASed header, kick off routine to DAS all headers
 		// between last DASed header and h. This situation could occur
 		// either on start or due to network latency/disconnection.
-		if h.Height > (height+1) { // TODO @renaynay: what if height = 7 and h.Height = 9 (so only need to catch up on 8
+		if h.Height > (height + 1) { // TODO @renaynay: what if height = 7 and h.Height = 9 (so only need to catch up on 8
 			// DAS headers between last DASed height up to the current
 			// header
 			go d.catchUp(ctx, height, h.Height-1)
@@ -159,9 +159,7 @@ func (d *DASer) catchUp(ctx context.Context, from, to int64) {
 
 	// start sampling from height at checkpoint+1 since the
 	// checkpoint height has already been successfully DASed
-	fmt.Println("from: ", from, " to: ", to)
 	for height := from + 1; height <= to; height++ {
-		fmt.Println("catchup loop height: ", height)
 		h, err := d.getter.GetByHeight(ctx, uint64(height))
 		if err != nil {
 			if err == context.Canceled {

--- a/das/daser.go
+++ b/das/daser.go
@@ -73,6 +73,9 @@ func (d *DASer) Start(context.Context) error {
 	d.cancel = cancel
 	d.sampleDn, d.catchUpDn = make(chan struct{}), make(chan struct{})
 
+	// kick off catch-up routine scheduler
+	go d.catchUpScheduler(dasCtx, checkpoint)
+	// kick off sampling routine for recently received headers
 	go d.sample(dasCtx, sub, checkpoint)
 	return nil
 }
@@ -101,9 +104,6 @@ func (d *DASer) sample(ctx context.Context, sub header.Subscription, checkpoint 
 		sub.Cancel()
 		close(d.sampleDn)
 	}()
-
-	// kick off catchUpScheduler
-	go d.catchUpScheduler(ctx, checkpoint)
 
 	for {
 		h, err := sub.NextHeader(ctx)

--- a/das/daser.go
+++ b/das/daser.go
@@ -124,9 +124,14 @@ func (d *DASer) sample(ctx context.Context, sub header.Subscription, checkpoint 
 		if h.Height > checkpoint+1 {
 			// DAS headers between last DASed height up to the current
 			// header
-			d.jobsCh <- &catchUpJob{
-				from: checkpoint,
-				to:   h.Height - 1,
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				d.jobsCh <- &catchUpJob{
+					from: checkpoint,
+					to:   h.Height - 1,
+				}
 			}
 		}
 

--- a/das/daser.go
+++ b/das/daser.go
@@ -123,14 +123,14 @@ func (d *DASer) sample(ctx context.Context, sub header.Subscription, checkpoint 
 		if h.Height > checkpoint+1 {
 			// DAS headers between last DASed height up to the current
 			// header
+			job := &catchUpJob{
+				from: checkpoint,
+				to:   h.Height - 1,
+			}
 			select {
 			case <-ctx.Done():
 				return
-			default:
-				d.jobsCh <- &catchUpJob{
-					from: checkpoint,
-					to:   h.Height - 1,
-				}
+			case d.jobsCh <- job:
 			}
 		}
 

--- a/das/daser.go
+++ b/das/daser.go
@@ -165,7 +165,7 @@ func (d *DASer) catchUpScheduler(ctx context.Context, jobsCh chan *catchUpJob, c
 		// TODO @renaynay: Implement Share Cache #180 to ensure no duplicate DASing over same
 		//  header
 		if err := storeCheckpoint(d.cstore, checkpoint); err != nil {
-			log.Errorw("da: storing latest DASed checkpoint to disk", "height", checkpoint, "err", err)
+			log.Errorw("storing checkpoint to disk", "height", checkpoint, "err", err)
 		}
 		// signal that all catchUp routines have finished
 		close(d.catchUpDn)
@@ -226,7 +226,6 @@ func (d *DASer) catchUp(ctx context.Context, job *catchUpJob) {
 			"square width", len(h.DAH.RowsRoots), "finished (s)", sampleTime.Seconds())
 	}
 
-	totalElapsedTime := time.Since(routineStartTime)
-	log.Infow("successfully sampled all headers up to network head", "from", job.from,
-		"to", job.to, "finished (s)", totalElapsedTime.Seconds())
+	log.Infow("successfully caught up", "from", job.from,
+		"to", job.to, "finished (s)", time.Since(routineStartTime))
 }

--- a/das/daser.go
+++ b/das/daser.go
@@ -214,7 +214,7 @@ func (d *DASer) catchUp(ctx context.Context, job *catchUpJob) {
 			}
 
 			log.Errorw("failed to get next header", "height", height, "err", err)
-			continue // TODO @renaynay: should we really continue in this case?
+			return
 		}
 
 		startTime := time.Now()

--- a/das/daser.go
+++ b/das/daser.go
@@ -230,7 +230,7 @@ func (d *DASer) catchUp(ctx context.Context, job *catchUpJob) {
 		}
 
 		sampleTime := time.Since(startTime)
-		log.Infow("sampling successful", "height", h.Height, "hash", h.Hash(),
+		log.Debugw("sampled past header", "height", h.Height, "hash", h.Hash(),
 			"square width", len(h.DAH.RowsRoots), "finished (s)", sampleTime.Seconds())
 	}
 

--- a/das/daser.go
+++ b/das/daser.go
@@ -19,8 +19,8 @@ type DASer struct {
 	da   share.Availability
 	hsub header.Subscriber
 
-	// getter allows the DASer to fetch a header at a certain height
-	// and blocks until it becomes available.
+	// getter allows the DASer to fetch an ExtendedHeader (EH) at a certain height
+	// and blocks until the EH has been processed by the header store.
 	getter HeaderGetter
 	// checkpoint store
 	cstore datastore.Datastore

--- a/das/daser.go
+++ b/das/daser.go
@@ -67,7 +67,7 @@ func (d *DASer) Start(context.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Infow("loaded latest DASed checkpoint", "height", checkpoint)
+	log.Infow("loaded checkpoint", "height", checkpoint)
 
 	dasCtx, cancel := context.WithCancel(context.Background())
 	d.cancel = cancel

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
+	format "github.com/ipfs/go-ipld-format"
 	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,14 +21,16 @@ import (
 // the DASer checkpoint is updated to network head.
 func TestDASerLifecycle(t *testing.T) {
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	cstore := wrapCheckpointStore(ds)
+	dag := mdutils.Mock()
 
 	// 15 headers from the past and 15 future headers
-	mockGet, shareServ, sub := createDASerSubcomponents(t, 15, 15)
+	mockGet, shareServ, sub := createDASerSubcomponents(t, dag, 15, 15)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	t.Cleanup(cancel)
 
-	daser := NewDASer(shareServ, sub, mockGet, ds)
+	daser := NewDASer(shareServ, sub, mockGet, cstore)
 
 	err := daser.Start(ctx)
 	require.NoError(t, err)
@@ -49,11 +52,70 @@ func TestDASerLifecycle(t *testing.T) {
 	assert.Equal(t, int64(15), checkpoint)
 }
 
+func TestDASer_Restart(t *testing.T) {
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	cstore := wrapCheckpointStore(ds)
+	dag := mdutils.Mock()
+
+	// 15 headers from the past and 15 future headers
+	mockGet, shareServ, sub := createDASerSubcomponents(t, dag, 15, 15)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+	t.Cleanup(cancel)
+
+	daser := NewDASer(shareServ, sub, mockGet, cstore)
+
+	err := daser.Start(ctx)
+	require.NoError(t, err)
+
+	// wait for dasing catch-up routine to finish
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case <-mockGet.doneCh:
+	}
+
+	err = daser.Stop(ctx)
+	require.NoError(t, err)
+
+	// reset mockGet, generate 15 "past" headers, building off chain head which is 30
+	mockGet.generateHeaders(t, dag, 30, 45)
+	mockGet.doneCh = make(chan struct{})
+	// reset dummy subscriber
+	mockGet.fillSubWithHeaders(t, sub, dag, 45, 60)
+	// manually set mockGet head to trigger stop at 45
+	mockGet.head = int64(45)
+
+	// restart DASer with new context
+	restartCtx, restartCancel := context.WithTimeout(context.Background(), time.Second*15)
+	t.Cleanup(restartCancel)
+
+	err = daser.Start(restartCtx)
+	require.NoError(t, err)
+
+	// wait for dasing catch-up routine to finish
+	select {
+	case <-restartCtx.Done():
+		t.Fatal(ctx.Err())
+	case <-mockGet.doneCh:
+	}
+
+	err = daser.Stop(restartCtx)
+	require.NoError(t, err)
+
+	// load checkpoint and ensure it's at network head
+	checkpoint, err := loadCheckpoint(daser.cstore)
+	require.NoError(t, err)
+	// ensure checkpoint is stored at 45
+	assert.Equal(t, int64(45), checkpoint)
+}
+
 func TestDASer_catchUp(t *testing.T) {
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 	cstore := wrapCheckpointStore(ds)
+	dag := mdutils.Mock()
 
-	mockGet, shareServ, _ := createDASerSubcomponents(t, 5, 0)
+	mockGet, shareServ, _ := createDASerSubcomponents(t, dag, 5, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -79,8 +141,9 @@ func TestDASer_catchUp(t *testing.T) {
 func TestDASer_catchUp_oneHeader(t *testing.T) {
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 	cstore := wrapCheckpointStore(ds)
+	dag := mdutils.Mock()
 
-	mockGet, shareServ, _ := createDASerSubcomponents(t, 6, 0)
+	mockGet, shareServ, _ := createDASerSubcomponents(t, dag, 6, 0)
 
 	// store checkpoint
 	err := storeCheckpoint(cstore, 5) // pick arbitrary height as last checkpoint
@@ -110,8 +173,12 @@ func TestDASer_catchUp_oneHeader(t *testing.T) {
 // to store in mockGetter) and numSub (number of headers to store
 // in the mock header.Subscriber), returning a newly instantiated
 // mockGetter, share.Service, and mock header.Subscriber.
-func createDASerSubcomponents(t *testing.T, numGetter, numSub int) (*mockGetter, share.Service, header.Subscriber) {
-	dag := mdutils.Mock()
+func createDASerSubcomponents(
+	t *testing.T,
+	dag format.DAGService,
+	numGetter,
+	numSub int,
+) (*mockGetter, share.Service, *header.DummySubscriber) {
 	shareServ := share.NewService(dag, share.NewLightAvailability(dag))
 
 	mockGet := &mockGetter{
@@ -119,26 +186,26 @@ func createDASerSubcomponents(t *testing.T, numGetter, numSub int) (*mockGetter,
 		doneCh:  make(chan struct{}),
 	}
 
-	// generate 15 headers from the past for HeaderGetter
-	for i := 0; i < numGetter; i++ {
-		dah := share.RandFillDAG(t, 16, dag)
+	mockGet.generateHeaders(t, dag, 0, numGetter)
 
-		randHeader := header.RandExtendedHeader(t)
-		randHeader.DataHash = dah.Hash()
-		randHeader.DAH = dah
-		randHeader.Height = int64(i + 1)
+	sub := new(header.DummySubscriber)
+	mockGet.fillSubWithHeaders(t, sub, dag, numGetter, numGetter+numSub)
 
-		mockGet.headers[int64(i+1)] = randHeader
-	}
-	mockGet.head = int64(numGetter) // network head
+	return mockGet, shareServ, sub
+}
 
-	sub := &header.DummySubscriber{
-		Headers: make([]*header.ExtendedHeader, numSub),
-	}
+// fillSubWithHeaders generates `num` headers from the future for p2pSub to pipe through to DASer.
+func (m *mockGetter) fillSubWithHeaders(
+	t *testing.T,
+	sub *header.DummySubscriber,
+	dag format.DAGService,
+	startHeight,
+	endHeight int,
+) {
+	sub.Headers = make([]*header.ExtendedHeader, endHeight-startHeight)
 
-	// generate 15 headers from the future for p2pSub to pipe through to DASer
 	index := 0
-	for i := numGetter; i < numGetter+numSub; i++ {
+	for i := startHeight; i < endHeight; i++ {
 		dah := share.RandFillDAG(t, 16, dag)
 
 		randHeader := header.RandExtendedHeader(t)
@@ -147,10 +214,11 @@ func createDASerSubcomponents(t *testing.T, numGetter, numSub int) (*mockGetter,
 		randHeader.Height = int64(i + 1)
 
 		sub.Headers[index] = randHeader
+		// also store to mock getter for duplicate fetching
+		m.headers[int64(i+1)] = randHeader
+
 		index++
 	}
-
-	return mockGet, shareServ, sub
 }
 
 type mockGetter struct {
@@ -158,6 +226,21 @@ type mockGetter struct {
 
 	head    int64
 	headers map[int64]*header.ExtendedHeader
+}
+
+func (m *mockGetter) generateHeaders(t *testing.T, dag format.DAGService, startHeight, endHeight int) {
+	for i := startHeight; i < endHeight; i++ {
+		dah := share.RandFillDAG(t, 16, dag)
+
+		randHeader := header.RandExtendedHeader(t)
+		randHeader.DataHash = dah.Hash()
+		randHeader.DAH = dah
+		randHeader.Height = int64(i + 1)
+
+		m.headers[int64(i+1)] = randHeader
+	}
+	// set network head
+	m.head = int64(startHeight + endHeight)
 }
 
 func (m *mockGetter) Head(context.Context) (*header.ExtendedHeader, error) {

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -18,7 +18,7 @@ import (
 
 // TestDASerLifecycle tests to ensure every mock block is DASed and
 // the DASer checkpoint is updated to network head.
-func TestDASerLifecycle (t *testing.T) {
+func TestDASerLifecycle(t *testing.T) {
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 	cstore := NewCheckpointStore(ds) // we aren't storing the checkpoint so that DASer starts DASing from height 1.
 

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -20,13 +20,24 @@ func TestDASer(t *testing.T) {
 		Headers: []*header.ExtendedHeader{randHeader},
 	}
 
-	daser := NewDASer(shareServ, sub)
+	mockGet := new(mockGetter)
+
+	daser := NewDASer(shareServ, sub, mockGet, nil) // TODO @renaynay
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {
-		daser.sampling(context.Background(), sub)
+		daser.sampleLatest(context.Background(), sub)
 		wg.Done()
 	}(wg)
 	wg.Wait()
 }
+
+type mockGetter struct {
+
+}
+
+func (m mockGetter) GetByHeight(ctx context.Context, u uint64) (*header.ExtendedHeader, error) {
+	panic("implement me")
+}
+

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -61,7 +61,8 @@ func TestDASer_catchUp(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {
-		daser.catchUp(ctx, 2, mockGet.head) // pick random number as `from` parameter
+		// catch up from height 2 to head
+		daser.catchUp(ctx, 2, mockGet.head)
 		wg.Done()
 	}(wg)
 	wg.Wait()
@@ -76,7 +77,7 @@ func TestDASer_catchUp_oneHeader(t *testing.T) {
 	mockGet, shareServ, _ := createDASerSubcomponents(t, 6, 0)
 
 	// store checkpoint
-	err := storeCheckpoint(cstore, 5) // pick random header as last checkpoint
+	err := storeCheckpoint(cstore, 5) // pick arbitrary height as last checkpoint
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -4,12 +4,51 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	mdutils "github.com/ipfs/go-merkledag/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-node/service/header"
 	"github.com/celestiaorg/celestia-node/service/share"
 )
 
-func TestDASer(t *testing.T) {
+// TestDASerLifecycle tests to ensure every mock block is DASed and
+// the DASer checkpoint is updated to network head.
+func TestDASerLifecycle(t *testing.T) {
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	cstore := NewCheckpointStore(ds) // we aren't storing the checkpoint so that DASer starts DASing from height 1.
+
+	mockGet, shareServ, sub := createDASerSubcomponents(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+	t.Cleanup(cancel)
+
+	daser := NewDASer(shareServ, sub, mockGet, cstore)
+
+	err := daser.Start(ctx)
+	require.NoError(t, err)
+
+	select {
+	// wait for sampleLatest routine to finish so that it stores the
+	// latest DASed checkpoint so that it stores the latest DASed checkpoint
+	case <-daser.sampleLatestDn:
+	case <-ctx.Done():
+	}
+
+	// load checkpoint and ensure it's at network head
+	checkpoint, err := loadCheckpoint(cstore)
+	require.NoError(t, err)
+	assert.Equal(t, int64(30), checkpoint)
+
+	err = daser.Stop(ctx)
+	require.NoError(t, err)
+}
+
+func TestDASer_sampleLatest(t *testing.T) {
 	shareServ, dah := share.RandLightServiceWithSquare(t, 16)
 
 	randHeader := header.RandExtendedHeader(t)
@@ -21,23 +60,97 @@ func TestDASer(t *testing.T) {
 	}
 
 	mockGet := new(mockGetter)
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	cstore := NewCheckpointStore(ds)
 
-	daser := NewDASer(shareServ, sub, mockGet, nil) // TODO @renaynay
+	daser := NewDASer(shareServ, sub, mockGet, cstore)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {
-		daser.sampleLatest(context.Background(), sub)
+		daser.sampleLatest(context.Background(), sub, 0)
 		wg.Done()
 	}(wg)
 	wg.Wait()
 }
 
+func TestDASer_sampleCheckpoint(t *testing.T) {
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	cstore := NewCheckpointStore(ds)
+
+	mockGet, shareServ, _ := createDASerSubcomponents(t)
+
+	// store checkpoint
+	err := storeCheckpoint(cstore, 2) // pick random header as last checkpoint
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	daser := NewDASer(shareServ, nil, mockGet, cstore)
+	checkpoint, err := loadCheckpoint(cstore)
+	require.NoError(t, err)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		daser.sampleFromCheckpoint(ctx, checkpoint, mockGet.head)
+		wg.Done()
+	}(wg)
+	wg.Wait()
+}
+
+func createDASerSubcomponents(t *testing.T) (*mockGetter, share.Service, header.Subscriber) {
+	dag := mdutils.Mock()
+	shareServ := share.NewService(dag, share.NewLightAvailability(dag))
+
+	mockGet := &mockGetter{
+		headers: make(map[int64]*header.ExtendedHeader),
+	}
+
+	// generate 15 headers from the past for HeaderGetter
+	for i := 0; i < 15; i++ {
+		dah := share.RandFillDAG(t, 16, dag)
+
+		randHeader := header.RandExtendedHeader(t)
+		randHeader.DataHash = dah.Hash()
+		randHeader.DAH = dah
+		randHeader.Height = int64(i + 1)
+
+		mockGet.headers[int64(i+1)] = randHeader
+	}
+	mockGet.head = 15 // network head
+
+	sub := &header.DummySubscriber{
+		Headers: make([]*header.ExtendedHeader, 15),
+	}
+
+	// generate 15 headers from the future for p2pSub to pipe through to DASer
+	index := 0
+	for i := 15; i < 30; i++ {
+		dah := share.RandFillDAG(t, 16, dag)
+
+		randHeader := header.RandExtendedHeader(t)
+		randHeader.DataHash = dah.Hash()
+		randHeader.DAH = dah
+		randHeader.Height = int64(i + 1)
+
+		sub.Headers[index] = randHeader
+		index++
+	}
+
+	return mockGet, shareServ, sub
+}
+
 type mockGetter struct {
-
+	head    int64
+	headers map[int64]*header.ExtendedHeader
 }
 
-func (m mockGetter) GetByHeight(ctx context.Context, u uint64) (*header.ExtendedHeader, error) {
-	panic("implement me")
+func (m mockGetter) Head(context.Context) (*header.ExtendedHeader, error) {
+	return m.headers[m.head], nil
 }
 
+func (m mockGetter) GetByHeight(_ context.Context, height uint64) (*header.ExtendedHeader, error) {
+	return m.headers[int64(height)], nil
+}

--- a/das/doc.go
+++ b/das/doc.go
@@ -1,0 +1,22 @@
+/*
+Package das contains the most important functionality provided by celestia-node.
+It contains logic for running data availability sampling (DAS) routines on block
+headers in the network. DAS is the process of verifying the availability of block
+data by sampling chunks or shares of those blocks.
+
+Package das can confirm the availability of block data in the network via the
+Availability interface which is implemented both in `full` and `light` mode.
+`Full` availability ensures the full reparation of a block's data square (meaning
+the instance will sample for enough shares to be able to fully repair the block's
+data square) while `light` availability samples for shares randomly until it is
+sufficiently likely that all block data is available as it is assumed that there
+are enough `light` availability instances active on the network doing sampling over
+the same block to collectively verify its availability.
+
+The central component of this package is the `DASer`. It performs one basic function:
+a sampling loop that performs DAS on new ExtendedHeaders in the network. The DASer kicks
+off this loop by loading its last DASed header (`checkpoint`) and kicking off a `catchUp`
+loop to DAS all headers between the checkpoint and the current network head. It simultaneously
+continues to perform DAS over new ExtendedHeaders received via gossipsub.
+*/
+package das

--- a/das/interface.go
+++ b/das/interface.go
@@ -6,10 +6,9 @@ import (
 	"github.com/celestiaorg/celestia-node/service/header"
 )
 
-// HeaderGetter contains the behavior necessary for the DASer
-// to retrieve headers that have become newly available during the
-// syncing process in order to perform data availability sampling
-// over headers from the past.
+// HeaderGetter contains the behavior necessary for the DASer to retrieve
+// headers that have been processed during header sync in order to
+// perform data availability sampling over them.
 type HeaderGetter interface {
 	// GetByHeight returns the ExtendedHeader corresponding to the given
 	// block height.

--- a/das/interface.go
+++ b/das/interface.go
@@ -11,8 +11,6 @@ import (
 // syncing process in order to perform data availability sampling
 // over headers from the past.
 type HeaderGetter interface {
-	// Head returns the ExtendedHeader of the chain head.
-	Head(context.Context) (*header.ExtendedHeader, error)
 	// GetByHeight returns the ExtendedHeader corresponding to the given
 	// block height.
 	GetByHeight(context.Context, uint64) (*header.ExtendedHeader, error)

--- a/das/interface.go
+++ b/das/interface.go
@@ -2,6 +2,7 @@ package das
 
 import (
 	"context"
+
 	"github.com/celestiaorg/celestia-node/service/header"
 )
 

--- a/das/interface.go
+++ b/das/interface.go
@@ -6,7 +6,7 @@ import (
 	"github.com/celestiaorg/celestia-node/service/header"
 )
 
-// HeaderGetter contains the behaviour necessary for the DASer
+// HeaderGetter contains the behavior necessary for the DASer
 // to retrieve headers that have become newly available during the
 // syncing process in order to perform data availability sampling
 // over headers from the past.

--- a/das/interface.go
+++ b/das/interface.go
@@ -1,0 +1,18 @@
+package das
+
+import (
+	"context"
+	"github.com/celestiaorg/celestia-node/service/header"
+)
+
+// HeaderGetter contains the behaviour necessary for the DASer
+// to retrieve headers that have become newly available during the
+// syncing process in order to perform data availability sampling
+// over headers from the past.
+type HeaderGetter interface {
+	// Head returns the ExtendedHeader of the chain head.
+	Head(context.Context) (*header.ExtendedHeader, error)
+	// GetByHeight returns the ExtendedHeader corresponding to the given
+	// block height.
+	GetByHeight(context.Context, uint64) (*header.ExtendedHeader, error)
+}

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -140,8 +140,8 @@ func ShareService(lc fx.Lifecycle, dag ipld.DAGService, avail share.Availability
 }
 
 // DASer constructs a new Data Availability Sampler.
-func DASer(lc fx.Lifecycle, avail share.Availability, sub header.Subscriber) *das.DASer {
-	das := das.NewDASer(avail, sub)
+func DASer(lc fx.Lifecycle, avail share.Availability, sub header.Subscriber, hstore header.Store) *das.DASer {
+	das := das.NewDASer(avail, sub, hstore)
 	lc.Append(fx.Hook{
 		OnStart: das.Start,
 		OnStop:  das.Stop,

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -145,7 +145,7 @@ func DASer(
 	avail share.Availability,
 	sub header.Subscriber,
 	hstore header.Store,
-	ds datastore.Datastore,
+	ds datastore.Batching,
 ) *das.DASer {
 	das := das.NewDASer(avail, sub, hstore, ds)
 	lc.Append(fx.Hook{

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -140,8 +140,14 @@ func ShareService(lc fx.Lifecycle, dag ipld.DAGService, avail share.Availability
 }
 
 // DASer constructs a new Data Availability Sampler.
-func DASer(lc fx.Lifecycle, avail share.Availability, sub header.Subscriber, hstore header.Store) *das.DASer {
-	das := das.NewDASer(avail, sub, hstore)
+func DASer(
+	lc fx.Lifecycle,
+	avail share.Availability,
+	sub header.Subscriber,
+	hstore header.Store,
+	ds datastore.Datastore,
+) *das.DASer {
+	das := das.NewDASer(avail, sub, hstore, ds)
 	lc.Append(fx.Hook{
 		OnStart: das.Start,
 		OnStop:  das.Stop,

--- a/service/header/testing.go
+++ b/service/header/testing.go
@@ -228,7 +228,13 @@ func (mhs *DummySubscriber) Subscribe() (Subscription, error) {
 
 func (mhs *DummySubscriber) NextHeader(ctx context.Context) (*ExtendedHeader, error) {
 	defer func() {
-		mhs.Headers = make([]*ExtendedHeader, 0)
+		if len(mhs.Headers) > 1 {
+			// pop the already-returned header
+			cp := mhs.Headers
+			mhs.Headers = cp[1:]
+		} else {
+			mhs.Headers = make([]*ExtendedHeader, 0)
+		}
 	}()
 	if len(mhs.Headers) == 0 {
 		return nil, context.Canceled


### PR DESCRIPTION
This PR implements DASing of past headers in a single routine. 

Eventually, this will be parallelised. 

## TODO 
- [x] figure out what to do in the instance that DASer runs and samples new headers [100:150] and DASer is stopped, so sample routine stores latest checkpoint to disk as last DASed height (150) but catchUp routine has only sampled from [1:40] so there is a gap missing from (40: 100)?
- [x] fix constructor
- [x] cleanup 
- [x] lint
- [x] doc.go
- [x] open issue for parallelisation of DASer
- [x] open issue for `DASState`

Resolves https://github.com/celestiaorg/celestia-node/issues/181.

