### PR TITLE
Makefile: Add `make clean` cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ build:
 	@go build -ldflags ${LDFLAGS} ./cmd/celestia
 .PHONY: build
 
+## clean: Clean up celestia-node binary.
+clean:
+	@echo "--> Cleaning up celestia binary (located in ./build/celestia)"
+	@rm build/celestia
+
 ## install: Build and install the celestia-node binary into the GOBIN directory.
 install:
 	@echo "--> Installing Celestia"


### PR DESCRIPTION
Cleans up celestia bin from `build/` dir.

Based on #575. 