### PR TITLE
params: Introduce `CUSTOM` network type

### DIFF
--- a/node/init.go
+++ b/node/init.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/libs/fslock"
 	"github.com/celestiaorg/celestia-node/libs/utils"
+	"github.com/celestiaorg/celestia-node/params"
 )
 
 // Init initializes the Node FileSystem Store for the given Node Type 'tp' in the directory under 'path' with
@@ -118,7 +119,7 @@ func initDir(path string) error {
 	if utils.Exists(path) {
 		// if the dir already exists and `CELESTIA_CUSTOM` env var is set,
 		// fail out to prevent store corruption
-		if _, ok := os.LookupEnv("CELESTIA_CUSTOM"); ok {
+		if _, ok := os.LookupEnv(params.EnvCustomNetwork); ok {
 			return fmt.Errorf("cannot run a custom network over an already-existing node store")
 		}
 		return nil

--- a/node/init.go
+++ b/node/init.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -115,6 +116,11 @@ func initRoot(path string) error {
 // initDir creates a dir if not exist
 func initDir(path string) error {
 	if utils.Exists(path) {
+		// if the dir already exists and `CELESTIA_CUSTOM` env var is set,
+		// fail out to prevent store corruption
+		if _, ok := os.LookupEnv("CELESTIA_CUSTOM"); ok {
+			return fmt.Errorf("cannot run a custom network over an already-existing node store")
+		}
 		return nil
 	}
 	return os.Mkdir(path, perms)

--- a/params/bootstrap.go
+++ b/params/bootstrap.go
@@ -1,9 +1,12 @@
 package params
 
 import (
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
+
+var log = logging.Logger("params")
 
 // BootstrappersInfosFor returns address information of bootstrap peers for a given network.
 func BootstrappersInfosFor(net Network) ([]peer.AddrInfo, error) {
@@ -39,11 +42,13 @@ func parseAddrInfos(addrs []string) ([]peer.AddrInfo, error) {
 	for _, addr := range addrs {
 		maddr, err := ma.NewMultiaddr(addr)
 		if err != nil {
+			log.Errorw("parsing and validating addr", "addr", addr, "err", err)
 			return nil, err
 		}
 
 		info, err := peer.AddrInfoFromP2pAddr(maddr)
 		if err != nil {
+			log.Errorw("parsing info from multiaddr", "maddr", maddr, "err", err)
 			return nil, err
 		}
 		infos = append(infos, *info)

--- a/params/default.go
+++ b/params/default.go
@@ -1,6 +1,7 @@
 package params
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -14,25 +15,47 @@ func DefaultNetwork() Network {
 }
 
 func init() {
+	// check if a different network from the registry was specified
+	if network, ok := os.LookupEnv("CELESTIA_NETWORK"); ok {
+		if _, exists := networksList[Network(network)]; !exists {
+			panic("unknown network specified")
+		}
+		defaultNetwork = Network(network)
+		return
+	}
 	// check if private network option set
 	if genesis, ok := os.LookupEnv("CELESTIA_PRIVATE_GENESIS"); ok {
 		defaultNetwork = Private
 		genesisList[Private] = strings.ToUpper(genesis)
 	}
 	// check if custom network option set
-	if customNet, ok := os.LookupEnv("CELESTIA_CUSTOM_NETWORK"); ok {
-		genesis, ok := os.LookupEnv("CELESTIA_CUSTOM_GENESIS")
-		if !ok {
-			panic("custom network specified without a custom genesis hash")
+	if customNet, ok := os.LookupEnv("CELESTIA_CUSTOM"); ok {
+		fmt.Print("\n\nWARNING: Celestia custom network specified. Only use this option if the node is " +
+			"freshly created and initialized.\n**DO NOT** run a custom network over an already-existing node " +
+			"store!\n\n")
+
+		params := strings.Split(customNet, "=")
+		// ensure both params are present
+		if len(params) != 2 {
+			panic("must provide CELESTIA_CUSTOM in this format: <network_ID>=<genesis hash>")
 		}
-		bootstrappers, ok := os.LookupEnv("CELESTIA_CUSTOM_BOOTSTRAPPERS")
-		if !ok {
-			panic("custom network specified without custom bootstrappers")
-		}
-		// set all params
-		defaultNetwork = Network(customNet)
+		netID, genHash := params[0], params[1]
+
+		defaultNetwork = Network(netID)
+		// register new network and set as default for node to use
 		networksList[defaultNetwork] = struct{}{}
-		genesisList[defaultNetwork] = strings.ToUpper(genesis)
-		bootstrapList[defaultNetwork] = strings.Split(bootstrappers, ",")
+		genesisList[defaultNetwork] = strings.ToUpper(genHash)
+	}
+	// check if custom bootstrappers were provided for a network
+	if bootstrappers, ok := os.LookupEnv("CELESTIA_BOOTSTRAPPERS"); ok {
+		params := strings.Split(bootstrappers, "=")
+		// ensure both params are present
+		if len(params) != 2 {
+			panic("must provide CELESTIA_BOOTSTRAPPERS in this format: " +
+				"<network_ID>=<boostrappers comma separated list>")
+		}
+
+		netID, list := params[0], params[1]
+		bootstrapList[Network(netID)] = strings.Split(list, ",")
 	}
 }

--- a/params/default.go
+++ b/params/default.go
@@ -14,8 +14,25 @@ func DefaultNetwork() Network {
 }
 
 func init() {
+	// check if private network option set
 	if genesis, ok := os.LookupEnv("CELESTIA_PRIVATE_GENESIS"); ok {
 		defaultNetwork = Private
 		genesisList[Private] = strings.ToUpper(genesis)
+	}
+	// check if custom network option set
+	if customNet, ok := os.LookupEnv("CELESTIA_CUSTOM_NETWORK"); ok {
+		genesis, ok := os.LookupEnv("CELESTIA_CUSTOM_GENESIS")
+		if !ok {
+			panic("custom network specified without a custom genesis hash")
+		}
+		bootstrappers, ok := os.LookupEnv("CELESTIA_CUSTOM_BOOTSTRAPPERS")
+		if !ok {
+			panic("custom network specified without custom bootstrappers")
+		}
+		// set all params
+		defaultNetwork = Network(customNet)
+		networksList[defaultNetwork] = struct{}{}
+		genesisList[defaultNetwork] = strings.ToUpper(genesis)
+		bootstrapList[defaultNetwork] = strings.Split(bootstrappers, ",")
 	}
 }

--- a/params/default.go
+++ b/params/default.go
@@ -28,9 +28,8 @@ func init() {
 		}
 		netID, genHash := params[0], params[1]
 
-		defaultNetwork = Network(netID)
 		// register new network and set as default for node to use
-		networksList[defaultNetwork] = struct{}{}
+		networksList[Network(netID)] = struct{}{}
 		genesisList[defaultNetwork] = strings.ToUpper(genHash)
 	}
 	// check if a custom network was specified
@@ -38,6 +37,7 @@ func init() {
 		if err := Network(network).Validate(); err != nil {
 			panic("unknown network specified")
 		}
+		defaultNetwork = Network(network)
 	}
 	// check if custom bootstrappers were provided for a network
 	if bootstrappers, ok := os.LookupEnv("CELESTIA_CUSTOM_BOOTSTRAPPERS"); ok {

--- a/params/default.go
+++ b/params/default.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+const (
+	EnvCustomNetwork  = "CELESTIA_CUSTOM"
+	EnvPrivateGenesis = "CELESTIA_PRIVATE_GENESIS"
+)
+
 // defaultNetwork defines a default network for the Celestia Node.
 var defaultNetwork = DevNet
 
@@ -16,22 +21,22 @@ func DefaultNetwork() Network {
 
 func init() {
 	// check if custom network option set
-	if custom, ok := os.LookupEnv("CELESTIA_CUSTOM"); ok {
+	if custom, ok := os.LookupEnv(EnvCustomNetwork); ok {
 		fmt.Print("\n\nWARNING: Celestia custom network specified. Only use this option if the node is " +
 			"freshly created and initialized.\n**DO NOT** run a custom network over an already-existing node " +
 			"store!\n\n")
 		// ensure all three params are present
 		params := strings.Split(custom, ":")
 		if len(params) != 3 {
-			panic("must provide CELESTIA_CUSTOM in this format: " +
-				"<network_ID>:<genesis hash>:<comma-separated list of bootstrappers>")
+			panic(fmt.Sprintf("must provide %s in this format: "+
+				"<network_ID>:<genesis hash>:<comma-separated list of bootstrappers>", EnvCustomNetwork))
 		}
 		netID, genHash, bootstrappers := params[0], params[1], params[2]
 		// validate bootstrappers
 		bs := strings.Split(bootstrappers, ",")
 		_, err := parseAddrInfos(bs)
 		if err != nil {
-			println("env CELESTIA_CUSTOM: contains invalid multiaddress")
+			println(fmt.Sprintf("env %s: contains invalid multiaddress", EnvCustomNetwork))
 			panic(err)
 		}
 		bootstrapList[Network(netID)] = bs
@@ -42,7 +47,7 @@ func init() {
 		genesisList[defaultNetwork] = strings.ToUpper(genHash)
 	}
 	// check if private network option set
-	if genesis, ok := os.LookupEnv("CELESTIA_PRIVATE_GENESIS"); ok {
+	if genesis, ok := os.LookupEnv(EnvPrivateGenesis); ok {
 		defaultNetwork = Private
 		genesisList[Private] = strings.ToUpper(genesis)
 	}


### PR DESCRIPTION
This PR introduces the ability to set a custom network type, genesis hash, and bootstrappers via setting environment variables. If a custom network is specified, the following warning will be printed for the user: 

```
WARNING: Celestia custom network specified. Only use this option if the node is freshly created and initialized.
**DO NOT** run a custom network over an already-existing node store!
```

*Note*: the terms `chain-id` and `network name/ID` are used interchangeably.

### ENV VAR DOCS

* `CELESTIA_CUSTOM_GENESIS="<chain-id>=<genesis_hash>"` adds the new network to the registry with the given genesis hash
* `CELESTIA_CUSTOM_NETWORK="<chain-id>"` picks the given network from the registry (it must already exist inside the registry)
* `CELESTIA_CUSTOM_BOOTSTRAPPERS="<chain-id>=<comma-separated list of boostrappers>"` adds or overrides bootstrappers for the given network in the registry

### Example start command

This command will start a celestia full node on the custom network `MyCustomNetwork`, with the genesis hash `D001B097E894F94B37F8FB0A5B8185812F5FBF8A07E6B0BCB560D647CAFB709B` and the bootstrapper `/dns4/andromeda.celestia-devops.dev/tcp/2121/p2p/12D3KooWKvPXtV1yaQ6e3BRNUHa5Phh8daBwBi3KkGaSSkUPys6D`.

```
CELESTIA_CUSTOM_GENESIS="MyCustomNetwork=D001B097E894F94B37F8FB0A5B8185812F5FBF8A07E6B0BCB560D647CAFB709B"  CELESTIA_CUSTOM_BOOTSTRAPPERS="MyCustomNetwork=/dns4/andromeda.celestia-devops.dev/tcp/2121/p2p/12D3KooWKvPXtV1yaQ6e3BRNUHa5Phh8daBwBi3KkGaSSkUPys6D" CELESTIA_CUSTOM_NETWORK="MyCustomNetwork" ./build/celestia full start
```

Based on some logic from https://github.com/celestiaorg/celestia-node/pull/552