### PR TITLE
chore: adapt node cmd to app/cosmos

### DIFF
--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -4,21 +4,32 @@ import (
 	"context"
 	"os"
 
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/config"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/spf13/cobra"
 
 	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/encoding"
 	"github.com/celestiaorg/celestia-node/cmd"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func init() {
-	// This is necessary to ensure that the account addresses are correctly prefixed
-	// as in the celestia application.
-	cfg := sdk.GetConfig()
-	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
-	cfg.Seal()
+var encodingConfig encoding.EncodingConfig = encoding.MakeEncodingConfig(app.ModuleEncodingRegisters...)
 
+var initClientCtx client.Context = client.Context{}.
+	WithCodec(encodingConfig.Codec).
+	WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
+	WithTxConfig(encodingConfig.TxConfig).
+	WithLegacyAmino(encodingConfig.Amino).
+	WithInput(os.Stdin).
+	WithAccountRetriever(types.AccountRetriever{}).
+	WithBroadcastMode(flags.BroadcastBlock).
+	WithHomeDir(app.DefaultNodeHome).
+	WithViper("CELESTIA")
+
+func init() {
 	rootCmd.AddCommand(
 		bridgeCmd,
 		lightCmd,
@@ -36,12 +47,18 @@ func main() {
 }
 
 func run() error {
-	return rootCmd.ExecuteContext(cmd.WithEnv(context.Background()))
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
+	cfg.Seal()
+
+	ctx := context.WithValue(context.Background(), client.ClientContextKey, &initClientCtx)
+	return rootCmd.ExecuteContext(cmd.WithEnv(ctx))
 }
 
 var rootCmd = &cobra.Command{
 	Use: "celestia [  bridge  ||  full ||  light  ] [subcommand]",
 	Short: `
+		____      __          __  _
 	  / ____/__  / /__  _____/ /_(_)___ _
 	 / /   / _ \/ / _ \/ ___/ __/ / __  /
 	/ /___/  __/ /  __(__  ) /_/ / /_/ /
@@ -50,5 +67,20 @@ var rootCmd = &cobra.Command{
 	Args: cobra.NoArgs,
 	CompletionOptions: cobra.CompletionOptions{
 		DisableDefaultCmd: true,
+	},
+	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+		initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
+		if err != nil {
+			return err
+		}
+		initClientCtx, err = config.ReadFromClientConfig(initClientCtx)
+		if err != nil {
+			return err
+		}
+
+		if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
+			return err
+		}
+		return nil
 	},
 }

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -78,7 +78,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
+		if err = client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
After upgrade of #736, we need to adapt our cmd to be compliant with what app/cosmos wants

This is especially needed for our keys cmds for the current state

A separate issue to refactor out this part is needed 
cc: @renaynay 