### PR TITLE
test: write full node reconstruction test on the share service level

### DIFF
--- a/ipld/read.go
+++ b/ipld/read.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/tendermint/tendermint/pkg/da"
@@ -35,7 +36,7 @@ func RetrieveData(
 	}
 	errGroup, ctx := errgroup.WithContext(parentCtx)
 	errGroup.Go(func() error {
-		return fillQuadrant(ctx, quadrant, dag, dataSquare)
+		return fillQuadrant(ctx, quadrant, merkledag.NewSession(ctx, dag), dataSquare)
 	})
 	if err := errGroup.Wait(); err != nil {
 		return nil, err

--- a/service/share/full_availability_test.go
+++ b/service/share/full_availability_test.go
@@ -3,8 +3,10 @@ package share
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-node/service/header"
 )
@@ -35,10 +37,40 @@ func TestShareAvailableOverMocknet_Full(t *testing.T) {
 	defer cancel()
 
 	net := NewDAGNet(ctx, t)
-	_, root := net.RandFullService(16)
-	serv := net.CleanService()
+	_, root := net.RandFullService(32)
+	serv := net.CleanFullService()
 	net.ConnectAll()
 
 	err := serv.SharesAvailable(ctx, root)
+	assert.NoError(t, err)
+}
+
+func TestShareAvailable_FullOverLights(t *testing.T) {
+	const (
+		origSquareSize = 8
+		lightNodes     = 192
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	net := NewDAGNet(ctx, t)
+	_, root := net.RandFullService(origSquareSize) // make a source node, a.k.a bridge
+	full := net.CleanFullService()                 // make a full which reconstructs data
+
+	lights := make([]Service, lightNodes)
+	for i := 0; i < len(lights); i++ {
+		lights[i] = net.CleanLightService()
+	}
+	net.ConnectAll()
+	for i := 0; i < len(lights); i++ {
+		err := lights[i].SharesAvailable(ctx, root)
+		require.NoError(t, err)
+	}
+
+	// ensure there is no connection between source and full nodes
+	// so that full reconstructs from the light nodes only
+	net.Disconnect(0, 1)
+
+	err := full.SharesAvailable(ctx, root)
 	assert.NoError(t, err)
 }

--- a/service/share/light_availability.go
+++ b/service/share/light_availability.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	format "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
 
 	"github.com/celestiaorg/celestia-node/ipld"
 )
@@ -43,7 +44,7 @@ func (la *lightAvailability) SharesAvailable(ctx context.Context, dah *Root) err
 	for _, s := range samples {
 		go func(s Sample) {
 			root, leaf := translate(dah, s.Row, s.Col)
-			_, err := ipld.GetLeaf(ctx, la.getter, root, leaf, len(dah.RowsRoots))
+			_, err := ipld.GetLeaf(ctx, merkledag.NewSession(ctx, la.getter), root, leaf, len(dah.RowsRoots))
 			// we don't really care about Share bodies at this point
 			// it also means we now saved the Share in local storage
 			select {

--- a/service/share/light_availability_test.go
+++ b/service/share/light_availability_test.go
@@ -36,7 +36,7 @@ func TestShareAvailableOverMocknet(t *testing.T) {
 
 	net := NewDAGNet(ctx, t)
 	_, root := net.RandLightService(16)
-	serv := net.CleanService()
+	serv := net.CleanLightService()
 	net.ConnectAll()
 
 	err := serv.SharesAvailable(ctx, root)


### PR DESCRIPTION
This PR:
* Add test to assert that full node can reconstruct block from light clients only
* Updates test utilities accordingly
* Uses bitswap sessions for ShareAvailability
	* Provides share retrieval speed improvements.