### PR TITLE
BREAKING CHANGE(header/p2p/exchange): Upgrade and reformat protocol ID

### DIFF
--- a/header/p2p/exchange.go
+++ b/header/p2p/exchange.go
@@ -13,12 +13,11 @@ import (
 	"github.com/libp2p/go-libp2p-core/protocol"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 
-	"github.com/celestiaorg/go-libp2p-messenger/serde"
-
 	"github.com/celestiaorg/celestia-node/header"
-
 	p2p_pb "github.com/celestiaorg/celestia-node/header/p2p/pb"
 	header_pb "github.com/celestiaorg/celestia-node/header/pb"
+	"github.com/celestiaorg/celestia-node/params"
+	"github.com/celestiaorg/go-libp2p-messenger/serde"
 )
 
 var log = logging.Logger("header/p2p")
@@ -27,7 +26,7 @@ var log = logging.Logger("header/p2p")
 // gossipsub topic.
 const PubSubTopic = "header-sub"
 
-var exchangeProtocolID = protocol.ID("/header-ex/v0.0.1")
+var exchangeProtocolID = protocol.ID(fmt.Sprintf("/header-ex/v0.0.2/%s", params.DefaultNetwork()))
 
 // Exchange enables sending outbound ExtendedHeaderRequests to the network as well as
 // handling inbound ExtendedHeaderRequests from the network.


### PR DESCRIPTION
This PR introduces a **breaking** change to upgrade the p2p header exchange protocol ID such that it takes the following format: `/header-ex/v0.0.2/<network_ID>`

example: 

```
/header-ex/v0.0.2/dryrun-2
```

Use this PR in favour of https://github.com/celestiaorg/celestia-node/pull/546