### PR TITLE
header/p2p: set ValidatorData field for header message

### DIFF
--- a/header/p2p/subscriber.go
+++ b/header/p2p/subscriber.go
@@ -54,7 +54,7 @@ func (p *Subscriber) AddValidator(val header.Validator) error {
 				"err", err)
 			return pubsub.ValidationReject
 		}
-
+		msg.ValidatorData = maybeHead
 		return val(ctx, maybeHead)
 	}
 	return p.pubsub.RegisterTopicValidator(PubSubTopic, pval)

--- a/header/p2p/subscription.go
+++ b/header/p2p/subscription.go
@@ -2,6 +2,8 @@ package p2p
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 
@@ -36,15 +38,13 @@ func (s *subscription) NextHeader(ctx context.Context) (*header.ExtendedHeader, 
 	}
 	log.Debugw("received message", "topic", msg.Message.GetTopic(), "sender", msg.ReceivedFrom)
 
-	var header header.ExtendedHeader
-	err = header.UnmarshalBinary(msg.Data)
-	if err != nil {
-		log.Errorw("unmarshalling data from message", "err", err)
-		return nil, err
+	header, ok := msg.ValidatorData.(*header.ExtendedHeader)
+	if !ok {
+		panic(fmt.Sprintf("invalid type received %s", reflect.TypeOf(msg.ValidatorData)))
 	}
 
 	log.Debugw("received new ExtendedHeader", "height", header.Height, "hash", header.Hash())
-	return &header, nil
+	return header, nil
 }
 
 // Cancel cancels the subscription to new ExtendedHeaders from the network.

--- a/header/p2p/subscription_test.go
+++ b/header/p2p/subscription_test.go
@@ -66,6 +66,9 @@ func TestSubscriber(t *testing.T) {
 	_, err = p2pSub2.Subscribe()
 	require.NoError(t, err)
 
+	p2pSub1.AddValidator(func(context.Context, *header.ExtendedHeader) pubsub.ValidationResult { //nolint:errcheck
+		return pubsub.ValidationAccept
+	})
 	subscription, err := p2pSub1.Subscribe()
 	require.NoError(t, err)
 


### PR DESCRIPTION
Second part for #823


Note: ValidatorData for fraud package is implemented in #938 