### PR TITLE
fix(service/header): unlock the heightSub lock on a rare case

### DIFF
--- a/service/header/store_heightsub.go
+++ b/service/header/store_heightsub.go
@@ -49,6 +49,7 @@ func (hs *heightSub) Sub(ctx context.Context, height uint64) (*ExtendedHeader, e
 		// This is a rare case we have to account for.
 		// The lock above can park a goroutine long enough for hs.height to change for a requested height,
 		// leaving the request never fulfilled and the goroutine deadlocked.
+		hs.heightReqsLk.Unlock()
 		return nil, errElapsedHeight
 	}
 	resp := make(chan *ExtendedHeader, 1)


### PR DESCRIPTION
Luckily, this wasn't causing any problems to us yet and I just caught it randomly by looking at the code. Pretty embarrassing bug it is.