### PR TITLE
chore: update .gitignore to include go.work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ vendor
 celestia
 cel-shed
 coverage.txt
+go.work


### PR DESCRIPTION
I had to make local changes in rsmt2d(public Get/SetCell), and new go work feature appeared to be useful for that, and I don't want it to be accidentally committed, as it defines workspace specifically for local development