### PR TITLE
service/header/core_listener: Fix bug where old block headers are spammed to headersub by bridge nodes

### DIFF
--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/types"
@@ -190,7 +191,9 @@ func (f *BlockFetcher) IsSyncing(ctx context.Context) (bool, error) {
 }
 
 // WaitFinishSync will block until the Core connection has finished syncing,
-// returning a nil error.
+// returning a nil error. A non-nil error will be returned if the context is
+// canceled or if there is an error fetching syncing status from the Core
+// connection.
 func (f *BlockFetcher) WaitFinishSync(ctx context.Context) error {
 	for {
 		select {
@@ -204,7 +207,8 @@ func (f *BlockFetcher) WaitFinishSync(ctx context.Context) error {
 			if !syncing {
 				return nil
 			}
-			// TODO @renaynay: should I wait a second or two to request again? Doesn't make sense to keep requesting.
+			// wait a second before requesting sync status again
+			time.Sleep(time.Second)
 		}
 	}
 }

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"time"
 
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/types"
@@ -188,27 +187,4 @@ func (f *BlockFetcher) IsSyncing(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return resp.SyncInfo.CatchingUp, nil
-}
-
-// WaitFinishSync will block until the Core connection has finished syncing,
-// returning a nil error. A non-nil error will be returned if the context is
-// canceled or if there is an error fetching syncing status from the Core
-// connection.
-func (f *BlockFetcher) WaitFinishSync(ctx context.Context) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			syncing, err := f.IsSyncing(ctx)
-			if err != nil {
-				return err
-			}
-			if !syncing {
-				return nil
-			}
-			// wait a second before requesting sync status again
-			time.Sleep(time.Second)
-		}
-	}
 }


### PR DESCRIPTION
Resolves #499.