### PR TITLE
feat|refactor(header/sync): network head determination

### DIFF
--- a/header/header.go
+++ b/header/header.go
@@ -87,7 +87,7 @@ func (eh *ExtendedHeader) IsBefore(h *ExtendedHeader) bool {
 	return eh.Height < h.Height
 }
 
-// Equals returns whether the hash of the given header matches.
+// Equals returns whether the hash and height of the given header match.
 func (eh *ExtendedHeader) Equals(header *ExtendedHeader) bool {
 	return eh.Height == header.Height && bytes.Equal(eh.Hash(), header.Hash())
 }

--- a/header/header.go
+++ b/header/header.go
@@ -82,6 +82,16 @@ func (eh *ExtendedHeader) LastHeader() bts.HexBytes {
 	return eh.RawHeader.LastBlockID.Hash
 }
 
+// IsBefore returns whether the given header is of a higher height.
+func (eh *ExtendedHeader) IsBefore(h *ExtendedHeader) bool {
+	return eh.Height < h.Height
+}
+
+// Equals checks equality of tho headers by comparing hashes
+func (eh *ExtendedHeader) Equals(header *ExtendedHeader) bool {
+	return eh.Height == header.Height && bytes.Equal(eh.Hash(), header.Hash())
+}
+
 // ValidateBasic performs *basic* validation to check for missed/incorrect fields.
 func (eh *ExtendedHeader) ValidateBasic() error {
 	err := eh.RawHeader.ValidateBasic()

--- a/header/header.go
+++ b/header/header.go
@@ -87,7 +87,7 @@ func (eh *ExtendedHeader) IsBefore(h *ExtendedHeader) bool {
 	return eh.Height < h.Height
 }
 
-// Equals checks equality of tho headers by comparing hashes
+// Equals returns whether the hash of the given header matches.
 func (eh *ExtendedHeader) Equals(header *ExtendedHeader) bool {
 	return eh.Height == header.Height && bytes.Equal(eh.Hash(), header.Hash())
 }

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -16,19 +16,20 @@ var log = logging.Logger("header/sync")
 
 // Syncer implements efficient synchronization for headers.
 //
-// Subjective header - the latest known local header that is not expired(within trusting period)
-// Network header - the latest network header
+// Subjective header - the latest known header that is not expired (within trusting period)
+// Network header - the latest header received from the network
+
 //
 // There are two main processes running in Syncer:
 // 1. Main syncing loop(s.syncLoop)
-//    * Performs syncing from the known subjective header up to the network header
+//    * Performs syncing from the subjective header up to the network head
 //    * Syncs by requesting missing headers from Exchange or
 //    * By accessing cache of pending network headers received from PubSub
 // 2. Receives new headers from PubSub subnetwork (s.incomingNetHead)
 //    * Once received, tries to append it to the store
 //    * Or, if not adjacent to head of the store,
 //      * verifies against the latest known subjective header
-//    	* adds the header to pending cache(making it the latest known subjective header)
+//    	* adds the header to pending cache, thereby making it the latest known subjective header
 //      * and triggers syncing loop to catch up to that point.
 type Syncer struct {
 	sub      header.Subscriber
@@ -153,7 +154,7 @@ func (s *Syncer) syncLoop() {
 	}
 }
 
-// sync ensures we are synced from the local header Store's Head up to the new subjective head
+// sync ensures we are synced from the Store's head up to the new subjective head
 func (s *Syncer) sync(ctx context.Context) {
 	newHead := s.pending.Head()
 	if newHead == nil {

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -173,6 +173,10 @@ func (s *Syncer) objectiveHead(ctx context.Context) (*header.ExtendedHeader, err
 		return sbjHead, nil
 	}
 	// otherwise, request head from a trusted peer, as we assume it is fully synced
+	// TODO(@Wondertan): Here is another potential network optimization:
+	//  * From sbjHead's timestamp and current time predict the time to the next header(TNH)
+	//  * If now >= TNH && now <= TNH + (THP) header propagation time
+	//    * Wait for header to arrive instead of requesting it
 	maybeHead, err := s.exchange.Head(ctx)
 	if err != nil {
 		return nil, err

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -297,18 +297,13 @@ func (s *Syncer) syncLoop() {
 	}
 }
 
-// sync ensures we are synced up to subjective header.
+// sync ensures we are synced from the local header Store's Head up to the new subjective head
 func (s *Syncer) sync(ctx context.Context) {
-	pendHead := s.pending.Head()
-	if pendHead == nil {
+	newHead := s.pending.Head()
+	if newHead == nil {
 		return
 	}
 
-	s.syncTo(ctx, pendHead)
-}
-
-// syncTo requests headers from locally stored head up to the new head.
-func (s *Syncer) syncTo(ctx context.Context, newHead *header.ExtendedHeader) {
 	head, err := s.store.Head(ctx)
 	if err != nil {
 		log.Errorw("getting head during sync", "err", err)
@@ -316,7 +311,7 @@ func (s *Syncer) syncTo(ctx context.Context, newHead *header.ExtendedHeader) {
 	}
 
 	if head.Height == newHead.Height {
-		return
+		return // should never happen, but just in case
 	}
 
 	log.Infow("syncing headers",

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -35,6 +35,8 @@ type Syncer struct {
 	exchange header.Exchange
 	store    header.Store
 
+	blockTime time.Duration
+
 	// stateLk protects state which represents the current or latest sync
 	stateLk sync.RWMutex
 	state   State
@@ -47,11 +49,12 @@ type Syncer struct {
 }
 
 // NewSyncer creates a new instance of Syncer.
-func NewSyncer(exchange header.Exchange, store header.Store, sub header.Subscriber) *Syncer {
+func NewSyncer(exchange header.Exchange, store header.Store, sub header.Subscriber, blockTime time.Duration) *Syncer {
 	return &Syncer{
 		sub:         sub,
 		exchange:    exchange,
 		store:       store,
+		blockTime:   blockTime,
 		triggerSync: make(chan struct{}, 1), // should be buffered
 	}
 }

--- a/header/sync/sync_head.go
+++ b/header/sync/sync_head.go
@@ -1,0 +1,167 @@
+package sync
+
+import (
+	"context"
+	"errors"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+
+	"github.com/celestiaorg/celestia-node/header"
+)
+
+// subjectiveHead returns the latest known local header that is not expired(within trusting period).
+// If the header is expired, it is retrieved from a trusted peer without validation;
+// in other words, an automatic subjective initialization is performed.
+func (s *Syncer) subjectiveHead(ctx context.Context) (*header.ExtendedHeader, error) {
+	// pending head is the latest known subjective head Syncer syncs to, so try to get it
+	// NOTES:
+	// * Empty when no sync is in progress
+	// * Pending cannot be expired, guaranteed
+	pendHead := s.pending.Head()
+	if pendHead != nil {
+		return pendHead, nil
+	}
+	// if empty, get subjective head out of the store
+	netHead, err := s.store.Head(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// check if our subjective header is not expired and use it
+	if !netHead.IsExpired() {
+		return netHead, nil
+	}
+	log.Infow("subjective header expired", "height", netHead.Height)
+	// otherwise, request network head from a trusted peer
+	netHead, err = s.exchange.Head(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// and set as the new subjective head without validation,
+	// or, in other words, do 'automatic subjective initialization'
+	s.newNetHead(ctx, netHead, true)
+	switch {
+	default:
+		log.Infow("subjective initialization finished", "height", netHead.Height)
+		return netHead, nil
+	case netHead.IsExpired():
+		log.Warnw("subjective initialization with an expired header", "height", netHead.Height)
+	case !netHead.IsRecent(s.blockTime):
+		log.Warnw("subjective initialization with an old header", "height", netHead.Height)
+	}
+	log.Warn("trusted peer is out of sync")
+	return netHead, nil
+}
+
+// networkHead returns the latest network header.
+// Known subjective head is considered network head if it is recent enough(now-timestamp<=blocktime).
+// Otherwise, network header is requested from a trusted peer and set as the new subjective head,
+// assuming that trusted peer is always synced.
+func (s *Syncer) networkHead(ctx context.Context) (*header.ExtendedHeader, error) {
+	sbjHead, err := s.subjectiveHead(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// if subjective header is recent enough (relative to the network's block time) - just use it
+	if sbjHead.IsRecent(s.blockTime) {
+		return sbjHead, nil
+	}
+	// otherwise, request head from a trusted peer, as we assume it is fully synced
+	//
+	// the lock construction here ensures only one routine requests at a time
+	// while others wait via Rlock
+	if !s.netReqLk.TryLock() {
+		s.netReqLk.RLock()
+		defer s.netReqLk.RUnlock()
+		return s.subjectiveHead(ctx)
+	}
+	defer s.netReqLk.Unlock()
+	// TODO(@Wondertan): Here is another potential networking optimization:
+	//  * From sbjHead's timestamp and current time predict the time to the next header(TNH)
+	//  * If now >= TNH && now <= TNH + (THP) header propagation time
+	//    * Wait for header to arrive instead of requesting it
+	//  * This way we don't request as we know the new network header arrives exactly
+	netHead, err := s.exchange.Head(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// process netHead returned from the trusted peer and validate against the subjective head
+	// NOTE: We could trust the netHead like we do during 'automatic subjective initialization'
+	// but in this case our subjective head is not expired, so we should verify maybeHead
+	// and only if it is valid, set it as new head
+	s.newNetHead(ctx, netHead, false)
+	// maybeHead was either accepted or rejected as the new subjective
+	// anyway return most current known subjective head
+	return s.subjectiveHead(ctx)
+}
+
+// incomingNetHead processes new gossiped network headers.
+func (s *Syncer) incomingNetHead(ctx context.Context, netHead *header.ExtendedHeader) pubsub.ValidationResult {
+	// Try to short-circuit netHead with append. If not adjacent/from future - try it as new network header
+	_, err := s.store.Append(ctx, netHead)
+	switch err {
+	case nil:
+		// a happy case where we appended maybe head directly, so accept
+		return pubsub.ValidationAccept
+	case header.ErrNonAdjacent:
+		// not adjacent, maybe we've missed a few headers or its from the past
+	default:
+		var verErr *header.VerifyError
+		if errors.As(err, &verErr) {
+			return pubsub.ValidationReject
+		}
+		// might be a storage error or something else, but we can still try to continue processing netHead
+		log.Errorw("appending network header",
+			"height", netHead.Height,
+			"hash", netHead.Hash().String(),
+			"err", err)
+	}
+	// try as new head
+	return s.newNetHead(ctx, netHead, false)
+}
+
+// newNetHead sets the network header as the new subjective head with preceding validation(per request).
+func (s *Syncer) newNetHead(ctx context.Context, netHead *header.ExtendedHeader, trust bool) pubsub.ValidationResult {
+	// validate netHead against subjective head
+	if !trust {
+		if res := s.validate(ctx, netHead); res != pubsub.ValidationAccept {
+			// netHead was either ignored or rejected
+			return res
+		}
+	}
+	// and if valid, set it as new subjective head
+	s.pending.Add(netHead)
+	s.wantSync()
+	log.Infow("new network head", "height", netHead.Height, "hash", netHead.Hash())
+	return pubsub.ValidationAccept
+}
+
+// validate checks validity of the given header against the subjective head.
+func (s *Syncer) validate(ctx context.Context, new *header.ExtendedHeader) pubsub.ValidationResult {
+	sbjHead, err := s.subjectiveHead(ctx)
+	if err != nil {
+		log.Errorw("getting subjective head during validation", "err", err)
+		return pubsub.ValidationIgnore // local error, so ignore
+	}
+	// ignore header if it's from the past
+	if !sbjHead.IsBefore(new) {
+		log.Warnw("received known network header",
+			"current_height", sbjHead.Height,
+			"header_height", new.Height,
+			"header_hash", new.Hash())
+		return pubsub.ValidationIgnore
+	}
+	// perform verification
+	err = sbjHead.VerifyNonAdjacent(new)
+	var verErr *header.VerifyError
+	if errors.As(err, &verErr) {
+		log.Errorw("invalid network header",
+			"height_of_invalid", new.Height,
+			"hash_of_invalid", new.Hash(),
+			"height_of_subjective", sbjHead.Height,
+			"hash_of_subjective", sbjHead.Hash(),
+			"reason", verErr.Reason)
+		return pubsub.ValidationReject
+	}
+	// and accept if the header is good
+	return pubsub.ValidationAccept
+}

--- a/header/sync/sync_test.go
+++ b/header/sync/sync_test.go
@@ -79,7 +79,7 @@ func TestSyncCatchUp(t *testing.T) {
 	require.NoError(t, err)
 
 	// 3. syncer rcvs header from the future and starts catching-up
-	res := syncer.processIncoming(ctx, suite.GenExtendedHeaders(1)[0])
+	res := syncer.incomingHead(ctx, suite.GenExtendedHeaders(1)[0])
 	assert.Equal(t, pubsub.ValidationAccept, res)
 
 	_, err = localStore.GetByHeight(ctx, 102)

--- a/header/sync/sync_test.go
+++ b/header/sync/sync_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/celestiaorg/celestia-node/header/store"
 )
 
+var blockTime = 30 * time.Second
+
 func TestSyncSimpleRequestingHead(t *testing.T) {
 	// this way we force local head of Syncer to expire, so it requests a new one from trusted peer
 	header.TrustingPeriod = time.Microsecond
@@ -33,7 +35,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	require.NoError(t, err)
 
 	localStore := store.NewTestStore(ctx, t, head)
-	syncer := NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{})
+	syncer := NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{}, blockTime)
 	err = syncer.Start(ctx)
 	require.NoError(t, err)
 
@@ -67,7 +69,7 @@ func TestSyncCatchUp(t *testing.T) {
 
 	remoteStore := store.NewTestStore(ctx, t, head)
 	localStore := store.NewTestStore(ctx, t, head)
-	syncer := NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{})
+	syncer := NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{}, blockTime)
 	// 1. Initial sync
 	err := syncer.Start(ctx)
 	require.NoError(t, err)
@@ -111,7 +113,7 @@ func TestSyncPendingRangesWithMisses(t *testing.T) {
 
 	remoteStore := store.NewTestStore(ctx, t, head)
 	localStore := store.NewTestStore(ctx, t, head)
-	syncer := NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{})
+	syncer := NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{}, blockTime)
 	err := syncer.Start(ctx)
 	require.NoError(t, err)
 

--- a/header/sync/sync_test.go
+++ b/header/sync/sync_test.go
@@ -40,7 +40,8 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	err = syncer.Start(ctx)
 	require.NoError(t, err)
 
-	_, err = localStore.GetByHeight(ctx, 100)
+	time.Sleep(time.Millisecond * 10) // needs some to realize it is syncing
+	err = syncer.WaitSync(ctx)
 	require.NoError(t, err)
 
 	exp, err := remoteStore.Head(ctx)
@@ -83,7 +84,8 @@ func TestSyncCatchUp(t *testing.T) {
 	res := syncer.incomingHead(ctx, suite.GenExtendedHeaders(1)[0])
 	assert.Equal(t, pubsub.ValidationAccept, res)
 
-	_, err = localStore.GetByHeight(ctx, 102)
+	time.Sleep(time.Millisecond * 10) // needs some to realize it is syncing
+	err = syncer.WaitSync(ctx)
 	require.NoError(t, err)
 
 	exp, err := remoteStore.Head(ctx)

--- a/header/sync/sync_test.go
+++ b/header/sync/sync_test.go
@@ -81,7 +81,7 @@ func TestSyncCatchUp(t *testing.T) {
 	require.NoError(t, err)
 
 	// 3. syncer rcvs header from the future and starts catching-up
-	res := syncer.incomingHead(ctx, suite.GenExtendedHeaders(1)[0])
+	res := syncer.incomingNetHead(ctx, suite.GenExtendedHeaders(1)[0])
 	assert.Equal(t, pubsub.ValidationAccept, res)
 
 	time.Sleep(time.Millisecond * 10) // needs some to realize it is syncing
@@ -174,7 +174,7 @@ func TestSyncer_OnlyOneRecentRequest(t *testing.T) {
 	res := make(chan *header.ExtendedHeader)
 	for i := 0; i < 10; i++ {
 		go func() {
-			head, err := syncer.objectiveHead(ctx)
+			head, err := syncer.networkHead(ctx)
 			if err != nil {
 				panic(err)
 			}

--- a/header/verify.go
+++ b/header/verify.go
@@ -26,6 +26,11 @@ func (eh *ExtendedHeader) IsExpired() bool {
 	return !expirationTime.After(time.Now())
 }
 
+// IsRecent checks if header is recent against the given blockTime.
+func (eh *ExtendedHeader) IsRecent(blockTime time.Duration) bool {
+	return time.Since(eh.Time) <= blockTime // TODO @renaynay: should we allow for a 5-10 block drift here?
+}
+
 // VerifyNonAdjacent validates non-adjacent untrusted header against trusted 'eh'.
 func (eh *ExtendedHeader) VerifyNonAdjacent(untrst *ExtendedHeader) error {
 	if err := eh.verify(untrst); err != nil {

--- a/node/rpc_test.go
+++ b/node/rpc_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
+	"github.com/celestiaorg/celestia-node/params"
+
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/local"
@@ -242,7 +244,7 @@ func setupHeaderService(ctx context.Context, t *testing.T) *service.Service {
 	_, err := localStore.Append(ctx, suite.GenExtendedHeaders(5)...)
 	require.NoError(t, err)
 	// create syncer
-	syncer := sync.NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{})
+	syncer := sync.NewSyncer(local.NewExchange(remoteStore), localStore, &header.DummySubscriber{}, params.BlockTime)
 
 	return service.NewHeaderService(syncer, nil, nil, nil, localStore)
 }

--- a/node/services/service.go
+++ b/node/services/service.go
@@ -34,7 +34,7 @@ func HeaderSyncer(
 	sub header.Subscriber,
 	fservice fraud.Service,
 ) (*sync.Syncer, error) {
-	syncer := sync.NewSyncer(ex, store, sub)
+	syncer := sync.NewSyncer(ex, store, sub, params.BlockTime)
 	lifecycleCtx := fxutil.WithLifecycle(ctx, lc)
 	lc.Append(fx.Hook{
 		OnStart: func(startCtx context.Context) error {

--- a/params/network.go
+++ b/params/network.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"errors"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 )
@@ -14,12 +15,15 @@ const (
 	Mamaki Network = "mamaki"
 	// Private can be used to set up any private network, including local testing setups.
 	Private Network = "private"
+	// BlockTime is a network block time.
+	// TODO @renaynay @Wondertan (#790)
+	BlockTime = time.Second * 30
 )
 
 // Network is a type definition for DA network run by Celestia Node.
 type Network string
 
-// Bootstrappers is a type definition for nodes that will be used as bootstrappers
+// Bootstrappers is a type definition for nodes that will be used as bootstrappers.
 type Bootstrappers []peer.AddrInfo
 
 // ErrInvalidNetwork is thrown when unknown network is used.


### PR DESCRIPTION
### Context
In https://github.com/celestiaorg/celestia-node/pull/978 we started adding the `Head` method to Syncer; however, it's not that straightforward, and the deeper we looked, the more issues we found in Syncer related to the new `Head` method, so it was decided to extract a separate preparation PR that ensures the new `Head` is safe to use by multiple routines and returns as recent header as possible.

The previous version of Syncer struggled with two issues:
* On Syncer's start, synchronization didn't start and waited for a gossiped header trigger sync and set a sync target (only when the subjective head was not expired)
  * This is why Node could wait up to block time second to start syncing
* There was no way to request the most recent objective header of the network
  * I.e. if the user wanted to request the latest possible state, it wasn't able to do that besides waiting for full sync to finish

### Changes
The new reimplementation fixes these two problems and improves code readability and docs. Mainly, it splits the existing `trustedHead` into two methods `subjectiveHead` and `networkHead`. The `networkHead` is supposed to be used by the future `Head`.
Where the latter now relies on the latest known header timestamp and block time to determine its recency. If the header is not recent, we request it from the trusted peer(s), assuming it's always synced.
> In fact two of our bootstrappers falling out of sync, creating syncing issues.

Besides that, three more issues under `fix` commits related to multithreading were fixed with supporting tests.

### Other
Tested sync manually(thought with some struggles due to broken bootstrappers).
_As always, review CBC and checkout locally to see the full picture._

### TODO
- [x] Double check that the node correctly determines recency, as their DA network might be lagging one block behind
- [ ] Do we need time drift?
- [ ] Telemetry