### PR TITLE
cmd | node: Refactor core flags

### DIFF
--- a/cmd/flags_core.go
+++ b/cmd/flags_core.go
@@ -66,9 +66,11 @@ func ParseCoreFlags(cmd *cobra.Command, env *Env) error {
 			return err
 		}
 		env.AddOptions(node.WithGRPCPort(grpc))
+		return nil
 	}
-	// TODO @renaynay: implement some sort of sanity check to make sure grpc/rpc aren't provided without
-	//  --core also being specified?
+	if cmd.Flag(coreGRPCFlag).Changed || cmd.Flag(coreRPCFlag).Changed {
+		return fmt.Errorf("cannot specify RPC/gRPC ports without specifying an IP address for --core")
+	}
 	return nil
 }
 

--- a/cmd/flags_core.go
+++ b/cmd/flags_core.go
@@ -57,7 +57,7 @@ func ParseCoreFlags(cmd *cobra.Command, env *Env) error {
 		if err != nil {
 			return err
 		}
-		env.AddOptions(node.WithRemoteCore(ip, rpc))
+		env.AddOptions(node.WithRemoteCoreIP(ip), node.WithRemoteCoreRPCPort(rpc))
 
 		grpc := cmd.Flag(coreGRPCFlag).Value.String()
 		// sanity check gRPC endpoint

--- a/cmd/flags_core.go
+++ b/cmd/flags_core.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	coreFlag     = "core"
-	coreRPCFlag  = "core.rpc"
-	coreGRPCFlag = "core.grpc"
+	coreFlag     = "core.ip"
+	coreRPCFlag  = "core.rpc.port"
+	coreGRPCFlag = "core.grpc.port"
 )
 
 // CoreFlags gives a set of hardcoded Core flags.
@@ -30,12 +30,12 @@ func CoreFlags() *flag.FlagSet {
 	flags.String(
 		coreRPCFlag,
 		"26657",
-		"Set a custom RPC port for the core node connection. The --core flag must also be provided.",
+		"Set a custom RPC port for the core node connection. The --core.ip flag must also be provided.",
 	)
 	flags.String(
 		coreGRPCFlag,
 		"9090",
-		"Set a custom gRPC port for the core node connection. The --core flag must also be provided.",
+		"Set a custom gRPC port for the core node connection. The --core.ip flag must also be provided.",
 	)
 
 	return flags
@@ -43,10 +43,10 @@ func CoreFlags() *flag.FlagSet {
 
 // ParseCoreFlags parses Core flags from the given cmd and applies values to Env.
 func ParseCoreFlags(cmd *cobra.Command, env *Env) error {
-	coreRemote := cmd.Flag(coreFlag).Value.String()
-	if coreRemote != "" {
+	coreIP := cmd.Flag(coreFlag).Value.String()
+	if coreIP != "" {
 		// sanity check given core ip addr and strip leading protocol
-		ip, err := sanityCheckIP(coreRemote)
+		ip, err := sanityCheckIP(coreIP)
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ func ParseCoreFlags(cmd *cobra.Command, env *Env) error {
 		return nil
 	}
 	if cmd.Flag(coreGRPCFlag).Changed || cmd.Flag(coreRPCFlag).Changed {
-		return fmt.Errorf("cannot specify RPC/gRPC ports without specifying an IP address for --core")
+		return fmt.Errorf("cannot specify RPC/gRPC ports without specifying an IP address for --core.ip")
 	}
 	return nil
 }

--- a/cmd/flags_core.go
+++ b/cmd/flags_core.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"net"
-	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	coreRemoteFlag = "core.remote"
-	coreGRPCFlag   = "core.grpc"
+	coreFlag     = "core"
+	coreRPCFlag  = "core.rpc"
+	coreGRPCFlag = "core.grpc"
 )
 
 // CoreFlags gives a set of hardcoded Core flags.
@@ -21,16 +22,20 @@ func CoreFlags() *flag.FlagSet {
 	flags := &flag.FlagSet{}
 
 	flags.String(
-		coreRemoteFlag,
+		coreFlag,
 		"",
-		"Indicates node to connect to the given remote core node. "+
-			"Example: <protocol>://<ip>:<port>, tcp://127.0.0.1:26657",
+		"Indicates node to connect to the given core node. "+
+			"Example: <ip>, 127.0.0.1. Assumes RPC port 26657 and gRPC port 9009 as default unless otherwise specified.",
+	)
+	flags.String(
+		coreRPCFlag,
+		"26657",
+		"Set a custom RPC port for the core node connection. The --core flag must also be provided.",
 	)
 	flags.String(
 		coreGRPCFlag,
-		"",
-		"Indicates node to connect to the given celestia-app gRPC endpoint for state-related queries"+
-			"Example: <ip>:<port>, 127.0.0.1:9090",
+		"9090",
+		"Set a custom gRPC port for the core node connection. The --core flag must also be provided.",
 	)
 
 	return flags
@@ -38,44 +43,45 @@ func CoreFlags() *flag.FlagSet {
 
 // ParseCoreFlags parses Core flags from the given cmd and applies values to Env.
 func ParseCoreFlags(cmd *cobra.Command, env *Env) error {
-	coreRemote := cmd.Flag(coreRemoteFlag).Value.String()
+	coreRemote := cmd.Flag(coreFlag).Value.String()
 	if coreRemote != "" {
-		proto, addr, err := validateAddress(coreRemote)
-		if err != nil {
-			return fmt.Errorf("cmd: while parsing '%s': %w", coreRemoteFlag, err)
-		}
-
-		env.AddOptions(node.WithRemoteCore(proto, addr))
-	}
-
-	grpcEndpoint := cmd.Flag(coreGRPCFlag).Value.String()
-	if grpcEndpoint != "" {
-		// parse ip:port from the endpoint
-		grpcURL, err := url.Parse(grpcEndpoint)
+		// sanity check given core ip addr and strip leading protocol
+		ip, err := sanityCheckIP(coreRemote)
 		if err != nil {
 			return err
 		}
-		env.AddOptions(node.WithGRPCEndpoint(grpcURL.Host))
-	}
 
+		rpc := cmd.Flag(coreRPCFlag).Value.String()
+		// sanity check rpc endpoint
+		_, err = strconv.Atoi(rpc)
+		if err != nil {
+			return err
+		}
+		env.AddOptions(node.WithRemoteCore(ip, rpc))
+
+		grpc := cmd.Flag(coreGRPCFlag).Value.String()
+		// sanity check gRPC endpoint
+		_, err = strconv.Atoi(grpc)
+		if err != nil {
+			return err
+		}
+		env.AddOptions(node.WithGRPCPort(grpc))
+	}
+	// TODO @renaynay: implement some sort of sanity check to make sure grpc/rpc aren't provided without
+	//  --core also being specified?
 	return nil
 }
 
-// validateAddress parses the given address of the remote core node
-// and checks if it configures correctly
-func validateAddress(address string) (string, string, error) {
-	u, err := url.Parse(address)
-	if err != nil {
-		return "", "", err
+// sanityCheckIP trims leading protocol scheme and port from the given
+// IP address if present.
+func sanityCheckIP(ip string) (string, error) {
+	original := ip
+	ip = strings.TrimPrefix(ip, "http://")
+	ip = strings.TrimPrefix(ip, "https://")
+	ip = strings.TrimPrefix(ip, "tcp://")
+	ip = strings.Split(ip, ":")[0]
+	if ip == "" {
+		return "", fmt.Errorf("invalid IP addr given: %s", original)
 	}
-
-	if u.Scheme == "" || u.Host == "" {
-		return "", "", fmt.Errorf("both protocol and host must present in the address")
-	}
-
-	if _, _, err := net.SplitHostPort(u.Host); err != nil {
-		return "", "", fmt.Errorf("incorrect address provided for Remote Core")
-	}
-
-	return u.Scheme, u.Host, nil
+	return ip, nil
 }

--- a/cmd/flags_core.go
+++ b/cmd/flags_core.go
@@ -44,33 +44,33 @@ func CoreFlags() *flag.FlagSet {
 // ParseCoreFlags parses Core flags from the given cmd and applies values to Env.
 func ParseCoreFlags(cmd *cobra.Command, env *Env) error {
 	coreIP := cmd.Flag(coreFlag).Value.String()
-	if coreIP != "" {
-		// sanity check given core ip addr and strip leading protocol
-		ip, err := sanityCheckIP(coreIP)
-		if err != nil {
-			return err
+	if coreIP == "" {
+		if cmd.Flag(coreGRPCFlag).Changed || cmd.Flag(coreRPCFlag).Changed {
+			return fmt.Errorf("cannot specify RPC/gRPC ports without specifying an IP address for --core.ip")
 		}
-
-		rpc := cmd.Flag(coreRPCFlag).Value.String()
-		// sanity check rpc endpoint
-		_, err = strconv.Atoi(rpc)
-		if err != nil {
-			return err
-		}
-		env.AddOptions(node.WithRemoteCoreIP(ip), node.WithRemoteCoreRPCPort(rpc))
-
-		grpc := cmd.Flag(coreGRPCFlag).Value.String()
-		// sanity check gRPC endpoint
-		_, err = strconv.Atoi(grpc)
-		if err != nil {
-			return err
-		}
-		env.AddOptions(node.WithGRPCPort(grpc))
 		return nil
 	}
-	if cmd.Flag(coreGRPCFlag).Changed || cmd.Flag(coreRPCFlag).Changed {
-		return fmt.Errorf("cannot specify RPC/gRPC ports without specifying an IP address for --core.ip")
+	// sanity check given core ip addr and strip leading protocol
+	ip, err := sanityCheckIP(coreIP)
+	if err != nil {
+		return err
 	}
+
+	rpc := cmd.Flag(coreRPCFlag).Value.String()
+	// sanity check rpc endpoint
+	_, err = strconv.Atoi(rpc)
+	if err != nil {
+		return err
+	}
+	env.AddOptions(node.WithRemoteCoreIP(ip), node.WithRemoteCorePort(rpc))
+
+	grpc := cmd.Flag(coreGRPCFlag).Value.String()
+	// sanity check gRPC endpoint
+	_, err = strconv.Atoi(grpc)
+	if err != nil {
+		return err
+	}
+	env.AddOptions(node.WithGRPCPort(grpc))
 	return nil
 }
 

--- a/core/client.go
+++ b/core/client.go
@@ -13,14 +13,14 @@ import (
 type Client = client.Client
 
 // NewRemote creates a new Client that communicates with a remote Core endpoint over HTTP.
-func NewRemote(protocol, remoteAddr string) (Client, error) {
+func NewRemote(endpoint string) (Client, error) {
 	httpClient := retryhttp.NewClient()
 	httpClient.RetryMax = 2
 	// suppress logging
 	httpClient.Logger = nil
 
 	return http.NewWithClient(
-		fmt.Sprintf("%s://%s", protocol, remoteAddr),
+		fmt.Sprintf("tcp://%s", endpoint),
 		httpClient.StandardClient(),
 	)
 }

--- a/core/client.go
+++ b/core/client.go
@@ -13,14 +13,14 @@ import (
 type Client = client.Client
 
 // NewRemote creates a new Client that communicates with a remote Core endpoint over HTTP.
-func NewRemote(endpoint string) (Client, error) {
+func NewRemote(ip, port string) (Client, error) {
 	httpClient := retryhttp.NewClient()
 	httpClient.RetryMax = 2
 	// suppress logging
 	httpClient.Logger = nil
 
 	return http.NewWithClient(
-		fmt.Sprintf("tcp://%s", endpoint),
+		fmt.Sprintf("tcp://%s:%s", ip, port),
 		httpClient.StandardClient(),
 	)
 }

--- a/core/testing.go
+++ b/core/testing.go
@@ -55,7 +55,9 @@ func StartTestClient(ctx context.Context, t *testing.T) (tmservice.Service, Clie
 	nd, _, cfg := StartTestKVApp(ctx, t)
 	endpoint, err := GetEndpoint(cfg)
 	require.NoError(t, err)
-	client, err := NewRemote(endpoint)
+	ip, port, err := net.SplitHostPort(endpoint)
+	require.NoError(t, err)
+	client, err := NewRemote(ip, port)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := client.Stop()

--- a/node/components.go
+++ b/node/components.go
@@ -79,7 +79,7 @@ func baseComponents(cfg *Config, store Store) fx.Option {
 		fx.Invoke(invokeWatchdog(store.Path())),
 		p2p.Components(cfg.P2P),
 		// state components
-		statecomponents.Components(cfg.Core.GRPCAddr, cfg.Key),
+		statecomponents.Components(cfg.Core.IP, cfg.Core.GRPCPort, cfg.Key),
 		// RPC components
 		rpc.Components(cfg.RPC),
 	)

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -1,18 +1,18 @@
 package node
 
 // WithRemoteCore configures Node to start with remote Core.
-func WithRemoteCore(protocol string, address string) Option {
+func WithRemoteCore(ip, port string) Option {
 	return func(sets *settings) {
-		sets.cfg.Core.Protocol = protocol
-		sets.cfg.Core.RemoteAddr = address
+		sets.cfg.Core.IP = ip
+		sets.cfg.Core.RPCPort = port
 	}
 }
 
-// WithGRPCEndpoint configures Node to connect to given gRPC address
+// WithGRPCPort configures Node to connect to given gRPC port
 // for state-related queries.
-func WithGRPCEndpoint(address string) Option {
+func WithGRPCPort(port string) Option {
 	return func(sets *settings) {
-		sets.cfg.Core.GRPCAddr = address
+		sets.cfg.Core.GRPCPort = port
 	}
 }
 

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -1,9 +1,15 @@
 package node
 
-// WithRemoteCore configures Node to start with remote Core.
-func WithRemoteCore(ip, port string) Option {
+// WithRemoteCoreIP configures Node to connect to the given remote Core IP.
+func WithRemoteCoreIP(ip string) Option {
 	return func(sets *settings) {
 		sets.cfg.Core.IP = ip
+	}
+}
+
+// WithRemoteCoreRPCPort configures Node to connect to the given remote Core port.
+func WithRemoteCoreRPCPort(port string) Option {
+	return func(sets *settings) {
 		sets.cfg.Core.RPCPort = port
 	}
 }

--- a/node/config_opts.go
+++ b/node/config_opts.go
@@ -7,8 +7,8 @@ func WithRemoteCoreIP(ip string) Option {
 	}
 }
 
-// WithRemoteCoreRPCPort configures Node to connect to the given remote Core port.
-func WithRemoteCoreRPCPort(port string) Option {
+// WithRemoteCorePort configures Node to connect to the given remote Core port.
+func WithRemoteCorePort(port string) Option {
 	return func(sets *settings) {
 		sets.cfg.Core.RPCPort = port
 	}

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -16,12 +16,13 @@ import (
 
 // Config combines all configuration fields for managing the relationship with a Core node.
 type Config struct {
-	Protocol   string
-	RemoteAddr string
-	GRPCAddr   string
+	IP       string
+	RPCPort  string
+	GRPCPort string
 }
 
-// DefaultConfig returns default configuration for Core subsystem.
+// DefaultConfig returns default configuration for managing the
+// node's connection to a Celestia-Core endpoint.
 func DefaultConfig() Config {
 	return Config{}
 }
@@ -33,7 +34,7 @@ func Components(cfg Config) fx.Option {
 		fxutil.ProvideAs(headercore.NewExchange, new(header.Exchange)),
 		fx.Invoke(HeaderListener),
 		fx.Provide(func(lc fx.Lifecycle) (core.Client, error) {
-			if cfg.RemoteAddr == "" {
+			if cfg.IP == "" {
 				return nil, fmt.Errorf("no celestia-core endpoint given")
 			}
 			client, err := RemoteClient(cfg)
@@ -71,5 +72,5 @@ func HeaderListener(
 
 // RemoteClient provides a constructor for core.Client over RPC.
 func RemoteClient(cfg Config) (core.Client, error) {
-	return core.NewRemote(cfg.Protocol, cfg.RemoteAddr)
+	return core.NewRemote(fmt.Sprintf("%s:%s", cfg.IP, cfg.RPCPort))
 }

--- a/node/core/core.go
+++ b/node/core/core.go
@@ -72,5 +72,5 @@ func HeaderListener(
 
 // RemoteClient provides a constructor for core.Client over RPC.
 func RemoteClient(cfg Config) (core.Client, error) {
-	return core.NewRemote(fmt.Sprintf("%s:%s", cfg.IP, cfg.RPCPort))
+	return core.NewRemote(cfg.IP, cfg.RPCPort)
 }

--- a/node/state/core.go
+++ b/node/state/core.go
@@ -10,10 +10,11 @@ import (
 // CoreAccessor constructs a new instance of state.Accessor over
 // a celestia-core connection.
 func CoreAccessor(
-	endpoint string,
+	coreIP,
+	grpcPort string,
 ) func(fx.Lifecycle, *apptypes.KeyringSigner) (state.Accessor, error) {
 	return func(lc fx.Lifecycle, signer *apptypes.KeyringSigner) (state.Accessor, error) {
-		ca := state.NewCoreAccessor(signer, endpoint)
+		ca := state.NewCoreAccessor(signer, coreIP, grpcPort)
 		lc.Append(fx.Hook{
 			OnStart: ca.Start,
 			OnStop:  ca.Stop,

--- a/node/state/state.go
+++ b/node/state/state.go
@@ -16,10 +16,10 @@ var log = logging.Logger("state-access-constructor")
 
 // Components provides all components necessary to construct the
 // state service.
-func Components(coreEndpoint string, cfg key.Config) fx.Option {
+func Components(coreIP, grpcPort string, cfg key.Config) fx.Option {
 	return fx.Options(
 		fx.Provide(Keyring(cfg)),
-		fx.Provide(CoreAccessor(coreEndpoint)),
+		fx.Provide(CoreAccessor(coreIP, grpcPort)),
 		fx.Provide(Service),
 	)
 }

--- a/node/testing.go
+++ b/node/testing.go
@@ -37,7 +37,8 @@ func TestNode(t *testing.T, tp Type, opts ...Option) *Node {
 	ip, port, err := net.SplitHostPort(endpoint)
 	require.NoError(t, err)
 	opts = append(opts,
-		WithRemoteCore(ip, port),
+		WithRemoteCoreIP(ip),
+		WithRemoteCoreRPCPort(port),
 		WithNetwork(params.Private),
 		WithRPCPort("0"),
 		WithKeyringSigner(TestKeyringSigner(t)),

--- a/node/testing.go
+++ b/node/testing.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -31,8 +32,12 @@ func TestNode(t *testing.T, tp Type, opts ...Option) *Node {
 
 	store := MockStore(t, DefaultConfig(tp))
 	_, _, cfg := core.StartTestKVApp(ctx, t)
+	endpoint, err := core.GetEndpoint(cfg)
+	require.NoError(t, err)
+	ip, port, err := net.SplitHostPort(endpoint)
+	require.NoError(t, err)
 	opts = append(opts,
-		WithRemoteCore(core.GetEndpoint(cfg)),
+		WithRemoteCore(ip, port),
 		WithNetwork(params.Private),
 		WithRPCPort("0"),
 		WithKeyringSigner(TestKeyringSigner(t)),

--- a/node/testing.go
+++ b/node/testing.go
@@ -38,7 +38,7 @@ func TestNode(t *testing.T, tp Type, opts ...Option) *Node {
 	require.NoError(t, err)
 	opts = append(opts,
 		WithRemoteCoreIP(ip),
-		WithRemoteCoreRPCPort(port),
+		WithRemoteCorePort(port),
 		WithNetwork(params.Private),
 		WithRPCPort("0"),
 		WithKeyringSigner(TestKeyringSigner(t)),

--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -65,7 +65,9 @@ func NewSwamp(t *testing.T, options ...Option) *Swamp {
 	core.StartTestNode(ctx, t, ic.App, ic.CoreCfg)
 	endpoint, err := core.GetEndpoint(ic.CoreCfg)
 	require.NoError(t, err)
-	remote, err := core.NewRemote(endpoint)
+	ip, port, err := net.SplitHostPort(endpoint)
+	require.NoError(t, err)
+	remote, err := core.NewRemote(ip, port)
 	require.NoError(t, err)
 
 	err = remote.Start()

--- a/node/tests/swamp/swamp.go
+++ b/node/tests/swamp/swamp.go
@@ -63,8 +63,9 @@ func NewSwamp(t *testing.T, options ...Option) *Swamp {
 	// so, we are not creating bridge nodes with each one containing its own core client
 	// instead we are assigning all created BNs to 1 Core from the swamp
 	core.StartTestNode(ctx, t, ic.App, ic.CoreCfg)
-	protocol, ip := core.GetEndpoint(ic.CoreCfg)
-	remote, err := core.NewRemote(protocol, ip)
+	endpoint, err := core.GetEndpoint(ic.CoreCfg)
+	require.NoError(t, err)
+	remote, err := core.NewRemote(endpoint)
 	require.NoError(t, err)
 
 	err = remote.Start()

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -21,9 +21,10 @@ import (
 type CoreAccessor struct {
 	signer *apptypes.KeyringSigner
 
-	coreEndpoint string
-	coreConn     *grpc.ClientConn
-	queryCli     banktypes.QueryClient
+	coreIP   string
+	grpcPort string
+	coreConn *grpc.ClientConn
+	queryCli banktypes.QueryClient
 }
 
 // NewCoreAccessor dials the given celestia-core endpoint and
@@ -31,11 +32,13 @@ type CoreAccessor struct {
 // connection.
 func NewCoreAccessor(
 	signer *apptypes.KeyringSigner,
-	endpoint string,
+	coreIP,
+	grpcPort string,
 ) *CoreAccessor {
 	return &CoreAccessor{
-		signer:       signer,
-		coreEndpoint: endpoint,
+		signer:   signer,
+		coreIP:   coreIP,
+		grpcPort: grpcPort,
 	}
 }
 
@@ -44,7 +47,8 @@ func (ca *CoreAccessor) Start(ctx context.Context) error {
 		return fmt.Errorf("core-access: already connected to core endpoint")
 	}
 	// dial given celestia-core endpoint
-	client, err := grpc.DialContext(ctx, ca.coreEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	endpoint := fmt.Sprintf("%s:%s", ca.coreIP, ca.grpcPort)
+	client, err := grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
This PR consolidates flags related to adding a core endpoint. The reasoning behind this is to prevent users from having to pass too many flags once #571 is resolved (since the core accessor will now need both a `gRPC` and `RPC` endpoint for the celestia-core connection).

## New flags

**In the case that the default ports are exposed (grpc:9090, rpc:26657) on the celestia-core endpoint**:
```
celestia <node_type> start --core <ip addr of core endpoint>
```
**In the case that custom ports are exposed on the celestia-core endpoint**:
```
celestia <node_type> start --core <ip addr of core endpoint> --core.grpc 9090 --core.rpc 26657
```

If `--core.grpc` || `--core.rpc` are not provided, we assume the defaults and attempt to connect.

