### PR TITLE
service/header/p2p_exchange: Revert exchange protocol upgrade 

### DIFF
--- a/service/header/p2p_exchange.go
+++ b/service/header/p2p_exchange.go
@@ -13,11 +13,10 @@ import (
 
 	"github.com/celestiaorg/go-libp2p-messenger/serde"
 
-	params "github.com/celestiaorg/celestia-node/params"
 	pb "github.com/celestiaorg/celestia-node/service/header/pb"
 )
 
-var exchangeProtocolID = protocol.ID(fmt.Sprintf("/header-ex/v0.0.1/%s", params.GetNetwork()))
+var exchangeProtocolID = protocol.ID("/header-ex/v0.0.1")
 
 // P2PExchange enables sending outbound ExtendedHeaderRequests to the network as well as
 // handling inbound ExtendedHeaderRequests from the network.


### PR DESCRIPTION
Resolves problems reported in #511 (and consequently #510) for now as we pushed a protocol upgrade without handling for backwards compatibility with the latest release / devnet. 

We will re-introduce this upgrade in the next release. 

