### PR TITLE
(cmd | node/rpc): Make RPC port configurable and ensure port 0 used for swamp

### DIFF
--- a/cmd/celestia/bridge.go
+++ b/cmd/celestia/bridge.go
@@ -27,6 +27,7 @@ func init() {
 			cmdnode.CoreFlags(),
 			cmdnode.TrustedHashFlags(),
 			cmdnode.MiscFlags(),
+			cmdnode.RPCFlags(),
 		),
 		cmdnode.Start(
 			cmdnode.NodeFlags(node.Bridge),
@@ -34,6 +35,7 @@ func init() {
 			cmdnode.CoreFlags(),
 			cmdnode.TrustedHashFlags(),
 			cmdnode.MiscFlags(),
+			cmdnode.RPCFlags(),
 		),
 		bridgeKeyCmd,
 	)
@@ -72,6 +74,11 @@ var bridgeCmd = &cobra.Command{
 		}
 
 		err = cmdnode.ParseMiscFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		err = cmdnode.ParseRPCFlags(cmd, env)
 		if err != nil {
 			return err
 		}

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -29,6 +29,7 @@ func init() {
 			// NOTE: for now, state-related queries can only be accessed
 			// over an RPC connection with a celestia-core node.
 			cmdnode.CoreFlags(),
+			cmdnode.RPCFlags(),
 		),
 		cmdnode.Start(
 			cmdnode.NodeFlags(node.Full),
@@ -38,6 +39,7 @@ func init() {
 			// NOTE: for now, state-related queries can only be accessed
 			// over an RPC connection with a celestia-core node.
 			cmdnode.CoreFlags(),
+			cmdnode.RPCFlags(),
 		),
 		fullKeyCmd,
 	)
@@ -76,6 +78,11 @@ var fullCmd = &cobra.Command{
 		}
 
 		err = cmdnode.ParseMiscFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		err = cmdnode.ParseRPCFlags(cmd, env)
 		if err != nil {
 			return err
 		}

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -29,6 +29,7 @@ func init() {
 			// NOTE: for now, state-related queries can only be accessed
 			// over an RPC connection with a celestia-core node.
 			cmdnode.CoreFlags(),
+			cmdnode.RPCFlags(),
 		),
 		cmdnode.Start(
 			cmdnode.NodeFlags(node.Light),
@@ -38,6 +39,7 @@ func init() {
 			// NOTE: for now, state-related queries can only be accessed
 			// over an RPC connection with a celestia-core node.
 			cmdnode.CoreFlags(),
+			cmdnode.RPCFlags(),
 		),
 		lightKeyCmd,
 	)
@@ -75,6 +77,11 @@ var lightCmd = &cobra.Command{
 		}
 
 		err = cmdnode.ParseMiscFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		err = cmdnode.ParseRPCFlags(cmd, env)
 		if err != nil {
 			return err
 		}

--- a/cmd/flags_rpc.go
+++ b/cmd/flags_rpc.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
+	"github.com/celestiaorg/celestia-node/node"
+)
+
+var (
+	portFlag = "rpc.port"
+)
+
+// RPCFlags gives a set of hardcoded node/rpc package flags.
+func RPCFlags() *flag.FlagSet {
+	flags := &flag.FlagSet{}
+
+	flags.String(
+		portFlag,
+		"",
+		"Set a custom RPC port (default: 26658)",
+	)
+
+	return flags
+}
+
+// ParseRPCFlags parses RPC flags from the given cmd and applies values to Env.
+func ParseRPCFlags(cmd *cobra.Command, env *Env) error {
+	port := cmd.Flag(portFlag).Value.String()
+	if port != "" {
+		env.AddOptions(node.WithRPCPort(port))
+	}
+	return nil
+}

--- a/node/components.go
+++ b/node/components.go
@@ -10,9 +10,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
-
 	nodecore "github.com/celestiaorg/celestia-node/node/core"
-
 	"github.com/celestiaorg/celestia-node/node/p2p"
 	"github.com/celestiaorg/celestia-node/node/rpc"
 	"github.com/celestiaorg/celestia-node/node/services"
@@ -75,17 +73,7 @@ func baseComponents(cfg *Config, store Store) fx.Option {
 		fx.Provide(statecomponents.NewService),
 		fx.Provide(statecomponents.CoreAccessor(cfg.Core.GRPCAddr)),
 		// RPC component
-		fx.Provide(func(lc fx.Lifecycle) *rpc.Server {
-			// TODO @renaynay @Wondertan: not providing any custom config
-			//  functionality here as this component is meant to be removed on
-			//  implementation of https://github.com/celestiaorg/celestia-node/pull/506.
-			serv := rpc.NewServer(rpc.DefaultConfig())
-			lc.Append(fx.Hook{
-				OnStart: serv.Start,
-				OnStop:  serv.Stop,
-			})
-			return serv
-		}),
+		fx.Provide(rpc.RPC(cfg.RPC)),
 	)
 }
 

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -16,6 +16,14 @@ func WithGRPCEndpoint(address string) Option {
 	}
 }
 
+// WithRPCPort configures Node to expose the given port for RPC
+// queries.
+func WithRPCPort(port string) Option {
+	return func(sets *settings) {
+		sets.cfg.RPC.Port = port
+	}
+}
+
 // WithTrustedHash sets TrustedHash to the Config.
 func WithTrustedHash(hash string) Option {
 	return func(sets *settings) {

--- a/node/node_full_test.go
+++ b/node/node_full_test.go
@@ -16,7 +16,6 @@ func TestNewFullAndLifecycle(t *testing.T) {
 	assert.NotZero(t, node.Type)
 
 	startCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	err := node.Start(startCtx)
 	require.NoError(t, err)

--- a/node/rpc/component.go
+++ b/node/rpc/component.go
@@ -1,0 +1,19 @@
+package rpc
+
+import (
+	"go.uber.org/fx"
+)
+
+func RPC(cfg Config) func(lc fx.Lifecycle) *Server {
+	return func(lc fx.Lifecycle) *Server {
+		// TODO @renaynay @Wondertan: not providing any custom config
+		//  functionality here as this component is meant to be removed on
+		//  implementation of https://github.com/celestiaorg/celestia-node/pull/506.
+		serv := NewServer(cfg)
+		lc.Append(fx.Hook{
+			OnStart: serv.Start,
+			OnStop:  serv.Stop,
+		})
+		return serv
+	}
+}

--- a/node/rpc/config.go
+++ b/node/rpc/config.go
@@ -1,12 +1,12 @@
 package rpc
 
 type Config struct {
-	ListenAddr string
+	Port string
 }
 
 func DefaultConfig() Config {
 	return Config{
 		// do NOT expose the same port as celestia-core by default so that both can run on the same machine
-		ListenAddr: "0.0.0.0:26658",
+		Port: "26658",
 	}
 }

--- a/node/rpc/server.go
+++ b/node/rpc/server.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 
@@ -36,7 +37,8 @@ func NewServer(cfg Config) *Server {
 
 // Start starts the RPC Server, listening on the given address.
 func (s *Server) Start(context.Context) error {
-	listener, err := net.Listen("tcp", s.cfg.ListenAddr)
+	listenAddr := fmt.Sprintf("0.0.0.0:%s", s.cfg.Port)
+	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		return err
 	}

--- a/node/rpc/server_test.go
+++ b/node/rpc/server_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	server := NewServer(DefaultConfig())
+	server := NewServer(Config{
+		Port: "0",
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -249,6 +249,7 @@ func (s *Swamp) newNode(t node.Type, store node.Store, options ...node.Option) *
 		node.WithHost(s.createPeer(ks)),
 		node.WithTrustedHash(s.trustedHash),
 		node.WithNetwork(params.Private),
+		node.WithRPCPort("0"),
 	)
 
 	node, err := node.New(t, store, options...)


### PR DESCRIPTION
Make RPC port configurable and ensure that `TestSwamp` uses port 0 option to prevent trying to use same port for every node.