### PR TITLE
service/rpc: Return `/namespaced_data` and `/namespaced_shares` as flattened hex

### DIFF
--- a/service/rpc/share.go
+++ b/service/rpc/share.go
@@ -25,8 +25,8 @@ var nIDKey = "nid"
 // NamespacedSharesResponse represents the response to a
 // SharesByNamespace request.
 type NamespacedSharesResponse struct {
-	Shares []share.Share `json:"shares"`
-	Height uint64        `json:"height"`
+	Shares string `json:"shares"`
+	Height uint64 `json:"height"`
 }
 
 // NamespacedDataResponse represents the response to a
@@ -48,7 +48,7 @@ func (h *Handler) handleSharesByNamespaceRequest(w http.ResponseWriter, r *http.
 		return
 	}
 	resp, err := json.Marshal(&NamespacedSharesResponse{
-		Shares: shares,
+		Shares: hex.EncodeToString(flatten(shares)),
 		Height: uint64(headerHeight),
 	})
 	if err != nil {

--- a/service/rpc/share.go
+++ b/service/rpc/share.go
@@ -32,8 +32,8 @@ type NamespacedSharesResponse struct {
 // NamespacedDataResponse represents the response to a
 // DataByNamespace request.
 type NamespacedDataResponse struct {
-	Data   [][]byte `json:"data"`
-	Height uint64   `json:"height"`
+	Data   string `json:"data"`
+	Height uint64 `json:"height"`
 }
 
 func (h *Handler) handleSharesByNamespaceRequest(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +78,7 @@ func (h *Handler) handleDataByNamespaceRequest(w http.ResponseWriter, r *http.Re
 		return
 	}
 	resp, err := json.Marshal(&NamespacedDataResponse{
-		Data:   data,
+		Data:   hex.EncodeToString(flatten(data)),
 		Height: uint64(headerHeight),
 	})
 	if err != nil {
@@ -139,4 +139,12 @@ func parseGetByNamespaceArgs(r *http.Request) (height uint64, nID namespace.ID, 
 	}
 
 	return height, nID, nil
+}
+
+func flatten(data [][]byte) []byte {
+	flat := make([]byte, 0)
+	for _, d := range data {
+		flat = append(flat, d...)
+	}
+	return flat
 }


### PR DESCRIPTION
Instead of returning some base64 encoded string, we should return `/namespaced_data` and `/namespaced_shares` as flattened, hex-encoded bytes.

## GET `/namespaced_shares/{nID}/height/{height}`

### Request
```
curl -X GET <ip>:26658/namespaced_shares/ca0724d103a7c5bb/height/173350
```
### Response

```
{"shares":"ca0724d103a7c5bbc801d9a51f3b9c31a0af6ab37586e6cf50826e89e0dce53977b719e0ee221cbafde6b9eb02615485c94085d5e109938ba5b62c849e139e105690c4ab18ab824bb29fc872a0a245093a62db5a9f972d8a84d19866fc3ecd7192aaebe5218454fa7baa1e95896c44a0b3a09e6e033ee645dfa39c33f3bddcdb9fae07b26c37c6eed839b7d55c941c2c2aeb0e066596ec2c713f7f2e30453fa3445cee1e77fff91375b42a042dbba88d154bc851f5d214896d3418cc4d69a4cef50bcf707e9f9ab84e261675b22d9888973f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","height":173350}
```

## GET `/namespaced_data/{nID}/height/{height}`

### Request
```
curl -X GET <ip>:26658/namespaced_data/ca0724d103a7c5bb/height/173350
```
### Response

```
{"data":"d9a51f3b9c31a0af6ab37586e6cf50826e89e0dce53977b719e0ee221cbafde6b9eb02615485c94085d5e109938ba5b62c849e139e105690c4ab18ab824bb29fc872a0a245093a62db5a9f972d8a84d19866fc3ecd7192aaebe5218454fa7baa1e95896c44a0b3a09e6e033ee645dfa39c33f3bddcdb9fae07b26c37c6eed839b7d55c941c2c2aeb0e066596ec2c713f7f2e30453fa3445cee1e77fff91375b42a042dbba88d154bc851f5d214896d3418cc4d69a4cef50bcf707e9f9ab84e261675b22d9888973f","height":173350}
```