### PR TITLE
swamp/tests: light node syncs with multiple trusted peers

### DIFF
--- a/cmd/flags_header.go
+++ b/cmd/flags_header.go
@@ -64,7 +64,7 @@ func ParseTrustedPeerFlags(cmd *cobra.Command, env *Env) error {
 		}
 	}
 
-	env.AddOptions(node.WithTrustedPeers(tpeers))
+	env.AddOptions(node.WithTrustedPeers(tpeers...))
 
 	return nil
 }

--- a/cmd/flags_header.go
+++ b/cmd/flags_header.go
@@ -62,8 +62,9 @@ func ParseTrustedPeerFlags(cmd *cobra.Command, env *Env) error {
 		if err != nil {
 			return fmt.Errorf("cmd: while parsing '%s' with peer addr '%s': %w", headersTrustedPeersFlag, tpeer, err)
 		}
-		env.AddOptions(node.WithTrustedPeer(tpeer))
 	}
+
+	env.AddOptions(node.WithTrustedPeers(tpeers))
 
 	return nil
 }

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -19,7 +19,7 @@ func WithTrustedHash(hash string) Option {
 }
 
 // WithTrustedPeers appends a slice of TrustedPeers to the Config.
-func WithTrustedPeers(addr []string) Option {
+func WithTrustedPeers(addr ...string) Option {
 	return func(cfg *Config, _ *settings) (_ error) {
 		cfg.Services.TrustedPeers = append(cfg.Services.TrustedPeers, addr...)
 		return

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -18,7 +18,7 @@ func WithTrustedHash(hash string) Option {
 	}
 }
 
-// WithTrustedPeers appends a slice of TrustedPeers to the Config.
+// WithTrustedPeers appends new "trusted peers" to the Config.
 func WithTrustedPeers(addr ...string) Option {
 	return func(cfg *Config, _ *settings) (_ error) {
 		cfg.Services.TrustedPeers = append(cfg.Services.TrustedPeers, addr...)

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -18,10 +18,10 @@ func WithTrustedHash(hash string) Option {
 	}
 }
 
-// WithTrustedPeer appends TrustedPeer to the Config.
-func WithTrustedPeer(addr string) Option {
+// WithTrustedPeers appends a slice of TrustedPeers to the Config.
+func WithTrustedPeers(addr []string) Option {
 	return func(cfg *Config, _ *settings) (_ error) {
-		cfg.Services.TrustedPeers = append(cfg.Services.TrustedPeers, addr)
+		cfg.Services.TrustedPeers = append(cfg.Services.TrustedPeers, addr...)
 		return
 	}
 }

--- a/node/tests/sync_test.go
+++ b/node/tests/sync_test.go
@@ -172,10 +172,9 @@ Steps:
 4. Create a Full Node(FN) with a connection to BN as a trusted peer
 5. Start a FN
 6. Check FN is synced to height 30
-7. Create a Light Node(LN) with a connection to FN as a trusted  peer
-8. Start a LN with a defined connection to the FN
-9. Start LN
-10. Check LN is synced to height 50
+7. Create a Light Node(LN) with a connection to FN as a trusted peer
+8. Start LN
+9. Check LN is synced to height 50
 */
 func TestSyncLightWithFull(t *testing.T) {
 	sw := swamp.NewSwamp(t, swamp.DefaultComponents())
@@ -225,6 +224,22 @@ func TestSyncLightWithFull(t *testing.T) {
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 50))
 }
 
+/*
+Test-Case: Sync a Light Node with multiple trusted peers
+Pre-Requisites:
+- CoreClient is started by swamp
+- CoreClient has generated 20 blocks
+Steps:
+1. Create a Bridge Node(BN)
+2. Start a BN
+3. Check BN is synced to height 20
+4. Create a Full Node(FN) with a connection to BN as a trusted peer
+5. Start a FN
+6. Check FN is synced to height 30
+7. Create a Light Node(LN) with a connection to BN, FN as trusted peers
+8. Start LN
+9. Check LN is synced to height 50
+*/
 func TestSyncLightWithMultiplePeers(t *testing.T) {
 	sw := swamp.NewSwamp(t, swamp.DefaultComponents())
 

--- a/node/tests/sync_test.go
+++ b/node/tests/sync_test.go
@@ -47,9 +47,8 @@ func TestSyncLightWithBridge(t *testing.T) {
 
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
-	trustedPeers := []string{addrs[0].String()}
 
-	light := sw.NewLightNode(node.WithTrustedPeers(trustedPeers))
+	light := sw.NewLightNode(node.WithTrustedPeers(addrs[0].String()))
 
 	err = light.Start(ctx)
 	require.NoError(t, err)
@@ -96,10 +95,9 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
-	trustedPeers := []string{addrs[0].String()}
 
 	store := node.MockStore(t, node.DefaultConfig(node.Light))
-	light := sw.NewNodeWithStore(node.Light, store, node.WithTrustedPeers(trustedPeers))
+	light := sw.NewNodeWithStore(node.Light, store, node.WithTrustedPeers(addrs[0].String()))
 	require.NoError(t, light.Start(ctx))
 
 	h, err = light.HeaderServ.GetByHeight(ctx, 30)
@@ -110,7 +108,7 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 	require.NoError(t, light.Stop(ctx))
 	require.NoError(t, sw.RemoveNode(light, node.Light))
 
-	light = sw.NewNodeWithStore(node.Light, store, node.WithTrustedPeers(trustedPeers))
+	light = sw.NewNodeWithStore(node.Light, store, node.WithTrustedPeers(addrs[0].String()))
 	require.NoError(t, light.Start(ctx))
 
 	h, err = light.HeaderServ.GetByHeight(ctx, 40)
@@ -149,9 +147,8 @@ func TestSyncFullWithBridge(t *testing.T) {
 
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
-	trustedPeers := []string{addrs[0].String()}
 
-	full := sw.NewFullNode(node.WithTrustedPeers(trustedPeers))
+	full := sw.NewFullNode(node.WithTrustedPeers(addrs[0].String()))
 	require.NoError(t, full.Start(ctx))
 
 	h, err = full.HeaderServ.GetByHeight(ctx, 30)
@@ -196,9 +193,8 @@ func TestSyncLightWithFull(t *testing.T) {
 
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
-	trustedPeers := []string{addrs[0].String()}
 
-	full := sw.NewFullNode(node.WithTrustedPeers(trustedPeers))
+	full := sw.NewFullNode(node.WithTrustedPeers(addrs[0].String()))
 	require.NoError(t, full.Start(ctx))
 
 	h, err = full.HeaderServ.GetByHeight(ctx, 30)
@@ -208,9 +204,8 @@ func TestSyncLightWithFull(t *testing.T) {
 
 	addrs, err = peer.AddrInfoToP2pAddrs(host.InfoFromHost(full.Host))
 	require.NoError(t, err)
-	trustedPeers = []string{addrs[0].String()}
 
-	light := sw.NewLightNode(node.WithTrustedPeers(trustedPeers))
+	light := sw.NewLightNode(node.WithTrustedPeers(addrs[0].String()))
 
 	err = sw.Network.UnlinkPeers(bridge.Host.ID(), light.Host.ID())
 	require.NoError(t, err)
@@ -240,7 +235,7 @@ Steps:
 8. Start LN
 9. Check LN is synced to height 50
 */
-func TestSyncLightWithMultiplePeers(t *testing.T) {
+func TestSyncLightWithTrustedPeers(t *testing.T) {
 	sw := swamp.NewSwamp(t, swamp.DefaultComponents())
 
 	bridge := sw.NewBridgeNode()
@@ -263,7 +258,7 @@ func TestSyncLightWithMultiplePeers(t *testing.T) {
 
 	trustedPeers := []string{addrs[0].String()}
 
-	full := sw.NewFullNode(node.WithTrustedPeers(trustedPeers))
+	full := sw.NewFullNode(node.WithTrustedPeers(addrs[0].String()))
 	require.NoError(t, full.Start(ctx))
 
 	h, err = full.HeaderServ.GetByHeight(ctx, 30)
@@ -276,7 +271,7 @@ func TestSyncLightWithMultiplePeers(t *testing.T) {
 
 	trustedPeers = append(trustedPeers, addrs[0].String())
 
-	light := sw.NewLightNode(node.WithTrustedPeers(trustedPeers))
+	light := sw.NewLightNode(node.WithTrustedPeers(trustedPeers...))
 
 	err = light.Start(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
- Edit WithTrustedPeers to accept a slice of strings/multiaddresses
- Adapt flags
- Minor prettifying of how we treat addr[0] as a separate var called `trustedPeers`
- Increased timeout context for start/stop for stable local execution on macOS, when user executes `make test` in cli

Resolves #418 