### PR TITLE
params:  Allow running `CELESTIA_CUSTOM` without bootstrappers (for bridge)

### DIFF
--- a/node/services/service.go
+++ b/node/services/service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ipfs/go-datastore"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -106,6 +107,8 @@ func HeaderStoreInit(cfg *Config) func(context.Context, params.Network, header.S
 		if err != nil {
 			return err
 		}
+
+		fmt.Println("\n\n\nTRUSTED HASH: ", trustedHash.String(), "\n\n")
 
 		err = store.Init(ctx, s, ex, trustedHash)
 		if err != nil {

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ipfs/go-datastore"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -107,8 +106,6 @@ func HeaderStoreInit(cfg *Config) func(context.Context, params.Network, header.S
 		if err != nil {
 			return err
 		}
-
-		fmt.Println("\n\n\nTRUSTED HASH: ", trustedHash.String(), "\n\n")
 
 		err = store.Init(ctx, s, ex, trustedHash)
 		if err != nil {

--- a/params/default.go
+++ b/params/default.go
@@ -29,7 +29,7 @@ func init() {
 		// ensure at least custom network is set
 		params := strings.Split(custom, ":")
 		if len(params) == 0 {
-			panic(fmt.Sprintf("must provide at least <network_ID> to use a custom network"))
+			panic("must provide at least <network_ID> to use a custom network")
 		}
 		netID := params[0]
 		defaultNetwork = Network(netID)

--- a/params/default.go
+++ b/params/default.go
@@ -29,7 +29,7 @@ func init() {
 		// ensure at least custom network is set
 		params := strings.Split(custom, ":")
 		if len(params) == 0 {
-			panic("must provide at least <network_ID> to use a custom network")
+			panic("params: must provide at least <network_ID> to use a custom network")
 		}
 		netID := params[0]
 		defaultNetwork = Network(netID)
@@ -46,7 +46,7 @@ func init() {
 			bs := strings.Split(bootstrappers, ",")
 			_, err := parseAddrInfos(bs)
 			if err != nil {
-				println(fmt.Sprintf("env %s: contains invalid multiaddress", EnvCustomNetwork))
+				println(fmt.Sprintf("params: env %s: contains invalid multiaddress", EnvCustomNetwork))
 				panic(err)
 			}
 			bootstrapList[Network(netID)] = bs

--- a/params/default.go
+++ b/params/default.go
@@ -21,30 +21,36 @@ func DefaultNetwork() Network {
 
 func init() {
 	// check if custom network option set
+	// format: CELESTIA_CUSTOM=<netID>:<trustedHash>:<bootstrapPeerList>
 	if custom, ok := os.LookupEnv(EnvCustomNetwork); ok {
 		fmt.Print("\n\nWARNING: Celestia custom network specified. Only use this option if the node is " +
 			"freshly created and initialized.\n**DO NOT** run a custom network over an already-existing node " +
 			"store!\n\n")
-		// ensure all three params are present
+		// ensure at least custom network is set
 		params := strings.Split(custom, ":")
-		if len(params) != 3 {
-			panic(fmt.Sprintf("must provide %s in this format: "+
-				"<network_ID>:<genesis hash>:<comma-separated list of bootstrappers>", EnvCustomNetwork))
+		if len(params) == 0 {
+			panic(fmt.Sprintf("must provide at least <network_ID> to use a custom network"))
 		}
-		netID, genHash, bootstrappers := params[0], params[1], params[2]
-		// validate bootstrappers
-		bs := strings.Split(bootstrappers, ",")
-		_, err := parseAddrInfos(bs)
-		if err != nil {
-			println(fmt.Sprintf("env %s: contains invalid multiaddress", EnvCustomNetwork))
-			panic(err)
-		}
-		bootstrapList[Network(netID)] = bs
-		// set custom network as default network for node to use
+		netID := params[0]
 		defaultNetwork = Network(netID)
-		// register network and genesis hash
 		networksList[defaultNetwork] = struct{}{}
-		genesisList[defaultNetwork] = strings.ToUpper(genHash)
+		// check if genesis hash provided and register it if exists
+		if len(params) == 2 {
+			genHash := params[1]
+			genesisList[defaultNetwork] = strings.ToUpper(genHash)
+		}
+		// check if bootstrappers were provided and register
+		if len(params) == 3 {
+			bootstrappers := params[2]
+			// validate bootstrappers
+			bs := strings.Split(bootstrappers, ",")
+			_, err := parseAddrInfos(bs)
+			if err != nil {
+				println(fmt.Sprintf("env %s: contains invalid multiaddress", EnvCustomNetwork))
+				panic(err)
+			}
+			bootstrapList[Network(netID)] = bs
+		}
 	}
 	// check if private network option set
 	if genesis, ok := os.LookupEnv(EnvPrivateGenesis); ok {

--- a/params/genesis.go
+++ b/params/genesis.go
@@ -1,5 +1,7 @@
 package params
 
+import "fmt"
+
 // GenesisFor reports a hash of a genesis block for a given network.
 // Genesis is strictly defined and can't be modified.
 // To run a custom genesis private network use CELESTIA_PRIVATE_GENESIS env var.
@@ -8,7 +10,12 @@ func GenesisFor(net Network) (string, error) {
 		return "", err
 	}
 
-	return genesisList[net], nil
+	genHash, ok := genesisList[net]
+	if !ok {
+		return "", fmt.Errorf("trusted hash not found for network %s", net)
+	}
+
+	return genHash, nil
 }
 
 // NOTE: Every time we add a new long-running network, its genesis hash has to be added here.

--- a/params/genesis.go
+++ b/params/genesis.go
@@ -12,7 +12,7 @@ func GenesisFor(net Network) (string, error) {
 
 	genHash, ok := genesisList[net]
 	if !ok {
-		return "", fmt.Errorf("trusted hash not found for network %s", net)
+		return "", fmt.Errorf("params: trusted hash not found for network %s", net)
 	}
 
 	return genHash, nil


### PR DESCRIPTION
This PR allows the `CELESTIA_CUSTOM` environment variable to be set with only a network name. Both `genesis hash` and `bootstrappers` are optional additions.