### PR TITLE
service/state: Only request balance if node is synced

### DIFF
--- a/header/interface.go
+++ b/header/interface.go
@@ -104,8 +104,7 @@ type Store interface {
 // Getter contains the behavior necessary for a component to retrieve
 // headers that have been processed during header sync.
 type Getter interface {
-	// Head returns the ExtendedHeader of the chain head.
-	Head(context.Context) (*ExtendedHeader, error)
+	Head
 
 	// Get returns the ExtendedHeader corresponding to the given hash.
 	Get(context.Context, tmbytes.HexBytes) (*ExtendedHeader, error)
@@ -115,4 +114,12 @@ type Getter interface {
 
 	// GetRangeByHeight returns the given range [from:to) of ExtendedHeaders.
 	GetRangeByHeight(ctx context.Context, from, to uint64) ([]*ExtendedHeader, error)
+}
+
+// Head contains the behavior necessary for a component to retrieve
+// the chain head. Note that "chain head" is subjective to the component
+// reporting it.
+type Head interface {
+	// Head returns the ExtendedHeader of the chain head.
+	Head(context.Context) (*ExtendedHeader, error)
 }

--- a/header/sync/interface.go
+++ b/header/sync/interface.go
@@ -1,0 +1,10 @@
+package sync
+
+import "context"
+
+// Sub provides a subscription to whether Syncer is
+// synced up to network head.
+type Sub interface {
+	WaitSync(context.Context) error
+	Finished() bool
+}

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -88,6 +88,12 @@ func (s *Syncer) WaitSync(ctx context.Context) error {
 	return err
 }
 
+// Head returns the Syncer's pending head if it exists, and if not, eagerly
+// fetches the head from the header.Exchange.
+func (s *Syncer) Head(ctx context.Context) (*header.ExtendedHeader, error) {
+	return s.trustedHead(ctx)
+}
+
 // State collects all the information about a sync.
 type State struct {
 	ID                   uint64 // incrementing ID of a sync

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -91,7 +91,18 @@ func (s *Syncer) WaitSync(ctx context.Context) error {
 // Head returns the Syncer's pending head if it exists, and if not, eagerly
 // fetches the head from the header.Exchange.
 func (s *Syncer) Head(ctx context.Context) (*header.ExtendedHeader, error) {
-	return s.trustedHead(ctx)
+	// try pending head
+	pendHead := s.pending.Head()
+	if pendHead != nil {
+		return pendHead, nil
+	}
+	// if no pending head, eagerly fetch head from network
+	objHead, err := s.exchange.Head(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.pending.Add(objHead)
+	return objHead, nil
 }
 
 // State collects all the information about a sync.

--- a/node/state/state.go
+++ b/node/state/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/fraud"
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/header/sync"
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/node/core"
 	"github.com/celestiaorg/celestia-node/node/key"
@@ -33,9 +34,10 @@ func Service(
 	lc fx.Lifecycle,
 	accessor state.Accessor,
 	store header.Store,
+	sync *sync.Syncer,
 	fservice fraud.Service,
 ) *state.Service {
-	serv := state.NewService(accessor, store)
+	serv := state.NewService(accessor, store, sync)
 	lifecycleCtx := fxutil.WithLifecycle(ctx, lc)
 	lc.Append(fx.Hook{
 		OnStart: func(startCtx context.Context) error {

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -2,8 +2,6 @@ package state
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/sync"
 	"github.com/celestiaorg/nmt/namespace"
@@ -40,15 +38,17 @@ func (s *Service) SubmitPayForData(
 }
 
 func (s *Service) Balance(ctx context.Context) (*Balance, error) {
-	if !s.sync.Finished() {
-		return nil, fmt.Errorf("node is not synced up to network head yet, balances will not be current")
+	err := s.sync.WaitSync(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return s.accessor.Balance(ctx)
 }
 
 func (s *Service) BalanceForAddress(ctx context.Context, addr Address) (*Balance, error) {
-	if !s.sync.Finished() {
-		return nil, fmt.Errorf("node is not synced up to network head yet, balances will not be current")
+	err := s.sync.WaitSync(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return s.accessor.BalanceForAddress(ctx, addr)
 }

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -2,8 +2,10 @@ package state
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/header/sync"
 	"github.com/celestiaorg/nmt/namespace"
 )
 
@@ -16,13 +18,15 @@ type Service struct {
 	accessor Accessor
 
 	getter header.Getter
+	sync   sync.Sub
 }
 
 // NewService constructs a new state Service.
-func NewService(accessor Accessor, getter header.Getter) *Service {
+func NewService(accessor Accessor, getter header.Getter, sync sync.Sub) *Service {
 	return &Service{
 		accessor: accessor,
 		getter:   getter,
+		sync:     sync,
 	}
 }
 
@@ -40,6 +44,9 @@ func (s *Service) Balance(ctx context.Context) (*Balance, error) {
 }
 
 func (s *Service) BalanceForAddress(ctx context.Context, addr Address) (*Balance, error) {
+	if !s.sync.Finished() {
+		return nil, fmt.Errorf("node is not synced up to network head yet, balances will not be current")
+	}
 	return s.accessor.BalanceForAddress(ctx, addr)
 }
 

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -40,6 +40,9 @@ func (s *Service) SubmitPayForData(
 }
 
 func (s *Service) Balance(ctx context.Context) (*Balance, error) {
+	if !s.sync.Finished() {
+		return nil, fmt.Errorf("node is not synced up to network head yet, balances will not be current")
+	}
 	return s.accessor.Balance(ctx)
 }
 


### PR DESCRIPTION
Since balance retrieval will now rely on the node's chain rather than just proxying the request through to the core node, `/balance` requests will only return successfully if the node is synced to network head.

Based on #911.

TODO: 

- [ ] some sort of mechanism to block until sync service properly starts (recognises the new network head)
- [ ] blocked by #978 