### PR TITLE
fix(ipld): fix races in the Retriever's doRequest method

### DIFF
--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -104,9 +104,10 @@ type retrievalSession struct {
 	sharesLks   []sync.Mutex
 	sharesCount uint32
 
-	squareLk sync.RWMutex
-	square   [][]byte
-	squareDn chan struct{}
+	squareLk  sync.RWMutex
+	square    [][]byte
+	squareSig chan struct{}
+	squareDn  chan struct{}
 }
 
 // newSession creates a new retrieval session and kicks off requesting process.
@@ -129,7 +130,8 @@ func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHead
 		quadrants: newQuadrants(dah),
 		sharesLks: make([]sync.Mutex, size*size),
 		square:    make([][]byte, size*size),
-		squareDn:  make(chan struct{}, 1),
+		squareSig: make(chan struct{}, 1),
+		squareDn:  make(chan struct{}),
 	}
 
 	square, err := rsmt2d.ImportExtendedDataSquare(ses.square, ses.codec, ses.treeFn)
@@ -146,11 +148,14 @@ func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHead
 // square reconstruction. "Attempt" because there is no way currently to
 // guarantee that reconstruction can be performed with the shares provided.
 func (rs *retrievalSession) Done() <-chan struct{} {
-	return rs.squareDn
+	return rs.squareSig
 }
 
 // Reconstruct tries to reconstruct the data square and returns it on success.
 func (rs *retrievalSession) Reconstruct() (*rsmt2d.ExtendedDataSquare, error) {
+	if rs.isReconstructed() {
+		return rs.squareImported, nil
+	}
 	// prevent further writes to the square
 	rs.squareLk.Lock()
 	defer rs.squareLk.Unlock()
@@ -173,7 +178,20 @@ func (rs *retrievalSession) Reconstruct() (*rsmt2d.ExtendedDataSquare, error) {
 		return nil, err
 	}
 	log.Infow("data square reconstructed", "data_hash", hex.EncodeToString(rs.dah.Hash()), "size", len(rs.dah.RowsRoots))
+	close(rs.squareDn)
 	return rs.squareImported, nil
+}
+
+// isReconstructed report true whether the square attached to the session
+// is already reconstructed.
+func (rs *retrievalSession) isReconstructed() bool {
+	select {
+	case <-rs.squareDn:
+		// return early if square is already reconstructed
+		return true
+	default:
+		return false
+	}
 }
 
 func (rs *retrievalSession) Close() error {
@@ -246,22 +264,28 @@ func (rs *retrievalSession) doRequest(ctx context.Context, q *quadrant) {
 					// if already locked and written - do nothing
 					return
 				}
-				// on success, write the share into the square
-				rs.squareLk.RLock()
-				// NOTE: The R lock here is *not* to protect rs.square from multiple
+				// The R lock here is *not* to protect rs.square from multiple
 				// concurrent shares writes but to avoid races between share writes and
 				// repairing attempts.
 				// Shares are written atomically in their own slice slots and these "writes" do
 				// not need synchronization!
+				rs.squareLk.RLock()
+				defer rs.squareLk.RUnlock()
+				// the routine could be blocked above for some time during which the square
+				// might be reconstructed, if so don't write anything and return
+				if rs.isReconstructed() {
+					return
+				}
 				rs.square[idx] = share
-				rs.squareLk.RUnlock()
 				// if we have >= 1/4 of the square we can start trying to Reconstruct
 				// TODO(@Wondertan): This is not an ideal way to know when to start
 				//  reconstruction and can cause idle reconstruction tries in some cases,
 				//  but it is totally fine for the happy case and for now.
+				//  The earlier we correctly know that we have the full square - the earlier
+				//  we cancel ongoing requests - the less data is being wastedly transferred.
 				if atomic.AddUint32(&rs.sharesCount, 1) >= uint32(size*size) {
 					select {
-					case rs.squareDn <- struct{}{}:
+					case rs.squareSig <- struct{}{}:
 					default:
 					}
 				}

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -250,11 +250,12 @@ func (rs *retrievalSession) doRequest(ctx context.Context, q *quadrant) {
 			// the left or the right side of the tree represent some portion of the quadrant
 			// which we put into the rs.square share-by-share by calculating shares' indexes using q.index
 			GetShares(ctx, rs.bget, nd.Links()[q.x].Cid, size, func(j int, share Share) {
-				// NOTE: Each share can be fetched twice, from two sources(Row or Col).
+				// NOTE: Each share can appear twice here, for a Row and Col, respectively.
 				// These shares are always equal, and we allow only the first one to be written
 				// in the square.
-				// NOTE-2: We never actually fetch shares from the network *twice*,
-				// and they are cached on IPLD(blockservice) level.
+				// NOTE-2: We never actually fetch shares from the network *twice*.
+				// Once a share is downloaded from the network it is cached on the 
+				// IPLD(blockservice) level.
 				//
 				// calc index of the share
 				idx := q.index(i, j)

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -103,6 +103,7 @@ type retrievalSession struct {
 	quadrants   []*quadrant
 	squareLk    sync.RWMutex
 	square      [][]byte
+	sharesLks   []sync.Mutex
 	sharesCount uint32
 	done        chan struct{}
 }
@@ -126,6 +127,7 @@ func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHead
 		dah:       dah,
 		quadrants: newQuadrants(dah),
 		square:    make([][]byte, size*size),
+		sharesLks: make([]sync.Mutex, size*size),
 		done:      make(chan struct{}, 1),
 	}
 
@@ -229,29 +231,39 @@ func (rs *retrievalSession) doRequest(ctx context.Context, q *quadrant) {
 			// the left or the right side of the tree represent some portion of the quadrant
 			// which we put into the rs.square share-by-share by calculating shares' indexes using q.index
 			GetShares(ctx, rs.bget, nd.Links()[q.x].Cid, size, func(j int, share Share) {
-				// the R lock here is *not* to protect rs.square from multiple concurrent shares writes
-				// but to avoid races between share writes and repairing attempts
-				// shares are written atomically in their own slice slot
+				// NOTE: Each share can be fetched twice, from two sources(Row or Col).
+				// These shares are always equal, and we allow only the first one to be written
+				// in the square.
+				// NOTE-2: We never actually fetch shares from the network *twice*,
+				// and they are cached on IPLD(blockservice) level.
+				//
+				// calc index of the share
 				idx := q.index(i, j)
+				// try to lock the share
+				ok := rs.sharesLks[idx].TryLock()
+				if !ok {
+					// if already locked and written - do nothing
+					return
+				}
+				// on success, write the share into the square
 				rs.squareLk.RLock()
-				// write only set nil shares, because shares can be passed here
-				// twice for the same coordinate from row or column
-				// NOTE: we never actually fetch the share from the network twice,
-				//  and it is cached on IPLD(blockservice) level
-				if rs.square[idx] == nil {
-					rs.square[idx] = share
-					// if we have >= 1/4 of the square we can start trying to Reconstruct
-					// TODO(@Wondertan): This is not an ideal way to know when to start
-					//  reconstruction and can cause idle reconstruction tries in some cases,
-					//  but it is totally fine for the happy case and for now.
-					if atomic.AddUint32(&rs.sharesCount, 1) >= uint32(size*size) {
-						select {
-						case rs.done <- struct{}{}:
-						default:
-						}
+				// NOTE: The R lock here is *not* to protect rs.square from multiple
+				// concurrent shares writes but to avoid races between share writes and
+				// repairing attempts.
+				// Shares are written atomically in their own slice slots and these "writes" do
+				// not need synchronization!
+				rs.square[idx] = share
+				rs.squareLk.RUnlock()
+				// if we have >= 1/4 of the square we can start trying to Reconstruct
+				// TODO(@Wondertan): This is not an ideal way to know when to start
+				//  reconstruction and can cause idle reconstruction tries in some cases,
+				//  but it is totally fine for the happy case and for now.
+				if atomic.AddUint32(&rs.sharesCount, 1) >= uint32(size*size) {
+					select {
+					case rs.done <- struct{}{}:
+					default:
 					}
 				}
-				rs.squareLk.RUnlock()
 			})
 		}(i, root)
 	}

--- a/ipld/retriever.go
+++ b/ipld/retriever.go
@@ -101,11 +101,12 @@ type retrievalSession struct {
 	squareImported *rsmt2d.ExtendedDataSquare
 
 	quadrants   []*quadrant
-	squareLk    sync.RWMutex
-	square      [][]byte
 	sharesLks   []sync.Mutex
 	sharesCount uint32
-	done        chan struct{}
+
+	squareLk sync.RWMutex
+	square   [][]byte
+	squareDn chan struct{}
 }
 
 // newSession creates a new retrieval session and kicks off requesting process.
@@ -126,9 +127,9 @@ func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHead
 		codec:     DefaultRSMT2DCodec(),
 		dah:       dah,
 		quadrants: newQuadrants(dah),
-		square:    make([][]byte, size*size),
 		sharesLks: make([]sync.Mutex, size*size),
-		done:      make(chan struct{}, 1),
+		square:    make([][]byte, size*size),
+		squareDn:  make(chan struct{}, 1),
 	}
 
 	square, err := rsmt2d.ImportExtendedDataSquare(ses.square, ses.codec, ses.treeFn)
@@ -145,7 +146,7 @@ func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHead
 // square reconstruction. "Attempt" because there is no way currently to
 // guarantee that reconstruction can be performed with the shares provided.
 func (rs *retrievalSession) Done() <-chan struct{} {
-	return rs.done
+	return rs.squareDn
 }
 
 // Reconstruct tries to reconstruct the data square and returns it on success.
@@ -260,7 +261,7 @@ func (rs *retrievalSession) doRequest(ctx context.Context, q *quadrant) {
 				//  but it is totally fine for the happy case and for now.
 				if atomic.AddUint32(&rs.sharesCount, 1) >= uint32(size*size) {
 					select {
-					case rs.done <- struct{}{}:
+					case rs.squareDn <- struct{}{}:
 					default:
 					}
 				}


### PR DESCRIPTION
Mainly this PR fixes two races:
1. One race happens when in one slice slot, two routines are trying to write the same share. Two because we have two sources for each share: Row and Col. Also, this does not happen on a happy path, and only in case, Retriever tries to fetch as many shares as possible to reconstruct the block, explaining why the race was uncovered with #702.

The mentioned race is a known one, and we had an incorrect attempt previously to fix it https://github.com/celestiaorg/celestia-node/commit/cca832acb6dbb03ac734fa5090d50bc319b9d0ba. 

This fix is correct and achieved by keeping a mutex per share. If a share comes from any of two sources first, it locks the slot and prevents a share from another source from being written.

2. The second race happened after the square was reconstructed. During the reconstruction, some new shares could arrive and wait on the lock. Once reconstructed, they were unlocked and continued to write in an already filled-up square slice causing multiple races with the same root. Basically, the reconstructed square was returned to the user, while Retriever internal was continue to writing. This PR fixes that and ensure that after unlocking writings routines check if reconstruction happened and if so aborts them.

Closes https://github.com/celestiaorg/celestia-node/issues/814

P.S. The complexity of the code in Retriever is starting to grow, and it's hard to test it. We will likely need to refactor the code(I have a brief picture in my head). However, though, this should happen after all the API improvements land in rsmt2d.