### PR TITLE
params: Fix issue in `CELESTIA_CUSTOM` to be able to parse genesis even if bootstrappers not provided

### DIFF
--- a/params/default.go
+++ b/params/default.go
@@ -35,7 +35,7 @@ func init() {
 		defaultNetwork = Network(netID)
 		networksList[defaultNetwork] = struct{}{}
 		// check if genesis hash provided and register it if exists
-		if len(params) == 2 {
+		if len(params) >= 2 {
 			genHash := params[1]
 			genesisList[defaultNetwork] = strings.ToUpper(genHash)
 		}


### PR DESCRIPTION
Resolves #776 