### PR TITLE
feat: `/heath` rpc endpoint

### DIFF
--- a/service/rpc/endpoints.go
+++ b/service/rpc/endpoints.go
@@ -6,6 +6,9 @@ import (
 )
 
 func (h *Handler) RegisterEndpoints(rpc *Server) {
+	// health endpoints
+	rpc.RegisterHandlerFunc(healthEndpoint, h.handleHealthRequest, http.MethodGet)
+
 	// state endpoints
 	rpc.RegisterHandlerFunc(balanceEndpoint, h.handleBalanceRequest, http.MethodGet)
 	rpc.RegisterHandlerFunc(fmt.Sprintf("%s/{%s}", balanceEndpoint, addrKey), h.handleBalanceForAddrRequest,

--- a/service/rpc/health.go
+++ b/service/rpc/health.go
@@ -1,0 +1,30 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const healthEndpoint = "/health"
+
+// HealthResponse represents the response to a
+// `/health` request.
+type HealthResponse struct {
+	Status string `json:"status"`
+}
+
+func (h *Handler) handleHealthRequest(w http.ResponseWriter, r *http.Request) {
+	availResp := &HealthResponse{
+		Status: "ok",
+	}
+
+	resp, err := json.Marshal(availResp)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, healthEndpoint, err)
+		return
+	}
+	_, werr := w.Write(resp)
+	if werr != nil {
+		log.Errorw("serving request", "endpoint", healthEndpoint, "err", err)
+	}
+}

--- a/service/rpc/health.go
+++ b/service/rpc/health.go
@@ -10,12 +10,24 @@ const healthEndpoint = "/health"
 // HealthResponse represents the response to a
 // `/health` request.
 type HealthResponse struct {
-	Status string `json:"status"`
+	StateService  bool             `json:"state_service"`
+	ShareService  bool             `json:"share_service"`
+	DASStatus     DasStateResponse `json:"das_status"`
+	HeaderSyncing bool             `json:"header_syncing"`
 }
 
 func (h *Handler) handleHealthRequest(w http.ResponseWriter, r *http.Request) {
 	availResp := &HealthResponse{
-		Status: "ok",
+		StateService:  !h.state.IsStopped(),
+		ShareService:  !h.share.IsStopped(),
+		HeaderSyncing: h.header.IsSyncing(),
+	}
+
+	if h.das != nil {
+		dasState := new(DasStateResponse)
+		dasState.SampleRoutine = h.das.SampleRoutineState()
+		dasState.CatchUpRoutine = h.das.CatchUpRoutineState()
+		availResp.DASStatus = *dasState
 	}
 
 	resp, err := json.Marshal(availResp)

--- a/service/share/share.go
+++ b/service/share/share.go
@@ -82,7 +82,7 @@ func (s *Service) Start(context.Context) error {
 }
 
 func (s *Service) Stop(context.Context) error {
-	if s.session == nil || s.cancel == nil {
+	if s.IsStopped() {
 		return fmt.Errorf("share: Service already stopped")
 	}
 
@@ -90,6 +90,11 @@ func (s *Service) Stop(context.Context) error {
 	s.cancel = nil
 	s.session = nil
 	return nil
+}
+
+// IsStopped checks if context was canceled.
+func (s *Service) IsStopped() bool {
+	return s.session != nil || s.cancel != nil
 }
 
 func (s *Service) GetShare(ctx context.Context, dah *Root, row, col int) (Share, error) {

--- a/service/share/share.go
+++ b/service/share/share.go
@@ -94,7 +94,7 @@ func (s *Service) Stop(context.Context) error {
 
 // IsStopped checks if context was canceled.
 func (s *Service) IsStopped() bool {
-	return s.session != nil || s.cancel != nil
+	return s.session == nil || s.cancel == nil
 }
 
 func (s *Service) GetShare(ctx context.Context, dah *Root, row, col int) (Share, error) {


### PR DESCRIPTION
Would close #739 ?

If I've understood correctly, the `/health` endpoint is just for checking if the rpc is running - not sure if this is still wanted/necessary though, feel free to delete.

Should more health endpoints be created for any other services? For example, with the new `DASState`, the /daser endpoint seems like a great "health check" to me