### PR TITLE
Add install target in Makefile, move old behavior to go-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SHELL=/usr/bin/env bash
 PROJECTNAME=$(shell basename "$(PWD)")
 LDFLAGS="-X 'main.buildTime=$(shell date)' -X 'main.lastCommit=$(shell git rev-parse HEAD)' -X 'main.semanticVersion=$(shell git describe --tags --dirty=-dev)'"
+ifeq (${PREFIX},)
+	PREFIX := /usr/local
+endif
 
 ## help: Get more info on make commands.
 help: Makefile
@@ -19,11 +22,17 @@ clean:
 	@echo "--> Cleaning up ./build"
 	@rm -rf build/*
 
-## install: Build and install the celestia-node binary into the GOBIN directory.
-install:
+## install: Build and install the celestia-node binary into the $PREFIX (/usr/local/ by default) directory.
+install: build
+	@echo "--> Installing Celestia"
+	@install -v ./build/* -t ${PREFIX}/bin/
+.PHONY: install
+
+## go-install: Build and install the celestia-node binary into the GOBIN directory.
+go-install:
 	@echo "--> Installing Celestia"
 	@go install -ldflags ${LDFLAGS}  ./cmd/celestia
-.PHONY: install
+.PHONY: go-install
 
 ## shed: Build cel-shed binary.
 cel-shed:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ See the official docs page for system requirements per node type:
 ```sh
 git clone https://github.com/celestiaorg/celestia-node.git 
 cd celestia-node
-make install
+make build
+sudo make install
 ```
 
 For more information on setting up a node and the hardware requirements needed, go visit our docs at <https://docs.celestia.org>.


### PR DESCRIPTION
Resolves #332 

Although I agree with [marbar3778](https://github.com/marbar3778)'s assertion that this is an issue maybe better fixed by documentation and we could continue to use the golang native tooling, here is a PR with the Makefile target implemented as proposed.

 I moved the existing `go install ...` behavior to `make go-install`. I also elected to always build before install and prompt for sudo within the `install` target, to keep the UX as `make install` rather than `make build; sudo make install`.

`$PREFIX` can be overridden like `make PREFIX=/my/dir` if needed, but I'm not sure this is worth mentioning in the README