### PR TITLE
feat(rpc): Transaction proxy for staking tx types

### DIFF
--- a/cmd/cel-key/main.go
+++ b/cmd/cel-key/main.go
@@ -62,6 +62,7 @@ func main() {
 func run() error {
 	cfg := sdk.GetConfig()
 	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
+	cfg.SetBech32PrefixForValidator(app.Bech32PrefixValAddr, app.Bech32PrefixValPub)
 	cfg.Seal()
 
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &initClientCtx)

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -18,6 +18,7 @@ func init() {
 	// as in the celestia application.
 	cfg := sdk.GetConfig()
 	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
+	cfg.SetBech32PrefixForValidator(app.Bech32PrefixValAddr, app.Bech32PrefixValPub)
 	cfg.Seal()
 
 	rootCmd.AddCommand(

--- a/service/rpc/endpoints.go
+++ b/service/rpc/endpoints.go
@@ -13,6 +13,10 @@ func (h *Handler) RegisterEndpoints(rpc *Server) {
 	rpc.RegisterHandlerFunc(submitTxEndpoint, h.handleSubmitTx, http.MethodPost)
 	rpc.RegisterHandlerFunc(submitPFDEndpoint, h.handleSubmitPFD, http.MethodPost)
 	rpc.RegisterHandlerFunc(transferEndpoint, h.handleTransfer, http.MethodPost)
+	rpc.RegisterHandlerFunc(delegationEndpoint, h.handleDelegation, http.MethodPost)
+	rpc.RegisterHandlerFunc(undelegationEndpoint, h.handleUndelegation, http.MethodPost)
+	rpc.RegisterHandlerFunc(cancelUnbondingEndpoint, h.handleCancelUnbonding, http.MethodPost)
+	rpc.RegisterHandlerFunc(beginRedelegationEndpoint, h.handleRedelegation, http.MethodPost)
 
 	// share endpoints
 	rpc.RegisterHandlerFunc(fmt.Sprintf("%s/{%s}/height/{%s}", namespacedSharesEndpoint, nIDKey, heightKey),

--- a/service/rpc/state.go
+++ b/service/rpc/state.go
@@ -13,10 +13,14 @@ import (
 )
 
 const (
-	balanceEndpoint   = "/balance"
-	submitTxEndpoint  = "/submit_tx"
-	submitPFDEndpoint = "/submit_pfd"
-	transferEndpoint  = "/transfer"
+	balanceEndpoint           = "/balance"
+	submitTxEndpoint          = "/submit_tx"
+	submitPFDEndpoint         = "/submit_pfd"
+	transferEndpoint          = "/transfer"
+	delegationEndpoint        = "/delegate"
+	undelegationEndpoint      = "/begin_unbonding"
+	cancelUnbondingEndpoint   = "/cancel_unbond"
+	beginRedelegationEndpoint = "/begin_redelegate"
 )
 
 var addrKey = "address"
@@ -35,6 +39,21 @@ type submitPFDRequest struct {
 }
 
 type transferRequest struct {
+	To       string `json:"to"`
+	Amount   int64  `json:"amount"`
+	GasLimit uint64 `json:"gas_limit"`
+}
+
+// delegationRequest represents a request for both delegation
+// and for beginning and canceling undelegation
+type delegationRequest struct {
+	To       string `json:"to"`
+	Amount   int64  `json:"amount"`
+	GasLimit uint64 `json:"gas_limit"`
+}
+
+type redelegationRequest struct {
+	From     string `json:"from"`
 	To       string `json:"to"`
 	Amount   int64  `json:"amount"`
 	GasLimit uint64 `json:"gas_limit"`
@@ -170,5 +189,146 @@ func (h *Handler) handleTransfer(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write(resp)
 	if err != nil {
 		log.Errorw("writing response", "endpoint", transferEndpoint, "err", err)
+	}
+}
+
+func (h *Handler) handleDelegation(w http.ResponseWriter, r *http.Request) {
+	var req delegationRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, delegationEndpoint, err)
+		return
+	}
+	if req.Amount <= 0 {
+		writeError(w, http.StatusBadRequest, delegationEndpoint, errors.New("amount must be greater than 0"))
+		return
+	}
+	addr, err := types.ValAddressFromBech32(req.To)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, delegationEndpoint, err)
+		return
+	}
+	amount := types.NewInt(req.Amount)
+
+	txResp, err := h.state.Delegate(r.Context(), addr, amount, req.GasLimit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, delegationEndpoint, err)
+		return
+	}
+	resp, err := json.Marshal(txResp)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, delegationEndpoint, err)
+		return
+	}
+	_, err = w.Write(resp)
+	if err != nil {
+		log.Errorw("writing response", "endpoint", delegationEndpoint, "err", err)
+	}
+}
+
+func (h *Handler) handleUndelegation(w http.ResponseWriter, r *http.Request) {
+	var req delegationRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, undelegationEndpoint, err)
+		return
+	}
+	if req.Amount <= 0 {
+		writeError(w, http.StatusBadRequest, undelegationEndpoint, errors.New("amount must be greater than 0"))
+		return
+	}
+	addr, err := types.ValAddressFromBech32(req.To)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, undelegationEndpoint, err)
+		return
+	}
+	amount := types.NewInt(req.Amount)
+
+	txResp, err := h.state.Undelegate(r.Context(), addr, amount, req.GasLimit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, undelegationEndpoint, err)
+		return
+	}
+	resp, err := json.Marshal(txResp)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, undelegationEndpoint, err)
+		return
+	}
+	_, err = w.Write(resp)
+	if err != nil {
+		log.Errorw("writing response", "endpoint", undelegationEndpoint, "err", err)
+	}
+}
+
+func (h *Handler) handleCancelUnbonding(w http.ResponseWriter, r *http.Request) {
+	var req delegationRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, cancelUnbondingEndpoint, err)
+		return
+	}
+	if req.Amount <= 0 {
+		writeError(w, http.StatusBadRequest, cancelUnbondingEndpoint, errors.New("amount must be greater than 0"))
+		return
+	}
+	addr, err := types.ValAddressFromBech32(req.To)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, cancelUnbondingEndpoint, err)
+		return
+	}
+	amount := types.NewInt(req.Amount)
+
+	txResp, err := h.state.CancelUnbondingDelegation(r.Context(), addr, amount, req.GasLimit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, cancelUnbondingEndpoint, err)
+		return
+	}
+	resp, err := json.Marshal(txResp)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, cancelUnbondingEndpoint, err)
+		return
+	}
+	_, err = w.Write(resp)
+	if err != nil {
+		log.Errorw("writing response", "endpoint", cancelUnbondingEndpoint, "err", err)
+	}
+}
+
+func (h *Handler) handleRedelegation(w http.ResponseWriter, r *http.Request) {
+	var req redelegationRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, beginRedelegationEndpoint, err)
+		return
+	}
+	if req.Amount <= 0 {
+		writeError(w, http.StatusBadRequest, beginRedelegationEndpoint, errors.New("amount must be greater than 0"))
+		return
+	}
+	srcAddr, err := types.ValAddressFromBech32(req.From)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, beginRedelegationEndpoint, err)
+		return
+	}
+	dstAddr, err := types.ValAddressFromBech32(req.To)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, beginRedelegationEndpoint, err)
+		return
+	}
+	amount := types.NewInt(req.Amount)
+
+	txResp, err := h.state.BeginRedelegate(r.Context(), srcAddr, dstAddr, amount, req.GasLimit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, beginRedelegationEndpoint, err)
+		return
+	}
+	resp, err := json.Marshal(txResp)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, beginRedelegationEndpoint, err)
+		return
+	}
+	_, err = w.Write(resp)
+	if err != nil {
+		log.Errorw("writing response", "endpoint", beginRedelegationEndpoint, "err", err)
 	}
 }

--- a/service/rpc/state.go
+++ b/service/rpc/state.go
@@ -52,6 +52,7 @@ type delegationRequest struct {
 	GasLimit uint64 `json:"gas_limit"`
 }
 
+// delegationRequest represents a request for redelegation
 type redelegationRequest struct {
 	From     string `json:"from"`
 	To       string `json:"to"`

--- a/service/rpc/state.go
+++ b/service/rpc/state.go
@@ -52,7 +52,7 @@ type delegationRequest struct {
 	GasLimit uint64 `json:"gas_limit"`
 }
 
-// delegationRequest represents a request for redelegation
+// redelegationRequest represents a request for redelegation
 type redelegationRequest struct {
 	From     string `json:"from"`
 	To       string `json:"to"`

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -239,7 +239,6 @@ func (ca *CoreAccessor) CancelUnbondingDelegation(
 		return nil, err
 	}
 	coins := sdktypes.NewCoin(app.BondDenom, amount)
-	// TODO(distractedm1nd): Is this the best way to be getting the height? Should it be head.Height or head.Height - 1?
 	head, err := ca.getter.Head(ctx)
 	if err != nil {
 		return nil, err

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -227,7 +227,8 @@ func (ca *CoreAccessor) Transfer(
 func (ca *CoreAccessor) CancelUnbondingDelegation(
 	ctx context.Context,
 	valAddr Address,
-	amount Int,
+	amount,
+	height Int,
 	gasLim uint64,
 ) (*TxResponse, error) {
 	validator, ok := valAddr.(sdktypes.ValAddress)
@@ -239,11 +240,7 @@ func (ca *CoreAccessor) CancelUnbondingDelegation(
 		return nil, err
 	}
 	coins := sdktypes.NewCoin(app.BondDenom, amount)
-	head, err := ca.getter.Head(ctx)
-	if err != nil {
-		return nil, err
-	}
-	msg := stakingtypes.NewMsgCancelUnbondingDelegation(from, validator, head.Height, coins)
+	msg := stakingtypes.NewMsgCancelUnbondingDelegation(from, validator, height.Int64(), coins)
 	signedTx, err := ca.constructSignedTx(ctx, msg, apptypes.SetGasLimit(gasLim))
 	if err != nil {
 		return nil, err

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -226,11 +226,11 @@ func (ca *CoreAccessor) Transfer(
 
 func (ca *CoreAccessor) CancelUnbondingDelegation(
 	ctx context.Context,
-	validator Address,
+	valAddr Address,
 	amount Int,
 	gasLim uint64,
 ) (*TxResponse, error) {
-	valAddr, ok := validator.(sdktypes.ValAddress)
+	validator, ok := valAddr.(sdktypes.ValAddress)
 	if !ok {
 		return nil, fmt.Errorf("state: unsupported address type")
 	}
@@ -244,7 +244,7 @@ func (ca *CoreAccessor) CancelUnbondingDelegation(
 	if err != nil {
 		return nil, err
 	}
-	msg := stakingtypes.NewMsgCancelUnbondingDelegation(from, valAddr, head.Height, coins)
+	msg := stakingtypes.NewMsgCancelUnbondingDelegation(from, validator, head.Height, coins)
 	signedTx, err := ca.constructSignedTx(ctx, msg, apptypes.SetGasLimit(gasLim))
 	if err != nil {
 		return nil, err
@@ -254,16 +254,16 @@ func (ca *CoreAccessor) CancelUnbondingDelegation(
 
 func (ca *CoreAccessor) BeginRedelegate(
 	ctx context.Context,
-	delAddr Address,
-	newValidatorAddr Address,
+	srcValAddr,
+	dstValAddr Address,
 	amount Int,
 	gasLim uint64,
 ) (*TxResponse, error) {
-	srcValAddr, ok := delAddr.(sdktypes.ValAddress)
+	srcValidator, ok := srcValAddr.(sdktypes.ValAddress)
 	if !ok {
 		return nil, fmt.Errorf("state: unsupported address type")
 	}
-	dstValAddr, ok := newValidatorAddr.(sdktypes.ValAddress)
+	dstValidator, ok := dstValAddr.(sdktypes.ValAddress)
 	if !ok {
 		return nil, fmt.Errorf("state: unsupported address type")
 	}
@@ -272,7 +272,7 @@ func (ca *CoreAccessor) BeginRedelegate(
 		return nil, err
 	}
 	coins := sdktypes.NewCoin(app.BondDenom, amount)
-	msg := stakingtypes.NewMsgBeginRedelegate(from, srcValAddr, dstValAddr, coins)
+	msg := stakingtypes.NewMsgBeginRedelegate(from, srcValidator, dstValidator, coins)
 	signedTx, err := ca.constructSignedTx(ctx, msg, apptypes.SetGasLimit(gasLim))
 	if err != nil {
 		return nil, err

--- a/service/state/interface.go
+++ b/service/state/interface.go
@@ -37,12 +37,12 @@ type Accessor interface {
 	// SubmitPayForData builds, signs and submits a PayForData transaction.
 	SubmitPayForData(ctx context.Context, nID namespace.ID, data []byte, gasLim uint64) (*TxResponse, error)
 
-	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator
+	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
 	CancelUnbondingDelegation(ctx context.Context, valAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
 	// BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
 	BeginRedelegate(ctx context.Context, srcValAddr, dstValAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
-	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator
+	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.
 	Undelegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
-	// Delegate sends a user's liquid tokens to a validator for delegation
+	// Delegate sends a user's liquid tokens to a validator for delegation.
 	Delegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
 }

--- a/service/state/interface.go
+++ b/service/state/interface.go
@@ -36,4 +36,13 @@ type Accessor interface {
 	SubmitTx(ctx context.Context, tx Tx) (*TxResponse, error)
 	// SubmitPayForData builds, signs and submits a PayForData transaction.
 	SubmitPayForData(ctx context.Context, nID namespace.ID, data []byte, gasLim uint64) (*TxResponse, error)
+
+	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator
+	CancelUnbondingDelegation(ctx context.Context, valAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
+	// BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
+	BeginRedelegate(ctx context.Context, srcValAddr, dstValAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
+	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator
+	Undelegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
+	// Delegate sends a user's liquid tokens to a validator for delegation
+	Delegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
 }

--- a/service/state/interface.go
+++ b/service/state/interface.go
@@ -38,7 +38,7 @@ type Accessor interface {
 	SubmitPayForData(ctx context.Context, nID namespace.ID, data []byte, gasLim uint64) (*TxResponse, error)
 
 	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
-	CancelUnbondingDelegation(ctx context.Context, valAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
+	CancelUnbondingDelegation(ctx context.Context, valAddr Address, amount, height Int, gasLim uint64) (*TxResponse, error)
 	// BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
 	BeginRedelegate(ctx context.Context, srcValAddr, dstValAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
 	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -54,10 +54,11 @@ func (s *Service) Transfer(ctx context.Context, to Address, amount Int, gasLimit
 func (s *Service) CancelUnbondingDelegation(
 	ctx context.Context,
 	valAddr Address,
-	amount Int,
+	amount,
+	height Int,
 	gasLim uint64,
 ) (*TxResponse, error) {
-	return s.accessor.CancelUnbondingDelegation(ctx, valAddr, amount, gasLim)
+	return s.accessor.CancelUnbondingDelegation(ctx, valAddr, amount, height, gasLim)
 }
 
 func (s *Service) BeginRedelegate(

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -51,6 +51,33 @@ func (s *Service) Transfer(ctx context.Context, to Address, amount Int, gasLimit
 	return s.accessor.Transfer(ctx, to, amount, gasLimit)
 }
 
+func (s *Service) CancelUnbondingDelegation(
+	ctx context.Context,
+	valAddr Address,
+	amount Int,
+	gasLim uint64,
+) (*TxResponse, error) {
+	return s.accessor.CancelUnbondingDelegation(ctx, valAddr, amount, gasLim)
+}
+
+func (s *Service) BeginRedelegate(
+	ctx context.Context,
+	srcValAddr,
+	dstValAddr Address,
+	amount Int,
+	gasLim uint64,
+) (*TxResponse, error) {
+	return s.accessor.BeginRedelegate(ctx, srcValAddr, dstValAddr, amount, gasLim)
+}
+
+func (s *Service) Undelegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error) {
+	return s.accessor.Undelegate(ctx, delAddr, amount, gasLim)
+}
+
+func (s *Service) Delegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error) {
+	return s.accessor.Delegate(ctx, delAddr, amount, gasLim)
+}
+
 func (s *Service) Start(context.Context) error {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	return nil


### PR DESCRIPTION
Resolves #946 

- [X] Implement each transaction type proxy inside of core_access.go
- [X]  expose these methods via higher level Accessor interface and have Service proxy to the accessor's impl of them
- [x]  expose via RPC
- [x]  Testing