### PR TITLE
deps: bump rsmt2d to 0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/celestiaorg/celestia-app v0.4.0
 	github.com/celestiaorg/go-libp2p-messenger v0.1.0
 	github.com/celestiaorg/nmt v0.8.0
-	github.com/celestiaorg/rsmt2d v0.4.0
+	github.com/celestiaorg/rsmt2d v0.5.0
 	github.com/cosmos/cosmos-sdk v0.44.3
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/gammazero/workerpool v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,9 @@ github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:f
 github.com/celestiaorg/nmt v0.8.0 h1:wtX7GRouLbmBe+ffnc8+cOg2UbWteM+Y1imZuZ/EeqU=
 github.com/celestiaorg/nmt v0.8.0/go.mod h1:3bqzTj8xKj0DgQUpOgZzoxvtNkC3MS/hTbQ6dn8SIa0=
 github.com/celestiaorg/rsmt2d v0.3.1/go.mod h1:2Frw4GEYUnVu6Mvlo+CUzuC2/8wn+zLwVVtp+muN6vg=
-github.com/celestiaorg/rsmt2d v0.4.0 h1:mpICbeXYKE1yNW8VBzgBrcnzuMKzutpROH1g2xI7Ls4=
 github.com/celestiaorg/rsmt2d v0.4.0/go.mod h1:EZ+O2KdCq8xI7WFwjATLdhtMdrdClmAs2w7zENDr010=
+github.com/celestiaorg/rsmt2d v0.5.0 h1:Wa0uNZUXl8lIMJnSunjoD65ktqBedXZD0z2ZU3xKYYw=
+github.com/celestiaorg/rsmt2d v0.5.0/go.mod h1:EZ+O2KdCq8xI7WFwjATLdhtMdrdClmAs2w7zENDr010=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=

--- a/ipld/get_test.go
+++ b/ipld/get_test.go
@@ -93,14 +93,14 @@ func TestBlockRecovery(t *testing.T) {
 
 			// recover a partially complete square
 			rdata := removeRandShares(flat, tc.d)
-			err = rsmt2d.RepairExtendedDataSquare(
-				rowRoots,
-				colRoots,
+			eds, err = rsmt2d.ImportExtendedDataSquare(
 				rdata,
 				rsmt2d.NewRSGF8Codec(),
 				recoverTree.Constructor,
 			)
+			require.NoError(t, err)
 
+			err = eds.Repair(rowRoots, colRoots, rsmt2d.NewRSGF8Codec(), recoverTree.Constructor)
 			if tc.expectErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errString)

--- a/ipld/retriever_quadrant.go
+++ b/ipld/retriever_quadrant.go
@@ -34,7 +34,7 @@ type quadrant struct {
 // newQuadrants constructs a slice of quadrants from DAHeader.
 // There are always 4 quadrants per each source (row and col), so 8 in total.
 // The ordering of quadrants is random.
-func newQuadrants(dah *da.DataAvailabilityHeader) [][]*quadrant {
+func newQuadrants(dah *da.DataAvailabilityHeader) []*quadrant {
 	// combine all the roots into one slice, so they can be easily accessible by index
 	daRoots := [][][]byte{
 		dah.RowsRoots,
@@ -66,12 +66,14 @@ func newQuadrants(dah *da.DataAvailabilityHeader) [][]*quadrant {
 				source: source,
 			}
 		}
-		// shuffle quadrants to be fetched in random order
-		rand.Shuffle(len(quadrants), func(i, j int) { quadrants[i], quadrants[j] = quadrants[j], quadrants[i] })
 	}
-	// randomize sources, s.t. downloading on the network happens from both rows and cols
-	rand.Shuffle(len(sources), func(i, j int) { sources[i], sources[j] = sources[j], sources[i] })
-	return sources
+	quadrants := make([]*quadrant, 0, numQuadrants*2)
+	for _, qs := range sources {
+		quadrants = append(quadrants, qs...)
+	}
+	// shuffle quadrants to be fetched in random order
+	rand.Shuffle(len(quadrants), func(i, j int) { quadrants[i], quadrants[j] = quadrants[j], quadrants[i] })
+	return quadrants
 }
 
 // index calculates index for a share in a data square slice flattened by rows.


### PR DESCRIPTION
I tried updating to this version before but didn't like that we needed to keep both flattened and imported squares, so that code became even bulkier for the next currently unpushed iteration of Retriever, so I decided to wait until the requested rsmt2d API changes to land before upgrading(cc @adlerjohn), but now we have to update as core updated already. 