### PR TITLE
cmd: Minor clean up in validation of given rpc endpoint

### DIFF
--- a/cmd/flags_core.go
+++ b/cmd/flags_core.go
@@ -73,7 +73,7 @@ func validateAddress(address string) (string, string, error) {
 		return "", "", fmt.Errorf("both protocol and host must present in the address")
 	}
 
-	if _, port, err := net.SplitHostPort(u.Host); err != nil || port == "" {
+	if _, _, err := net.SplitHostPort(u.Host); err != nil {
 		return "", "", fmt.Errorf("incorrect address provided for Remote Core")
 	}
 


### PR DESCRIPTION
There is no need to check if `port == ""` as `net.SplitHostPort` errors out if port is empty. 