### PR TITLE
service/share: Remove unused `share.Service` interface

### DIFF
--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -216,7 +216,7 @@ func createDASerSubcomponents(
 	dag format.DAGService,
 	numGetter,
 	numSub int,
-) (*mockGetter, share.Service, *header.DummySubscriber) {
+) (*mockGetter, *share.Service, *header.DummySubscriber) {
 	shareServ := share.NewService(dag, share.NewLightAvailability(dag))
 
 	mockGet := &mockGetter{

--- a/node/node.go
+++ b/node/node.go
@@ -54,7 +54,7 @@ type Node struct {
 	// p2p protocols
 	PubSub *pubsub.PubSub
 	// services
-	ShareServ  share.Service   // not optional
+	ShareServ  *share.Service  // not optional
 	HeaderServ *header.Service // not optional
 	StateServ  *state.Service  // not optional
 

--- a/node/rpc/component.go
+++ b/node/rpc/component.go
@@ -25,7 +25,7 @@ func ServerComponent(cfg rpc.Config) func(lc fx.Lifecycle) *rpc.Server {
 
 func HandlerComponents(
 	state *state.Service,
-	share share.Service,
+	share *share.Service,
 	header *header.Service,
 	serv *rpc.Server,
 ) {

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -122,7 +122,7 @@ func HeaderStoreInit(cfg *Config) func(context.Context, params.Network, header.S
 }
 
 // ShareService constructs new share.Service.
-func ShareService(lc fx.Lifecycle, dag ipld.DAGService, avail share.Availability) share.Service {
+func ShareService(lc fx.Lifecycle, dag ipld.DAGService, avail share.Availability) *share.Service {
 	service := share.NewService(dag, avail)
 	lc.Append(fx.Hook{
 		OnStart: service.Start,

--- a/service/rpc/handler.go
+++ b/service/rpc/handler.go
@@ -12,11 +12,11 @@ var log = logging.Logger("rpc")
 
 type Handler struct {
 	state  *state.Service
-	share  share.Service
+	share  *share.Service
 	header *header.Service
 }
 
-func NewHandler(state *state.Service, share share.Service, header *header.Service) *Handler {
+func NewHandler(state *state.Service, share *share.Service, header *header.Service) *Handler {
 	return &Handler{
 		state:  state,
 		share:  share,

--- a/service/share/testing.go
+++ b/service/share/testing.go
@@ -30,21 +30,21 @@ import (
 
 // RandLightServiceWithSquare provides a share.Service filled with 'n' NMT
 // trees of 'n' random shares, essentially storing a whole square.
-func RandLightServiceWithSquare(t *testing.T, n int) (Service, *Root) {
+func RandLightServiceWithSquare(t *testing.T, n int) (*Service, *Root) {
 	dag := mdutils.Mock()
 	return NewService(dag, NewLightAvailability(dag)), RandFillDAG(t, n, dag)
 }
 
 // RandLightService provides an unfilled share.Service with corresponding
 // format.DAGService than can be filled by the test.
-func RandLightService() (Service, format.DAGService) {
+func RandLightService() (*Service, format.DAGService) {
 	dag := mdutils.Mock()
 	return NewService(dag, NewLightAvailability(dag)), dag
 }
 
 // RandFullServiceWithSquare provides a share.Service filled with 'n' NMT
 // trees of 'n' random shares, essentially storing a whole square.
-func RandFullServiceWithSquare(t *testing.T, n int) (Service, *Root) {
+func RandFullServiceWithSquare(t *testing.T, n int) (*Service, *Root) {
 	dag := mdutils.Mock()
 	return NewService(dag, NewFullAvailability(dag)), RandFillDAG(t, n, dag)
 }
@@ -89,12 +89,12 @@ func NewDAGNet(ctx context.Context, t *testing.T) *DAGNet {
 	}
 }
 
-func (dn *DAGNet) RandLightService(n int) (Service, *Root) {
+func (dn *DAGNet) RandLightService(n int) (*Service, *Root) {
 	dag, root := dn.RandDAG(n)
 	return NewService(dag, NewLightAvailability(dag)), root
 }
 
-func (dn *DAGNet) RandFullService(n int) (Service, *Root) {
+func (dn *DAGNet) RandFullService(n int) (*Service, *Root) {
 	dag, root := dn.RandDAG(n)
 	return NewService(dag, NewFullAvailability(dag)), root
 }
@@ -104,7 +104,7 @@ func (dn *DAGNet) RandDAG(n int) (format.DAGService, *Root) {
 	return dag, RandFillDAG(dn.t, n, dag)
 }
 
-func (dn *DAGNet) CleanService() Service {
+func (dn *DAGNet) CleanService() *Service {
 	dag := dn.CleanDAG()
 	return NewService(dag, NewLightAvailability(dag))
 }


### PR DESCRIPTION
This PR removes the `share.Service` interface as it doesn't have any use and exports the previously private `service` struct instead, using it throughout the codebase.

Overrides #695