### PR TITLE
node/state: Generate key for node if no key found in keystore path

### DIFF
--- a/cmd/celestia/bridge.go
+++ b/cmd/celestia/bridge.go
@@ -28,6 +28,7 @@ func init() {
 			cmdnode.TrustedHashFlags(),
 			cmdnode.MiscFlags(),
 			cmdnode.RPCFlags(),
+			cmdnode.KeyFlags(),
 		),
 		cmdnode.Start(
 			cmdnode.NodeFlags(node.Bridge),
@@ -36,6 +37,7 @@ func init() {
 			cmdnode.TrustedHashFlags(),
 			cmdnode.MiscFlags(),
 			cmdnode.RPCFlags(),
+			cmdnode.KeyFlags(),
 		),
 		bridgeKeyCmd,
 	)
@@ -82,6 +84,8 @@ var bridgeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		cmdnode.ParseKeyFlags(cmd, env)
 
 		return nil
 	},

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -30,6 +30,7 @@ func init() {
 			// over an RPC connection with a celestia-core node.
 			cmdnode.CoreFlags(),
 			cmdnode.RPCFlags(),
+			cmdnode.KeyFlags(),
 		),
 		cmdnode.Start(
 			cmdnode.NodeFlags(node.Full),
@@ -40,6 +41,7 @@ func init() {
 			// over an RPC connection with a celestia-core node.
 			cmdnode.CoreFlags(),
 			cmdnode.RPCFlags(),
+			cmdnode.KeyFlags(),
 		),
 		fullKeyCmd,
 	)
@@ -86,6 +88,8 @@ var fullCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		cmdnode.ParseKeyFlags(cmd, env)
 
 		return nil
 	},

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -30,6 +30,7 @@ func init() {
 			// over an RPC connection with a celestia-core node.
 			cmdnode.CoreFlags(),
 			cmdnode.RPCFlags(),
+			cmdnode.KeyFlags(),
 		),
 		cmdnode.Start(
 			cmdnode.NodeFlags(node.Light),
@@ -40,6 +41,7 @@ func init() {
 			// over an RPC connection with a celestia-core node.
 			cmdnode.CoreFlags(),
 			cmdnode.RPCFlags(),
+			cmdnode.KeyFlags(),
 		),
 		lightKeyCmd,
 	)
@@ -85,6 +87,8 @@ var lightCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		cmdnode.ParseKeyFlags(cmd, env)
 
 		return nil
 	},

--- a/cmd/flags_key.go
+++ b/cmd/flags_key.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
+	"github.com/celestiaorg/celestia-node/node"
+)
+
+var keyringAccNameFlag = "keyring.AccName"
+
+func KeyFlags() *flag.FlagSet {
+	flags := &flag.FlagSet{}
+
+	flags.String(keyringAccNameFlag, "", "Directs node's keyring signer to use the key prefixed with the "+
+		"given string.")
+	return flags
+}
+
+func ParseKeyFlags(cmd *cobra.Command, env *Env) {
+	keyringAccName := cmd.Flag(keyringAccNameFlag).Value.String()
+	if keyringAccName != "" {
+		env.AddOptions(node.WithKeyringAccName(keyringAccName))
+	}
+}

--- a/cmd/flags_key.go
+++ b/cmd/flags_key.go
@@ -7,7 +7,7 @@ import (
 	"github.com/celestiaorg/celestia-node/node"
 )
 
-var keyringAccNameFlag = "keyring.AccName"
+var keyringAccNameFlag = "keyring.accname"
 
 func KeyFlags() *flag.FlagSet {
 	flags := &flag.FlagSet{}

--- a/node/components.go
+++ b/node/components.go
@@ -71,7 +71,7 @@ func baseComponents(cfg *Config, store Store) fx.Option {
 		p2p.Components(cfg.P2P),
 		// state components
 		fx.Provide(statecomponents.NewService),
-		fx.Provide(statecomponents.CoreAccessor(cfg.Core.GRPCAddr)),
+		fx.Provide(statecomponents.CoreAccessor(cfg.Core.GRPCAddr, cfg.Key.KeyringAccName)),
 		// RPC components
 		fx.Provide(rpc.ServerComponent(cfg.RPC)),
 		fx.Invoke(rpc.HandlerComponents),

--- a/node/config.go
+++ b/node/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/celestiaorg/celestia-node/node/core"
+	"github.com/celestiaorg/celestia-node/node/key"
 	"github.com/celestiaorg/celestia-node/node/p2p"
 	"github.com/celestiaorg/celestia-node/node/services"
 	"github.com/celestiaorg/celestia-node/service/rpc"
@@ -19,6 +20,7 @@ type ConfigLoader func() (*Config, error)
 // It combines configuration units for all Node subsystems.
 type Config struct {
 	Core     core.Config
+	Key      key.Config
 	P2P      p2p.Config
 	RPC      rpc.Config
 	Services services.Config
@@ -31,18 +33,21 @@ func DefaultConfig(tp Type) *Config {
 	case Bridge:
 		return &Config{
 			Core:     core.DefaultConfig(),
+			Key:      key.DefaultConfig(),
 			P2P:      p2p.DefaultConfig(),
 			RPC:      rpc.DefaultConfig(),
 			Services: services.DefaultConfig(),
 		}
 	case Light:
 		return &Config{
+			Key:      key.DefaultConfig(),
 			RPC:      rpc.DefaultConfig(),
 			P2P:      p2p.DefaultConfig(),
 			Services: services.DefaultConfig(),
 		}
 	case Full:
 		return &Config{
+			Key:      key.DefaultConfig(),
 			RPC:      rpc.DefaultConfig(),
 			P2P:      p2p.DefaultConfig(),
 			Services: services.DefaultConfig(),

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -59,3 +59,10 @@ func WithMutualPeers(addrs []string) Option {
 		sets.cfg.P2P.MutualPeers = addrs
 	}
 }
+
+// WithKeyringAccName sets the `KeyringAccName` field in the key config.
+func WithKeyringAccName(name string) Option {
+	return func(sets *settings) {
+		sets.cfg.Key.KeyringAccName = name
+	}
+}

--- a/node/key/key.go
+++ b/node/key/key.go
@@ -1,0 +1,13 @@
+package key
+
+// Config contains configuration parameters for constructing
+// the node's keyring signer.
+type Config struct {
+	KeyringAccName string
+}
+
+func DefaultConfig() Config {
+	return Config{
+		KeyringAccName: "",
+	}
+}

--- a/node/state/core.go
+++ b/node/state/core.go
@@ -16,13 +16,12 @@ import (
 	"github.com/celestiaorg/celestia-node/service/state"
 )
 
-var (
-	log = logging.Logger("state-access-constructor")
+var log = logging.Logger("state-access-constructor")
 
-	keyringAccName = "celes"
-)
-
-func CoreAccessor(endpoint string) func(fx.Lifecycle, keystore.Keystore, params.Network) (state.Accessor, error) {
+func CoreAccessor(
+	endpoint,
+	keyringAccName string,
+) func(fx.Lifecycle, keystore.Keystore, params.Network) (state.Accessor, error) {
 	return func(lc fx.Lifecycle, ks keystore.Keystore, net params.Network) (state.Accessor, error) {
 		// TODO @renaynay: Include option for setting custom `userInput` parameter with
 		//  implementation of https://github.com/celestiaorg/celestia-node/issues/415.
@@ -33,39 +32,42 @@ func CoreAccessor(endpoint string) func(fx.Lifecycle, keystore.Keystore, params.
 			return nil, err
 		}
 		signer := apptypes.NewKeyringSigner(ring, keyringAccName, string(net))
-		keys, err := signer.List()
-		if err != nil {
-			return nil, err
-		}
-		// check if key exists with prefix `celes`
-		var (
-			exists = false
-			name   = ""
-		)
-		for _, key := range keys {
-			if key.GetName()[:5] == keyringAccName {
-				exists = true
-				name = key.GetName()
-			}
-		}
-		// if no key was found in keystore path, generate new key for node
-		if !exists {
-			log.Infow("NO KEY FOUND IN STORE, GENERATING NEW KEY...", "path", ks.Path())
-			info, mn, err := signer.NewMnemonic(keyringAccName, keyring.English, "", "",
-				hd.Secp256k1)
+
+		var info keyring.Info
+		// if custom keyringAccName provided, find key for that name
+		if keyringAccName != "" {
+			keyInfo, err := signer.Key(keyringAccName)
 			if err != nil {
 				return nil, err
 			}
+			info = keyInfo
+		} else {
+			// check if key exists for signer
+			keys, err := signer.List()
+			if err != nil {
+				return nil, err
+			}
+			// if no key was found in keystore path, generate new key for node
+			if len(keys) == 0 {
+				log.Infow("NO KEY FOUND IN STORE, GENERATING NEW KEY...", "path", ks.Path())
+				keyInfo, mn, err := signer.NewMnemonic("my_celes_key", keyring.English, "",
+					"", hd.Secp256k1)
+				if err != nil {
+					return nil, err
+				}
+				log.Info("NEW KEY GENERATED...")
+				fmt.Printf("\nNAME: %s\nADDRESS: %s\nMNEMONIC (save this somewhere safe!!!): \n%s\n\n",
+					keyInfo.GetName(), keyInfo.GetAddress().String(), mn)
 
-			name = info.GetName()
-
-			log.Info("NEW KEY GENERATED...")
-			fmt.Printf("\nNAME: %s\nADDRESS: %s\nMNEMONIC (save this somewhere safe!!!): \n%s\n\n",
-				info.GetName(), info.GetAddress().String(), mn)
+				info = keyInfo
+			} else {
+				// if one or more keys are present and no keyringAccName was given, use the first key in list
+				info = keys[0]
+			}
 		}
 
 		log.Infow("constructed keyring signer", "backend", keyring.BackendTest, "path", ks.Path(),
-			"key name", name, "chain-id", string(net))
+			"key name", info.GetName(), "chain-id", string(net))
 
 		ca := state.NewCoreAccessor(signer, endpoint)
 		lc.Append(fx.Hook{

--- a/node/state/core.go
+++ b/node/state/core.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -44,7 +45,9 @@ func CoreAccessor(endpoint string) func(fx.Lifecycle, keystore.Keystore, params.
 			if err != nil {
 				return nil, err
 			}
-			log.Infow("NEW KEY GENERATED...", "name", info.GetName(), "mnemonic", mn)
+			log.Info("NEW KEY GENERATED...")
+			fmt.Printf("\nNAME: %s\nADDRESS: %s\nMNEMONIC (save this somewhere safe!!!): \n%s\n\n",
+				info.GetName(), info.GetAddress().String(), mn)
 		}
 
 		log.Infow("constructed keyring signer", "backend", keyring.BackendTest, "path", ks.Path(),

--- a/node/state/core.go
+++ b/node/state/core.go
@@ -39,7 +39,7 @@ func CoreAccessor(endpoint string) func(fx.Lifecycle, keystore.Keystore, params.
 		}
 		// if no key was found in keystore path, generate new key for node
 		if len(keys) == 0 {
-			log.Infow("NO KEY FOUND IN PATH, GENERATING NEW KEY...", "path", ks.Path())
+			log.Infow("NO KEY FOUND IN STORE, GENERATING NEW KEY...", "path", ks.Path())
 			info, mn, err := signer.NewMnemonic(keyringAccName, keyring.English, "", "",
 				hd.Secp256k1)
 			if err != nil {

--- a/node/state/core.go
+++ b/node/state/core.go
@@ -1,9 +1,9 @@
 package state
 
 import (
-	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"os"
 
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"


### PR DESCRIPTION
This PR adds logic to check if a key was found in the given keystore path, and if not, a new key is generated on spot for the node to use for state interaction, allowing for better UX upon node start up.

New logs: 

```
2022-05-16T11:04:36.200+0100	INFO	state-access-constructor	state/core.go:42	NO KEY FOUND IN PATH, GENERATING NEW KEY...	{"path": "/Users/<>/.celestia-full/keys"}
2022-05-16T11:04:36.208+0100	INFO	state-access-constructor	state/core.go:48	NEW KEY GENERATED...

NAME: celes
ADDRESS: celes1gflh3mcttn02w7ahhjuucw8ajt69zu2g43wl9y
MNEMONIC (save this somewhere safe!!!):
present disorder solve luxury junk army lamp toward motor hello butter rate oppose parade absurd turtle person arrive tomato junk noise script mass rocket

```