### PR TITLE
node/services: Invoke function to ensure that an empty block is stored at least once

### DIFF
--- a/node/components.go
+++ b/node/components.go
@@ -17,6 +17,7 @@ import (
 	"github.com/celestiaorg/celestia-node/node/services"
 	statecomponents "github.com/celestiaorg/celestia-node/node/state"
 	"github.com/celestiaorg/celestia-node/params"
+	"github.com/celestiaorg/celestia-node/service/share"
 )
 
 // lightComponents keeps all the components as DI options required to build a Light Node.
@@ -62,7 +63,7 @@ func baseComponents(cfg *Config, store Store) fx.Option {
 		fx.Provide(store.Datastore),
 		fx.Provide(store.Keystore),
 		// share components
-		fx.Invoke(services.StoreEmptyBlock),
+		fx.Invoke(share.EnsureEmptySquareExists),
 		fx.Provide(services.ShareService),
 		// header components
 		fx.Provide(services.HeaderService),

--- a/node/components.go
+++ b/node/components.go
@@ -61,13 +61,17 @@ func baseComponents(cfg *Config, store Store) fx.Option {
 		fx.Supply(store.Config),
 		fx.Provide(store.Datastore),
 		fx.Provide(store.Keystore),
+		// share components
+		fx.Invoke(services.StoreEmptyBlock),
 		fx.Provide(services.ShareService),
+		// header components
 		fx.Provide(services.HeaderService),
 		fx.Provide(services.HeaderStore),
 		fx.Invoke(services.HeaderStoreInit(&cfg.Services)),
 		fx.Provide(services.HeaderSyncer),
 		fxutil.ProvideAs(services.P2PSubscriber, new(header.Broadcaster), new(header.Subscriber)),
 		fx.Provide(services.HeaderP2PExchangeServer),
+		// p2p components
 		fx.Invoke(invokeWatchdog(store.Path())),
 		p2p.Components(cfg.P2P),
 		// state components

--- a/node/services/empty_block.go
+++ b/node/services/empty_block.go
@@ -1,0 +1,32 @@
+package services
+
+import (
+	"bytes"
+	"context"
+
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/tendermint/tendermint/pkg/consts"
+
+	"github.com/celestiaorg/celestia-node/ipld"
+)
+
+// StoreEmptyBlock checks if the given DAG contains an empty block data square.
+// If it does not, it stores an empty block. This optimization exists to prevent
+// redundant storing of empty block data so that it is only stored once and returned
+// upon request for a block with an empty data square. Ref: header/header.go#L56
+func StoreEmptyBlock(ctx context.Context, dag format.DAGService) error {
+	shares := make([][]byte, consts.MinSharecount)
+	for i := 0; i < consts.MinSharecount; i++ {
+		shares[i] = tailPaddingShare
+	}
+
+	_, err := ipld.AddShares(ctx, shares, dag)
+	return err
+}
+
+// tail is filler for all tail padded shares
+// it is allocated once and used everywhere
+var tailPaddingShare = append(
+	append(make([]byte, 0, consts.ShareSize), consts.TailPaddingNamespaceID...),
+	bytes.Repeat([]byte{0}, consts.ShareSize-consts.NamespaceSize)...,
+)

--- a/service/share/empty.go
+++ b/service/share/empty.go
@@ -1,4 +1,4 @@
-package services
+package share
 
 import (
 	"bytes"
@@ -10,11 +10,11 @@ import (
 	"github.com/celestiaorg/celestia-node/ipld"
 )
 
-// StoreEmptyBlock checks if the given DAG contains an empty block data square.
+// EnsureEmptySquareExists checks if the given DAG contains an empty block data square.
 // If it does not, it stores an empty block. This optimization exists to prevent
 // redundant storing of empty block data so that it is only stored once and returned
 // upon request for a block with an empty data square. Ref: header/header.go#L56
-func StoreEmptyBlock(ctx context.Context, dag format.DAGService) error {
+func EnsureEmptySquareExists(ctx context.Context, dag format.DAGService) error {
 	shares := make([][]byte, consts.MinSharecount)
 	for i := 0; i < consts.MinSharecount; i++ {
 		shares[i] = tailPaddingShare


### PR DESCRIPTION
This fixes an issue with an optimisation inside of `header.MakeExtendedHeader` where if a block has empty data, we do not store it to prevent unnecessary redundancy. The problem is, we forgot to ensure that an empty block was stored **at least once**. We found this bug while trying to run a light node against a bridge node on `dryrun-2` and found that the `DAS` functionality in light node was hanging -- this was due to the bridge node not being able to serve blocks to the light node as a result of never having stored that empty block.

This PR ensures that. 

There is an additional problem with this PR however, which is that an empty block will be stored upon construction *every time*. To fix that, we need to implement a solution that checks to see if an empty block has already been stored in the DAG, and if so, skip storing. Issue: https://github.com/celestiaorg/celestia-node/issues/748. 

Thanks to @Wondertan for remembering this optimization :) 