### PR TITLE
cmd/cel-key: Extract key utility into separate binary to prevent tight coupling between sdk and celestia-node binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,18 @@ install-shed:
 	@go install ./cmd/cel-shed
 .PHONY: install-shed
 
+## key: Build cel-key binary.
+cel-key:
+	@echo "--> Building cel-key"
+	@go build ./cmd/cel-key
+.PHONY: cel-key
+
+## install-key: Build and install the cel-key binary into the GOBIN directory.
+install-key:
+	@echo "--> Installing cel-key"
+	@go install ./cmd/cel-key
+.PHONY: install-key
+
 ## fmt: Formats only *.go (excluding *.pb.go *pb_test.go). Runs `gofmt & goimports` internally.
 fmt:
 	@find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s

--- a/cmd/cel-key/main.go
+++ b/cmd/cel-key/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/spf13/cobra"
 
@@ -32,6 +33,7 @@ var initClientCtx = client.Context{}.
 var rootCmd = keys.Commands("~")
 
 func init() {
+	rootCmd.PersistentFlags().AddFlagSet(DirectoryFlags())
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
 		if err != nil {
@@ -45,7 +47,8 @@ func init() {
 		if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
 			return err
 		}
-		return nil
+
+		return ParseDirectoryFlags(cmd)
 	}
 }
 
@@ -57,6 +60,10 @@ func main() {
 }
 
 func run() error {
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
+	cfg.Seal()
+
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &initClientCtx)
 	return rootCmd.ExecuteContext(cmd.WithEnv(ctx))
 }

--- a/cmd/cel-key/main.go
+++ b/cmd/cel-key/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-node/cmd"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/config"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var encodingConfig = encoding.MakeEncodingConfig(app.ModuleEncodingRegisters...)
+
+var initClientCtx = client.Context{}.
+	WithCodec(encodingConfig.Codec).
+	WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
+	WithTxConfig(encodingConfig.TxConfig).
+	WithLegacyAmino(encodingConfig.Amino).
+	WithInput(os.Stdin).
+	WithAccountRetriever(types.AccountRetriever{}).
+	WithBroadcastMode(flags.BroadcastBlock).
+	WithHomeDir(app.DefaultNodeHome).
+	WithViper("CELESTIA")
+
+var rootCmd = keys.Commands("~")
+
+func init() {
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
+		if err != nil {
+			return err
+		}
+		initClientCtx, err = config.ReadFromClientConfig(initClientCtx)
+		if err != nil {
+			return err
+		}
+
+		if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func run() error {
+	ctx := context.WithValue(context.Background(), client.ClientContextKey, &initClientCtx)
+	return rootCmd.ExecuteContext(cmd.WithEnv(ctx))
+}

--- a/cmd/cel-key/main.go
+++ b/cmd/cel-key/main.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"context"
-	"github.com/celestiaorg/celestia-app/app"
-	"github.com/celestiaorg/celestia-app/app/encoding"
-	"github.com/celestiaorg/celestia-node/cmd"
+	"os"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/spf13/cobra"
-	"os"
+
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-node/cmd"
 )
 
 var encodingConfig = encoding.MakeEncodingConfig(app.ModuleEncodingRegisters...)
@@ -44,6 +46,13 @@ func init() {
 			return err
 		}
 		return nil
+	}
+}
+
+func main() {
+	err := run()
+	if err != nil {
+		os.Exit(1)
 	}
 }
 

--- a/cmd/cel-key/node_types.go
+++ b/cmd/cel-key/node_types.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
+	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
+)
+
+var (
+	nodeDirKey = "node.type"
+
+	bridgeDir = "~/.celestia-bridge/keys"
+	fullDir   = "~/.celestia-full/keys"
+	lightDir  = "~/.celestia-light/keys"
+)
+
+func DirectoryFlags() *flag.FlagSet {
+	flags := &flag.FlagSet{}
+	flags.String(nodeDirKey, "", "Sets key utility to use the node type's directory (e.g. "+
+		"~/.celestia-light if --node.type light is passed.")
+
+	return flags
+}
+
+func ParseDirectoryFlags(cmd *cobra.Command) error {
+	nodeType := cmd.Flag(nodeDirKey).Value.String()
+	if nodeType == "" {
+		return nil
+	}
+
+	switch nodeType {
+	case "bridge":
+		if err := cmd.Flags().Set(sdkflags.FlagKeyringDir, bridgeDir); err != nil {
+			return err
+		}
+	case "full":
+		if err := cmd.Flags().Set(sdkflags.FlagKeyringDir, fullDir); err != nil {
+			return err
+		}
+	case "light":
+		if err := cmd.Flags().Set(sdkflags.FlagKeyringDir, lightDir); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("node type %s is not valid. Provided node types: (bridge || full || light)",
+			nodeType)
+	}
+	return nil
+}

--- a/cmd/celestia/bridge.go
+++ b/cmd/celestia/bridge.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/spf13/cobra"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
@@ -13,13 +12,6 @@ import (
 // parent command.
 
 func init() {
-	bridgeKeyCmd := keys.Commands("~/.celestia-bridge/keys")
-	bridgeKeyCmd.Short = "Manage your bridge node account keys"
-	bridgeKeyCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		_, err := cmdnode.GetEnv(cmd.Context())
-		return err
-	}
-
 	bridgeCmd.AddCommand(
 		cmdnode.Init(
 			cmdnode.NodeFlags(node.Bridge),
@@ -39,7 +31,6 @@ func init() {
 			cmdnode.RPCFlags(),
 			cmdnode.KeyFlags(),
 		),
-		bridgeKeyCmd,
 	)
 }
 

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/spf13/cobra"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
@@ -13,13 +12,6 @@ import (
 // parent command.
 
 func init() {
-	fullKeyCmd := keys.Commands("~/.celestia-full/keys")
-	fullKeyCmd.Short = "Manage your full node account keys"
-	fullKeyCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		_, err := cmdnode.GetEnv(cmd.Context())
-		return err
-	}
-
 	fullCmd.AddCommand(
 		cmdnode.Init(
 			cmdnode.NodeFlags(node.Full),
@@ -43,7 +35,6 @@ func init() {
 			cmdnode.RPCFlags(),
 			cmdnode.KeyFlags(),
 		),
-		fullKeyCmd,
 	)
 }
 

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/spf13/cobra"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
@@ -13,13 +12,6 @@ import (
 // parent command.
 
 func init() {
-	lightKeyCmd := keys.Commands("~/.celestia-light/keys")
-	lightKeyCmd.Short = "Manage your light node account keys"
-	lightKeyCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		_, err := cmdnode.GetEnv(cmd.Context())
-		return err
-	}
-
 	lightCmd.AddCommand(
 		cmdnode.Init(
 			cmdnode.NodeFlags(node.Light),
@@ -43,7 +35,6 @@ func init() {
 			cmdnode.RPCFlags(),
 			cmdnode.KeyFlags(),
 		),
-		lightKeyCmd,
 	)
 }
 

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -4,21 +4,32 @@ import (
 	"context"
 	"os"
 
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/config"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/spf13/cobra"
 
 	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/encoding"
 	"github.com/celestiaorg/celestia-node/cmd"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func init() {
-	// This is necessary to ensure that the account addresses are correctly prefixed
-	// as in the celestia application.
-	cfg := sdk.GetConfig()
-	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
-	cfg.Seal()
+var encodingConfig encoding.EncodingConfig = encoding.MakeEncodingConfig(app.ModuleEncodingRegisters...)
 
+var initClientCtx client.Context = client.Context{}.
+	WithCodec(encodingConfig.Codec).
+	WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
+	WithTxConfig(encodingConfig.TxConfig).
+	WithLegacyAmino(encodingConfig.Amino).
+	WithInput(os.Stdin).
+	WithAccountRetriever(types.AccountRetriever{}).
+	WithBroadcastMode(flags.BroadcastBlock).
+	WithHomeDir(app.DefaultNodeHome).
+	WithViper("CELESTIA")
+
+func init() {
 	rootCmd.AddCommand(
 		bridgeCmd,
 		lightCmd,
@@ -36,12 +47,18 @@ func main() {
 }
 
 func run() error {
-	return rootCmd.ExecuteContext(cmd.WithEnv(context.Background()))
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
+	cfg.Seal()
+
+	ctx := context.WithValue(context.Background(), client.ClientContextKey, &initClientCtx)
+	return rootCmd.ExecuteContext(cmd.WithEnv(ctx))
 }
 
 var rootCmd = &cobra.Command{
 	Use: "celestia [  bridge  ||  full ||  light  ] [subcommand]",
 	Short: `
+		____      __          __  _
 	  / ____/__  / /__  _____/ /_(_)___ _
 	 / /   / _ \/ / _ \/ ___/ __/ / __  /
 	/ /___/  __/ /  __(__  ) /_/ / /_/ /
@@ -50,5 +67,20 @@ var rootCmd = &cobra.Command{
 	Args: cobra.NoArgs,
 	CompletionOptions: cobra.CompletionOptions{
 		DisableDefaultCmd: true,
+	},
+	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+		initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
+		if err != nil {
+			return err
+		}
+		initClientCtx, err = config.ReadFromClientConfig(initClientCtx)
+		if err != nil {
+			return err
+		}
+
+		if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
+			return err
+		}
+		return nil
 	},
 }

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
-	"github.com/celestiaorg/celestia-node/cmd"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/spf13/cobra"
 	"os"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
 	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-node/cmd"
 )
 
 func init() {

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -12,6 +12,12 @@ import (
 )
 
 func init() {
+	// This is necessary to ensure that the account addresses are correctly prefixed
+	// as in the celestia application.
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
+	cfg.Seal()
+
 	rootCmd.AddCommand(
 		bridgeCmd,
 		lightCmd,
@@ -29,10 +35,6 @@ func main() {
 }
 
 func run() error {
-	cfg := sdk.GetConfig()
-	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
-	cfg.Seal()
-
 	return rootCmd.ExecuteContext(cmd.WithEnv(context.Background()))
 }
 


### PR DESCRIPTION
This PR extracts the cosmos sdk key utility from the main celestia-node binary and into a separate `cel-key` binary. 

Use the following flag `--node.type <bridge || full || light>` in order to set the keyring-dir to bridge, light, or full store directory. 

This prevents us having to use cosmos sdk client context initialisation (which is quite messy) inside celestia-node binary.

Thank you @evan-forbes and @Bidon15 for figuring out how to make the key utility actually work after it was broken during the upgrade :) 

### Makefile

`make cel-key` --> builds cel-key binary

`make install-key` --> installs cel-key in GOBIN