### PR TITLE
chore: resolving linter errors on main

### DIFF
--- a/fraud/testing.go
+++ b/fraud/testing.go
@@ -108,7 +108,7 @@ func (m *mockProof) Height() uint64 {
 }
 
 func (m *mockProof) Validate(*header.ExtendedHeader) error {
-	if m.Valid != true {
+	if !m.Valid {
 		return errors.New("mockProof: proof is not valid")
 	}
 	return nil

--- a/node/node.go
+++ b/node/node.go
@@ -37,6 +37,8 @@ var log = logging.Logger("node")
 // * Light
 // * Full
 type Node struct {
+	fx.In `ignore-unexported:"true"`
+
 	Type          Type
 	Network       params.Network
 	Bootstrappers params.Bootstrappers
@@ -155,7 +157,7 @@ func newNode(opts ...fx.Option) (*Node, error) {
 	node := new(Node)
 	app := fx.New(
 		fx.NopLogger,
-		fx.Extract(node),
+		fx.Populate(node),
 		fx.Options(opts...),
 	)
 	if err := app.Err(); err != nil {


### PR DESCRIPTION
On main rn there are two linter errors, making any branches need to fix the linting errors when a PR is opened. This fixes that

So `fx.Extract` got deprecated (actually it was soft-deprecated a while ago but they recently forced the deprecation)
The solution is to throw the `Node` struct directly into `fx.Populate`, meaning we need to add `fx.In` to the struct, and ignore the unexported fields (start, stop)

Other one is probably from fraudsync, as its in `fraud/testing.go`