### PR TITLE
feat(ipld): concurrent GetSharesByNamespace

### DIFF
--- a/ipld/get.go
+++ b/ipld/get.go
@@ -2,17 +2,12 @@ package ipld
 
 import (
 	"context"
-	"sort"
-	"sync"
 
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 
 	"github.com/celestiaorg/celestia-node/ipld/plugin"
-	"github.com/celestiaorg/nmt"
-
-	"github.com/celestiaorg/nmt/namespace"
 )
 
 // GetShare fetches and returns the data for leaf `leafIndex` of root `rootCid`.
@@ -126,126 +121,6 @@ func GetProof(
 
 	// recursively walk down through selected children
 	return GetProof(ctx, bGetter, root, proof, leaf, total)
-}
-
-// GetSharesByNamespace returns all the shares from the given root
-// with the given namespace.ID.
-func GetSharesByNamespace(
-	ctx context.Context,
-	bGetter blockservice.BlockGetter,
-	root cid.Cid,
-	nID namespace.ID,
-) ([]Share, error) {
-	leaves := GetLeavesByNamespace(ctx, bGetter, root, nID)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	shares := make([]Share, len(leaves))
-	for i, leaf := range leaves {
-		shares[i] = leafToShare(leaf)
-	}
-
-	return shares, nil
-}
-
-// GetLeavesByNamespace returns all the leaves from the given root with the given namespace.ID.
-// If nothing is found it returns data as nil.
-func GetLeavesByNamespace(
-	ctx context.Context,
-	bGetter blockservice.BlockGetter,
-	root cid.Cid,
-	nID namespace.ID,
-) []ipld.Node {
-	type job struct {
-		id  cid.Cid
-		pos int
-	}
-
-	// TODO: There has to be a more elegant solution
-	// bookkeeping is needed to be able to sort the leaves after the walk
-	type result struct {
-		node ipld.Node
-		pos  int
-	}
-
-	// TODO: Should this be NumWorkersLimit?
-	// we don't know the amount of shares in the namespace, so we cannot preallocate properly
-	jobs := make(chan *job, NumWorkersLimit)
-	jobs <- &job{id: root}
-
-	// the wg counter cannot be preallocated either, it is incremented with each job
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
-	var leaves []result
-	mu := &sync.Mutex{}
-
-	// once the wait group is done, we can close the jobs channel to break the following loop
-	go func() {
-		wg.Wait()
-		close(jobs)
-	}()
-
-	for j := range jobs {
-		j := j
-		// TODO: This is using the pool from get_shares.go, is this okay?
-		pool.Submit(func() {
-			defer wg.Done()
-			err := SanityCheckNID(nID)
-			if err != nil {
-				return
-			}
-
-			rootH := plugin.NamespacedSha256FromCID(j.id)
-			if nID.Less(nmt.MinNamespace(rootH, nID.Size())) || !nID.LessOrEqual(nmt.MaxNamespace(rootH, nID.Size())) {
-				return
-			}
-
-			nd, err := plugin.GetNode(ctx, bGetter, j.id)
-			if err != nil {
-				return
-			}
-
-			lnks := nd.Links()
-			// wg counter should be incremented before adding new jobs
-			if len(lnks) > 1 {
-				wg.Add(len(lnks))
-			}
-
-			if len(lnks) == 1 {
-				mu.Lock()
-				leaves = append(leaves, result{nd, j.pos})
-				mu.Unlock()
-				return
-			}
-
-			for i, lnk := range lnks {
-				select {
-				case jobs <- &job{
-					id:  lnk.Cid,
-					pos: j.pos*2 + i,
-				}:
-				case <-ctx.Done():
-					return
-				}
-			}
-		})
-	}
-
-	if len(leaves) > 0 {
-		sort.SliceStable(leaves, func(i, j int) bool {
-			return leaves[i].pos < leaves[j].pos
-		})
-
-		output := make([]ipld.Node, len(leaves))
-		for i, leaf := range leaves {
-			output[i] = leaf.node
-		}
-		return output
-	}
-
-	return nil
 }
 
 // leafToShare converts an NMT leaf into a Share.

--- a/ipld/get.go
+++ b/ipld/get.go
@@ -208,6 +208,11 @@ func GetLeavesByNamespace(
 			}
 
 			lnks := nd.Links()
+			// wg counter should be incremented before adding new jobs
+			if len(lnks) > 1 {
+				wg.Add(len(lnks))
+			}
+
 			if len(lnks) == 1 {
 				mu.Lock()
 				leaves = append(leaves, result{nd, j.pos})
@@ -221,7 +226,6 @@ func GetLeavesByNamespace(
 					id:  lnk.Cid,
 					pos: j.pos*2 + i,
 				}:
-					wg.Add(1)
 				case <-ctx.Done():
 					return
 				}

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -17,7 +17,7 @@ import (
 	"github.com/celestiaorg/nmt/namespace"
 )
 
-// TODO(@distractedm1nd) Find a better figure than NumWorkersLimit for this pool.
+// TODO(@distractedm1nd) Find a better figure than NumWorkersLimit for this pool. Issue #970
 // namespacePool is a worker pool responsible for the goroutines spawned by getLeavesByNamespace
 var namespacePool = workerpool.New(NumWorkersLimit)
 

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"sync"
 
-	"github.com/celestiaorg/celestia-node/ipld/plugin"
-	"github.com/celestiaorg/nmt"
-	"github.com/celestiaorg/nmt/namespace"
 	"github.com/gammazero/workerpool"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
+
+	"github.com/celestiaorg/celestia-node/ipld/plugin"
+	"github.com/celestiaorg/nmt"
+	"github.com/celestiaorg/nmt/namespace"
 )
 
 // TODO(@distractedm1nd) Should the namespace pool use NumWorkersLimit? This should probably be configurable.

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -2,7 +2,6 @@ package ipld
 
 import (
 	"context"
-	"golang.org/x/sync/errgroup"
 	"sync"
 	"sync/atomic"
 
@@ -14,6 +13,8 @@ import (
 	"github.com/celestiaorg/celestia-node/ipld/plugin"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // TODO(@distractedm1nd) Find a better figure than NumWorkersLimit for this pool.

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -71,18 +71,17 @@ type fetchedBounds struct {
 }
 
 func (b *fetchedBounds) Update(index int64) {
-	for ok := false; !ok; {
-		ok = true
-		if lowest := atomic.LoadInt64(&b.lowest); index < lowest {
-			ok = atomic.CompareAndSwapInt64(&b.lowest, lowest, index)
+	for {
+		lowest := atomic.LoadInt64(&b.lowest)
+		if index >= lowest || atomic.CompareAndSwapInt64(&b.lowest, lowest, index) {
+			break
 		}
 	}
-	// not an `else if` because an element can be both the lower and higher bound
-	// for example, if there is only one share in the namespace
-	for ok := false; !ok; {
-		ok = true
-		if highest := atomic.LoadInt64(&b.highest); index > highest {
-			ok = atomic.CompareAndSwapInt64(&b.highest, highest, index)
+
+	for {
+		highest := atomic.LoadInt64(&b.highest)
+		if index <= highest || atomic.CompareAndSwapInt64(&b.highest, highest, index) {
+			break
 		}
 	}
 }

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -48,16 +48,6 @@ type wrappedWaitGroup struct {
 	counter int64
 }
 
-func createWrappedWaitGroup(jobs chan *job) *wrappedWaitGroup {
-	wg := &wrappedWaitGroup{
-		wg:      sync.WaitGroup{},
-		jobs:    jobs,
-		counter: 0,
-	}
-	wg.Add(1)
-	return wg
-}
-
 func (w *wrappedWaitGroup) Add(count int64) {
 	w.wg.Add(int(count))
 	atomic.AddInt64(&w.counter, count)
@@ -122,7 +112,9 @@ func getLeavesByNamespace(
 	jobs := make(chan *job, (maxShares+1)/2)
 	jobs <- &job{id: root}
 
-	wg := createWrappedWaitGroup(jobs)
+	var wg wrappedWaitGroup
+	wg.jobs = jobs
+	wg.Add(1)
 
 	// we overallocate space for leaves since we do not know how many we will find
 	// on the level above, the length of the Row is passed in as maxShares

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -2,9 +2,10 @@ package ipld
 
 import (
 	"context"
-	"github.com/celestiaorg/nmt"
 	"sync"
 	"sync/atomic"
+
+	"github.com/celestiaorg/nmt"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -16,6 +17,7 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 
 	"github.com/celestiaorg/celestia-node/ipld/plugin"
+
 	"github.com/celestiaorg/nmt/namespace"
 )
 

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -114,8 +114,9 @@ func GetLeavesByNamespace(
 	bounds := fetchedBounds{maxShares, 0}
 	mu := sync.Mutex{}
 
-	// TODO(@distractedm1nd) Can this buffer be smaller? In get_shares it is (shares+1)/2
-	jobs := make(chan *job, maxShares)
+	// buffer the jobs to avoid blocking, we only need as many
+	// queued as the number of shares in the second-to-last layer
+	jobs := make(chan *job, (maxShares+1)/2)
 	jobs <- &job{id: root}
 
 	// the wg counter cannot be preallocated either, it is incremented with each job

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -74,14 +74,9 @@ func GetLeavesByNamespace(
 	root cid.Cid,
 	nID namespace.ID,
 ) []ipld.Node {
-	type job struct {
-		id  cid.Cid
-		pos int
-	}
-
-	// TODO: There has to be a more elegant solution
 	// bookkeeping is needed to be able to sort the leaves after the walk
-	type result struct {
+	type job struct {
+		id   cid.Cid
 		node ipld.Node
 		pos  int
 	}
@@ -95,7 +90,7 @@ func GetLeavesByNamespace(
 	wg := WrappedWaitGroup{sync.WaitGroup{}, sync.Mutex{}, 0}
 	wg.Add(1)
 
-	var leaves []result
+	var leaves []job
 	mu := &sync.Mutex{}
 
 	for wg.IsWorking() {
@@ -126,7 +121,7 @@ func GetLeavesByNamespace(
 					wg.Add(linkCount)
 				} else if linkCount == 1 {
 					mu.Lock()
-					leaves = append(leaves, result{nd, j.pos})
+					leaves = append(leaves, job{nd.Cid(), nd, j.pos})
 					mu.Unlock()
 					return
 				}

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -1,0 +1,165 @@
+package ipld
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/celestiaorg/celestia-node/ipld/plugin"
+	"github.com/celestiaorg/nmt"
+	"github.com/celestiaorg/nmt/namespace"
+	"github.com/gammazero/workerpool"
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+// TODO(@distractedm1nd) Should the namespace pool use NumWorkersLimit? This should probably be configurable.
+// Worker pool responsible for the goroutines spawned by GetLeavesByNamespace
+var namespacePool = workerpool.New(NumWorkersLimit)
+
+// GetSharesByNamespace returns all the shares from the given root
+// with the given namespace.ID.
+func GetSharesByNamespace(
+	ctx context.Context,
+	bGetter blockservice.BlockGetter,
+	root cid.Cid,
+	nID namespace.ID,
+) ([]Share, error) {
+	leaves := GetLeavesByNamespace(ctx, bGetter, root, nID)
+
+	shares := make([]Share, len(leaves))
+	for i, leaf := range leaves {
+		shares[i] = leafToShare(leaf)
+	}
+
+	return shares, nil
+}
+
+type WrappedWaitGroup struct {
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	counter int
+}
+
+func (w *WrappedWaitGroup) Add(count int) {
+	w.wg.Add(count)
+	w.mu.Lock()
+	w.counter += count
+	w.mu.Unlock()
+}
+
+func (w *WrappedWaitGroup) Done() {
+	w.wg.Done()
+	w.mu.Lock()
+	w.counter--
+	w.mu.Unlock()
+}
+
+func (w *WrappedWaitGroup) Wait() {
+	w.wg.Wait()
+}
+
+func (w *WrappedWaitGroup) IsWorking() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.counter > 0
+}
+
+// GetLeavesByNamespace returns all the leaves from the given root with the given namespace.ID.
+// If nothing is found it returns data as nil.
+func GetLeavesByNamespace(
+	ctx context.Context,
+	bGetter blockservice.BlockGetter,
+	root cid.Cid,
+	nID namespace.ID,
+) []ipld.Node {
+	type job struct {
+		id  cid.Cid
+		pos int
+	}
+
+	// TODO: There has to be a more elegant solution
+	// bookkeeping is needed to be able to sort the leaves after the walk
+	type result struct {
+		node ipld.Node
+		pos  int
+	}
+
+	// TODO: Should this be NumWorkersLimit?
+	// we don't know the amount of shares in the namespace, so we cannot preallocate properly
+	jobs := make(chan *job, NumWorkersLimit)
+	jobs <- &job{id: root}
+
+	// the wg counter cannot be preallocated either, it is incremented with each job
+	wg := WrappedWaitGroup{sync.WaitGroup{}, sync.Mutex{}, 0}
+	wg.Add(1)
+
+	var leaves []result
+	mu := &sync.Mutex{}
+
+	for wg.IsWorking() {
+		select {
+		case j := <-jobs:
+			namespacePool.Submit(func() {
+				defer wg.Done()
+
+				err := SanityCheckNID(nID)
+				if err != nil {
+					return
+				}
+
+				rootH := plugin.NamespacedSha256FromCID(j.id)
+				if nID.Less(nmt.MinNamespace(rootH, nID.Size())) || !nID.LessOrEqual(nmt.MaxNamespace(rootH, nID.Size())) {
+					return
+				}
+
+				nd, err := plugin.GetNode(ctx, bGetter, j.id)
+				if err != nil {
+					return
+				}
+
+				lnks := nd.Links()
+				linkCount := len(lnks)
+				// wg counter should be incremented before adding new jobs
+				if linkCount > 1 {
+					wg.Add(linkCount)
+				} else if linkCount == 1 {
+					mu.Lock()
+					leaves = append(leaves, result{nd, j.pos})
+					mu.Unlock()
+					return
+				}
+
+				for i, lnk := range lnks {
+					select {
+					case jobs <- &job{
+						id:  lnk.Cid,
+						pos: j.pos*2 + i,
+					}:
+					case <-ctx.Done():
+						return
+					}
+				}
+			})
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
+
+	wg.Wait()
+	if len(leaves) > 0 {
+		sort.Slice(leaves, func(i, j int) bool {
+			return leaves[i].pos < leaves[j].pos
+		})
+
+		output := make([]ipld.Node, len(leaves))
+		for i, leaf := range leaves {
+			output[i] = leaf.node
+		}
+		return output
+	}
+
+	return nil
+}

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -48,7 +48,7 @@ type wrappedWaitGroup struct {
 	counter int64
 }
 
-func CreateWrappedWaitGroup(jobs chan *job) *wrappedWaitGroup {
+func createWrappedWaitGroup(jobs chan *job) *wrappedWaitGroup {
 	wg := &wrappedWaitGroup{
 		wg:      sync.WaitGroup{},
 		jobs:    jobs,
@@ -122,7 +122,7 @@ func getLeavesByNamespace(
 	jobs := make(chan *job, (maxShares+1)/2)
 	jobs <- &job{id: root}
 
-	wg := CreateWrappedWaitGroup(jobs)
+	wg := createWrappedWaitGroup(jobs)
 
 	// we overallocate space for leaves since we do not know how many we will find
 	// on the level above, the length of the Row is passed in as maxShares

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -138,7 +138,7 @@ func getLeavesByNamespace(
 	wg.Add(1)
 
 	// we use an errgroup so that only the first encountered retrieval error is returned
-	retrievalErr, ctx := errgroup.WithContext(ctx)
+	var retrievalErr errgroup.Group
 
 	// we overallocate space for leaves since we do not know how many we will find
 	// on the level above, the length of the Row is passed in as maxShares
@@ -175,9 +175,8 @@ func getLeavesByNamespace(
 					span.RecordError(err, trace.WithAttributes(
 						attribute.Int("pos", j.pos),
 					))
-					// we need to explicitly write nil at the index,
-					// for the case that the final share cannot be fetched
-					leaves[j.pos] = nil
+					// we still need to update the bounds
+					bounds.Update(int64(j.pos))
 					return
 				}
 

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -190,7 +190,6 @@ func getLeavesByNamespace(
 
 				// this node has links in the namespace, so keep walking
 				for i, lnk := range links {
-
 					newJob := &job{
 						id: lnk.Cid,
 						// position represents the index in a flattened binary tree,
@@ -207,7 +206,6 @@ func getLeavesByNamespace(
 					// by passing the previous check, we know we will have one more node to process
 					// note: it is important to increase the counter before sending to the channel
 					wg.Add(1)
-
 					select {
 					case jobs <- newJob:
 						span.AddEvent("added-job", trace.WithAttributes(
@@ -220,7 +218,7 @@ func getLeavesByNamespace(
 				}
 			})
 		case <-ctx.Done():
-			return nil, retrievalErr
+			return nil, ctx.Err()
 		}
 	}
 }

--- a/ipld/get_namespaced_shares.go
+++ b/ipld/get_namespaced_shares.go
@@ -2,10 +2,12 @@ package ipld
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"sync"
 	"sync/atomic"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/gammazero/workerpool"
 	"github.com/ipfs/go-blockservice"

--- a/ipld/get_shares.go
+++ b/ipld/get_shares.go
@@ -2,6 +2,8 @@ package ipld
 
 import (
 	"context"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"sync"
 
 	"github.com/gammazero/workerpool"
@@ -52,6 +54,9 @@ var pool = workerpool.New(NumWorkersLimit)
 // implementation that rely on this property are explicitly tagged with
 // (bin-tree-feat).
 func GetShares(ctx context.Context, bGetter blockservice.BlockGetter, root cid.Cid, shares int, put func(int, Share)) {
+	ctx, span := tracer.Start(ctx, "get-shares")
+	defer span.End()
+
 	// this buffer ensures writes to 'jobs' are never blocking (bin-tree-feat)
 	jobs := make(chan *job, (shares+1)/2) // +1 for the case where 'shares' is 1
 	jobs <- &job{id: root}
@@ -68,7 +73,10 @@ func GetShares(ctx context.Context, bGetter blockservice.BlockGetter, root cid.C
 			// work over each job concurrently, s.t. shares do not block
 			// processing of each other
 			pool.Submit(func() {
+				ctx, span := tracer.Start(ctx, "process-job")
+				defer span.End()
 				defer wg.Done()
+
 				nd, err := plugin.GetNode(ctx, bGetter, j.id)
 				if err != nil {
 					// we don't really care about errors here
@@ -82,11 +90,13 @@ func GetShares(ctx context.Context, bGetter blockservice.BlockGetter, root cid.C
 					// leaf has its own additional leaf(hack) so get it
 					nd, err := plugin.GetNode(ctx, bGetter, lnks[0].Cid)
 					if err != nil {
-						// again, we don't care
+						// again, we don't really care much, just fetch as much as possible
+						span.RecordError(err)
 						return
 					}
 					// successfully fetched a share/leaf
 					// ladies and gentlemen, we got em!
+					span.AddEvent("found-leaf")
 					put(j.pos, leafToShare(nd))
 					return
 				}
@@ -100,6 +110,10 @@ func GetShares(ctx context.Context, bGetter blockservice.BlockGetter, root cid.C
 						// s.t. 'if' above knows where to put a share
 						pos: j.pos*2 + i,
 					}:
+						span.AddEvent("added-job", trace.WithAttributes(
+							attribute.String("cid", lnk.Cid.String()),
+							attribute.Int("pos", j.pos*2+i),
+						))
 					case <-ctx.Done():
 						return
 					}

--- a/ipld/get_shares.go
+++ b/ipld/get_shares.go
@@ -52,11 +52,6 @@ var pool = workerpool.New(NumWorkersLimit)
 // implementation that rely on this property are explicitly tagged with
 // (bin-tree-feat).
 func GetShares(ctx context.Context, bGetter blockservice.BlockGetter, root cid.Cid, shares int, put func(int, Share)) {
-	// job is not used anywhere else, so can be kept here
-	type job struct {
-		id  cid.Cid
-		pos int
-	}
 	// this buffer ensures writes to 'jobs' are never blocking (bin-tree-feat)
 	jobs := make(chan *job, (shares+1)/2) // +1 for the case where 'shares' is 1
 	jobs <- &job{id: root}

--- a/ipld/get_shares.go
+++ b/ipld/get_shares.go
@@ -1,10 +1,12 @@
 package ipld
 
 import (
-	"context"
+	"sync"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"sync"
+
+	"context"
 
 	"github.com/gammazero/workerpool"
 	"github.com/ipfs/go-blockservice"

--- a/ipld/get_test.go
+++ b/ipld/get_test.go
@@ -255,8 +255,7 @@ func TestGetLeavesByNamespace_MultipleRowsContainingSameNamespaceId(t *testing.T
 
 	for _, row := range eds.RowRoots() {
 		rcid := plugin.MustCidFromNamespacedSha256(row)
-		nodes, err := GetLeavesByNamespace(ctx, bServ, rcid, nid)
-		require.NoError(t, err)
+		nodes := GetLeavesByNamespace(ctx, bServ, rcid, nid)
 
 		for _, node := range nodes {
 			// test that the data returned by GetLeavesByNamespace for nid
@@ -317,9 +316,8 @@ func assertNoRowContainsNID(
 
 	// for each row root cid check if the minNID exists
 	for _, rowCID := range rowRootCIDs {
-		data, err := GetLeavesByNamespace(context.Background(), bServ, rowCID, nID)
+		data := GetLeavesByNamespace(context.Background(), bServ, rowCID, nID)
 		assert.Nil(t, data)
-		assert.Nil(t, err)
 	}
 }
 

--- a/ipld/get_test.go
+++ b/ipld/get_test.go
@@ -206,24 +206,25 @@ func TestGetLeavesByNamespace_IncompleteData(t *testing.T) {
 	// remove the second share from the first row
 	rcid := plugin.MustCidFromNamespacedSha256(roots[0])
 	node, err := plugin.GetNode(ctx, bServ, rcid)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Left side of the tree contains the original shares
 	data, err := plugin.GetNode(ctx, bServ, node.Links()[0].Cid)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Second share is the left side's right child
 	l, err := plugin.GetNode(ctx, bServ, data.Links()[0].Cid)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	r, err := plugin.GetNode(ctx, bServ, l.Links()[1].Cid)
+	require.NoError(t, err)
 	err = bServ.DeleteBlock(ctx, r.Cid())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	nodes, err := getLeavesByNamespace(ctx, bServ, rcid, nid, len(shares))
 	assert.Equal(t, nil, nodes[1])
 	// TODO(distractedm1nd): Decide if we should return an array containing nil
 	assert.Equal(t, 4, len(nodes))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetLeavesByNamespace_AbsentNamespaceId(t *testing.T) {

--- a/ipld/get_test.go
+++ b/ipld/get_test.go
@@ -169,7 +169,7 @@ func TestGetSharesByNamespace(t *testing.T) {
 
 			for _, row := range eds.RowRoots() {
 				rcid := plugin.MustCidFromNamespacedSha256(row)
-				shares, err := GetSharesByNamespace(ctx, bServ, rcid, nID)
+				shares, err := GetSharesByNamespace(ctx, bServ, rcid, nID, len(eds.RowRoots()))
 				require.NoError(t, err)
 
 				for _, share := range shares {
@@ -255,7 +255,7 @@ func TestGetLeavesByNamespace_MultipleRowsContainingSameNamespaceId(t *testing.T
 
 	for _, row := range eds.RowRoots() {
 		rcid := plugin.MustCidFromNamespacedSha256(row)
-		nodes := GetLeavesByNamespace(ctx, bServ, rcid, nid)
+		nodes := GetLeavesByNamespace(ctx, bServ, rcid, nid, len(shares))
 
 		for _, node := range nodes {
 			// test that the data returned by GetLeavesByNamespace for nid
@@ -308,15 +308,16 @@ func assertNoRowContainsNID(
 	eds *rsmt2d.ExtendedDataSquare,
 	nID namespace.ID,
 ) {
+	rowRootCount := len(eds.RowRoots())
 	// get all row root cids
-	rowRootCIDs := make([]cid.Cid, len(eds.RowRoots()))
+	rowRootCIDs := make([]cid.Cid, rowRootCount)
 	for i, rowRoot := range eds.RowRoots() {
 		rowRootCIDs[i] = plugin.MustCidFromNamespacedSha256(rowRoot)
 	}
 
 	// for each row root cid check if the minNID exists
 	for _, rowCID := range rowRootCIDs {
-		data := GetLeavesByNamespace(context.Background(), bServ, rowCID, nID)
+		data := GetLeavesByNamespace(context.Background(), bServ, rowCID, nID, rowRootCount)
 		assert.Nil(t, data)
 	}
 }

--- a/ipld/get_test.go
+++ b/ipld/get_test.go
@@ -180,6 +180,52 @@ func TestGetSharesByNamespace(t *testing.T) {
 	}
 }
 
+func TestGetLeavesByNamespace_IncompleteData(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	bServ := mdutils.Bserv()
+
+	shares := RandShares(t, 16)
+
+	// set all shares to the same namespace id
+	nid := shares[0][:NamespaceSize]
+
+	for i, nspace := range shares {
+		if i == len(shares) {
+			break
+		}
+
+		copy(nspace[:NamespaceSize], nid)
+	}
+
+	eds, err := AddShares(ctx, shares, bServ)
+	require.NoError(t, err)
+
+	roots := eds.RowRoots()
+
+	// remove the second share from the first row
+	rcid := plugin.MustCidFromNamespacedSha256(roots[0])
+	node, err := plugin.GetNode(ctx, bServ, rcid)
+	assert.Nil(t, err)
+
+	// Left side of the tree contains the original shares
+	data, err := plugin.GetNode(ctx, bServ, node.Links()[0].Cid)
+	assert.Nil(t, err)
+
+	// Second share is the left side's right child
+	l, err := plugin.GetNode(ctx, bServ, data.Links()[0].Cid)
+	assert.Nil(t, err)
+	r, err := plugin.GetNode(ctx, bServ, l.Links()[1].Cid)
+	err = bServ.DeleteBlock(ctx, r.Cid())
+	assert.Nil(t, err)
+
+	nodes, err := getLeavesByNamespace(ctx, bServ, rcid, nid, len(shares))
+	assert.Equal(t, nil, nodes[1])
+	// TODO(distractedm1nd): Decide if we should return an array containing nil
+	assert.Equal(t, 4, len(nodes))
+	assert.Error(t, err)
+}
+
 func TestGetLeavesByNamespace_AbsentNamespaceId(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/ipld/get_test.go
+++ b/ipld/get_test.go
@@ -255,10 +255,11 @@ func TestGetLeavesByNamespace_MultipleRowsContainingSameNamespaceId(t *testing.T
 
 	for _, row := range eds.RowRoots() {
 		rcid := plugin.MustCidFromNamespacedSha256(row)
-		nodes := GetLeavesByNamespace(ctx, bServ, rcid, nid, len(shares))
+		nodes, err := getLeavesByNamespace(ctx, bServ, rcid, nid, len(shares))
+		assert.Nil(t, err)
 
 		for _, node := range nodes {
-			// test that the data returned by GetLeavesByNamespace for nid
+			// test that the data returned by getLeavesByNamespace for nid
 			// matches the commonNamespaceData that was copied across almost all data
 			share := node.RawData()[1:]
 			assert.Equal(t, commonNamespaceData, share[NamespaceSize:])
@@ -317,8 +318,9 @@ func assertNoRowContainsNID(
 
 	// for each row root cid check if the minNID exists
 	for _, rowCID := range rowRootCIDs {
-		data := GetLeavesByNamespace(context.Background(), bServ, rowCID, nID, rowRootCount)
+		data, err := getLeavesByNamespace(context.Background(), bServ, rowCID, nID, rowRootCount)
 		assert.Nil(t, data)
+		assert.Nil(t, err)
 	}
 }
 

--- a/ipld/helpers.go
+++ b/ipld/helpers.go
@@ -1,8 +1,9 @@
 package ipld
 
 import (
-	"fmt"
 	"github.com/ipfs/go-cid"
+
+	"fmt"
 )
 
 // job represents an encountered node to investigate during the `GetShares` and `GetSharesByNamespace` routines

--- a/ipld/helpers.go
+++ b/ipld/helpers.go
@@ -1,12 +1,12 @@
 package ipld
 
 import (
-	"github.com/ipfs/go-cid"
-
 	"fmt"
+
+	"github.com/ipfs/go-cid"
 )
 
-// job represents an encountered node to investigate during the `GetShares` and `GetSharesByNamespace` routines
+// job represents an encountered node to investigate during the `GetShares` and `GetSharesByNamespace` routines.
 type job struct {
 	id  cid.Cid
 	pos int

--- a/ipld/helpers.go
+++ b/ipld/helpers.go
@@ -1,6 +1,15 @@
 package ipld
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/ipfs/go-cid"
+)
+
+// job represents an encountered node to investigate during the `GetShares` and `GetSharesByNamespace` routines
+type job struct {
+	id  cid.Cid
+	pos int
+}
 
 func SanityCheckNID(nID []byte) error {
 	if len(nID) != NamespaceSize {

--- a/service/share/share.go
+++ b/service/share/share.go
@@ -122,6 +122,7 @@ func (s *Service) GetShares(ctx context.Context, root *Root) ([][]Share, error) 
 	return shares, nil
 }
 
+// GetSharesByNamespace iterates over a square's row roots and accumulates the found shares in the given namespace.ID.
 func (s *Service) GetSharesByNamespace(ctx context.Context, root *Root, nID namespace.ID) ([]Share, error) {
 	err := ipld.SanityCheckNID(nID)
 	if err != nil {

--- a/service/share/share.go
+++ b/service/share/share.go
@@ -143,7 +143,7 @@ func (s *Service) GetSharesByNamespace(ctx context.Context, root *Root, nID name
 		// shadow loop variables, to ensure correct values are captured
 		i, rootCID := i, rootCID
 		errGroup.Go(func() (err error) {
-			shares[i], err = ipld.GetSharesByNamespace(ctx, s.bServ, rootCID, nID)
+			shares[i], err = ipld.GetSharesByNamespace(ctx, s.bServ, rootCID, nID, len(root.RowsRoots))
 			return
 		})
 	}


### PR DESCRIPTION
Closes #697. Still very much a WIP, so a draft, have some open questions:

- [X] I feel like there should be a more elegant solution to keeping the leaves in order during the walk, so that we can avoid sorting afterwards. Haven't really been able to figure it out yet though `Answer: Overallocation is possible`
- [X] Should we be using the same pool from `get_shares.go`? `Answer: No`
- [X] Since we cannot preallocate the number of shares in the namespace, I buffered the channel with `NumWorkersLimit`. Does this make sense? `Answer: No`
- [X] Since the `job` struct is now in two locations, should we export it somewhere? I have a feeling that it may be too early to abstract it `Answer: Exported`
- [X]  `GetLeavesByNamespace` doesn't return an error anymore, felt right but still not 100% sure about it `Answer: now returns error again`