### PR TITLE
fix: add .info and .address to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ build/
 *.coverprofile
 *.test
 *.orig
+*.address
+*.info
 */vendor
 vendor
 .DS_Store


### PR DESCRIPTION
`.address` and `.info `is created after running `make test`.
Added to `.gitignore` to avoid committing them by mistake.