### PR TITLE
feat(params): network configurations via environment vars

### DIFF
--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -17,11 +17,19 @@ import (
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 	"github.com/tendermint/tendermint/types"
 
+	"github.com/celestiaorg/celestia-node/params"
+
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/libs/keystore"
 	"github.com/celestiaorg/celestia-node/node"
 	"github.com/celestiaorg/celestia-node/node/p2p"
 )
+
+func init() {
+	// NOTE: This way any pkg that imports swamp also gets it network to be private.
+	// This is ok as Swamp must not be imported from non-testing environment.
+	params.DefaultNetwork = params.Private
+}
 
 var blackholeIP6 = net.ParseIP("100::")
 

--- a/params/bootstrap.go
+++ b/params/bootstrap.go
@@ -1,6 +1,9 @@
 package params
 
 import (
+	"os"
+	"strings"
+
 	"github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -46,4 +49,29 @@ var bootstrapList = map[Network][]string{
 		"/dns4/libra.celestia-devops.dev/tcp/2121/p2p/12D3KooWK5aDotDcLsabBmWDazehQLMsDkRyARm1k7f1zGAXqbt4",
 		"/dns4/norma.celestia-devops.dev/tcp/2121/p2p/12D3KooWHYczJDVNfYVkLcNHPTDKCeiVvRhg8Q9JU3bE3m9eEVyY",
 	},
+	Private: {},
+}
+
+func init() {
+	if bootstrappers, ok := os.LookupEnv("CELESTIA_BOOTSTRAPPERS"); ok {
+		// validate value correctness
+		bs := strings.Split(bootstrappers, ",")
+		maddrs := make([]ma.Multiaddr, len(bs))
+		for i, addr := range bs {
+			maddr, err := ma.NewMultiaddr(addr)
+			if err != nil {
+				println("wrong multiaddress in CELESTIA_BOOTSTRAPPERS")
+				panic(err)
+			}
+			maddrs[i] = maddr
+		}
+
+		_, err := peer.AddrInfosFromP2pAddrs(maddrs...)
+		if err != nil {
+			println("wrong multiaddress in CELESTIA_BOOTSTRAPPERS")
+			panic(err)
+		}
+
+		bootstrapList[Private] = bs
+	}
 }

--- a/params/genesis.go
+++ b/params/genesis.go
@@ -6,6 +6,8 @@ import (
 )
 
 // Genesis reports a hash of a genesis block for the current network.
+// Genesis is strictly defined and can't be modified.
+// To run a custom genesis private network use CELESTIA_PRIVATE_GENESIS env var.
 func Genesis() string {
 	return genesisList[network] // network is guaranteed to be valid
 }
@@ -26,7 +28,7 @@ var genesisList = map[Network]string{
 }
 
 func init() {
-	if genesis, ok := os.LookupEnv("CELESTIA_GENESIS_HASH"); ok {
+	if genesis, ok := os.LookupEnv("CELESTIA_PRIVATE_GENESIS"); ok {
 		network = Private
 		genesisList[Private] = strings.ToUpper(genesis)
 	}

--- a/params/genesis.go
+++ b/params/genesis.go
@@ -1,5 +1,10 @@
 package params
 
+import (
+	"os"
+	"strings"
+)
+
 // Genesis reports a hash of a genesis block for the current network.
 func Genesis() string {
 	return genesisList[network] // network is guaranteed to be valid
@@ -16,5 +21,13 @@ func GenesisFor(net Network) (string, error) {
 
 // NOTE: Every time we add a new long-running network, its genesis hash has to be added here.
 var genesisList = map[Network]string{
-	DevNet: "4632277C441CA6155C4374AC56048CF4CFE3CBB2476E07A548644435980D5E17",
+	DevNet:  "4632277C441CA6155C4374AC56048CF4CFE3CBB2476E07A548644435980D5E17",
+	Private: "",
+}
+
+func init() {
+	if genesis, ok := os.LookupEnv("CELESTIA_GENESIS_HASH"); ok {
+		network = Private
+		genesisList[Private] = strings.ToUpper(genesis)
+	}
 }

--- a/params/networks.go
+++ b/params/networks.go
@@ -17,8 +17,7 @@ const (
 	// DevNet or devnet-2 according to celestiaorg/networks
 	DevNet Network = "devnet-2"
 	// Private can be used to set up any private network, including local testing setups.
-	// Use CELESTIA_GENESIS_HASH env var to enable Private by specifying its genesis block hash.
-	// Use CELESTIA_BOOTSTRAPPERS env var to set bootstrap peers for the private network.
+	// Use CELESTIA_PRIVATE_GENESIS env var to enable Private by specifying its genesis block hash.
 	Private Network = "private"
 )
 
@@ -26,7 +25,7 @@ const (
 type Network string
 
 // ErrInvalidNetwork is thrown when unknown network is used.
-var ErrInvalidNetwork = errors.New("build: invalid network")
+var ErrInvalidNetwork = errors.New("params: invalid network")
 
 // Validate the network.
 func (n Network) Validate() error {

--- a/params/networks.go
+++ b/params/networks.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"errors"
+	"os"
 )
 
 // GetNetwork returns the network of the current build.
@@ -47,6 +48,16 @@ var network Network
 
 // init ensures `network` is always set and correct
 func init() {
+	if net, ok := os.LookupEnv("CELESTIA_NETWORK"); ok {
+		network = Network(net)
+		if err := network.Validate(); err != nil {
+			println("env CELESTIA_NETWORK")
+			panic(err)
+		}
+
+		return
+	}
+
 	if network == "" {
 		network = DefaultNetwork
 	}

--- a/params/networks.go
+++ b/params/networks.go
@@ -1,6 +1,8 @@
 package params
 
-import "errors"
+import (
+	"errors"
+)
 
 // GetNetwork returns the network of the current build.
 func GetNetwork() Network {
@@ -14,6 +16,10 @@ var DefaultNetwork = DevNet
 const (
 	// DevNet or devnet-2 according to celestiaorg/networks
 	DevNet Network = "devnet-2"
+	// Private can be used to set up any private network, including local testing setups.
+	// Use CELESTIA_GENESIS_HASH env var to enable Private by specifying its genesis block hash.
+	// Use CELESTIA_BOOTSTRAPPERS env var to set bootstrap peers for the private network.
+	Private Network = "private"
 )
 
 // Network is a type definition for DA network run by Celestia Node.
@@ -32,7 +38,8 @@ func (n Network) Validate() error {
 
 // networksList is a strict list of all known long-standing networks.
 var networksList = map[Network]struct{}{
-	DevNet: {},
+	DevNet:  {},
+	Private: {},
 }
 
 // network is the currently used network within a build.


### PR DESCRIPTION
Mainly this PR adds:
* New Private network type for private or testing setups
* `CELESTIA_PRIVATE_GENESIS` env var which intstructs _private network_ on a node via setting genesis hash
* `CELESTIA_BOOTSTRAPPERS` env var which sets custom bootstrappers for _any_ network.
* `CELESTIA_NETWORK` env var which sets the network for the node.
Closes: https://github.com/celestiaorg/celestia-node/issues/550