### PR TITLE
docs/adr: Update p2p disc ADR to include bridge node details

### DIFF
--- a/docs/adr/adr-008-p2p-discovery.md
+++ b/docs/adr/adr-008-p2p-discovery.md
@@ -3,6 +3,7 @@
 ## Changelog
 
 - 2022.07.04 - discovery data structure
+- 2022.07.20 - detail bridge node behavior (@renaynay)
 
 ## Authors
 
@@ -47,13 +48,17 @@ type limitedSet struct {
 3. As soon as a new peer is found, the node will try to establish a connection with it. In case the connection is successful
 the node will call [Tag Peer](https://github.com/libp2p/go-libp2p-core/blob/525a0b13017263bde889a3295fa2e4212d7af8c5/connmgr/manager.go#L35) and add peer to the peer set, otherwise discovered peer will be dropped.
 
+### Bridge Nodes behavior:
+Bridge nodes will behave as full nodes, both advertising themselves at the `full` namespace and also actively finding/connecting to other full nodes.
+Bridge nodes do not perform sampling in order to reconstruct blocks since they get block data directly from the core network, but in order to increase the probability of a favourable network topology where `full` nodes are connected to enough nodes that provide enough shares in order to repair an EDS, bridge nodes should also actively connect to other nodes that advertise themselves as `full`.
+For example, while unlikely, it is possible that full nodes can be partitioned from bridge nodes such that they receive a header via gossipsub and try to reconstruct via sampling over that header, but are not connected to enough peers with enough shares to repair the EDS.
+Bridge node active discovery can alleviate this potential edge case by increasing the likelihood of full node <-> bridge node connections such that a wider variety of shares are available to full node such that they can repair the EDS.
 
 ### Light Nodes behavior:
 1. A node starts finding full nodes over DHT at `full` namespace using the `discoverer` interface.
 2. As soon as a new peer is found, the node will try to establish a connection with it. In case the connection is successful
    the node will call [Tag Peer](https://github.com/libp2p/go-libp2p-core/blob/525a0b13017263bde889a3295fa2e4212d7af8c5/connmgr/manager.go#L35) and add peer to the peer set, otherwise discovered peer will be dropped.
 
-*NOTE* Bridge node behaves the same as Full nodes.
 
 Tagging protects connections from ConnManager trimming/GCing. 
 ```go

--- a/docs/adr/adr-008-p2p-discovery.md
+++ b/docs/adr/adr-008-p2p-discovery.md
@@ -3,7 +3,7 @@
 ## Changelog
 
 - 2022.07.04 - discovery data structure
-- 2022.07.20 - detail bridge node behavior (@renaynay)
+- 2022.07.20 - detail bridge node behavior (@renaynay, @Wondertan)
 
 ## Authors
 


### PR DESCRIPTION
https://github.com/celestiaorg/celestia-node/pull/924 sparked a discussion over whether bridge nodes should also perform active discovery or not, and after a discussion with @Wondertan, we agreed that it should for the reasons described in the changes below.