### PR TITLE
node: Include expected err msg in`/namespaced_shares` test

### DIFF
--- a/node/rpc_test.go
+++ b/node/rpc_test.go
@@ -33,6 +33,7 @@ func TestNamespacedSharesRequest(t *testing.T) {
 	var tests = []struct {
 		nID         string
 		expectedErr bool
+		errMsg      string
 	}{
 		{
 			nID:         "0000000000000001",
@@ -41,10 +42,12 @@ func TestNamespacedSharesRequest(t *testing.T) {
 		{
 			nID:         "00000000000001",
 			expectedErr: true,
+			errMsg:      "expected namespace ID of size 8, got 7",
 		},
 		{
 			nID:         "000000000000000001",
 			expectedErr: true,
+			errMsg:      "expected namespace ID of size 8, got 9",
 		},
 	}
 
@@ -64,7 +67,7 @@ func TestNamespacedSharesRequest(t *testing.T) {
 				buf, err := ioutil.ReadAll(resp.Body)
 				require.NoError(t, err)
 				expectedErr := strings.Trim(string(buf), "\"\"") //nolint:staticcheck
-				require.Equal(t, "namespace id must be default size 8", expectedErr)
+				require.Equal(t, tt.errMsg, expectedErr)
 
 				return
 			}

--- a/service/share/share_test.go
+++ b/service/share/share_test.go
@@ -112,7 +112,7 @@ func TestService_GetSharesByNamespaceNotFound(t *testing.T) {
 	serv, root := RandLightServiceWithSquare(t, 1)
 	root.RowsRoots = nil
 
-	shares, err := serv.GetSharesByNamespace(context.Background(), root, []byte(""))
+	shares, err := serv.GetSharesByNamespace(context.Background(), root, []byte{1, 1, 1, 1, 1, 1, 1, 1})
 	assert.Len(t, shares, 0)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This PR fixes a failing test for the `/namespaced_shares` endpoint by adding an expected err message check.