### PR TITLE
chore(.gitignore): fix gitignore for files in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@ vendor
 .bak
 .idea/
 .vscode/
-./celestia
-./cel-shed
-./coverage.txt
+celestia
+cel-shed
+coverage.txt


### PR DESCRIPTION
For some reason `./` doesn't work with gitignore