### PR TITLE
feat(node/p2p): enable QUIC by default with the config

### DIFF
--- a/node/p2p/p2p.go
+++ b/node/p2p/p2p.go
@@ -39,11 +39,16 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		ListenAddresses: []string{
+			"/ip4/0.0.0.0/udp/2121/quic",
+			"/ip6/::/udp/2121/quic",
 			"/ip4/0.0.0.0/tcp/2121",
 			"/ip6/::/tcp/2121",
 		},
 		AnnounceAddresses: []string{},
 		NoAnnounceAddresses: []string{
+			"/ip4/0.0.0.0/udp/2121/quic",
+			"/ip4/127.0.0.1/tcp/2121/quic",
+			"/ip6/::/udp/2121/quic",
 			"/ip4/0.0.0.0/tcp/2121",
 			"/ip4/127.0.0.1/tcp/2121",
 			"/ip6/::/tcp/2121",


### PR DESCRIPTION
> Modular software plague warning ⚠️ ☢️ 

This makes our nodes use QUIC by default while still supporting TCP and falling back to it if there is a case. 
As simple as it is. 
 
Fixes #686 