### PR TITLE
Remove title from bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report to inform the community on your awesome finding!
-title: "[Bug]: "
+title: ""
 labels: ["bug",]
 body:
   - type: markdown


### PR DESCRIPTION
The issue template already automatically adds the `bug` label, so the `[Bug]: ` in the title is redundant.