### PR TITLE
fix(ipld): fix reconstruction by re-enabling re-importing of rsmt2d.ExtendedDataSquare

### DIFF
--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -151,6 +151,19 @@ func (rs *retrievalSession) Reconstruct() (*rsmt2d.ExtendedDataSquare, error) {
 	// prevent further writes to the square
 	rs.squareLk.Lock()
 	defer rs.squareLk.Unlock()
+
+	// TODO(@Wondertan): This is bad!
+	//  * We should not reimport the square multiple times
+	//  * We should set shares into imported square via SetShare(https://github.com/celestiaorg/rsmt2d/issues/83)
+	//  to accomplish the above point.
+	{
+		squareImported, err := rsmt2d.ImportExtendedDataSquare(rs.square, rs.codec, rs.treeFn)
+		if err != nil {
+			return nil, err
+		}
+		rs.squareImported = squareImported
+	}
+
 	// and try to repair with what we have
 	err := rs.squareImported.Repair(rs.dah.RowsRoots, rs.dah.ColumnRoots, rs.codec, rs.treeFn)
 	if err != nil {


### PR DESCRIPTION
An update of rsmt2d happened in https://github.com/celestiaorg/celestia-node/pull/737 during Mamaki launch preparation. This update changed our code not to reimport the square on each reconstruction attempt which silently sneaked in the problem, which is not reproducible with current tests. Reconstruction tests(#702) reproduce it, but they are not yet merged.

I was able to change the code to reproduce it reliably. Mainly I had to fetch only from columns and force the code to download only [2:4) quadrants. Unfortunately, it is hard to extract the reproducible case in a separate test, so we can either rely on reconstruction tests that are soon to be merged, or I can still try to make a test.

The reason for the bug is explained in #787, as well as a cleaner way to fix it. 
Closes #787

P.S. Was pretty hard to debug this case. I went on the wrong paths like 3 times. Though collected some minor findings that I am going to submit further. 