### PR TITLE
feat(params): add new Private network for private/testing setups

### DIFF
--- a/node/node_bridge_test.go
+++ b/node/node_bridge_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/celestia-node/params"
+
 	"github.com/celestiaorg/celestia-node/core"
 )
 
@@ -37,7 +39,7 @@ func TestBridge_WithMockedCoreClient(t *testing.T) {
 	repo := MockStore(t, DefaultConfig(Bridge))
 
 	_, client := core.StartTestClient(t)
-	node, err := New(Bridge, repo, WithCoreClient(client))
+	node, err := New(Bridge, repo, WithCoreClient(client), WithNetwork(params.Private))
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	assert.True(t, node.CoreClient.IsRunning())

--- a/node/node_light_test.go
+++ b/node/node_light_test.go
@@ -60,7 +60,7 @@ func TestLight_WithMutualPeers(t *testing.T) {
 }
 
 func TestLight_WithNetwork(t *testing.T) {
-	node := TestNode(t, Light, WithNetwork(params.DevNet))
+	node := TestNode(t, Light, WithNetwork(params.Private))
 	require.NotNil(t, node)
-	assert.Equal(t, node.Network, params.DevNet)
+	assert.Equal(t, node.Network, params.Private)
 }

--- a/node/testing.go
+++ b/node/testing.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/celestia-node/params"
+
 	"github.com/celestiaorg/celestia-node/core"
 )
 
@@ -19,7 +21,7 @@ func MockStore(t *testing.T, cfg *Config) Store {
 
 func TestNode(t *testing.T, tp Type, opts ...Option) *Node {
 	node, _ := core.StartTestKVApp(t)
-	opts = append(opts, WithRemoteCore(core.GetEndpoint(node)))
+	opts = append(opts, WithRemoteCore(core.GetEndpoint(node)), WithNetwork(params.Private))
 	store := MockStore(t, DefaultConfig(tp))
 	nd, err := New(tp, store, opts...)
 	require.NoError(t, err)

--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -17,6 +17,8 @@ import (
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 	"github.com/tendermint/tendermint/types"
 
+	"github.com/celestiaorg/celestia-node/params"
+
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/libs/keystore"
 	"github.com/celestiaorg/celestia-node/node"
@@ -246,6 +248,7 @@ func (s *Swamp) newNode(t node.Type, store node.Store, options ...node.Option) *
 	options = append(options,
 		node.WithHost(s.createPeer(ks)),
 		node.WithTrustedHash(s.trustedHash),
+		node.WithNetwork(params.Private),
 	)
 
 	node, err := node.New(t, store, options...)

--- a/params/bootstrap.go
+++ b/params/bootstrap.go
@@ -31,6 +31,7 @@ var bootstrapList = map[Network][]string{
 		"/dns4/libra.celestia-devops.dev/tcp/2121/p2p/12D3KooWK5aDotDcLsabBmWDazehQLMsDkRyARm1k7f1zGAXqbt4",
 		"/dns4/norma.celestia-devops.dev/tcp/2121/p2p/12D3KooWHYczJDVNfYVkLcNHPTDKCeiVvRhg8Q9JU3bE3m9eEVyY",
 	},
+	Private: {},
 }
 
 func parseAddrInfos(addrs []string) ([]peer.AddrInfo, error) {

--- a/params/default.go
+++ b/params/default.go
@@ -1,9 +1,21 @@
 package params
 
+import (
+	"os"
+	"strings"
+)
+
 // defaultNetwork defines a default network for the Celestia Node.
 var defaultNetwork = DevNet
 
 // DefaultNetwork returns the network of the current build.
 func DefaultNetwork() Network {
 	return defaultNetwork
+}
+
+func init() {
+	if genesis, ok := os.LookupEnv("CELESTIA_PRIVATE_GENESIS"); ok {
+		defaultNetwork = Private
+		genesisList[Private] = strings.ToUpper(genesis)
+	}
 }

--- a/params/genesis.go
+++ b/params/genesis.go
@@ -1,6 +1,8 @@
 package params
 
 // GenesisFor reports a hash of a genesis block for a given network.
+// Genesis is strictly defined and can't be modified.
+// To run a custom genesis private network use CELESTIA_PRIVATE_GENESIS env var.
 func GenesisFor(net Network) (string, error) {
 	if err := net.Validate(); err != nil {
 		return "", err
@@ -11,5 +13,6 @@ func GenesisFor(net Network) (string, error) {
 
 // NOTE: Every time we add a new long-running network, its genesis hash has to be added here.
 var genesisList = map[Network]string{
-	DevNet: "4632277C441CA6155C4374AC56048CF4CFE3CBB2476E07A548644435980D5E17",
+	DevNet:  "4632277C441CA6155C4374AC56048CF4CFE3CBB2476E07A548644435980D5E17",
+	Private: "",
 }

--- a/params/network.go
+++ b/params/network.go
@@ -1,18 +1,23 @@
 package params
 
-import "errors"
+import (
+	"errors"
+)
 
 // NOTE: Every time we add a new long-running network, it has to be added here.
 const (
 	// DevNet or devnet-2 according to celestiaorg/networks
 	DevNet Network = "devnet-2"
+	// Private can be used to set up any private network, including local testing setups.
+	// Use CELESTIA_PRIVATE_GENESIS env var to enable Private by specifying its genesis block hash.
+	Private Network = "private"
 )
 
 // Network is a type definition for DA network run by Celestia Node.
 type Network string
 
 // ErrInvalidNetwork is thrown when unknown network is used.
-var ErrInvalidNetwork = errors.New("build: invalid network")
+var ErrInvalidNetwork = errors.New("params: invalid network")
 
 // Validate the network.
 func (n Network) Validate() error {
@@ -24,5 +29,6 @@ func (n Network) Validate() error {
 
 // networksList is a strict list of all known long-standing networks.
 var networksList = map[Network]struct{}{
-	DevNet: {},
+	DevNet:  {},
+	Private: {},
 }


### PR DESCRIPTION
Substitutes #552.
Based on #556.
Closes #550 

Also, makes Node and Swamp tests run in the private setup. This is also why I did a cleanup in https://github.com/celestiaorg/celestia-node/pull/557