### PR TITLE
github/admin: fix the empty title for bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report to inform the community on your awesome finding!
-title: ""
 labels: ["bug",]
 body:
   - type: markdown


### PR DESCRIPTION
After merging #609 PR, bug template is not available anymore in our repo due to a template issue containing an explicit empty title. `title: ""`

This PR should fix this proprely and return back the bug template. 