### PR TITLE
swamp: fix TestFraudProofBroadcasting call of BlockTime

### DIFF
--- a/node/tests/fraud_test.go
+++ b/node/tests/fraud_test.go
@@ -29,7 +29,7 @@ import (
  Note: 15 is not available because DASer will be stopped before reaching this height due to receiving BEFP.
 */
 func TestFraudProofBroadcasting(t *testing.T) {
-	sw := swamp.NewSwamp(t, swamp.WithBlockInterval(time.Millisecond*100))
+	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Millisecond*100))
 
 	bridge := sw.NewBridgeNode(node.WithHeaderConstructFn(header.FraudMaker(t, 10)))
 


### PR DESCRIPTION
On latest main run, CI jobs have detected an issue : 
https://github.com/celestiaorg/celestia-node/runs/7115039774?check_suite_focus=true