### PR TITLE
header: `Exchange` interface implements `Getter`

### DIFF
--- a/header/core/exchange.go
+++ b/header/core/exchange.go
@@ -30,13 +30,13 @@ func NewExchange(fetcher *core.BlockFetcher, bServ blockservice.BlockService, co
 	}
 }
 
-func (ce *Exchange) RequestHeader(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
+func (ce *Exchange) GetByHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 	log.Debugw("requesting header", "height", height)
 	intHeight := int64(height)
 	return ce.getExtendedHeaderByHeight(ctx, &intHeight)
 }
 
-func (ce *Exchange) RequestHeaders(ctx context.Context, from, amount uint64) ([]*header.ExtendedHeader, error) {
+func (ce *Exchange) GetRangeByHeight(ctx context.Context, from, amount uint64) ([]*header.ExtendedHeader, error) {
 	if amount == 0 {
 		return nil, nil
 	}
@@ -44,7 +44,7 @@ func (ce *Exchange) RequestHeaders(ctx context.Context, from, amount uint64) ([]
 	log.Debugw("requesting headers", "from", from, "to", from+amount)
 	headers := make([]*header.ExtendedHeader, amount)
 	for i := range headers {
-		extHeader, err := ce.RequestHeader(ctx, from+uint64(i))
+		extHeader, err := ce.GetByHeight(ctx, from+uint64(i))
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +55,7 @@ func (ce *Exchange) RequestHeaders(ctx context.Context, from, amount uint64) ([]
 	return headers, nil
 }
 
-func (ce *Exchange) RequestByHash(ctx context.Context, hash tmbytes.HexBytes) (*header.ExtendedHeader, error) {
+func (ce *Exchange) Get(ctx context.Context, hash tmbytes.HexBytes) (*header.ExtendedHeader, error) {
 	log.Debugw("requesting header", "hash", hash.String())
 	block, err := ce.fetcher.GetBlockByHash(ctx, hash)
 	if err != nil {
@@ -80,7 +80,7 @@ func (ce *Exchange) RequestByHash(ctx context.Context, hash tmbytes.HexBytes) (*
 	return eh, nil
 }
 
-func (ce *Exchange) RequestHead(ctx context.Context) (*header.ExtendedHeader, error) {
+func (ce *Exchange) Head(ctx context.Context) (*header.ExtendedHeader, error) {
 	log.Debug("requesting head")
 	return ce.getExtendedHeaderByHeight(ctx, nil)
 }

--- a/header/core/exchange_test.go
+++ b/header/core/exchange_test.go
@@ -24,7 +24,7 @@ func TestCoreExchange_RequestHeaders(t *testing.T) {
 	generateBlocks(t, fetcher)
 
 	ce := NewExchange(fetcher, store, header.MakeExtendedHeader)
-	headers, err := ce.RequestHeaders(context.Background(), 1, 10)
+	headers, err := ce.GetRangeByHeight(context.Background(), 1, 10)
 	require.NoError(t, err)
 
 	assert.Equal(t, 10, len(headers))

--- a/header/interface.go
+++ b/header/interface.go
@@ -55,19 +55,7 @@ type Broadcaster interface {
 // Exchange encompasses the behavior necessary to request ExtendedHeaders
 // from the network.
 type Exchange interface {
-	// RequestHead requests the latest ExtendedHeader. Note that the ExtendedHeader
-	// must be verified thereafter.
-	RequestHead(ctx context.Context) (*ExtendedHeader, error)
-	// RequestHeader performs a request for the ExtendedHeader at the given
-	// height to the network. Note that the ExtendedHeader must be verified
-	// thereafter.
-	RequestHeader(ctx context.Context, height uint64) (*ExtendedHeader, error)
-	// RequestHeaders performs a request for the given range of ExtendedHeaders
-	// to the network. Note that the ExtendedHeaders must be verified thereafter.
-	RequestHeaders(ctx context.Context, origin, amount uint64) ([]*ExtendedHeader, error)
-	// RequestByHash performs a request for the ExtendedHeader by the given hash corresponding
-	// to the RawHeader. Note that the ExtendedHeader must be verified thereafter.
-	RequestByHash(ctx context.Context, hash tmbytes.HexBytes) (*ExtendedHeader, error)
+	Getter
 }
 
 var (

--- a/header/local/exchange.go
+++ b/header/local/exchange.go
@@ -28,21 +28,21 @@ func (l *Exchange) Stop(context.Context) error {
 	return nil
 }
 
-func (l *Exchange) RequestHead(ctx context.Context) (*header.ExtendedHeader, error) {
+func (l *Exchange) Head(ctx context.Context) (*header.ExtendedHeader, error) {
 	return l.store.Head(ctx)
 }
 
-func (l *Exchange) RequestHeader(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
+func (l *Exchange) GetByHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 	return l.store.GetByHeight(ctx, height)
 }
 
-func (l *Exchange) RequestHeaders(ctx context.Context, origin, amount uint64) ([]*header.ExtendedHeader, error) {
+func (l *Exchange) GetRangeByHeight(ctx context.Context, origin, amount uint64) ([]*header.ExtendedHeader, error) {
 	if amount == 0 {
 		return nil, nil
 	}
 	return l.store.GetRangeByHeight(ctx, origin, origin+amount)
 }
 
-func (l *Exchange) RequestByHash(ctx context.Context, hash bytes.HexBytes) (*header.ExtendedHeader, error) {
+func (l *Exchange) Get(ctx context.Context, hash bytes.HexBytes) (*header.ExtendedHeader, error) {
 	return l.store.Get(ctx, hash)
 }

--- a/header/p2p/exchange.go
+++ b/header/p2p/exchange.go
@@ -43,7 +43,7 @@ func NewExchange(host host.Host, peers peer.IDSlice) *Exchange {
 	}
 }
 
-func (ex *Exchange) RequestHead(ctx context.Context) (*header.ExtendedHeader, error) {
+func (ex *Exchange) Head(ctx context.Context) (*header.ExtendedHeader, error) {
 	log.Debug("requesting head")
 	// create request
 	req := &p2p_pb.ExtendedHeaderRequest{
@@ -57,7 +57,7 @@ func (ex *Exchange) RequestHead(ctx context.Context) (*header.ExtendedHeader, er
 	return headers[0], nil
 }
 
-func (ex *Exchange) RequestHeader(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
+func (ex *Exchange) GetByHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 	log.Debugw("requesting header", "height", height)
 	// sanity check height
 	if height == 0 {
@@ -75,7 +75,7 @@ func (ex *Exchange) RequestHeader(ctx context.Context, height uint64) (*header.E
 	return headers[0], nil
 }
 
-func (ex *Exchange) RequestHeaders(ctx context.Context, from, amount uint64) ([]*header.ExtendedHeader, error) {
+func (ex *Exchange) GetRangeByHeight(ctx context.Context, from, amount uint64) ([]*header.ExtendedHeader, error) {
 	log.Debugw("requesting headers", "from", from, "to", from+amount)
 	// create request
 	req := &p2p_pb.ExtendedHeaderRequest{
@@ -85,7 +85,7 @@ func (ex *Exchange) RequestHeaders(ctx context.Context, from, amount uint64) ([]
 	return ex.performRequest(ctx, req)
 }
 
-func (ex *Exchange) RequestByHash(ctx context.Context, hash tmbytes.HexBytes) (*header.ExtendedHeader, error) {
+func (ex *Exchange) Get(ctx context.Context, hash tmbytes.HexBytes) (*header.ExtendedHeader, error) {
 	log.Debugw("requesting header", "hash", hash.String())
 	// create request
 	req := &p2p_pb.ExtendedHeaderRequest{

--- a/header/p2p/exchange.go
+++ b/header/p2p/exchange.go
@@ -43,6 +43,8 @@ func NewExchange(host host.Host, peers peer.IDSlice) *Exchange {
 	}
 }
 
+// Head requests the latest ExtendedHeader. Note that the ExtendedHeader
+// must be verified thereafter.
 func (ex *Exchange) Head(ctx context.Context) (*header.ExtendedHeader, error) {
 	log.Debug("requesting head")
 	// create request
@@ -57,6 +59,9 @@ func (ex *Exchange) Head(ctx context.Context) (*header.ExtendedHeader, error) {
 	return headers[0], nil
 }
 
+// GetByHeight performs a request for the ExtendedHeader at the given
+// height to the network. Note that the ExtendedHeader must be verified
+// thereafter.
 func (ex *Exchange) GetByHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 	log.Debugw("requesting header", "height", height)
 	// sanity check height
@@ -75,6 +80,8 @@ func (ex *Exchange) GetByHeight(ctx context.Context, height uint64) (*header.Ext
 	return headers[0], nil
 }
 
+// GetRangeByHeight performs a request for the given range of ExtendedHeaders
+// to the network. Note that the ExtendedHeaders must be verified thereafter.
 func (ex *Exchange) GetRangeByHeight(ctx context.Context, from, amount uint64) ([]*header.ExtendedHeader, error) {
 	log.Debugw("requesting headers", "from", from, "to", from+amount)
 	// create request
@@ -85,6 +92,8 @@ func (ex *Exchange) GetRangeByHeight(ctx context.Context, from, amount uint64) (
 	return ex.performRequest(ctx, req)
 }
 
+// Get performs a request for the ExtendedHeader by the given hash corresponding
+// to the RawHeader. Note that the ExtendedHeader must be verified thereafter.
 func (ex *Exchange) Get(ctx context.Context, hash tmbytes.HexBytes) (*header.ExtendedHeader, error) {
 	log.Debugw("requesting header", "hash", hash.String())
 	// create request

--- a/header/p2p/exchange_test.go
+++ b/header/p2p/exchange_test.go
@@ -26,7 +26,7 @@ func TestExchange_RequestHead(t *testing.T) {
 	host, peer := createMocknet(ctx, t)
 	exchg, store := createP2PExAndServer(t, host, peer)
 	// perform header request
-	header, err := exchg.RequestHead(context.Background())
+	header, err := exchg.Head(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, store.headers[store.headHeight].Height, header.Height)
@@ -40,7 +40,7 @@ func TestExchange_RequestHeader(t *testing.T) {
 	host, peer := createMocknet(ctx, t)
 	exchg, store := createP2PExAndServer(t, host, peer)
 	// perform expected request
-	header, err := exchg.RequestHeader(context.Background(), 5)
+	header, err := exchg.GetByHeight(context.Background(), 5)
 	require.NoError(t, err)
 	assert.Equal(t, store.headers[5].Height, header.Height)
 	assert.Equal(t, store.headers[5].Hash(), header.Hash())
@@ -53,7 +53,7 @@ func TestExchange_RequestHeaders(t *testing.T) {
 	host, peer := createMocknet(ctx, t)
 	exchg, store := createP2PExAndServer(t, host, peer)
 	// perform expected request
-	gotHeaders, err := exchg.RequestHeaders(context.Background(), 1, 5)
+	gotHeaders, err := exchg.GetRangeByHeight(context.Background(), 1, 5)
 	require.NoError(t, err)
 	for _, got := range gotHeaders {
 		assert.Equal(t, store.headers[got.Height].Height, got.Height)

--- a/header/store/init.go
+++ b/header/store/init.go
@@ -16,7 +16,7 @@ func Init(ctx context.Context, store header.Store, ex header.Exchange, hash tmby
 	default:
 		return err
 	case header.ErrNoHead:
-		initial, err := ex.RequestByHash(ctx, hash)
+		initial, err := ex.Get(ctx, hash)
 		if err != nil {
 			return err
 		}

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -140,7 +140,7 @@ func (s *Syncer) trustedHead(ctx context.Context) (*header.ExtendedHeader, error
 	}
 
 	// otherwise, request head from a trustedPeer or, in other words, do automatic subjective initialization
-	objHead, err := s.exchange.RequestHead(ctx)
+	objHead, err := s.exchange.Head(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -331,12 +331,12 @@ func (s *Syncer) findHeaders(ctx context.Context, from, to uint64) ([]*header.Ex
 		// if we have some range cached - use it
 		r, ok := s.pending.FirstRangeWithin(from, to)
 		if !ok {
-			hs, err := s.exchange.RequestHeaders(ctx, from, amount)
+			hs, err := s.exchange.GetRangeByHeight(ctx, from, amount)
 			return append(out, hs...), err
 		}
 
 		// first, request everything between from and start of the found range
-		hs, err := s.exchange.RequestHeaders(ctx, from, r.Start-from)
+		hs, err := s.exchange.GetRangeByHeight(ctx, from, r.Start-from)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR changes `Exchange` interface to just implement `Getter` as they are performing the same functions just with different names. 