### PR TITLE
chore(das): prevent logging of success on failed sample

### DIFF
--- a/das/daser.go
+++ b/das/daser.go
@@ -146,6 +146,7 @@ func (d *DASer) sample(ctx context.Context, sub header.Subscription, checkpoint 
 			log.Errorw("sampling failed", "height", h.Height, "hash", h.Hash(),
 				"square width", len(h.DAH.RowsRoots), "data root", h.DAH.Hash(), "err", err)
 			// continue sampling
+			continue
 		}
 
 		sampleTime := time.Since(startTime)
@@ -233,6 +234,7 @@ func (d *DASer) catchUp(ctx context.Context, job *catchUpJob) (int64, error) {
 			log.Errorw("sampling failed", "height", h.Height, "hash", h.Hash(),
 				"square width", len(h.DAH.RowsRoots), "data root", h.DAH.Hash(), "err", err)
 			// continue sampling
+			continue
 		}
 
 		sampleTime := time.Since(startTime)

--- a/service/header/doc.go
+++ b/service/header/doc.go
@@ -41,6 +41,7 @@ For full and light nodes, the general flow of the header Service is as follows:
 	1. Syncer listens for new ExtendedHeaders from HeaderSub
 	2. If there is a gap between the local head of chain and the new, validated network head, the Syncer
 	   kicks off a sync routine to request all ExtendedHeaders between local head and network head.
-	3. While the Syncer requests headers between the local head and network head in batches, it appends them to the subjective chain via Store with the last batched header as the new local head.
+	3. While the Syncer requests headers between the local head and network head in batches, it appends them to the
+	   subjective chain via Store with the last batched header as the new local head.
 */
 package header


### PR DESCRIPTION
Successful logging can confuse when it is not really successful 