### PR TITLE
Update docker-build GH action to push sha tagged images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          platform: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64
           push: true
-          tags: ghcr.io/celestiaorg/celestia-node:latest
+          tags: ${{ steps.meta.outputs.tags }}
           file: docker/Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,8 +30,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to GHCR

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,10 +30,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
-      - name: "Build"
-        run: "make build"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to GHCR

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,8 +3,12 @@ name: "docker-build"
 on:
   push:
     branches:
-      - "main"
+      - "**"
   workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker-build:
@@ -19,6 +23,13 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
       - name: "Build"
         run: "make build"
       - name: Set up QEMU
@@ -34,6 +45,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          platform: linux/amd64, linux/arm64
           push: true
           tags: ghcr.io/celestiaorg/celestia-node:latest
           file: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,12 @@
 FROM --platform=$BUILDPLATFORM golang:1.17 as builder
 RUN apt-get update && \
     apt-get install make bash
-ENV HOME /celestia-node
-COPY / ${HOME}
-WORKDIR ${HOME}
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
 ARG TARGETOS TARGETARCH
-RUN env GOOS=TARGETOS GOARCH=TARGETARCH make build
+RUN env GOOS=$TARGETOS GOARCH=$TARGETARCH make build
 
 FROM ubuntu
 # Default node type can be overwritten in deployment manifest
@@ -14,7 +15,7 @@ ENV NODE_TYPE bridge
 COPY docker/entrypoint.sh /
 
 # Copy in the binary
-COPY --from=builder /celestia-node/celestia /
+COPY --from=builder /src/celestia /
 
 EXPOSE 2121
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && \
 ENV HOME /celestia-node
 COPY / ${HOME}
 WORKDIR ${HOME}
-ARG TARGETPLATFORM
-RUN env GOOS=linux GOARCH=TARGETPLATFORM make build
+ARG TARGETOS TARGETARCH
+RUN env GOOS=TARGETOS GOARCH=TARGETARCH make build
 
 FROM ubuntu
 # Default node type can be overwritten in deployment manifest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:1.17 as builder
-RUN apt update && \
-    apt install make bash
+FROM --platform=$BUILDPLATFORM golang:1.17 as builder
+RUN apt-get update && \
+    apt-get install make bash
 ENV HOME /celestia-node
 COPY / ${HOME}
 WORKDIR ${HOME}
-RUN env GOOS=linux GOARCH=amd64 make build
+ARG TARGETPLATFORM
+RUN env GOOS=linux GOARCH=TARGETPLATFORM make build
 
 FROM ubuntu
 # Default node type can be overwritten in deployment manifest


### PR DESCRIPTION
This PR updates the docker-build GH Action. Notable changes
- Runs on pushes to all branches and tags the image with the short sha of the git commit
- Builds multi platform (amd64 and arm64) images using cross compilation

You can see an example of a successful run [here](https://github.com/jbowen93/celestia-node/actions/runs/2018410000) with the resulting images pushed [here](https://github.com/jbowen93/celestia-node/pkgs/container/celestia-node)