### PR TITLE
service/state: Add `SubmitPayForData` endpoint

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -52,7 +52,8 @@ type Node struct {
 	DataExchange exchange.Interface
 	DAG          format.DAGService
 	// p2p protocols
-	PubSub     *pubsub.PubSub
+	PubSub *pubsub.PubSub
+	// services
 	ShareServ  share.Service   // not optional
 	HeaderServ *header.Service // not optional
 	StateServ  *state.Service  // not optional

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -10,7 +10,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/x/payment"
 	apptypes "github.com/celestiaorg/celestia-app/x/payment/types"
+	"github.com/celestiaorg/nmt/namespace"
 )
 
 // CoreAccessor implements Accessor over an RPC connection
@@ -64,6 +66,15 @@ func (ca *CoreAccessor) Stop(context.Context) error {
 	ca.coreConn = nil
 	ca.queryCli = nil
 	return nil
+}
+
+func (ca *CoreAccessor) SubmitPayForData(
+	ctx context.Context,
+	nID namespace.ID,
+	data []byte,
+	gasLim uint64,
+) (*TxResponse, error) {
+	return payment.SubmitPayForData(ctx, ca.signer, ca.coreConn, nID, data, gasLim)
 }
 
 func (ca *CoreAccessor) Balance(ctx context.Context) (*Balance, error) {

--- a/service/state/interface.go
+++ b/service/state/interface.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"context"
+
+	"github.com/celestiaorg/nmt/namespace"
 )
 
 // Accessor represents the behaviors necessary for a user to
@@ -12,6 +14,10 @@ type Accessor interface {
 	Start(context.Context) error
 	// Stop stops the state Accessor.
 	Stop(context.Context) error
+
+	// SubmitPayForData builds, signs and submits a PayForData transaction.
+	SubmitPayForData(ctx context.Context, nID namespace.ID, data []byte, gasLim uint64) (*TxResponse, error)
+
 	// Balance retrieves the Celestia coin balance
 	// for the node's account/signer.
 	Balance(ctx context.Context) (*Balance, error)

--- a/service/state/rpc.go
+++ b/service/state/rpc.go
@@ -47,7 +47,10 @@ func (s *Service) handleBalanceRequest(w http.ResponseWriter, r *http.Request) {
 	bal, err := s.accessor.Balance(r.Context())
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error())) //nolint:errcheck
+		_, werr := w.Write([]byte(err.Error()))
+		if werr != nil {
+			log.Errorw("writing response", "endpoint", balanceEndpoint, "err", werr)
+		}
 		log.Errorw("serving request", "endpoint", balanceEndpoint, "err", err)
 		return
 	}
@@ -71,14 +74,20 @@ func (s *Service) handleBalanceForAddrRequest(w http.ResponseWriter, r *http.Req
 	addr, err := types.AccAddressFromBech32(addrStr)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error())) //nolint:errcheck
+		_, werr := w.Write([]byte(err.Error()))
+		if werr != nil {
+			log.Errorw("writing response", "endpoint", balanceEndpoint, "err", werr)
+		}
 		log.Errorw("serving request", "endpoint", balanceEndpoint, "err", err)
 		return
 	}
 	bal, err := s.accessor.BalanceForAddress(r.Context(), addr)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error())) //nolint:errcheck
+		_, werr := w.Write([]byte(err.Error()))
+		if werr != nil {
+			log.Errorw("writing response", "endpoint", balanceEndpoint, "err", werr)
+		}
 		log.Errorw("serving request", "endpoint", balanceEndpoint, "err", err)
 		return
 	}
@@ -107,7 +116,10 @@ func (s *Service) handleSubmitTx(w http.ResponseWriter, r *http.Request) {
 	txResp, err := s.accessor.SubmitTx(r.Context(), raw)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error())) //nolint:errcheck
+		_, werr := w.Write([]byte(err.Error()))
+		if werr != nil {
+			log.Errorw("writing response", "endpoint", submitTxEndpoint, "err", werr)
+		}
 		log.Errorw("serving request", "endpoint", submitTxEndpoint, "err", err)
 		return
 	}

--- a/service/state/rpc.go
+++ b/service/state/rpc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/types"
@@ -13,17 +14,26 @@ import (
 	"github.com/celestiaorg/celestia-node/node/rpc"
 )
 
-var log = logging.Logger("state/rpc")
-
 var (
 	addrKey = "address"
 	txKey   = "tx"
+
+	log = logging.Logger("state/rpc")
 )
+
+// submitPFDRequest represents a request to submit a PayForData
+// transaction.
+type submitPFDRequest struct {
+	NamespaceID string `json:"namespace_id"`
+	Data        string `json:"data"`
+	GasLimit    uint64 `json:"gas_limit"`
+}
 
 func (s *Service) RegisterEndpoints(rpc *rpc.Server) {
 	rpc.RegisterHandlerFunc("/balance", s.handleBalanceRequest, http.MethodGet)
 	rpc.RegisterHandlerFunc(fmt.Sprintf("/balance/{%s}", addrKey), s.handleBalanceForAddrRequest, http.MethodGet)
 	rpc.RegisterHandlerFunc(fmt.Sprintf("/submit_tx/{%s}", txKey), s.handleSubmitTx, http.MethodPost)
+	rpc.RegisterHandlerFunc("/submit_pfd", s.handleSubmitPFD, http.MethodPost)
 }
 
 func (s *Service) handleBalanceRequest(w http.ResponseWriter, r *http.Request) {
@@ -99,5 +109,58 @@ func (s *Service) handleSubmitTx(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write(resp)
 	if err != nil {
 		log.Errorw("writing /balance response", "err", err)
+	}
+}
+
+func (s *Service) handleSubmitPFD(w http.ResponseWriter, r *http.Request) {
+	// parse body from request
+	raw, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Errorw("serving /submit_pfd request", "err", err)
+		return
+	}
+	// decode request
+	req := new(submitPFDRequest)
+	err = json.Unmarshal(raw, req)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Errorw("serving /submit_pfd request", "err", err)
+		return
+	}
+
+	nID, err := hex.DecodeString(req.NamespaceID)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Errorw("serving /submit_pfd request", "err", err)
+		return
+	}
+	data, err := hex.DecodeString(req.Data)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Errorw("serving /submit_pfd request", "err", err)
+		return
+	}
+
+	// perform request
+	txResp, err := s.accessor.SubmitPayForData(r.Context(), nID, data, req.GasLimit)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, werr := w.Write([]byte(err.Error()))
+		if werr != nil {
+			log.Errorw("writing /submit_pfd response", "err", werr)
+		}
+		log.Errorw("serving /submit_pfd request", "err", err)
+		return
+	}
+	resp, err := json.Marshal(txResp)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Errorw("serving /submit_pfd request", "err", err)
+		return
+	}
+	_, err = w.Write(resp)
+	if err != nil {
+		log.Errorw("writing /submit_pfd response", "err", err)
 	}
 }


### PR DESCRIPTION
This PR adds a `SubmitPayForData` endpoint that builds, signs and submits a `PayForData` msg using celestia-app's new `PayForData` API. 

So far, I've only tested the endpoint manually. Unit tests for checking state endpoints are likely not feasible (until a lightweight mock celestia-app is created), but we will look into creating a swamp test to stand up a single instance of celestia-app to test the state endpoints as an integration test instead.