### PR TITLE
Head method for syncer

### DIFF
--- a/header/header.go
+++ b/header/header.go
@@ -132,3 +132,7 @@ func (eh *ExtendedHeader) UnmarshalBinary(data []byte) error {
 	*eh = *out
 	return nil
 }
+
+func (eh *ExtendedHeader) Equals(header *ExtendedHeader) bool {
+	return bytes.Equal(eh.Hash(), header.Hash())
+}

--- a/header/interface.go
+++ b/header/interface.go
@@ -104,8 +104,7 @@ type Store interface {
 // Getter contains the behavior necessary for a component to retrieve
 // headers that have been processed during header sync.
 type Getter interface {
-	// Head returns the ExtendedHeader of the chain head.
-	Head(context.Context) (*ExtendedHeader, error)
+	Head
 
 	// Get returns the ExtendedHeader corresponding to the given hash.
 	Get(context.Context, tmbytes.HexBytes) (*ExtendedHeader, error)
@@ -115,4 +114,12 @@ type Getter interface {
 
 	// GetRangeByHeight returns the given range [from:to) of ExtendedHeaders.
 	GetRangeByHeight(ctx context.Context, from, to uint64) ([]*ExtendedHeader, error)
+}
+
+// Head contains the behavior necessary for a component to retrieve
+// the chain head. Note that "chain head" is subjective to the component
+// reporting it.
+type Head interface {
+	// Head returns the ExtendedHeader of the chain head.
+	Head(context.Context) (*ExtendedHeader, error)
 }

--- a/header/verify.go
+++ b/header/verify.go
@@ -26,6 +26,16 @@ func (eh *ExtendedHeader) IsExpired() bool {
 	return !expirationTime.After(time.Now())
 }
 
+// IsRecent checks if header is recent against the given blockTime.
+func (eh *ExtendedHeader) IsRecent(blockTime time.Duration) bool {
+	return time.Now().Sub(eh.Time) <= blockTime // TODO @renaynay: should we allow for a 5-10 block drift here?
+}
+
+// IsBefore returns whether the given header is of a higher height.
+func (eh *ExtendedHeader) IsBefore(h *ExtendedHeader) bool {
+	return eh.Height < h.Height
+}
+
 // VerifyNonAdjacent validates non-adjacent untrusted header against trusted 'eh'.
 func (eh *ExtendedHeader) VerifyNonAdjacent(untrst *ExtendedHeader) error {
 	if err := eh.verify(untrst); err != nil {

--- a/node/components.go
+++ b/node/components.go
@@ -88,7 +88,7 @@ func baseComponents(cfg *Config, store Store) fx.Option {
 		fx.Provide(services.HeaderStore),
 		fx.Invoke(services.HeaderStoreInit(&cfg.Services)),
 		fxutil.ProvideAs(services.FraudService, new(fraud.Service), new(fraud.Subscriber)),
-		fx.Provide(services.HeaderSyncer),
+		fx.Provide(services.HeaderSyncer(cfg.Services)),
 		fxutil.ProvideAs(services.P2PSubscriber, new(header.Broadcaster), new(header.Subscriber)),
 		fx.Provide(services.HeaderP2PExchangeServer),
 		// p2p components

--- a/node/rpc_test.go
+++ b/node/rpc_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/celestiaorg/celestia-node/header/local"
 	"github.com/celestiaorg/celestia-node/header/store"
 	"github.com/celestiaorg/celestia-node/header/sync"
+	"github.com/celestiaorg/celestia-node/params"
 	service "github.com/celestiaorg/celestia-node/service/header"
 	"github.com/celestiaorg/celestia-node/service/rpc"
 	"github.com/celestiaorg/celestia-node/service/share"
@@ -242,7 +243,7 @@ func setupHeaderService(ctx context.Context, t *testing.T) *service.Service {
 	_, err := localStore.Append(ctx, suite.GenExtendedHeaders(5)...)
 	require.NoError(t, err)
 	// create syncer
-	syncer := sync.NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{})
+	syncer := sync.NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{}, params.BlockTime)
 
 	return service.NewHeaderService(syncer, nil, nil, nil, localStore)
 }

--- a/node/services/config.go
+++ b/node/services/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	// Note: The trusted does *not* imply Headers are not verified, but trusted as reliable to fetch headers
 	// at any moment.
 	TrustedPeers []string
+	// BlockTime is the block time of the network.
+	BlockTime time.Duration
 	// NOTE: All further fields related to share/discovery.
 	// PeersLimit defines how many peers will be added during discovery.
 	PeersLimit uint
@@ -36,6 +38,7 @@ func DefaultConfig() Config {
 	return Config{
 		TrustedHash:       "",
 		TrustedPeers:      make([]string, 0),
+		BlockTime:         params.BlockTime,
 		PeersLimit:        3,
 		DiscoveryInterval: time.Second * 30,
 		AdvertiseInterval: time.Second * 30,

--- a/node/testing.go
+++ b/node/testing.go
@@ -42,6 +42,9 @@ func TestNode(t *testing.T, tp Type, opts ...Option) *Node {
 		WithNetwork(params.Private),
 		WithRPCPort("0"),
 		WithKeyringSigner(TestKeyringSigner(t)),
+		func(sets *settings) { // override the block time
+			sets.cfg.Services.BlockTime = time.Microsecond
+		},
 	)
 	nd, err := New(tp, store, opts...)
 	require.NoError(t, err)

--- a/params/network.go
+++ b/params/network.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"errors"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 )
@@ -13,6 +14,8 @@ const (
 	// Private can be used to set up any private network, including local testing setups.
 	// Use CELESTIA_PRIVATE_GENESIS env var to enable Private by specifying its genesis block hash.
 	Private Network = "private"
+	// TODO @renaynay @Wondertan: Set this once it's agreed upon, ideally this could point at a core const
+	BlockTime = time.Second * 30
 )
 
 // Network is a type definition for DA network run by Celestia Node.


### PR DESCRIPTION
feat: extract Head method into separate interface and make syncer impl
test: add test to ensure syncer Head returns its latest known head

refactor: Head returns either pending head or head from network

refactor: introduce blockTime param to eagerly fetch objHead from trustedPeer

fix todos and change logic of sbj head outdatedness check

doc: improve doc in trustedHead and remove TODO

doc: improve another doc and remove TODO

refactor: changes from discussion with @Wondertan

test | refactor: add test for trustedHead and remove public WithBlockTime opt

refactor: suggestions from @Wondertan and some fixes I found

sm prg for @renaynay

chore | test: fix two new tests to account for new sync logic, and lint

refactor: change mentions of trusted --> subjective

hlib prog