### PR TITLE
feat(Makefile): formatting and linter for markdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ fmt:
 lint:
 	@echo "--> Running linter"
 	@golangci-lint run
-	@markdownlint --config .markdownlint.yaml .
+	@markdownlint --config .markdownlint.yaml '**/*.md'
 .PHONY: lint
 
 ## test-unit: Running unit tests

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,14 @@ fmt:
 	@find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s
 	@find . -name '*.go' -type f -not -path "*.git*"  -not -name '*.pb.go' -not -name '*pb_test.go' | xargs goimports -w -local github.com/celestiaorg
 	@go mod tidy -compat=1.17
+	@markdownlint -fq -c .markdownlint.yaml .
 .PHONY: fmt
 
 ## lint: Linting *.go files using golangci-lint. Look for .golangci.yml for the list of linters.
 lint:
 	@echo "--> Running linter"
 	@golangci-lint run
+	@markdownlint -c .markdownlint.yaml .
 .PHONY: lint
 
 ## test-unit: Running unit tests

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ fmt:
 	@find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s
 	@find . -name '*.go' -type f -not -path "*.git*"  -not -name '*.pb.go' -not -name '*pb_test.go' | xargs goimports -w -local github.com/celestiaorg
 	@go mod tidy -compat=1.17
-	@markdownlint -fq -c .markdownlint.yaml .
+	@markdownlint --fix --quiet --config .markdownlint.yaml .
 .PHONY: fmt
 
 ## lint: Linting *.go files using golangci-lint. Look for .golangci.yml for the list of linters.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ fmt:
 lint:
 	@echo "--> Running linter"
 	@golangci-lint run
-	@markdownlint -c .markdownlint.yaml .
+	@markdownlint --config .markdownlint.yaml .
 .PHONY: lint
 
 ## test-unit: Running unit tests


### PR DESCRIPTION
A simple change; the only problem is that it requires installed `markdownlint` under the PATH. If we don't want this, we can either: ignore the error if not installed or extract into a separate Makefile command

Closes https://github.com/celestiaorg/celestia-node/issues/967