### PR TITLE
shares|ipld: Rework data retrieval 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/celestiaorg/celestia-app v0.2.0-rc-1
 	github.com/celestiaorg/go-libp2p-messenger v0.1.0
 	github.com/celestiaorg/nmt v0.8.0
-	github.com/celestiaorg/rsmt2d v0.3.1
+	github.com/celestiaorg/rsmt2d v0.4.0
 	github.com/cosmos/cosmos-sdk v0.44.3
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/celestiaorg/nmt v0.7.0/go.mod h1:3bqzTj8xKj0DgQUpOgZzoxvtNkC3MS/hTbQ6
 github.com/celestiaorg/nmt v0.8.0 h1:wtX7GRouLbmBe+ffnc8+cOg2UbWteM+Y1imZuZ/EeqU=
 github.com/celestiaorg/nmt v0.8.0/go.mod h1:3bqzTj8xKj0DgQUpOgZzoxvtNkC3MS/hTbQ6dn8SIa0=
 github.com/celestiaorg/rsmt2d v0.3.0/go.mod h1:2Frw4GEYUnVu6Mvlo+CUzuC2/8wn+zLwVVtp+muN6vg=
-github.com/celestiaorg/rsmt2d v0.3.1 h1:qFp6oZXG+QsMO8FqnI34EQ/j+yuJnlddC+nnAkQCq1Y=
-github.com/celestiaorg/rsmt2d v0.3.1/go.mod h1:2Frw4GEYUnVu6Mvlo+CUzuC2/8wn+zLwVVtp+muN6vg=
+github.com/celestiaorg/rsmt2d v0.4.0 h1:mpICbeXYKE1yNW8VBzgBrcnzuMKzutpROH1g2xI7Ls4=
+github.com/celestiaorg/rsmt2d v0.4.0/go.mod h1:EZ+O2KdCq8xI7WFwjATLdhtMdrdClmAs2w7zENDr010=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -2,162 +2,17 @@ package ipld
 
 import (
 	"context"
-	"math/rand"
 
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
-	"golang.org/x/sync/errgroup"
-
-	"github.com/tendermint/tendermint/pkg/da"
-	"github.com/tendermint/tendermint/pkg/wrapper"
 
 	"github.com/celestiaorg/celestia-node/ipld/plugin"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"
-	"github.com/celestiaorg/rsmt2d"
 )
 
-// RetrieveData asynchronously fetches block data using the minimum number
-// of requests to IPFS. It fails if one of the random samples sampled is not available.
-func RetrieveData(
-	parentCtx context.Context,
-	dah *da.DataAvailabilityHeader,
-	dag ipld.DAGService,
-	codec rsmt2d.Codec,
-) (*rsmt2d.ExtendedDataSquare, error) {
-	edsWidth := len(dah.RowsRoots)
-	rowRoots := dah.RowsRoots
-	dataSquare := make([][]byte, edsWidth*edsWidth)
-
-	quadrant, err := pickRandomQuadrant(rowRoots)
-	if err != nil {
-		return nil, err
-	}
-	errGroup, ctx := errgroup.WithContext(parentCtx)
-	errGroup.Go(func() error {
-		return fillQuadrant(ctx, quadrant, dag, dataSquare)
-	})
-	if err := errGroup.Wait(); err != nil {
-		return nil, err
-	}
-	batchAdder := NewNmtNodeAdder(parentCtx, ipld.NewBatch(parentCtx, dag, ipld.MaxSizeBatchOption(batchSize(edsWidth))))
-	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(edsWidth)/2, nmt.NodeVisitor(batchAdder.Visit))
-	extended, err := rsmt2d.RepairExtendedDataSquare(dah.RowsRoots, dah.ColumnRoots, dataSquare, codec, tree.Constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	return extended, batchAdder.Commit()
-}
-
-type quadrant struct {
-	isLeftSubtree bool
-	from          int
-	to            int
-	rootCids      []cid.Cid
-}
-
-func pickRandomQuadrant(roots [][]byte) (*quadrant, error) {
-	edsWidth := len(roots)
-	// get the random number from 1 to 4.
-	q := rand.Intn(4) + 1 //nolint:gosec
-	quadrant := &quadrant{rootCids: make([]cid.Cid, edsWidth/2)}
-	// quadrants 1 and 3 corresponds to left subtree,
-	// 2 and 4 to the right subtree
-	/*
-		| 1 | 2 |
-		| 3 | 4 |
-	*/
-	// choose subtree
-	if q%2 == 1 {
-		quadrant.isLeftSubtree = true
-	}
-
-	// define range of shares for sampling
-	if q > 2 {
-		quadrant.from = edsWidth / 2
-		quadrant.to = edsWidth
-	} else {
-		quadrant.to = edsWidth / 2
-	}
-
-	var err error
-	for index, counter := quadrant.from, 0; index < quadrant.to; index++ {
-		quadrant.rootCids[counter], err = plugin.CidFromNamespacedSha256(roots[index])
-		if err != nil {
-			return nil, err
-		}
-		counter++
-	}
-	return quadrant, nil
-}
-
-// fillQuadrant fetches 1/4 of shares for the given root
-func fillQuadrant(
-	ctx context.Context,
-	quadrant *quadrant,
-	dag ipld.NodeGetter,
-	dataSquare [][]byte,
-) error {
-	errGroup, ctx := errgroup.WithContext(ctx)
-	for i := 0; i < len(quadrant.rootCids); i++ {
-		i := i
-		errGroup.Go(func() error {
-			leaves, err := getSubtreeLeaves(
-				ctx,
-				quadrant.rootCids[i],
-				dag,
-				quadrant.isLeftSubtree,
-				uint32(len(quadrant.rootCids)/2),
-			)
-			if err != nil {
-				return err
-			}
-			quadrantWidth := len(quadrant.rootCids)
-			for leafIdx, leaf := range leaves {
-				// shares from the right subtree should be
-				// inserted after all shares from the left subtree
-				if !quadrant.isLeftSubtree {
-					leafIdx += len(leaves)
-				}
-				shareData := leaf.RawData()[1:]
-				// dataSquare represents a single dimensional slice
-				// of 4 quadrants. The representation of quadrants in dataSquare will be
-				// | 1 | | 2 | | 3 | | 4 |
-				// position is calculated by offsetting the index to respective quadrant
-				position := ((i + quadrant.from) * quadrantWidth * 2) + leafIdx
-				dataSquare[position] = shareData[NamespaceSize:]
-
-			}
-			return err
-		})
-	}
-	return errGroup.Wait()
-}
-
-// getSubtreeLeaves returns only one subtree - left or right
-func getSubtreeLeaves(
-	ctx context.Context,
-	root cid.Cid,
-	dag ipld.NodeGetter,
-	isLeftSubtree bool,
-	treeSize uint32,
-) ([]ipld.Node, error) {
-	nd, err := dag.Get(ctx, root)
-	if err != nil {
-		return nil, err
-	}
-	links := nd.Links()
-	subtreeRootHash := links[0].Cid
-	if !isLeftSubtree && len(links) > 1 {
-		subtreeRootHash = links[1].Cid
-	}
-
-	return getLeaves(ctx, dag, subtreeRootHash, make([]ipld.Node, 0, treeSize))
-}
-
-// getLeaves recursively starts going down to find all leafs from the given root
-func getLeaves(ctx context.Context, dag ipld.NodeGetter, root cid.Cid, leaves []ipld.Node) ([]ipld.Node, error) {
+// GetLeaves recursively starts going down to find all leafs from the given root
+func GetLeaves(ctx context.Context, dag ipld.NodeGetter, root cid.Cid, leaves []ipld.Node) ([]ipld.Node, error) {
 	// request the node
 	nd, err := dag.Get(ctx, root)
 	if err != nil {
@@ -177,8 +32,8 @@ func getLeaves(ctx context.Context, dag ipld.NodeGetter, root cid.Cid, leaves []
 	}
 
 	for _, node := range lnks {
-		// recursively walk down through selected children to get the leaves
-		leaves, err = getLeaves(ctx, dag, node.Cid, leaves)
+		// recursively walk down through selected children to request the leaves
+		leaves, err = GetLeaves(ctx, dag, node.Cid, leaves)
 		if err != nil {
 			return nil, err
 		}

--- a/ipld/read.go
+++ b/ipld/read.go
@@ -11,7 +11,8 @@ import (
 	"github.com/celestiaorg/nmt/namespace"
 )
 
-// GetLeaves recursively starts going down to find all leafs from the given root
+// GetLeaves gets all the leaves under the given root. It recursively starts traversing the DAG to find all the leafs.
+// It also takes a pre-allocated slice 'leaves'.
 func GetLeaves(ctx context.Context, dag ipld.NodeGetter, root cid.Cid, leaves []ipld.Node) ([]ipld.Node, error) {
 	// request the node
 	nd, err := dag.Get(ctx, root)

--- a/ipld/read_test.go
+++ b/ipld/read_test.go
@@ -114,65 +114,6 @@ func TestBlockRecovery(t *testing.T) {
 	}
 }
 
-func TestRetrieveBlockData(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	dag := mdutils.Mock()
-
-	type test struct {
-		name       string
-		squareSize int
-	}
-	tests := []test{
-		{"1x1(min)", 1},
-		{"32x32(med)", 32},
-	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			// generate EDS
-			eds := generateRandEDS(t, tc.squareSize)
-
-			shares := ExtractODSShares(eds)
-
-			in, err := PutData(ctx, shares, dag)
-			require.NoError(t, err)
-
-			// limit with deadline, specifically retrieval
-			ctx, cancel := context.WithTimeout(ctx, time.Second*2)
-			defer cancel()
-
-			dah := da.NewDataAvailabilityHeader(in)
-			out, err := RetrieveData(ctx, &dah, dag, rsmt2d.NewRSGF8Codec())
-			require.NoError(t, err)
-			assert.True(t, EqualEDS(in, out))
-		})
-	}
-}
-
-func TestRetrieveMaxBlockData(t *testing.T) {
-	parentCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	dag := mdutils.Mock()
-
-	// generate EDS
-	eds := generateRandEDS(t, MaxSquareSize)
-
-	shares := ExtractODSShares(eds)
-
-	in, err := PutData(parentCtx, shares, dag)
-	require.NoError(t, err)
-
-	// limit with deadline, specifically retrieval
-	ctx, cancel := context.WithTimeout(parentCtx, time.Second*50)
-	defer cancel()
-
-	dah := da.NewDataAvailabilityHeader(in)
-	out, err := RetrieveData(ctx, &dah, dag, rsmt2d.NewRSGF8Codec())
-	require.NoError(t, err)
-	assert.True(t, EqualEDS(in, out))
-}
-
 func Test_ConvertEDStoShares(t *testing.T) {
 	squareWidth := 16
 	origShares := RandNamespacedShares(t, squareWidth*squareWidth)

--- a/ipld/read_test.go
+++ b/ipld/read_test.go
@@ -93,10 +93,11 @@ func TestBlockRecovery(t *testing.T) {
 			flat := flatten(eds)
 
 			// recover a partially complete square
-			reds, err := rsmt2d.RepairExtendedDataSquare(
+			rdata := removeRandShares(flat, tc.d)
+			err = rsmt2d.RepairExtendedDataSquare(
 				rowRoots,
 				colRoots,
-				removeRandShares(flat, tc.d),
+				rdata,
 				rsmt2d.NewRSGF8Codec(),
 				recoverTree.Constructor,
 			)
@@ -108,6 +109,8 @@ func TestBlockRecovery(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
+			reds, err := rsmt2d.ImportExtendedDataSquare(rdata, rsmt2d.NewRSGF8Codec(), tree.Constructor)
+			require.NoError(t, err)
 			// check that the squares are equal
 			assert.Equal(t, flatten(eds), flatten(reds))
 		})

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -120,7 +120,7 @@ func (rs *retrieverSession) retrieve(ctx context.Context, q *quadrant) (*rsmt2d.
 	rs.request(ctx, q)
 
 	// try repair
-	eds, err := rsmt2d.RepairExtendedDataSquare(rs.dah.RowsRoots, rs.dah.ColumnRoots, rs.square, rs.codec, rs.treeFn)
+	err := rsmt2d.RepairExtendedDataSquare(rs.dah.RowsRoots, rs.dah.ColumnRoots, rs.square, rs.codec, rs.treeFn)
 	if err != nil {
 
 		// TODO(@Wondertan): This is a hack around limitation of rsmt2d. It sets empty zeroed shares back to nil
@@ -136,7 +136,12 @@ func (rs *retrieverSession) retrieve(ctx context.Context, q *quadrant) (*rsmt2d.
 		return nil, format.ErrNotFound
 	}
 
-	return eds, rs.adder.Commit()
+	err = rs.adder.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return rsmt2d.ImportExtendedDataSquare(rs.square, rs.codec, rs.treeFn)
 }
 
 type quadrant struct {

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -130,7 +130,7 @@ func (rs *retrieverSession) retrieve(ctx context.Context, q *quadrant) (*rsmt2d.
 	err := rsmt2d.RepairExtendedDataSquare(rs.dah.RowsRoots, rs.dah.ColumnRoots, rs.square, rs.codec, rs.treeFn)
 	if err != nil {
 		log.Errorw("not enough shares sampled to recover, retrying...", "err", err)
-		return nil, format.ErrNotFound
+		return nil, err
 	}
 
 	return rsmt2d.ImportExtendedDataSquare(rs.square, rs.codec, rs.treeFn)

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -1,0 +1,173 @@
+package ipld
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipfs/go-merkledag"
+	"github.com/tendermint/tendermint/pkg/da"
+	"github.com/tendermint/tendermint/pkg/wrapper"
+
+	"github.com/celestiaorg/celestia-node/ipld/plugin"
+	"github.com/celestiaorg/nmt"
+	"github.com/celestiaorg/rsmt2d"
+)
+
+var log = logging.Logger("ipld")
+
+// RetrieveQuadrantTimeout limits the time for retrieval of a quadrant
+// so that Retriever can retry another quadrant.
+var RetrieveQuadrantTimeout = time.Minute * 5
+
+// Retriever retrieves rsmt2d.ExtendedDataSquares from the IPLD network.
+// Instead of requesting data 'share by share' it requests data by quadrants
+// minimizing bandwidth usage in the happy cases.
+//
+//  ---- ----
+// | 0  | 1  |
+//  ---- ----
+// | 2  | 3  |
+//  ---- ----
+// Retriever randomly picks one of the data square quadrants and tries to request them one by one until it is able
+// the whole square.
+type Retriever struct {
+	dag   format.DAGService
+	codec rsmt2d.Codec
+}
+
+// NewRetriever creates a new instance of the Retriever over IPLD Service and rmst2d.Codec
+func NewRetriever(dag format.DAGService, codec rsmt2d.Codec) *Retriever {
+	return &Retriever{dag: dag, codec: codec}
+}
+
+// Retrieve retrieves all the data committed to DataAvailabilityHeader.
+// It aims to request from the network only 1/4 of the data and reconstructs other 3/4 parts using the rsmt2d.Codec.
+// It steadily tries to request other 3/4 data if 1/4 is not found within RetrieveQuadrantTimeout or unrecoverable.
+// TODO(@Wondertan): Randomize requesting from Col Roots with retrying.
+func (r *Retriever) Retrieve(ctx context.Context, dah *da.DataAvailabilityHeader) (*rsmt2d.ExtendedDataSquare, error) {
+	daroots := dah.RowsRoots
+	size, origSize := len(daroots), len(daroots)/2
+	roots := make([]cid.Cid, size)
+	for i := 0; i < size; i++ {
+		roots[i] = plugin.MustCidFromNamespacedSha256(daroots[i])
+	}
+
+	qs := make([]*quadrant, 4) // there are constantly four quadrants
+	for i := range qs {
+		// convert quadrant index to coordinate
+		x, y := i%2, 0
+		if i > 1 {
+			y = 1
+		}
+
+		qs[i] = &quadrant{
+			roots: roots[origSize*y : origSize*(y+1)],
+			x:     x,
+			y:     y,
+		}
+	}
+	// shuffling helps data to be equally distributed around the network
+	rand.Shuffle(len(qs), func(i, j int) { qs[i], qs[j] = qs[j], qs[i] })
+
+	ses := r.newSession(ctx, dah)
+	for _, q := range qs {
+		// TODO: ErrByzantineRow/Col
+		eds, err := ses.retrieve(ctx, q)
+		if err == nil {
+			return eds, nil
+		}
+		// retry quadrants until we have something or error
+	}
+
+	return nil, format.ErrNotFound
+}
+
+type retrieverSession struct {
+	dag   format.NodeGetter
+	adder *NmtNodeAdder
+
+	treeFn rsmt2d.TreeConstructorFn
+	codec  rsmt2d.Codec
+
+	dah    *da.DataAvailabilityHeader
+	square [][]byte
+}
+
+func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHeader) *retrieverSession {
+	size := len(dah.RowsRoots)
+	adder := NewNmtNodeAdder(ctx, format.NewBatch(ctx, r.dag, format.MaxSizeBatchOption(batchSize(size))))
+	return &retrieverSession{
+		dag:   merkledag.NewSession(ctx, r.dag),
+		adder: adder,
+		treeFn: func() rsmt2d.Tree {
+			tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(size)/2, nmt.NodeVisitor(adder.Visit))
+			return &tree
+		},
+		codec:  r.codec,
+		dah:    dah,
+		square: make([][]byte, size*size),
+	}
+}
+
+func (rs *retrieverSession) retrieve(ctx context.Context, q *quadrant) (*rsmt2d.ExtendedDataSquare, error) {
+	// request and fill quadrant's into
+	// we don't care about the errors here, just need to request as much data as we can to be able to reconstruct below
+	rs.request(ctx, q)
+
+	// try repair
+	eds, err := rsmt2d.RepairExtendedDataSquare(rs.dah.RowsRoots, rs.dah.ColumnRoots, rs.square, rs.codec, rs.treeFn)
+	if err != nil {
+
+		// TODO(@Wondertan): This is a hack around limitation of rsmt2d. It sets empty zeroed shares back to nil
+		//  reversing operation done inside rsmt2d
+		fillerChunk := bytes.Repeat([]byte{0}, 264)
+		for i, share := range rs.square {
+			if bytes.Equal(share, fillerChunk) {
+				rs.square[i] = nil
+			}
+		}
+
+		log.Errorw("not enough shares sampled to recover, retrying...", "err", err)
+		return nil, format.ErrNotFound
+	}
+
+	return eds, rs.adder.Commit()
+}
+
+type quadrant struct {
+	roots []cid.Cid
+	x, y  int
+}
+
+func (rs *retrieverSession) request(ctx context.Context, q *quadrant) {
+	ctx, cancel := context.WithTimeout(ctx, RetrieveQuadrantTimeout)
+	defer cancel()
+
+	size := len(q.roots)
+	for i, root := range q.roots {
+		nd, err := rs.dag.Get(ctx, root)
+		if err != nil {
+			log.Errorw("getting root", "err", err)
+			continue // so that we still try for other roots
+		}
+
+		// TODO(@Wondertan): GetLeaves should return everything it was able to request even on error,
+		// 	so that we fill as much data as possible
+		// get leaves of left or right subtree
+		nds, err := GetLeaves(ctx, rs.dag, nd.Links()[q.x].Cid, make([]format.Node, 0, size))
+		if err != nil {
+			log.Errorw("getting all the leaves", "err", err)
+			continue
+		}
+		// fill leaves into the square
+		for j, nd := range nds {
+			pos := i*size*2 + size*q.x + size*size*2*q.y + j
+			rs.square[pos] = nd.RawData()[1+NamespaceSize:]
+		}
+	}
+}

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -138,7 +138,15 @@ func (rs *retrieverSession) retrieve(ctx context.Context, q *quadrant) (*rsmt2d.
 
 type quadrant struct {
 	roots []cid.Cid
-	x, y  int
+	// Coordinates of each quadrant(x;y)
+	// ------  -------
+	// |  Q0 | | Q1  |
+	// |(0:0)| |(1:0)|
+	// ------  -------
+	// |  Q2 | | Q3  |
+	// |(0;1)| |(1;1)|
+	// ------  ------
+	x, y int
 }
 
 func (rs *retrieverSession) request(ctx context.Context, q *quadrant) {

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -1,7 +1,6 @@
 package ipld
 
 import (
-	"bytes"
 	"context"
 	"math/rand"
 	"time"
@@ -122,16 +121,6 @@ func (rs *retrieverSession) retrieve(ctx context.Context, q *quadrant) (*rsmt2d.
 	// try repair
 	err := rsmt2d.RepairExtendedDataSquare(rs.dah.RowsRoots, rs.dah.ColumnRoots, rs.square, rs.codec, rs.treeFn)
 	if err != nil {
-
-		// TODO(@Wondertan): This is a hack around limitation of rsmt2d. It sets empty zeroed shares back to nil
-		//  reversing operation done inside rsmt2d
-		fillerChunk := bytes.Repeat([]byte{0}, 264)
-		for i, share := range rs.square {
-			if bytes.Equal(share, fillerChunk) {
-				rs.square[i] = nil
-			}
-		}
-
 		log.Errorw("not enough shares sampled to recover, retrying...", "err", err)
 		return nil, format.ErrNotFound
 	}

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -33,8 +33,8 @@ var RetrieveQuadrantTimeout = time.Minute * 5
 //  ---- ----
 // | 2  | 3  |
 //  ---- ----
-// Retriever randomly picks one of the data square quadrants and tries to request them one by one until it is able
-// the whole square.
+// Retriever randomly picks one of the data square quadrants and tries to request them one by one until it is able to
+// reconstruct the whole square.
 type Retriever struct {
 	dag   format.DAGService
 	codec rsmt2d.Codec
@@ -71,7 +71,7 @@ func (r *Retriever) Retrieve(ctx context.Context, dah *da.DataAvailabilityHeader
 			y:     y,
 		}
 	}
-	// shuffling helps data to be equally distributed around the network
+	// shuffle quadrants to be fetched in random order
 	rand.Shuffle(len(qs), func(i, j int) { qs[i], qs[j] = qs[j], qs[i] })
 
 	ses := r.newSession(ctx, dah)
@@ -123,7 +123,7 @@ func (rs *retrieverSession) retrieve(ctx context.Context, q *quadrant) (*rsmt2d.
 			log.Errorw("committing DAG", "err", err)
 		}
 	}()
-	// request and fill quadrant's into
+	// request quadrant and fill it into rs.square slice
 	// we don't care about the errors here, just need to request as much data as we can to be able to reconstruct below
 	rs.request(ctx, q)
 
@@ -180,7 +180,6 @@ func (rs *retrieverSession) request(ctx context.Context, q *quadrant) {
 				rs.square[pos] = nd.RawData()[1+NamespaceSize:]
 			}
 		}(i, root)
-
 	}
 
 	// wait for each root

--- a/ipld/retriever_quadrant.go
+++ b/ipld/retriever_quadrant.go
@@ -1,0 +1,102 @@
+package ipld
+
+import (
+	"math"
+	"math/rand"
+
+	"github.com/ipfs/go-cid"
+	"github.com/tendermint/tendermint/pkg/da"
+
+	"github.com/celestiaorg/celestia-node/ipld/plugin"
+)
+
+// there are always 4 quadrants
+const numQuadrants = 4
+
+type quadrant struct {
+	// slice of roots to get shares from
+	roots []cid.Cid
+	// Example coordinates(x;y) of each quadrant when fetching from column roots
+	// ------  -------
+	// |  Q0 | | Q1  |
+	// |(0;0)| |(1;0)|
+	// ------  -------
+	// |  Q2 | | Q3  |
+	// |(0;1)| |(1;1)|
+	// ------  -------
+	x, y int
+	// source defines the axis for quadrant
+	// it can be either 1 or 0 similar to x and y
+	// where 0 is Row source and 1 is Col respectively
+	source int
+}
+
+// newQuadrants constructs a slice of quadrants from DAHeader.
+// Constantly, there are 4 quadrants for each source: row and col (8 in total).
+// The ordering of quadrants is random.
+func newQuadrants(dah *da.DataAvailabilityHeader) [][]*quadrant {
+	// combine all the roots into one slice, so they can be easily accessible by index
+	daRoots := [][][]byte{
+		dah.RowsRoots,
+		dah.ColumnRoots,
+	}
+	// create a quadrant slice for each source(row;col)
+	sources := [][]*quadrant{
+		make([]*quadrant, numQuadrants),
+		make([]*quadrant, numQuadrants),
+	}
+	for source, quadrants := range sources {
+		size, qsize := len(daRoots[source]), len(daRoots[source])/2
+		roots := make([]cid.Cid, size)
+		for i, root := range daRoots[source] {
+			roots[i] = plugin.MustCidFromNamespacedSha256(root)
+		}
+
+		for i := range quadrants {
+			// convert quadrant index into coordinates
+			x, y := i%2, i>>1
+			if source == 1 { // swap coordinates for column
+				x, y = y, x
+			}
+
+			quadrants[i] = &quadrant{
+				roots:  roots[qsize*y : qsize*(y+1)],
+				x:      x,
+				y:      y,
+				source: source,
+			}
+		}
+		// shuffle quadrants to be fetched in random order
+		rand.Shuffle(len(quadrants), func(i, j int) { quadrants[i], quadrants[j] = quadrants[j], quadrants[i] })
+	}
+	// randomize sources, s.t. downloading on the network happens from both rows and cols
+	rand.Shuffle(len(sources), func(i, j int) { sources[i], sources[j] = sources[j], sources[i] })
+	return sources
+}
+
+// index calculates index for a share in a data square slice flattened by rows.
+//
+// NOTE: The complexity of the formula below comes from:
+//  * Goal to avoid share copying
+//  * Goal to make formula generic for both rows and cols
+//  	* While data square is flattened by rows only
+// TODO(@Wondertan): This can be simplified by making rsmt2d working over 3D byte slice(not flattened)
+func (q *quadrant) index(rootIdx, cellIdx int) int {
+	size := len(q.roots)
+	// half square offsets, e.g. share is from Q3,
+	// so we add to index Q1+Q2
+	halfSquareOffsetCol := pow(size*2, q.source)
+	halfSquareOffsetRow := pow(size*2, q.source^1)
+	// offsets for the axis, e.g. share is from Q4.
+	// so we add to index Q3
+	offsetX := q.x * halfSquareOffsetCol * size
+	offsetY := q.y * halfSquareOffsetRow * size
+
+	rootIdx *= halfSquareOffsetRow
+	cellIdx *= halfSquareOffsetCol
+	return rootIdx + cellIdx + offsetX + offsetY
+}
+
+func pow(x, y int) int {
+	return int(math.Pow(float64(x), float64(y)))
+}

--- a/ipld/retriever_quadrant.go
+++ b/ipld/retriever_quadrant.go
@@ -32,7 +32,7 @@ type quadrant struct {
 }
 
 // newQuadrants constructs a slice of quadrants from DAHeader.
-// Constantly, there are 4 quadrants for each source: row and col (8 in total).
+// There are always 4 quadrants per each source (row and col), so 8 in total.
 // The ordering of quadrants is random.
 func newQuadrants(dah *da.DataAvailabilityHeader) [][]*quadrant {
 	// combine all the roots into one slice, so they can be easily accessible by index
@@ -54,7 +54,7 @@ func newQuadrants(dah *da.DataAvailabilityHeader) [][]*quadrant {
 
 		for i := range quadrants {
 			// convert quadrant index into coordinates
-			x, y := i%2, i>>1
+			x, y := i%2, i/2
 			if source == 1 { // swap coordinates for column
 				x, y = y, x
 			}

--- a/ipld/retriever_test.go
+++ b/ipld/retriever_test.go
@@ -1,0 +1,51 @@
+package ipld
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mdutils "github.com/ipfs/go-merkledag/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/pkg/da"
+
+	"github.com/celestiaorg/rsmt2d"
+)
+
+func TestRetriever_Retrieve(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dag := mdutils.Mock()
+	r := NewRetriever(dag, rsmt2d.NewRSGF8Codec())
+
+	type test struct {
+		name       string
+		squareSize int
+	}
+	tests := []test{
+		{"1x1(min)", 1},
+		{"2x2(med)", 2},
+		{"32x32(med)", 32},
+		{"128x128(max)", MaxSquareSize},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// generate EDS
+			shares := RandNamespacedShares(t, tc.squareSize*tc.squareSize)
+			in, err := PutData(ctx, shares.Raw(), dag)
+			require.NoError(t, err)
+
+			// limit with timeout, specifically retrieval
+			ctx, cancel := context.WithTimeout(ctx, time.Minute) // the timeout is big for the max size which is long
+			defer cancel()
+
+			dah := da.NewDataAvailabilityHeader(in)
+			out, err := r.Retrieve(ctx, &dah)
+			require.NoError(t, err)
+			assert.True(t, EqualEDS(in, out))
+		})
+	}
+}

--- a/ipld/retriever_test.go
+++ b/ipld/retriever_test.go
@@ -39,7 +39,7 @@ func TestRetriever_Retrieve(t *testing.T) {
 			require.NoError(t, err)
 
 			// limit with timeout, specifically retrieval
-			ctx, cancel := context.WithTimeout(ctx, time.Minute) // the timeout is big for the max size which is long
+			ctx, cancel := context.WithTimeout(ctx, time.Minute*2) // the timeout is big for the max size which is long
 			defer cancel()
 
 			dah := da.NewDataAvailabilityHeader(in)

--- a/service/header/core_listener_test.go
+++ b/service/header/core_listener_test.go
@@ -17,7 +17,7 @@ import (
 
 // TestCoreListener tests the lifecycle of the core listener.
 func TestCoreListener(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	t.Cleanup(cancel)
 
 	// create mocknet with two pubsub endpoints

--- a/service/share/full_availability.go
+++ b/service/share/full_availability.go
@@ -2,30 +2,41 @@ package share
 
 import (
 	"context"
+	"errors"
 
 	format "github.com/ipfs/go-ipld-format"
 
 	"github.com/celestiaorg/celestia-node/ipld"
-	"github.com/celestiaorg/rsmt2d"
 )
 
 // fullAvailability implements Availability using the full data square
 // recovery technique. It is considered "full" because it is required
 // to download enough shares to fully reconstruct the data square.
 type fullAvailability struct {
-	service format.DAGService
+	rtrv *ipld.Retriever
 }
 
 // NewFullAvailability creates a new full Availability.
-func NewFullAvailability(service format.DAGService) Availability {
+func NewFullAvailability(dag format.DAGService) Availability {
 	return &fullAvailability{
-		service: service,
+		rtrv: ipld.NewRetriever(dag, DefaultCodec()),
 	}
 }
 
 // SharesAvailable reconstructs the data committed to the given Root by requesting
 // enough Shares from the network.
 func (fa *fullAvailability) SharesAvailable(ctx context.Context, root *Root) error {
-	_, err := ipld.RetrieveData(ctx, root, fa.service, rsmt2d.NewRSGF8Codec())
+	ctx, cancel := context.WithTimeout(ctx, AvailabilityTimeout)
+	defer cancel()
+
+	_, err := fa.rtrv.Retrieve(ctx, root)
+	if err != nil {
+		log.Errorw("availability validation failed", "root", root.Hash(), "err", err)
+		if errors.Is(err, format.ErrNotFound) || errors.Is(err, context.DeadlineExceeded) {
+			return ErrNotAvailable
+		}
+
+		return err
+	}
 	return err
 }

--- a/service/share/interface.go
+++ b/service/share/interface.go
@@ -12,7 +12,7 @@ var ErrNotAvailable = errors.New("da: data not available")
 // AvailabilityTimeout specifies timeout for DA validation during which data have to be found on the network,
 // otherwise ErrNotAvailable is fired.
 // TODO: https://github.com/celestiaorg/celestia-node/issues/10
-const AvailabilityTimeout = 10 * time.Minute
+const AvailabilityTimeout = 20 * time.Minute
 
 // Availability defines interface for validation of Shares' availability.
 type Availability interface {

--- a/service/share/light_availability.go
+++ b/service/share/light_availability.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	format "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
 
 	"github.com/celestiaorg/celestia-node/ipld"
 )
@@ -39,11 +40,12 @@ func (la *lightAvailability) SharesAvailable(ctx context.Context, dah *Root) err
 	ctx, cancel := context.WithTimeout(ctx, AvailabilityTimeout)
 	defer cancel()
 
+	ses := merkledag.NewSession(ctx, la.getter)
 	errs := make(chan error, len(samples))
 	for _, s := range samples {
 		go func(s Sample) {
 			root, leaf := translate(dah, s.Row, s.Col)
-			_, err := ipld.GetLeaf(ctx, la.getter, root, leaf, len(dah.RowsRoots))
+			_, err := ipld.GetLeaf(ctx, ses, root, leaf, len(dah.RowsRoots))
 			// we don't really care about Share bodies at this point
 			// it also means we now saved the Share in local storage
 			select {


### PR DESCRIPTION
### What and Why
This PR comes from the requirement to make tests in #598 pass deterministically by reimplementing the original goal of #517. At first, I implemented the goal by simply updating the current code without reworking it. Unfortunately, that didn't work well, and there was a bug that made me stuck for a few days. After extensive multiday debugging, I cleaned up and reworked the existing implementation of RetrieveData in studying the code for the bug. The rework landed into a new `ipld.Retriever` component, which now not just requests the data via sampling quadrants but also retries for other quadrants. 

Eventually, the bug was about rsmt2d not being suitable for recovering over the same data square multiple times, as it sets nil shares to zeroed shares to the given flattened square slice(it actually updates the given slice in place after all!). ~~I will report and link here the issue soon with the suggested fix.~~ The issue https://github.com/celestiaorg/rsmt2d/issues/72. Unless it is fixed, this PR has a workaround with the TODO on it. 

### TODO
- [x] Rework IPLD batch committing logic
- [x] Fix rsmt2d's zeroing of nil shares (https://github.com/celestiaorg/rsmt2d/pull/76)
- [x] Use [rsmt2d v0.4.0](https://github.com/celestiaorg/rsmt2d/releases/tag/v0.4.0) with the above fix
- [x] Parallelize downloading from different roots
- [x] Add Debug logging
- [x] Improve comments
- [x] Add randomization with Col roots and retries(will fix in #508)
- [ ] Write unit test for quadrants retries(Currently tested only with unmerged tests in #598)
- [ ] Manually test that a Full Node is able to sync devnet

Closes #509
Closes #508
Closes #516 , 
Partially closes #604

Note: @vgonkivs was informed about the new implementation of RetrieveData