### PR TITLE
fix(ipld): simply rely on global rsmt2d.Codec constructor for now to avoid races

### DIFF
--- a/fraud/bad_encoding_test.go
+++ b/fraud/bad_encoding_test.go
@@ -35,7 +35,7 @@ func TestFraudProofValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	da := da.NewDataAvailabilityHeader(attackerEDS)
-	r := ipld.NewRetriever(dag, consts.DefaultCodec())
+	r := ipld.NewRetriever(dag)
 	_, err = r.Retrieve(context.Background(), &da)
 	var errByz *ipld.ErrByzantine
 	require.True(t, errors.As(err, &errByz))

--- a/ipld/get_test.go
+++ b/ipld/get_test.go
@@ -415,7 +415,7 @@ func TestRetrieveDataFailedWithByzantineError(t *testing.T) {
 
 	// ensure we rcv an error
 	da := da.NewDataAvailabilityHeader(attackerEDS)
-	r := NewRetriever(dag, DefaultRSMT2DCodec())
+	r := NewRetriever(dag)
 	_, err = r.Retrieve(ctx, &da)
 	var errByz *ErrByzantine
 	require.ErrorAs(t, err, &errByz)

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -37,13 +37,12 @@ var RetrieveQuadrantTimeout = time.Minute * 5
 // Retriever randomly picks one of the data square quadrants and tries to request them one by one until it is able to
 // reconstruct the whole square.
 type Retriever struct {
-	dag   format.DAGService
-	codec rsmt2d.Codec
+	dag format.DAGService
 }
 
 // NewRetriever creates a new instance of the Retriever over IPLD Service and rmst2d.Codec
-func NewRetriever(dag format.DAGService, codec rsmt2d.Codec) *Retriever {
-	return &Retriever{dag: dag, codec: codec}
+func NewRetriever(dag format.DAGService) *Retriever {
+	return &Retriever{dag: dag}
 }
 
 // Retrieve retrieves all the data committed to DataAvailabilityHeader.
@@ -136,7 +135,7 @@ func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHead
 			tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(size)/2, nmt.NodeVisitor(adder.Visit))
 			return &tree
 		},
-		codec:  r.codec,
+		codec:  DefaultRSMT2DCodec(),
 		dah:    dah,
 		square: make([][]byte, size*size),
 	}

--- a/ipld/retriever_test.go
+++ b/ipld/retriever_test.go
@@ -19,7 +19,7 @@ func TestRetriever_Retrieve(t *testing.T) {
 	defer cancel()
 
 	dag := mdutils.Mock()
-	r := NewRetriever(dag, DefaultRSMT2DCodec())
+	r := NewRetriever(dag)
 
 	type test struct {
 		name       string

--- a/service/share/full_availability.go
+++ b/service/share/full_availability.go
@@ -19,7 +19,7 @@ type fullAvailability struct {
 // NewFullAvailability creates a new full Availability.
 func NewFullAvailability(dag format.DAGService) Availability {
 	return &fullAvailability{
-		rtrv: ipld.NewRetriever(dag, ipld.DefaultRSMT2DCodec()),
+		rtrv: ipld.NewRetriever(dag),
 	}
 }
 

--- a/service/share/share.go
+++ b/service/share/share.go
@@ -62,7 +62,7 @@ type Service struct {
 // NewService creates new basic share.Service.
 func NewService(dag format.DAGService, avail Availability) *Service {
 	return &Service{
-		rtrv:         ipld.NewRetriever(dag, ipld.DefaultRSMT2DCodec()),
+		rtrv:         ipld.NewRetriever(dag),
 		Availability: avail,
 		dag:          dag,
 	}


### PR DESCRIPTION
Closes #719 