### PR TITLE
feat(rpc): implementing staking reads and replace sdk.Address

### DIFF
--- a/service/rpc/endpoints.go
+++ b/service/rpc/endpoints.go
@@ -23,7 +23,7 @@ func (h *Handler) RegisterEndpoints(rpc *Server) {
 		http.MethodGet)
 	rpc.RegisterHandlerFunc(fmt.Sprintf("%s/{%s}", queryUnbondingEndpoint, addrKey), h.handleQueryUnbonding,
 		http.MethodGet)
-	rpc.RegisterHandlerFunc(queryRedelegationEndpoint, h.handleQueryRedelegations,
+	rpc.RegisterHandlerFunc(queryRedelegationsEndpoint, h.handleQueryRedelegations,
 		http.MethodPost)
 
 	// share endpoints

--- a/service/rpc/endpoints.go
+++ b/service/rpc/endpoints.go
@@ -37,6 +37,14 @@ func (h *Handler) RegisterEndpoints(rpc *Server) {
 		http.MethodGet)
 	rpc.RegisterHandlerFunc(headEndpoint, h.handleHeadRequest, http.MethodGet)
 
+	// staking reads
+	rpc.RegisterHandlerFunc(queryDelegationEndpoint, h.handleQueryDelegation,
+		http.MethodPost)
+	rpc.RegisterHandlerFunc(queryUnbondingEndpoint, h.handleQueryUnbonding,
+		http.MethodPost)
+	rpc.RegisterHandlerFunc(queryRedelegationsEndpoing, h.handleQueryRedelegations,
+		http.MethodPost)
+
 	// DASer endpoints
 	// only register if DASer service is available
 	if h.das != nil {

--- a/service/rpc/endpoints.go
+++ b/service/rpc/endpoints.go
@@ -18,6 +18,14 @@ func (h *Handler) RegisterEndpoints(rpc *Server) {
 	rpc.RegisterHandlerFunc(cancelUnbondingEndpoint, h.handleCancelUnbonding, http.MethodPost)
 	rpc.RegisterHandlerFunc(beginRedelegationEndpoint, h.handleRedelegation, http.MethodPost)
 
+	// staking queries
+	rpc.RegisterHandlerFunc(fmt.Sprintf("%s/{%s}", queryDelegationEndpoint, addrKey), h.handleQueryDelegation,
+		http.MethodGet)
+	rpc.RegisterHandlerFunc(fmt.Sprintf("%s/{%s}", queryUnbondingEndpoint, addrKey), h.handleQueryUnbonding,
+		http.MethodGet)
+	rpc.RegisterHandlerFunc(queryRedelegationEndpoint, h.handleQueryRedelegations,
+		http.MethodPost)
+
 	// share endpoints
 	rpc.RegisterHandlerFunc(fmt.Sprintf("%s/{%s}/height/{%s}", namespacedSharesEndpoint, nIDKey, heightKey),
 		h.handleSharesByNamespaceRequest, http.MethodGet)
@@ -36,14 +44,6 @@ func (h *Handler) RegisterEndpoints(rpc *Server) {
 	rpc.RegisterHandlerFunc(fmt.Sprintf("%s/{%s}", headerByHeightEndpoint, heightKey), h.handleHeaderRequest,
 		http.MethodGet)
 	rpc.RegisterHandlerFunc(headEndpoint, h.handleHeadRequest, http.MethodGet)
-
-	// staking reads
-	rpc.RegisterHandlerFunc(queryDelegationEndpoint, h.handleQueryDelegation,
-		http.MethodPost)
-	rpc.RegisterHandlerFunc(queryUnbondingEndpoint, h.handleQueryUnbonding,
-		http.MethodPost)
-	rpc.RegisterHandlerFunc(queryRedelegationsEndpoing, h.handleQueryRedelegations,
-		http.MethodPost)
 
 	// DASer endpoints
 	// only register if DASer service is available

--- a/service/rpc/state.go
+++ b/service/rpc/state.go
@@ -13,17 +13,17 @@ import (
 )
 
 const (
-	balanceEndpoint           = "/balance"
-	submitTxEndpoint          = "/submit_tx"
-	submitPFDEndpoint         = "/submit_pfd"
-	transferEndpoint          = "/transfer"
-	delegationEndpoint        = "/delegate"
-	undelegationEndpoint      = "/begin_unbonding"
-	cancelUnbondingEndpoint   = "/cancel_unbond"
-	beginRedelegationEndpoint = "/begin_redelegate"
-	queryDelegationEndpoint   = "/query_delegation"
-	queryUnbondingEndpoint    = "/query_unbonding"
-	queryRedelegationEndpoint = "/query_redelegations"
+	balanceEndpoint            = "/balance"
+	submitTxEndpoint           = "/submit_tx"
+	submitPFDEndpoint          = "/submit_pfd"
+	transferEndpoint           = "/transfer"
+	delegationEndpoint         = "/delegate"
+	undelegationEndpoint       = "/begin_unbonding"
+	cancelUnbondingEndpoint    = "/cancel_unbond"
+	beginRedelegationEndpoint  = "/begin_redelegate"
+	queryDelegationEndpoint    = "/query_delegation"
+	queryUnbondingEndpoint     = "/query_unbonding"
+	queryRedelegationsEndpoint = "/query_redelegations"
 )
 
 var addrKey = "address"
@@ -78,7 +78,7 @@ type cancelUnbondRequest struct {
 	GasLimit uint64 `json:"gas_limit"`
 }
 
-type queryRedelegationRequest struct {
+type queryRedelegationsRequest struct {
 	From string `json:"from"`
 	To   string `json:"to"`
 }
@@ -367,9 +367,9 @@ func (h *Handler) handleQueryDelegation(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// convert address to Address type
-	addr, addrerr := types.ValAddressFromBech32(addrStr)
-	if addrerr != nil {
-		writeError(w, http.StatusBadRequest, queryDelegationEndpoint, addrerr)
+	addr, err := types.ValAddressFromBech32(addrStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, queryDelegationEndpoint, err)
 		return
 	}
 	delegation, err := h.state.QueryDelegation(r.Context(), addr)
@@ -398,9 +398,9 @@ func (h *Handler) handleQueryUnbonding(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// convert address to Address type
-	addr, addrerr := types.ValAddressFromBech32(addrStr)
-	if addrerr != nil {
-		writeError(w, http.StatusBadRequest, queryUnbondingEndpoint, addrerr)
+	addr, err := types.ValAddressFromBech32(addrStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, queryUnbondingEndpoint, err)
 		return
 	}
 	unbonding, err := h.state.QueryUnbonding(r.Context(), addr)
@@ -420,34 +420,34 @@ func (h *Handler) handleQueryUnbonding(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleQueryRedelegations(w http.ResponseWriter, r *http.Request) {
-	var req queryRedelegationRequest
+	var req queryRedelegationsRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, queryRedelegationEndpoint, err)
+		writeError(w, http.StatusBadRequest, queryRedelegationsEndpoint, err)
 		return
 	}
 	srcValAddr, err := types.ValAddressFromBech32(req.From)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, queryRedelegationEndpoint, err)
+		writeError(w, http.StatusBadRequest, queryRedelegationsEndpoint, err)
 		return
 	}
 	dstValAddr, err := types.ValAddressFromBech32(req.To)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, queryRedelegationEndpoint, err)
+		writeError(w, http.StatusBadRequest, queryRedelegationsEndpoint, err)
 		return
 	}
 	unbonding, err := h.state.QueryRedelegations(r.Context(), srcValAddr, dstValAddr)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, queryRedelegationEndpoint, err)
+		writeError(w, http.StatusInternalServerError, queryRedelegationsEndpoint, err)
 		return
 	}
 	resp, err := json.Marshal(unbonding)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, queryRedelegationEndpoint, err)
+		writeError(w, http.StatusInternalServerError, queryRedelegationsEndpoint, err)
 		return
 	}
 	_, err = w.Write(resp)
 	if err != nil {
-		log.Errorw("writing response", "endpoint", queryRedelegationEndpoint, "err", err)
+		log.Errorw("writing response", "endpoint", queryRedelegationsEndpoint, "err", err)
 	}
 }

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -339,12 +339,15 @@ func (ca *CoreAccessor) Delegate(
 
 func (ca *CoreAccessor) QueryDelegation(
 	ctx context.Context,
-	delAddr Address,
 	valAddr Address,
 ) (*stakingtypes.QueryDelegationResponse, error) {
 	_, ok := valAddr.(sdktypes.ValAddress)
 	if !ok {
 		return nil, fmt.Errorf("state: unsupported address type")
+	}
+	delAddr, err := ca.signer.GetSignerInfo().GetAddress()
+	if err != nil {
+		return nil, err
 	}
 	return ca.stakingCli.Delegation(ctx, &stakingtypes.QueryDelegationRequest{
 		DelegatorAddr: delAddr.String(),
@@ -354,12 +357,15 @@ func (ca *CoreAccessor) QueryDelegation(
 
 func (ca *CoreAccessor) QueryUnbonding(
 	ctx context.Context,
-	delAddr Address,
 	valAddr Address,
 ) (*stakingtypes.QueryUnbondingDelegationResponse, error) {
 	_, ok := valAddr.(sdktypes.ValAddress)
 	if !ok {
 		return nil, fmt.Errorf("state: unsupported address type")
+	}
+	delAddr, err := ca.signer.GetSignerInfo().GetAddress()
+	if err != nil {
+		return nil, err
 	}
 	return ca.stakingCli.UnbondingDelegation(ctx, &stakingtypes.QueryUnbondingDelegationRequest{
 		DelegatorAddr: delAddr.String(),
@@ -368,13 +374,16 @@ func (ca *CoreAccessor) QueryUnbonding(
 }
 func (ca *CoreAccessor) QueryRedelegations(
 	ctx context.Context,
-	delAddr,
 	srcValAddr,
 	dstValAddr Address,
 ) (*stakingtypes.QueryRedelegationsResponse, error) {
 	_, ok := srcValAddr.(sdktypes.ValAddress)
 	if !ok {
 		return nil, fmt.Errorf("state: unsupported address type")
+	}
+	delAddr, err := ca.signer.GetSignerInfo().GetAddress()
+	if err != nil {
+		return nil, err
 	}
 	return ca.stakingCli.Redelegations(ctx, &stakingtypes.QueryRedelegationsRequest{
 		DelegatorAddr:    delAddr.String(),

--- a/service/state/interface.go
+++ b/service/state/interface.go
@@ -49,14 +49,9 @@ type Accessor interface {
 	Delegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
 
 	// QueryDelegation retrieves the delegation information between a delegator and a validator.
-	QueryDelegation(ctx context.Context, delAddr, valAddr Address) (*staking.QueryDelegationResponse, error)
+	QueryDelegation(ctx context.Context, valAddr Address) (*staking.QueryDelegationResponse, error)
 	// QueryUnbonding retrieves the unbonding status between a delegator and a validator.
-	QueryUnbonding(ctx context.Context, delAddr, valAddr Address) (*staking.QueryUnbondingDelegationResponse, error)
+	QueryUnbonding(ctx context.Context, valAddr Address) (*staking.QueryUnbondingDelegationResponse, error)
 	// QueryRedelegations retrieves the status of the redelegations between a delegator and a validator.
-	QueryRedelegations(
-		ctx context.Context,
-		delAddr,
-		srcValAddr,
-		dstValAddr Address,
-	) (*staking.QueryRedelegationsResponse, error)
+	QueryRedelegations(ctx context.Context, srcValAddr, dstValAddr Address) (*staking.QueryRedelegationsResponse, error)
 }

--- a/service/state/interface.go
+++ b/service/state/interface.go
@@ -1,11 +1,11 @@
 package state
 
 import (
-	"cosmossdk.io/math"
-
 	"context"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/types"
+	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/celestiaorg/nmt/namespace"
 )
@@ -47,4 +47,16 @@ type Accessor interface {
 	Undelegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
 	// Delegate sends a user's liquid tokens to a validator for delegation.
 	Delegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
+
+	// QueryDelegation retrieves the delegation information between a delegator and a validator.
+	QueryDelegation(ctx context.Context, delAddr, valAddr Address) (*staking.QueryDelegationResponse, error)
+	// QueryUnbonding retrieves the unbonding status between a delegator and a validator.
+	QueryUnbonding(ctx context.Context, delAddr, valAddr Address) (*staking.QueryUnbondingDelegationResponse, error)
+	// QueryRedelegations retrieves the status of the redelegations between a delegator and a validator.
+	QueryRedelegations(
+		ctx context.Context,
+		delAddr,
+		srcValAddr,
+		dstValAddr Address,
+	) (*staking.QueryRedelegationsResponse, error)
 }

--- a/service/state/interface.go
+++ b/service/state/interface.go
@@ -4,8 +4,7 @@ import (
 	"context"
 
 	"cosmossdk.io/math"
-	"github.com/cosmos/cosmos-sdk/types"
-	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/celestiaorg/nmt/namespace"
 )
@@ -28,10 +27,10 @@ type Accessor interface {
 	// NOTE: the balance returned is the balance reported by the block right before
 	// the node's current head (head-1). This is due to the fact that for block N, the block's
 	// `AppHash` is the result of applying the previous block's transaction list.
-	BalanceForAddress(ctx context.Context, addr Address) (*Balance, error)
+	BalanceForAddress(ctx context.Context, addr AccAddress) (*Balance, error)
 
 	// Transfer sends the given amount of coins from default wallet of the node to the given account address.
-	Transfer(ctx context.Context, to types.Address, amount math.Int, gasLimit uint64) (*TxResponse, error)
+	Transfer(ctx context.Context, to AccAddress, amount math.Int, gasLimit uint64) (*TxResponse, error)
 	// SubmitTx submits the given transaction/message to the
 	// Celestia network and blocks until the tx is included in
 	// a block.
@@ -40,18 +39,24 @@ type Accessor interface {
 	SubmitPayForData(ctx context.Context, nID namespace.ID, data []byte, gasLim uint64) (*TxResponse, error)
 
 	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
-	CancelUnbondingDelegation(ctx context.Context, valAddr Address, amount, height Int, gasLim uint64) (*TxResponse, error)
+	CancelUnbondingDelegation(
+		ctx context.Context,
+		valAddr ValAddress,
+		amount,
+		height Int,
+		gasLim uint64,
+	) (*TxResponse, error)
 	// BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
-	BeginRedelegate(ctx context.Context, srcValAddr, dstValAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
+	BeginRedelegate(ctx context.Context, srcValAddr, dstValAddr ValAddress, amount Int, gasLim uint64) (*TxResponse, error)
 	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.
-	Undelegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
+	Undelegate(ctx context.Context, delAddr ValAddress, amount Int, gasLim uint64) (*TxResponse, error)
 	// Delegate sends a user's liquid tokens to a validator for delegation.
-	Delegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error)
+	Delegate(ctx context.Context, delAddr ValAddress, amount Int, gasLim uint64) (*TxResponse, error)
 
 	// QueryDelegation retrieves the delegation information between a delegator and a validator.
-	QueryDelegation(ctx context.Context, valAddr Address) (*staking.QueryDelegationResponse, error)
+	QueryDelegation(ctx context.Context, valAddr ValAddress) (*types.QueryDelegationResponse, error)
 	// QueryUnbonding retrieves the unbonding status between a delegator and a validator.
-	QueryUnbonding(ctx context.Context, valAddr Address) (*staking.QueryUnbondingDelegationResponse, error)
+	QueryUnbonding(ctx context.Context, valAddr ValAddress) (*types.QueryUnbondingDelegationResponse, error)
 	// QueryRedelegations retrieves the status of the redelegations between a delegator and a validator.
-	QueryRedelegations(ctx context.Context, srcValAddr, dstValAddr Address) (*staking.QueryRedelegationsResponse, error)
+	QueryRedelegations(ctx context.Context, srcValAddr, dstValAddr ValAddress) (*types.QueryRedelegationsResponse, error)
 }

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -83,26 +83,24 @@ func (s *Service) Delegate(ctx context.Context, delAddr Address, amount Int, gas
 
 func (s *Service) QueryDelegation(
 	ctx context.Context,
-	delAddr, valAddr Address,
+	valAddr Address,
 ) (*types.QueryDelegationResponse, error) {
-	return s.accessor.QueryDelegation(ctx, delAddr, valAddr)
+	return s.accessor.QueryDelegation(ctx, valAddr)
 }
 
 func (s *Service) QueryUnbonding(
 	ctx context.Context,
-	delAddr,
 	valAddr Address,
 ) (*types.QueryUnbondingDelegationResponse, error) {
-	return s.accessor.QueryUnbonding(ctx, delAddr, valAddr)
+	return s.accessor.QueryUnbonding(ctx, valAddr)
 }
 
 func (s *Service) QueryRedelegations(
 	ctx context.Context,
-	delAddr,
 	srcValAddr,
 	dstValAddr Address,
 ) (*types.QueryRedelegationsResponse, error) {
-	return s.accessor.QueryRedelegations(ctx, delAddr, srcValAddr, dstValAddr)
+	return s.accessor.QueryRedelegations(ctx, srcValAddr, dstValAddr)
 }
 
 func (s *Service) Start(context.Context) error {

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -3,6 +3,8 @@ package state
 import (
 	"context"
 
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/nmt/namespace"
 )
@@ -77,6 +79,30 @@ func (s *Service) Undelegate(ctx context.Context, delAddr Address, amount Int, g
 
 func (s *Service) Delegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error) {
 	return s.accessor.Delegate(ctx, delAddr, amount, gasLim)
+}
+
+func (s *Service) QueryDelegation(
+	ctx context.Context,
+	delAddr, valAddr Address,
+) (*types.QueryDelegationResponse, error) {
+	return s.accessor.QueryDelegation(ctx, delAddr, valAddr)
+}
+
+func (s *Service) QueryUnbonding(
+	ctx context.Context,
+	delAddr,
+	valAddr Address,
+) (*types.QueryUnbondingDelegationResponse, error) {
+	return s.accessor.QueryUnbonding(ctx, delAddr, valAddr)
+}
+
+func (s *Service) QueryRedelegations(
+	ctx context.Context,
+	delAddr,
+	srcValAddr,
+	dstValAddr Address,
+) (*types.QueryRedelegationsResponse, error) {
+	return s.accessor.QueryRedelegations(ctx, delAddr, srcValAddr, dstValAddr)
 }
 
 func (s *Service) Start(context.Context) error {

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -41,7 +41,7 @@ func (s *Service) Balance(ctx context.Context) (*Balance, error) {
 	return s.accessor.Balance(ctx)
 }
 
-func (s *Service) BalanceForAddress(ctx context.Context, addr Address) (*Balance, error) {
+func (s *Service) BalanceForAddress(ctx context.Context, addr AccAddress) (*Balance, error) {
 	return s.accessor.BalanceForAddress(ctx, addr)
 }
 
@@ -49,13 +49,13 @@ func (s *Service) SubmitTx(ctx context.Context, tx Tx) (*TxResponse, error) {
 	return s.accessor.SubmitTx(ctx, tx)
 }
 
-func (s *Service) Transfer(ctx context.Context, to Address, amount Int, gasLimit uint64) (*TxResponse, error) {
+func (s *Service) Transfer(ctx context.Context, to AccAddress, amount Int, gasLimit uint64) (*TxResponse, error) {
 	return s.accessor.Transfer(ctx, to, amount, gasLimit)
 }
 
 func (s *Service) CancelUnbondingDelegation(
 	ctx context.Context,
-	valAddr Address,
+	valAddr ValAddress,
 	amount,
 	height Int,
 	gasLim uint64,
@@ -66,31 +66,31 @@ func (s *Service) CancelUnbondingDelegation(
 func (s *Service) BeginRedelegate(
 	ctx context.Context,
 	srcValAddr,
-	dstValAddr Address,
+	dstValAddr ValAddress,
 	amount Int,
 	gasLim uint64,
 ) (*TxResponse, error) {
 	return s.accessor.BeginRedelegate(ctx, srcValAddr, dstValAddr, amount, gasLim)
 }
 
-func (s *Service) Undelegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error) {
+func (s *Service) Undelegate(ctx context.Context, delAddr ValAddress, amount Int, gasLim uint64) (*TxResponse, error) {
 	return s.accessor.Undelegate(ctx, delAddr, amount, gasLim)
 }
 
-func (s *Service) Delegate(ctx context.Context, delAddr Address, amount Int, gasLim uint64) (*TxResponse, error) {
+func (s *Service) Delegate(ctx context.Context, delAddr ValAddress, amount Int, gasLim uint64) (*TxResponse, error) {
 	return s.accessor.Delegate(ctx, delAddr, amount, gasLim)
 }
 
 func (s *Service) QueryDelegation(
 	ctx context.Context,
-	valAddr Address,
+	valAddr ValAddress,
 ) (*types.QueryDelegationResponse, error) {
 	return s.accessor.QueryDelegation(ctx, valAddr)
 }
 
 func (s *Service) QueryUnbonding(
 	ctx context.Context,
-	valAddr Address,
+	valAddr ValAddress,
 ) (*types.QueryUnbondingDelegationResponse, error) {
 	return s.accessor.QueryUnbonding(ctx, valAddr)
 }
@@ -98,7 +98,7 @@ func (s *Service) QueryUnbonding(
 func (s *Service) QueryRedelegations(
 	ctx context.Context,
 	srcValAddr,
-	dstValAddr Address,
+	dstValAddr ValAddress,
 ) (*types.QueryRedelegationsResponse, error) {
 	return s.accessor.QueryRedelegations(ctx, srcValAddr, dstValAddr)
 }

--- a/service/state/state.go
+++ b/service/state/state.go
@@ -15,8 +15,11 @@ type Tx = coretypes.Tx
 // TxResponse is an alias to the TxResponse type from Cosmos-SDK.
 type TxResponse = sdk.TxResponse
 
-// Address is an alias to the Address type from Cosmos-SDK.
-type Address = sdk.Address
+// ValAddress is an alias to the ValAddress type from Cosmos-SDK.
+type ValAddress = sdk.ValAddress
+
+// AccAddress is an alias to the AccAddress type from Cosmos-SDK.
+type AccAddress = sdk.AccAddress
 
 // Int is an alias to the Int type from Cosmos-SDK.
 type Int = math.Int


### PR DESCRIPTION
Closes #986.

Also removes the abstraction of `sdk.Address` to make it explicit that our queries only support their corresponding address type, `AccAddress` or `ValAddress`