### PR TITLE
fix(ipld/plugin): verify that data written to namespaceHasher has legit size

### DIFF
--- a/ipld/plugin/nmt.go
+++ b/ipld/plugin/nmt.go
@@ -53,9 +53,19 @@ func NewNamespaceHasher(hasher *nmt.Hasher) hash.Hash {
 }
 
 func (n *namespaceHasher) Write(data []byte) (int, error) {
-	n.tp = data[0]
+	ln, nln, hln := len(data), int(n.NamespaceLen), n.Hash.Size()
+	innerNodeSize, leafNodeSize := (nln*2+hln)*2, nln+consts.ShareSize
+	switch ln {
+	default:
+		return 0, fmt.Errorf("wrong data size")
+	case innerNodeSize, innerNodeSize + 1: // w/ and w/o additional type byte
+		n.tp = nmt.NodePrefix
+	case leafNodeSize, leafNodeSize + 1: // w/ and w/o additional type byte
+		n.tp = nmt.LeafPrefix
+	}
+
 	n.data = data[1:]
-	return len(data), nil
+	return ln, nil
 }
 
 func (n *namespaceHasher) Sum([]byte) []byte {


### PR DESCRIPTION
My understanding of the bug right now is that the bitswap msg that was rcvd from the network had the wrong size of inner nodes hashes, and instead of erroring out, our IPLD plugin panics. It's not clear what could cause the wrong msg size under normal conditions, but it's clear that we have to fix it by checking if the sizes of msgs are correct.

Closes #952 and closes #780