### PR TITLE
fix(share): protect datastore autobatch in CacheAvailability with a lock

### DIFF
--- a/service/share/cache_availability.go
+++ b/service/share/cache_availability.go
@@ -3,6 +3,7 @@ package share
 import (
 	"bytes"
 	"context"
+	"sync"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/autobatch"
@@ -27,7 +28,10 @@ var (
 type CacheAvailability struct {
 	avail Availability
 
-	ds *autobatch.Datastore
+	// TODO(@Wondertan): Once we come to parallelized DASer, this lock becomes a contention point
+	//  Related to #483
+	dsLk sync.RWMutex
+	ds   *autobatch.Datastore
 }
 
 // NewCacheAvailability wraps the given Availability with an additional datastore
@@ -50,18 +54,22 @@ func (ca *CacheAvailability) SharesAvailable(ctx context.Context, root *Root) er
 	}
 	// do not sample over Root that has already been sampled
 	key := rootKey(root)
+
+	ca.dsLk.RLock()
 	exists, err := ca.ds.Has(ctx, key)
-	if err != nil {
+	ca.dsLk.RUnlock()
+	if err != nil || exists {
 		return err
 	}
-	if exists {
-		return nil
-	}
+
 	err = ca.avail.SharesAvailable(ctx, root)
 	if err != nil {
 		return err
 	}
+
+	ca.dsLk.Lock()
 	err = ca.ds.Put(ctx, key, []byte{})
+	ca.dsLk.Unlock()
 	if err != nil {
 		log.Errorw("storing root of successful SharesAvailable request to disk", "err", err)
 	}


### PR DESCRIPTION
During the review of #786, I was assuming the autobatch datastore has an internal lock, but it turns out to be not the case.

Was found while making #592 
