### PR TITLE
cmd: Set rpc flag defaults

### DIFF
--- a/cmd/flags_rpc.go
+++ b/cmd/flags_rpc.go
@@ -5,6 +5,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/celestiaorg/celestia-node/node"
+	"github.com/celestiaorg/celestia-node/node/rpc"
 )
 
 var (
@@ -18,12 +19,12 @@ func RPCFlags() *flag.FlagSet {
 
 	flags.String(
 		addrFlag,
-		"0.0.0.0",
+		rpc.DefaultConfig().Address,
 		"Set a custom RPC listen address (default: localhost)",
 	)
 	flags.String(
 		portFlag,
-		"26658",
+		rpc.DefaultConfig().Port,
 		"Set a custom RPC port (default: 26658)",
 	)
 

--- a/cmd/flags_rpc.go
+++ b/cmd/flags_rpc.go
@@ -5,7 +5,6 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/celestiaorg/celestia-node/node"
-	"github.com/celestiaorg/celestia-node/node/rpc"
 )
 
 var (
@@ -19,12 +18,12 @@ func RPCFlags() *flag.FlagSet {
 
 	flags.String(
 		addrFlag,
-		rpc.DefaultConfig().Address,
+		"localhost",
 		"Set a custom RPC listen address (default: localhost)",
 	)
 	flags.String(
 		portFlag,
-		rpc.DefaultConfig().Port,
+		"26658",
 		"Set a custom RPC port (default: 26658)",
 	)
 

--- a/cmd/flags_rpc.go
+++ b/cmd/flags_rpc.go
@@ -18,12 +18,12 @@ func RPCFlags() *flag.FlagSet {
 
 	flags.String(
 		addrFlag,
-		"",
+		"0.0.0.0",
 		"Set a custom RPC listen address (default: localhost)",
 	)
 	flags.String(
 		portFlag,
-		"",
+		"26658",
 		"Set a custom RPC port (default: 26658)",
 	)
 

--- a/node/rpc/config.go
+++ b/node/rpc/config.go
@@ -7,7 +7,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		Address: "0.0.0.0",
+		Address: "localhost",
 		// do NOT expose the same port as celestia-core by default so that both can run on the same machine
 		Port: "26658",
 	}


### PR DESCRIPTION
This PR adds flag defaults for rpc addr and port.