### PR TITLE
service/share: Rename root to dah in JSON body of `/namespaced_shares` endpoint

### DIFF
--- a/service/share/rpc.go
+++ b/service/share/rpc.go
@@ -14,7 +14,7 @@ const namespacedSharesEndpoint = "/namespaced_shares"
 // request payload
 type sharesByNamespaceRequest struct {
 	NamespaceID string `json:"namespace_id"`
-	Root        string `json:"root"`
+	DAH         string `json:"dah"`
 }
 
 func (s *service) RegisterEndpoints(rpc *rpc.Server) {
@@ -38,7 +38,7 @@ func (s *service) handleSharesByNamespaceRequest(w http.ResponseWriter, r *http.
 		return
 	}
 	// decode and unmarshal root
-	rawRoot, err := hex.DecodeString(req.Root)
+	rawRoot, err := hex.DecodeString(req.DAH)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		log.Errorw("serving request", "endpoint", namespacedSharesEndpoint, "err", err)

--- a/service/share/rpc.go
+++ b/service/share/rpc.go
@@ -37,22 +37,22 @@ func (s *service) handleSharesByNamespaceRequest(w http.ResponseWriter, r *http.
 		log.Errorw("serving request", "endpoint", namespacedSharesEndpoint, "err", err)
 		return
 	}
-	// decode and unmarshal root
-	rawRoot, err := hex.DecodeString(req.DAH)
+	// decode and unmarshal DAH
+	rawDAH, err := hex.DecodeString(req.DAH)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		log.Errorw("serving request", "endpoint", namespacedSharesEndpoint, "err", err)
 		return
 	}
-	var root Root
-	err = json.Unmarshal(rawRoot, &root)
+	var dah Root
+	err = json.Unmarshal(rawDAH, &dah)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		log.Errorw("serving request", "endpoint", namespacedSharesEndpoint, "err", err)
 		return
 	}
 	// perform request
-	shares, err := s.GetSharesByNamespace(r.Context(), &root, nID)
+	shares, err := s.GetSharesByNamespace(r.Context(), &dah, nID)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, werr := w.Write([]byte(err.Error()))


### PR DESCRIPTION
## Description

This PR renames the field in the JSON request for `/namespaced_shares` from `root` to `dah` as `root` is a variable name we use inside celestia-node that not many people know about whereas `DAH` is more intuitive.


## Docs

### GET `/namespaced_shares`

Request

```
curl -X GET -d '{"namespace_id": "fffffffffffffffe", "dah": "7b22726f775f726f6f7473223a5b22414141414141414141414541414141414141414141622b30524d7377796534365a47482b4b66347a784a48364d55336457564d726f33794b4f6a4f3448644a31222c2241414141414141414141482f2f2f2f2f2f2f2f2f2f692f584d58737158512f665377634d633643486a746c7a3954644a6b3546713676362b356f614f66563171222c222f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f7a556e4b41357a426661756d79674d696646436e4738616537534d6c46724a416d3947346e75584858484d222c222f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2b3662644d455478527a75774f6873744c416c2f78303248396a5a4671325349524747795041623250756b225d2c22636f6c756d6e5f726f6f7473223a5b22414141414141414141414541414141414141414141576a344361724468634c58356667596c6d586d5a525231336a4e485a67442f7a6379656e6b6544472f6235222c2241414141414141414141482f2f2f2f2f2f2f2f2f2f686b4e37664e67757436416c4b736f4a4f567a4d343532486965376c7265375378347044747433537a3257222c222f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f312b794e563651376377685178313637766b705665787a576a744c7767416b696b326636344b4655503661222c222f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f7a5a685a736e75684749597071474d513566594f594d44446c2f5444486364762f6b6976647235356d7758225d7d"}' http://127.0.0.1:26658/namespaced_shares
```

Response

```
[]
```