### PR TITLE
service/state: Clean up RPC endpoint for `/submit_pfd`

### DIFF
--- a/service/state/rpc.go
+++ b/service/state/rpc.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/types"
@@ -136,16 +135,9 @@ func (s *Service) handleSubmitTx(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Service) handleSubmitPFD(w http.ResponseWriter, r *http.Request) {
-	// parse body from request
-	raw, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		log.Errorw("serving request", "endpoint", submitPFDEndpoint, "err", err)
-		return
-	}
 	// decode request
-	req := new(submitPFDRequest)
-	err = json.Unmarshal(raw, req)
+	var req submitPFDRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		log.Errorw("serving request", "endpoint", submitPFDEndpoint, "err", err)


### PR DESCRIPTION
### Manually test `/submit_pfd` endpoint

```
curl -X POST -d '{"namespace_id": "0000010000000100", 0000, "max_data_size": 16}' http://127.0.0.1:26658/submit_pfd
```