### PR TITLE
refactor(params): globalstateless network definition

### DIFF
--- a/node/components.go
+++ b/node/components.go
@@ -9,6 +9,8 @@ import (
 	"github.com/raulk/go-watchdog"
 	"go.uber.org/fx"
 
+	"github.com/celestiaorg/celestia-node/params"
+
 	nodecore "github.com/celestiaorg/celestia-node/node/core"
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/node/p2p"
@@ -51,6 +53,7 @@ func fullComponents(cfg *Config, store Store) fxutil.Option {
 // baseComponents keeps all the common components shared between different Node types.
 func baseComponents(cfg *Config, store Store) fxutil.Option {
 	return fxutil.Options(
+		fxutil.Supply(params.DefaultNetwork()),
 		fxutil.Provide(context.Background),
 		fxutil.Supply(cfg),
 		fxutil.Supply(store.Config),

--- a/node/fxutil/options.go
+++ b/node/fxutil/options.go
@@ -134,7 +134,7 @@ func OverrideSupply(vals ...interface{}) Option {
 				refVal, tp = refVal.Elem(), tp.Elem()
 			}
 
-			if !refVal.IsValid() {
+			if !refVal.IsValid() || refVal.IsZero() {
 				// All the really invalid cases are checked and errors for them are thrown above the line.
 				// Regarding this case, it is basically nil or zero value, and it is usually fine to allow zeros to be
 				// passed in the optional pattern, e.g WithSomething(nil), so you don't need to check for

--- a/node/node.go
+++ b/node/node.go
@@ -20,6 +20,7 @@ import (
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/node/rpc"
+	"github.com/celestiaorg/celestia-node/params"
 	"github.com/celestiaorg/celestia-node/service/header"
 	"github.com/celestiaorg/celestia-node/service/share"
 )
@@ -35,8 +36,9 @@ var log = logging.Logger("node")
 // * Light
 // * Full
 type Node struct {
-	Type   Type
-	Config *Config
+	Type    Type
+	Network params.Network
+	Config  *Config
 
 	// CoreClient provides access to a Core node process.
 	CoreClient core.Client `optional:"true"`

--- a/node/node_light_test.go
+++ b/node/node_light_test.go
@@ -9,6 +9,8 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/params"
 )
 
 func TestNewLightAndLifecycle(t *testing.T) {
@@ -55,4 +57,10 @@ func TestLight_WithMutualPeers(t *testing.T) {
 	node := TestNode(t, Light, WithMutualPeers(peers))
 	require.NotNil(t, node)
 	assert.Equal(t, node.Config.P2P.MutualPeers, peers)
+}
+
+func TestLight_WithNetwork(t *testing.T) {
+	node := TestNode(t, Light, WithNetwork(params.DevNet))
+	require.NotNil(t, node)
+	assert.Equal(t, node.Network, params.DevNet)
 }

--- a/node/p2p/bitswap.go
+++ b/node/p2p/bitswap.go
@@ -43,7 +43,7 @@ func DataExchange(cfg Config) func(bitSwapParams) (exchange.Interface, blockstor
 		if err != nil {
 			return nil, nil, err
 		}
-		prefix := protocol.ID(fmt.Sprintf("/celestia/%s", nparams.GetNetwork()))
+		prefix := protocol.ID(fmt.Sprintf("/celestia/%s", params.Net))
 		return bitswap.New(
 			ctx,
 			network.NewFromIpfsHost(params.Host, params.Cr, network.Prefix(prefix)),
@@ -57,6 +57,7 @@ type bitSwapParams struct {
 	fx.In
 
 	Ctx  context.Context
+	Net  nparams.Network
 	Lc   fx.Lifecycle
 	Host host.Host
 	Cr   routing.ContentRouting

--- a/node/p2p/host.go
+++ b/node/p2p/host.go
@@ -35,7 +35,7 @@ func Host(cfg Config) func(hostParams) (HostBase, error) {
 			libp2p.Peerstore(params.PStore),
 			libp2p.ConnectionManager(params.ConnMngr),
 			libp2p.ConnectionGater(params.ConnGater),
-			libp2p.UserAgent(fmt.Sprintf("celestia-%s", nparams.GetNetwork())),
+			libp2p.UserAgent(fmt.Sprintf("celestia-%s", params.Net)),
 			libp2p.NATPortMap(), // enables upnp
 			libp2p.DisableRelay(),
 			// to clearly define what defaults we rely upon
@@ -68,6 +68,7 @@ type hostParams struct {
 	fx.In
 
 	Ctx       context.Context
+	Net       nparams.Network
 	Lc        fx.Lifecycle
 	ID        peer.ID
 	Key       crypto.PrivKey

--- a/node/p2p/misc.go
+++ b/node/p2p/misc.go
@@ -31,13 +31,17 @@ func DefaultConnManagerConfig() ConnManagerConfig {
 }
 
 // ConnectionManager provides a constructor for ConnectionManager.
-func ConnectionManager(cfg Config) func() (coreconnmgr.ConnManager, error) {
-	return func() (coreconnmgr.ConnManager, error) {
+func ConnectionManager(cfg Config) func(params.Network) (coreconnmgr.ConnManager, error) {
+	return func(net params.Network) (coreconnmgr.ConnManager, error) {
 		fpeers, err := cfg.mutualPeers()
 		if err != nil {
 			return nil, err
 		}
-		bpeers := params.BootstrappersInfos()
+
+		bpeers, err := params.BootstrappersInfosFor(net)
+		if err != nil {
+			return nil, err
+		}
 
 		cm := connmgr.NewConnManager(cfg.ConnManager.Low, cfg.ConnManager.High, cfg.ConnManager.GracePeriod)
 		for _, info := range fpeers {

--- a/node/p2p/routing.go
+++ b/node/p2p/routing.go
@@ -25,10 +25,15 @@ func ContentRouting() routing.ContentRouting {
 // Basically, this provides a way to discover peer addresses by respecting public keys.
 func PeerRouting(cfg Config) func(routingParams) (routing.PeerRouting, error) {
 	return func(params routingParams) (routing.PeerRouting, error) {
+		bpeers, err := nparams.BootstrappersInfosFor(params.Net)
+		if err != nil {
+			return nil, err
+		}
+
 		opts := []dht.Option{
 			dht.Mode(dht.ModeAuto),
-			dht.BootstrapPeers(nparams.BootstrappersInfos()...),
-			dht.ProtocolPrefix(protocol.ID(fmt.Sprintf("/celestia/%s", nparams.GetNetwork()))),
+			dht.BootstrapPeers(bpeers...),
+			dht.ProtocolPrefix(protocol.ID(fmt.Sprintf("/celestia/%s", params.Net))),
 			dht.Datastore(params.DataStore),
 			dht.QueryFilter(dht.PublicQueryFilter),
 			dht.RoutingTableFilter(dht.PublicRoutingTableFilter),
@@ -66,6 +71,7 @@ type routingParams struct {
 	fx.In
 
 	Ctx       context.Context
+	Net       nparams.Network
 	Lc        fx.Lifecycle
 	Host      HostBase
 	DataStore datastore.Batching

--- a/node/services/config.go
+++ b/node/services/config.go
@@ -32,7 +32,7 @@ func DefaultConfig() Config {
 
 func (cfg *Config) trustedPeers(net params.Network) (infos []*peer.AddrInfo, err error) {
 	if len(cfg.TrustedPeers) == 0 {
-		log.Info("No trusted peers in config, initializing with default bootstrappers as trusted peers")
+		log.Infow("No trusted peers in config, initializing with default bootstrappers as trusted peers for network: ", net)
 		cfg.TrustedPeers, err = params.BootstrappersFor(net)
 		if err != nil {
 			return

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -12,6 +12,8 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"go.uber.org/fx"
 
+	"github.com/celestiaorg/celestia-node/params"
+
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/service/header"
@@ -54,9 +56,9 @@ func HeaderService(
 }
 
 // HeaderExchangeP2P constructs new P2PExchange for headers.
-func HeaderExchangeP2P(cfg Config) func(host host.Host) (header.Exchange, error) {
-	return func(host host.Host) (header.Exchange, error) {
-		peers, err := cfg.trustedPeers()
+func HeaderExchangeP2P(cfg Config) func(params.Network, host.Host) (header.Exchange, error) {
+	return func(net params.Network, host host.Host) (header.Exchange, error) {
+		peers, err := cfg.trustedPeers(net)
 		if err != nil {
 			return nil, err
 		}
@@ -94,9 +96,9 @@ func HeaderStore(lc fx.Lifecycle, ds datastore.Batching) (header.Store, error) {
 }
 
 // HeaderStoreInit initializes the store.
-func HeaderStoreInit(cfg *Config) func(context.Context, header.Store, header.Exchange) error {
-	return func(ctx context.Context, store header.Store, ex header.Exchange) error {
-		trustedHash, err := cfg.trustedHash()
+func HeaderStoreInit(cfg *Config) func(context.Context, params.Network, header.Store, header.Exchange) error {
+	return func(ctx context.Context, net params.Network, store header.Store, ex header.Exchange) error {
+		trustedHash, err := cfg.trustedHash(net)
 		if err != nil {
 			return err
 		}

--- a/node/settings.go
+++ b/node/settings.go
@@ -6,6 +6,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 
+	"github.com/celestiaorg/celestia-node/params"
+
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/celestia-node/node/p2p"
@@ -13,6 +15,15 @@ import (
 
 // Option for Node's Config.
 type Option func(*Config, *settings) error
+
+// WithNetwork specifies the Network to which the Node should connect to.
+// WARNING: Use this option with caution and never run the Node with different networks over the same persisted Store.
+func WithNetwork(net params.Network) Option {
+	return func(cfg *Config, sets *settings) error {
+		sets.Network = net
+		return nil
+	}
+}
 
 // WithP2PKey sets custom Ed25519 private key for p2p networking.
 func WithP2PKey(key crypto.PrivKey) Option {
@@ -59,6 +70,7 @@ func WithCoreClient(client core.Client) Option {
 
 // settings store all the non Config values that can be altered for Node with Options.
 type settings struct {
+	Network    params.Network
 	P2PKey     crypto.PrivKey
 	Host       p2p.HostBase
 	CoreClient core.Client
@@ -68,6 +80,7 @@ type settings struct {
 // TODO(@Bidon15): Pass settings instead of overrides func. Issue #300
 func (sets *settings) overrides() fxutil.Option {
 	return fxutil.OverrideSupply(
+		&sets.Network,
 		&sets.P2PKey,
 		&sets.Host,
 		&sets.CoreClient,

--- a/params/bootstrap.go
+++ b/params/bootstrap.go
@@ -5,20 +5,6 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-// DefaultBootstrappersInfos returns address information of bootstrap peers for the node's current network.
-func DefaultBootstrappersInfos() []peer.AddrInfo {
-	infos, err := parseAddrInfos(DefaultBootstrappers())
-	if err != nil {
-		panic(err)
-	}
-	return infos
-}
-
-// DefaultBootstrappers reports multiaddresses of bootstrap peers for the node's current network.
-func DefaultBootstrappers() []string {
-	return bootstrapList[defaultNetwork] // network is guaranteed to be valid
-}
-
 // BootstrappersInfosFor returns address information of bootstrap peers for a given network.
 func BootstrappersInfosFor(net Network) ([]peer.AddrInfo, error) {
 	bs, err := BootstrappersFor(net)

--- a/params/default.go
+++ b/params/default.go
@@ -1,30 +1,9 @@
 package params
 
-import "github.com/libp2p/go-libp2p-core/peer"
-
 // defaultNetwork defines a default network for the Celestia Node.
 var defaultNetwork = DevNet
 
 // DefaultNetwork returns the network of the current build.
 func DefaultNetwork() Network {
 	return defaultNetwork
-}
-
-// DefaultGenesis reports a hash of a genesis block for the current network.
-func DefaultGenesis() string {
-	return genesisList[defaultNetwork] // network is guaranteed to be valid
-}
-
-// DefaultBootstrappersInfos returns address information of bootstrap peers for the node's current network.
-func DefaultBootstrappersInfos() []peer.AddrInfo {
-	infos, err := parseAddrInfos(DefaultBootstrappers())
-	if err != nil {
-		panic(err)
-	}
-	return infos
-}
-
-// DefaultBootstrappers returns multiaddresses of bootstrap peers for the node's current network.
-func DefaultBootstrappers() []string {
-	return bootstrapList[defaultNetwork] // network is guaranteed to be valid
 }

--- a/params/default.go
+++ b/params/default.go
@@ -1,0 +1,30 @@
+package params
+
+import "github.com/libp2p/go-libp2p-core/peer"
+
+// defaultNetwork defines a default network for the Celestia Node.
+var defaultNetwork = DevNet
+
+// DefaultNetwork returns the network of the current build.
+func DefaultNetwork() Network {
+	return defaultNetwork
+}
+
+// DefaultGenesis reports a hash of a genesis block for the current network.
+func DefaultGenesis() string {
+	return genesisList[defaultNetwork] // network is guaranteed to be valid
+}
+
+// DefaultBootstrappersInfos returns address information of bootstrap peers for the node's current network.
+func DefaultBootstrappersInfos() []peer.AddrInfo {
+	infos, err := parseAddrInfos(DefaultBootstrappers())
+	if err != nil {
+		panic(err)
+	}
+	return infos
+}
+
+// DefaultBootstrappers returns multiaddresses of bootstrap peers for the node's current network.
+func DefaultBootstrappers() []string {
+	return bootstrapList[defaultNetwork] // network is guaranteed to be valid
+}

--- a/params/genesis.go
+++ b/params/genesis.go
@@ -1,10 +1,5 @@
 package params
 
-// DefaultGenesis reports a hash of a genesis block for the current network.
-func DefaultGenesis() string {
-	return genesisList[defaultNetwork] // network is guaranteed to be valid
-}
-
 // GenesisFor reports a hash of a genesis block for a given network.
 func GenesisFor(net Network) (string, error) {
 	if err := net.Validate(); err != nil {

--- a/params/genesis.go
+++ b/params/genesis.go
@@ -1,8 +1,8 @@
 package params
 
-// Genesis reports a hash of a genesis block for the current network.
-func Genesis() string {
-	return genesisList[network] // network is guaranteed to be valid
+// DefaultGenesis reports a hash of a genesis block for the current network.
+func DefaultGenesis() string {
+	return genesisList[defaultNetwork] // network is guaranteed to be valid
 }
 
 // GenesisFor reports a hash of a genesis block for a given network.

--- a/params/network.go
+++ b/params/network.go
@@ -2,14 +2,6 @@ package params
 
 import "errors"
 
-// GetDefaultNetwork returns the network of the current build.
-func GetDefaultNetwork() Network {
-	return defaultNetwork
-}
-
-// defaultNetwork defines a default network for the Celestia Node.
-var defaultNetwork = DevNet
-
 // NOTE: Every time we add a new long-running network, it has to be added here.
 const (
 	// DevNet or devnet-2 according to celestiaorg/networks

--- a/params/networks.go
+++ b/params/networks.go
@@ -2,13 +2,13 @@ package params
 
 import "errors"
 
-// GetNetwork returns the network of the current build.
-func GetNetwork() Network {
-	return network
+// GetDefaultNetwork returns the network of the current build.
+func GetDefaultNetwork() Network {
+	return defaultNetwork
 }
 
-// DefaultNetwork sets a default network for Celestia Node.
-var DefaultNetwork = DevNet
+// defaultNetwork defines a default network for the Celestia Node.
+var defaultNetwork = DevNet
 
 // NOTE: Every time we add a new long-running network, it has to be added here.
 const (
@@ -33,19 +33,4 @@ func (n Network) Validate() error {
 // networksList is a strict list of all known long-standing networks.
 var networksList = map[Network]struct{}{
 	DevNet: {},
-}
-
-// network is the currently used network within a build.
-// It can be set with 'ldflags'.
-var network Network
-
-// init ensures `network` is always set and correct
-func init() {
-	if network == "" {
-		network = DefaultNetwork
-	}
-
-	if err := network.Validate(); err != nil {
-		panic(err)
-	}
 }


### PR DESCRIPTION
Previously we had network being defined as global state in params pkg, this PR changes this so the network is registered on the node itself. This wasn't causing problems for us yet and this is a preemptive measure. Also, the more I think about it(in the context of #552), the more possible issues are jumping into my head and this solution doesn't have those. The main problem was with the way the Swamp environment had to override the network to be Private using a global state. This is now not an issue and each Node keeps track of the network on its own. 