### PR TITLE
swamp: Fixing nits for NewNodeWithStore and timeout

### DIFF
--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -204,6 +204,9 @@ func (s *Swamp) NewLightNode(options ...node.Option) *node.Node {
 	return s.NewNodeWithStore(node.Light, store, options...)
 }
 
+// NewNodeWithStore creates a new instance of Node with predefined Store.
+// Afterwards, the instance is stored in the swamp's Nodes' slice according to the
+// node's type provided from the user.
 func (s *Swamp) NewNodeWithStore(t node.Type, store node.Store, options ...node.Option) *node.Node {
 	var n *node.Node
 

--- a/node/tests/sync_test.go
+++ b/node/tests/sync_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/celestiaorg/celestia-node/node/tests/swamp"
 )
 
+// a default timeout for the context that is used in tests
+const defaultTimeout = 40 * time.Second
+
 /*
 Test-Case: Sync a Light Node with a Bridge Node
 Steps:
@@ -29,7 +32,7 @@ func TestSyncLightWithBridge(t *testing.T) {
 
 	bridge := sw.NewBridgeNode()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	t.Cleanup(cancel)
 
 	sw.WaitTillHeight(ctx, 20)
@@ -76,7 +79,7 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 
 	bridge := sw.NewBridgeNode()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	t.Cleanup(cancel)
 
 	sw.WaitTillHeight(ctx, 50)
@@ -128,7 +131,7 @@ func TestSyncFullWithBridge(t *testing.T) {
 
 	bridge := sw.NewBridgeNode()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	t.Cleanup(cancel)
 
 	sw.WaitTillHeight(ctx, 20)


### PR DESCRIPTION
- adding comments to public NewNodeWithStore
- removing redundant timeouts in sync tests

Ref: #538 