### PR TITLE
feat(rpc): writing error out as json

### DIFF
--- a/fraud/testing.go
+++ b/fraud/testing.go
@@ -108,7 +108,7 @@ func (m *mockProof) Height() uint64 {
 }
 
 func (m *mockProof) Validate(*header.ExtendedHeader) error {
-	if m.Valid != true {
+	if !m.Valid {
 		return errors.New("mockProof: proof is not valid")
 	}
 	return nil

--- a/node/node.go
+++ b/node/node.go
@@ -37,6 +37,8 @@ var log = logging.Logger("node")
 // * Light
 // * Full
 type Node struct {
+	fx.In `ignore-unexported:"true"`
+
 	Type          Type
 	Network       params.Network
 	Bootstrappers params.Bootstrappers
@@ -155,7 +157,7 @@ func newNode(opts ...fx.Option) (*Node, error) {
 	node := new(Node)
 	app := fx.New(
 		fx.NopLogger,
-		fx.Extract(node),
+		fx.Populate(node),
 		fx.Options(opts...),
 	)
 	if err := app.Err(); err != nil {

--- a/node/rpc_test.go
+++ b/node/rpc_test.go
@@ -92,11 +92,11 @@ func testGetNamespacedRequest(t *testing.T, endpointName string, assertResponseO
 				require.False(t, resp.StatusCode == http.StatusOK)
 				require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 
-				var errorMessage string
+				errorMessage := new(rpc.JSONError)
 				err := json.NewDecoder(resp.Body).Decode(&errorMessage)
 
 				require.NoError(t, err)
-				require.Equal(t, tt.errMsg, errorMessage)
+				require.Equal(t, tt.errMsg, errorMessage.Err)
 
 				return
 			}

--- a/node/rpc_test.go
+++ b/node/rpc_test.go
@@ -93,7 +93,7 @@ func testGetNamespacedRequest(t *testing.T, endpointName string, assertResponseO
 				require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 
 				errorMessage := new(rpc.JSONError)
-				err := json.NewDecoder(resp.Body).Decode(&errorMessage)
+				err := json.NewDecoder(resp.Body).Decode(errorMessage)
 
 				require.NoError(t, err)
 				require.Equal(t, tt.errMsg, errorMessage.Err)

--- a/service/rpc/util.go
+++ b/service/rpc/util.go
@@ -5,11 +5,15 @@ import (
 	"net/http"
 )
 
+type JSONError struct {
+	Err string `json:"error"`
+}
+
 func writeError(w http.ResponseWriter, statusCode int, endpoint string, err error) {
 	log.Errorw("serving request", "endpoint", endpoint, "err", err)
 
 	w.WriteHeader(statusCode)
-	errBody, jerr := json.Marshal(err.Error())
+	errBody, jerr := json.Marshal(JSONError{Err: err.Error()})
 	if jerr != nil {
 		log.Errorw("serializing error", "endpoint", endpoint, "err", jerr)
 		return


### PR DESCRIPTION
Our endpoints should write the error out in a JSON body to be API friendly, so instead of just

`rpc error: code = NotFound desc = account celestia1ljj5eduqftemu3vpkyd4z80knr2rprg8mqd5sl not found`

we write

```json
{
    "error": "rpc error: code = NotFound desc = account celestia1ljj5eduqftemu3vpkyd4z80knr2rprg8mqd5sl not found"
}
```