### PR TITLE
das: Return from sampling routine upon sampling failure

### DIFF
--- a/das/daser.go
+++ b/das/daser.go
@@ -231,8 +231,8 @@ func (d *DASer) catchUp(ctx context.Context, job *catchUpJob) (int64, error) {
 			}
 			log.Errorw("sampling failed", "height", h.Height, "hash", h.Hash(),
 				"square width", len(h.DAH.RowsRoots), "data root", h.DAH.Hash(), "err", err)
-			// continue sampling
-			continue
+			// report previous height as the last successfully sampled height
+			return height - 1, err
 		}
 
 		sampleTime := time.Since(startTime)

--- a/das/daser.go
+++ b/das/daser.go
@@ -104,7 +104,7 @@ func (d *DASer) sample(ctx context.Context, sub header.Subscription, checkpoint 
 		d.sampleDn <- struct{}{}
 	}()
 
-	// sampleHeight tracks the current height of this routine
+	// sampleHeight tracks the last successful height of this routine
 	sampleHeight := checkpoint
 
 	for {
@@ -145,8 +145,8 @@ func (d *DASer) sample(ctx context.Context, sub header.Subscription, checkpoint 
 			}
 			log.Errorw("sampling failed", "height", h.Height, "hash", h.Hash(),
 				"square width", len(h.DAH.RowsRoots), "data root", h.DAH.Hash(), "err", err)
-			// continue sampling
-			continue
+			log.Warn("DASer WILL BE STOPPED. IN ORDER TO CONTINUE SAMPLING, RE-START THE NODE")
+			return
 		}
 
 		sampleTime := time.Since(startTime)
@@ -185,17 +185,15 @@ func (d *DASer) catchUpManager(ctx context.Context, checkpoint int64) {
 		case job := <-d.jobsCh:
 			// perform catchUp routine
 			height, err := d.catchUp(ctx, job)
-			// update checkpoint before checking error as the height
-			// value from catchUp represents the last successfully DASed height,
-			// regardless of the routine's success
-			checkpoint = height
 			// exit routine if a catch-up job was unsuccessful
 			if err != nil {
 				log.Errorw("catch-up routine failed", "attempted range (from, to)", job.from,
 					job.to, "last successfully sampled height", height)
-				log.Warn("IN ORDER TO CONTINUE SAMPLING OVER PAST HEADERS, RE-START THE NODE")
+				log.Warn("DASer WILL BE STOPPED. IN ORDER TO CONTINUE SAMPLING OVER PAST HEADERS, RE-START THE NODE")
 				return
 			}
+			// store the height of the last successfully sampled header
+			checkpoint = height
 		}
 	}
 }

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -247,7 +247,7 @@ func TestDASer_catchUp_fails(t *testing.T) {
 	wg.Wait()
 
 	result := <-resultCh
-	require.Error(t, result.err)
+	require.ErrorIs(t, result.err, share.ErrNotAvailable)
 }
 
 // createDASerSubcomponents takes numGetter (number of headers

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -207,6 +207,49 @@ func TestDASer_catchUp_oneHeader(t *testing.T) {
 	require.NoError(t, result.err)
 }
 
+func TestDASer_catchUp_fails(t *testing.T) {
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	dag := mdutils.Mock()
+
+	mockGet, _, _ := createDASerSubcomponents(t, dag, 6, 0)
+	daser := NewDASer(share.NewBrokenAvailability(), nil, mockGet, ds)
+
+	// store checkpoint
+	err := storeCheckpoint(daser.cstore, 5) // pick arbitrary height as last checkpoint
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	checkpoint, err := loadCheckpoint(daser.cstore)
+	require.NoError(t, err)
+
+	type catchUpResult struct {
+		checkpoint int64
+		err        error
+	}
+	resultCh := make(chan *catchUpResult, 1)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		job := &catchUpJob{
+			from: checkpoint,
+			to:   mockGet.head,
+		}
+		checkpt, err := daser.catchUp(ctx, job)
+		resultCh <- &catchUpResult{
+			checkpoint: checkpt,
+			err:        err,
+		}
+	}()
+	wg.Wait()
+
+	result := <-resultCh
+	require.Error(t, result.err)
+}
+
 // createDASerSubcomponents takes numGetter (number of headers
 // to store in mockGetter) and numSub (number of headers to store
 // in the mock header.Subscriber), returning a newly instantiated

--- a/service/share/testing.go
+++ b/service/share/testing.go
@@ -2,7 +2,6 @@ package share
 
 import (
 	"context"
-	"errors"
 	"math"
 	"testing"
 
@@ -138,5 +137,5 @@ func NewBrokenAvailability() Availability {
 }
 
 func (b *brokenAvailability) SharesAvailable(context.Context, *Root) error {
-	return errors.New("da: data not available")
+	return ErrNotAvailable
 }

--- a/service/share/testing.go
+++ b/service/share/testing.go
@@ -2,6 +2,7 @@ package share
 
 import (
 	"context"
+	"errors"
 	"math"
 	"testing"
 
@@ -126,4 +127,16 @@ func (dn *DAGNet) ConnectAll() {
 
 	err = dn.net.ConnectAllButSelf()
 	require.NoError(dn.t, err)
+}
+
+// brokenAvailability allows to test error cases during sampling
+type brokenAvailability struct {
+}
+
+func NewBrokenAvailability() Availability {
+	return &brokenAvailability{}
+}
+
+func (b *brokenAvailability) SharesAvailable(context.Context, *Root) error {
+	return errors.New("da: data not available")
 }


### PR DESCRIPTION
This PR implements a change to, instead of logging the error and continuing sampling upon failure, to just return out of the sampling routine(s) (this is true for both the catchUp routine and the general samplingRoutine).

It also implements an error log + warn log prompting users to restart the node in order to re-start the sampling routine(s). 

This design will change once https://github.com/celestiaorg/celestia-node/issues/427 is implemented.