### PR TITLE
node: Distinct start node log to distinguish node type info from rest of logs

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -100,7 +100,8 @@ func (n *Node) Start(ctx context.Context) error {
 
 	// TODO(@Wondertan): Print useful information about the node:
 	//  * API/RPCServer address
-	log.Infof("started %s Node", n.Type)
+	log.Infof("\n\n/_____/  /_____/  /_____/  /_____/  /_____/ \n\nStarted celestia DA node \nNode "+
+		"type: %s\nNetwork: %s\n\n/_____/  /_____/  /_____/  /_____/  /_____/ \n", n.Type.String(), n.Network)
 
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(n.Host))
 	if err != nil {
@@ -111,6 +112,7 @@ func (n *Node) Start(ctx context.Context) error {
 	for _, addr := range addrs {
 		fmt.Println("* ", addr.String())
 	}
+	fmt.Println()
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -99,8 +99,6 @@ func (n *Node) Start(ctx context.Context) error {
 		return fmt.Errorf("node: failed to start: %w", err)
 	}
 
-	// TODO(@Wondertan): Print useful information about the node:
-	//  * API/RPCServer address
 	log.Infof("\n\n/_____/  /_____/  /_____/  /_____/  /_____/ \n\nStarted celestia DA node \nnode "+
 		"type: 	%s\nnetwork: 	%s\n\n/_____/  /_____/  /_____/  /_____/  /_____/ \n", strings.ToLower(n.Type.String()),
 		n.Network)

--- a/node/node.go
+++ b/node/node.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
@@ -100,8 +101,9 @@ func (n *Node) Start(ctx context.Context) error {
 
 	// TODO(@Wondertan): Print useful information about the node:
 	//  * API/RPCServer address
-	log.Infof("\n\n/_____/  /_____/  /_____/  /_____/  /_____/ \n\nStarted celestia DA node \nNode "+
-		"type: %s\nNetwork: %s\n\n/_____/  /_____/  /_____/  /_____/  /_____/ \n", n.Type.String(), n.Network)
+	log.Infof("\n\n/_____/  /_____/  /_____/  /_____/  /_____/ \n\nStarted celestia DA node \nnode "+
+		"type: 	%s\nnetwork: 	%s\n\n/_____/  /_____/  /_____/  /_____/  /_____/ \n", strings.ToLower(n.Type.String()),
+		n.Network)
 
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(n.Host))
 	if err != nil {


### PR DESCRIPTION
Looks like this now: 

```
2022-04-27T15:34:21.209+0100	INFO	node	node/node.go:104

/_____/  /_____/  /_____/  /_____/  /_____/

Started celestia DA node
node type: 	light
network: 	devnet-2

/_____/  /_____/  /_____/  /_____/  /_____/

The p2p host is listening on:
*  /ip4/192.168.1.172/tcp/2121/p2p/12D3KooWQAFwc4p5hQUpzU6UgLDEcMD5JVGpMrqWQ8SfUtrZ1G4v
*  /ip6/::1/tcp/2121/p2p/12D3KooWQAFwc4p5hQUpzU6UgLDEcMD5JVGpMrqWQ8SfUtrZ1G4v

```