### PR TITLE
chore: remove Go 1.16 from GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.16", "1.17"]
+        go: ["1.17"]
     steps:
       - uses: actions/checkout@v2
       - name: set up go


### PR DESCRIPTION
Fixes https://github.com/celestiaorg/celestia-node/issues/472