### PR TITLE
chore(node): always use `param` defined bootstrappers and remove Bootstrappers config field

### DIFF
--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -41,11 +41,3 @@ func WithMutualPeers(addrs []string) Option {
 		return nil
 	}
 }
-
-// WithBootstrapPeers sets the `BootstrapPeers` field in the config.
-func WithBootstrapPeers(addrs []string) Option {
-	return func(cfg *Config, _ *settings) (_ error) {
-		cfg.P2P.BootstrapPeers = addrs
-		return nil
-	}
-}

--- a/node/node_bridge_test.go
+++ b/node/node_bridge_test.go
@@ -167,16 +167,3 @@ func TestBridge_WithMutualPeers(t *testing.T) {
 
 	assert.Equal(t, node.Config.P2P.MutualPeers, peers)
 }
-
-func TestBridge_WithBootstrapPeers(t *testing.T) {
-	repo := MockStore(t, DefaultConfig(Bridge))
-	peers := []string{
-		"/ip6/100:0:114b:abc5:e13a:c32f:7a9e:f00a/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
-		"/ip4/192.168.1.10/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
-	}
-	node, err := New(Bridge, repo, WithBootstrapPeers(peers))
-	require.NoError(t, err)
-	require.NotNil(t, node)
-
-	assert.Equal(t, node.Config.P2P.BootstrapPeers, peers)
-}

--- a/node/node_light_test.go
+++ b/node/node_light_test.go
@@ -75,16 +75,3 @@ func TestLight_WithMutualPeers(t *testing.T) {
 
 	assert.Equal(t, node.Config.P2P.MutualPeers, peers)
 }
-
-func TestLight_WithBootstrapPeers(t *testing.T) {
-	repo := MockStore(t, DefaultConfig(Light))
-	peers := []string{
-		"/ip6/100:0:114b:abc5:e13a:c32f:7a9e:f00a/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
-		"/ip4/192.168.1.10/tcp/2121/p2p/12D3KooWSRqDfpLsQxpyUhLC9oXHD2WuZ2y5FWzDri7LT4Dw9fSi",
-	}
-	node, err := New(Light, repo, WithBootstrapPeers(peers))
-	require.NoError(t, err)
-	require.NotNil(t, node)
-
-	assert.Equal(t, node.Config.P2P.BootstrapPeers, peers)
-}

--- a/node/p2p/misc.go
+++ b/node/p2p/misc.go
@@ -9,6 +9,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
+
+	"github.com/celestiaorg/celestia-node/params"
 )
 
 // ConnManagerConfig configures connection manager.
@@ -35,11 +37,7 @@ func ConnectionManager(cfg Config) func() (coreconnmgr.ConnManager, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		bpeers, err := cfg.bootstrapPeers()
-		if err != nil {
-			return nil, err
-		}
+		bpeers := params.BootstrappersInfos()
 
 		cm := connmgr.NewConnManager(cfg.ConnManager.Low, cfg.ConnManager.High, cfg.ConnManager.GracePeriod)
 		for _, info := range fpeers {

--- a/node/p2p/p2p.go
+++ b/node/p2p/p2p.go
@@ -21,8 +21,6 @@ type Config struct {
 	// TODO(@Wondertan): This should be a build-time parameter. See https://github.com/celestiaorg/celestia-node/issues/63
 	// Bootstrapper is flag telling this node is a bootstrapper.
 	Bootstrapper bool
-	// BootstrapPeers is a list of network specific peers that help with network bootstrapping.
-	BootstrapPeers []string
 	// MutualPeers are peers which have a bidirectional peering agreement with the configured node.
 	// Connections with those peers are protected from being trimmed, dropped or negatively scored.
 	// NOTE: Any two peers must bidirectionally configure each other on their MutualPeers field.
@@ -47,11 +45,10 @@ func DefaultConfig() Config {
 			"/ip4/127.0.0.1/tcp/2121",
 			"/ip6/::/tcp/2121",
 		},
-		BootstrapPeers: []string{},
-		MutualPeers:    []string{},
-		Bootstrapper:   false,
-		PeerExchange:   false,
-		ConnManager:    DefaultConnManagerConfig(),
+		MutualPeers:  []string{},
+		Bootstrapper: false,
+		PeerExchange: false,
+		ConnManager:  DefaultConnManagerConfig(),
 	}
 }
 
@@ -73,18 +70,6 @@ func Components(cfg Config) fxutil.Option {
 		fxutil.Provide(AddrsFactory(cfg.AnnounceAddresses, cfg.NoAnnounceAddresses)),
 		fxutil.Invoke(Listen(cfg.ListenAddresses)),
 	)
-}
-
-func (cfg *Config) bootstrapPeers() (_ []peer.AddrInfo, err error) {
-	maddrs := make([]ma.Multiaddr, len(cfg.BootstrapPeers))
-	for i, addr := range cfg.BootstrapPeers {
-		maddrs[i], err = ma.NewMultiaddr(addr)
-		if err != nil {
-			return nil, fmt.Errorf("failure to parse config.P2P.BootstrapPeers: %s", err)
-		}
-	}
-
-	return peer.AddrInfosFromP2pAddrs(maddrs...)
 }
 
 func (cfg *Config) mutualPeers() (_ []peer.AddrInfo, err error) {

--- a/node/p2p/routing.go
+++ b/node/p2p/routing.go
@@ -25,14 +25,11 @@ func ContentRouting() routing.ContentRouting {
 // Basically, this provides a way to discover peer addresses by respecting public keys.
 func PeerRouting(cfg Config) func(routingParams) (routing.PeerRouting, error) {
 	return func(params routingParams) (routing.PeerRouting, error) {
-		bpeers, err := cfg.bootstrapPeers()
-		if err != nil {
-			return nil, err
-		}
-
+		bpeers := nparams.BootstrappersInfos()
 		prefix := fmt.Sprintf("/celestia/%s", nparams.GetNetwork())
 		mode := dht.ModeAuto
 		if cfg.Bootstrapper {
+			bpeers = nil // no bootstrappers for a bootstrapper ¯\_(ツ)_/¯
 			mode = dht.ModeServer
 		}
 

--- a/params/bootstrap.go
+++ b/params/bootstrap.go
@@ -1,5 +1,30 @@
 package params
 
+import (
+	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// BootstrappersInfos returns address information of bootstrap peers for the node's current network.
+func BootstrappersInfos() []peer.AddrInfo {
+	bs := Bootstrappers()
+	maddrs := make([]ma.Multiaddr, len(bs))
+	for i, addr := range bs {
+		maddr, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			panic(err)
+		}
+		maddrs[i] = maddr
+	}
+
+	infos, err := peer.AddrInfosFromP2pAddrs(maddrs...)
+	if err != nil {
+		panic(err)
+	}
+
+	return infos
+}
+
 // Bootstrappers reports multiaddresses of bootstrap peers for the node's current network.
 func Bootstrappers() []string {
 	return bootstrapList[network] // network is guaranteed to be valid


### PR DESCRIPTION
Currently, we allow users to configure bootstrap peers, while this set of peers is constant and defined by the network infrastructure providers, so this is something that users shouldn't be able to change deliberately. The only case where users would want to change their bootstrappers is when they want to join a different network, but this is something that will be done automatically when we start to support multiple networks (#349). Originally, we had this field to be able to quickly configure bootstrappers, but it was clear then that configuring this is not a good idea. Also, putting wrong values there may break network connectivity so altogether it makes sense to remove this field.

> This is what I decide to do together while fixing #488. Something simple to get into working mode again from a mild depressive state.

Closes #488, closes #489