### PR TITLE
feat(cmd): Provide ability to specify network to user

### DIFF
--- a/cmd/cel-shed/header.go
+++ b/cmd/cel-shed/header.go
@@ -21,12 +21,12 @@ var headerCmd = &cobra.Command{
 }
 
 var headerStoreInit = &cobra.Command{
-	Use: "store-init [node-type] [height]",
+	Use: "store-init [node-type] [network] [height]",
 	Short: `Forcefully initialize header store head to be of the given height. Requires the node being stopped. 
 Custom store path is not supported yet.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 2 {
+		if len(args) != 3 {
 			return fmt.Errorf("not enough arguments")
 		}
 
@@ -35,12 +35,16 @@ Custom store path is not supported yet.`,
 			return fmt.Errorf("invalid node-type")
 		}
 
-		height, err := strconv.Atoi(args[1])
+		network := args[1]
+
+		height, err := strconv.Atoi(args[2])
 		if err != nil {
 			return fmt.Errorf("invalid height: %w", err)
 		}
 
-		s, err := node.OpenStore(fmt.Sprintf("~/.celestia-%s", strings.ToLower(tp.String())))
+		s, err := node.OpenStore(
+			fmt.Sprintf("~/.celestia-%s-%s", strings.ToLower(tp.String()), strings.ToLower(network)),
+		)
 		if err != nil {
 			return err
 		}

--- a/cmd/celestia/bridge.go
+++ b/cmd/celestia/bridge.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	bridgeCmd.AddCommand(
 		cmdnode.Init(
-			cmdnode.NodeFlags(node.Bridge),
+			cmdnode.NodeFlags(),
 			cmdnode.P2PFlags(),
 			cmdnode.CoreFlags(),
 			cmdnode.MiscFlags(),
@@ -21,7 +21,7 @@ func init() {
 			cmdnode.KeyFlags(),
 		),
 		cmdnode.Start(
-			cmdnode.NodeFlags(node.Bridge),
+			cmdnode.NodeFlags(),
 			cmdnode.P2PFlags(),
 			cmdnode.CoreFlags(),
 			cmdnode.MiscFlags(),

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	fullCmd.AddCommand(
 		cmdnode.Init(
-			cmdnode.NodeFlags(node.Full),
+			cmdnode.NodeFlags(),
 			cmdnode.P2PFlags(),
 			cmdnode.HeadersFlags(),
 			cmdnode.MiscFlags(),
@@ -25,7 +25,7 @@ func init() {
 			cmdnode.KeyFlags(),
 		),
 		cmdnode.Start(
-			cmdnode.NodeFlags(node.Full),
+			cmdnode.NodeFlags(),
 			cmdnode.P2PFlags(),
 			cmdnode.HeadersFlags(),
 			cmdnode.MiscFlags(),

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	lightCmd.AddCommand(
 		cmdnode.Init(
-			cmdnode.NodeFlags(node.Light),
+			cmdnode.NodeFlags(),
 			cmdnode.P2PFlags(),
 			cmdnode.HeadersFlags(),
 			cmdnode.MiscFlags(),
@@ -25,7 +25,7 @@ func init() {
 			cmdnode.KeyFlags(),
 		),
 		cmdnode.Start(
-			cmdnode.NodeFlags(node.Light),
+			cmdnode.NodeFlags(),
 			cmdnode.P2PFlags(),
 			cmdnode.HeadersFlags(),
 			cmdnode.MiscFlags(),

--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -35,7 +35,7 @@ func NodeFlags() *flag.FlagSet {
 	flags.String(
 		nodeNetworkFlag,
 		"",
-		"The name of the network to connect to",
+		"The name of the network to connect to, e.g. arabica or mamaki",
 	)
 
 	return flags
@@ -45,7 +45,10 @@ func NodeFlags() *flag.FlagSet {
 func ParseNodeFlags(ctx context.Context, cmd *cobra.Command) (context.Context, error) {
 	network := cmd.Flag(nodeNetworkFlag).Value.String()
 	if network != "" {
-		params.SetDefaultNetwork(params.Network(network))
+		err := params.SetDefaultNetwork(params.Network(network))
+		if err != nil {
+			return ctx, err
+		}
 	} else {
 		network = string(params.DefaultNetwork())
 	}

--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -35,7 +35,7 @@ func NodeFlags() *flag.FlagSet {
 	flags.String(
 		nodeNetworkFlag,
 		"",
-		"The name of the network to connect to, e.g. arabica or mamaki",
+		"The name of the network to connect to, e.g. "+params.ListProvidedNetworks(),
 	)
 
 	return flags

--- a/params/default.go
+++ b/params/default.go
@@ -18,8 +18,12 @@ func DefaultNetwork() Network {
 	return defaultNetwork
 }
 
-func SetDefaultNetwork(net Network) {
+func SetDefaultNetwork(net Network) error {
+	if err := net.Validate(); err != nil {
+		return err
+	}
 	defaultNetwork = net
+	return nil
 }
 
 func init() {
@@ -35,7 +39,7 @@ func init() {
 			panic("params: must provide at least <network_ID> to use a custom network")
 		}
 		netID := params[0]
-		SetDefaultNetwork(Network(netID))
+		defaultNetwork = Network(netID)
 		networksList[defaultNetwork] = struct{}{}
 		// check if genesis hash provided and register it if exists
 		if len(params) >= 2 {

--- a/params/default.go
+++ b/params/default.go
@@ -7,8 +7,7 @@ import (
 )
 
 const (
-	EnvCustomNetwork  = "CELESTIA_CUSTOM"
-	EnvPrivateGenesis = "CELESTIA_PRIVATE_GENESIS"
+	EnvCustomNetwork = "CELESTIA_CUSTOM"
 )
 
 // defaultNetwork defines a default network for the Celestia Node.
@@ -17,6 +16,10 @@ var defaultNetwork = Arabica
 // DefaultNetwork returns the network of the current build.
 func DefaultNetwork() Network {
 	return defaultNetwork
+}
+
+func SetDefaultNetwork(net Network) {
+	defaultNetwork = net
 }
 
 func init() {
@@ -32,7 +35,7 @@ func init() {
 			panic("params: must provide at least <network_ID> to use a custom network")
 		}
 		netID := params[0]
-		defaultNetwork = Network(netID)
+		SetDefaultNetwork(Network(netID))
 		networksList[defaultNetwork] = struct{}{}
 		// check if genesis hash provided and register it if exists
 		if len(params) >= 2 {
@@ -51,10 +54,5 @@ func init() {
 			}
 			bootstrapList[Network(netID)] = bs
 		}
-	}
-	// check if private network option set
-	if genesis, ok := os.LookupEnv(EnvPrivateGenesis); ok {
-		defaultNetwork = Private
-		genesisList[Private] = strings.ToUpper(genesis)
 	}
 }

--- a/params/genesis.go
+++ b/params/genesis.go
@@ -4,7 +4,6 @@ import "fmt"
 
 // GenesisFor reports a hash of a genesis block for a given network.
 // Genesis is strictly defined and can't be modified.
-// To run a custom genesis private network use CELESTIA_PRIVATE_GENESIS env var.
 func GenesisFor(net Network) (string, error) {
 	if err := net.Validate(); err != nil {
 		return "", err

--- a/params/network.go
+++ b/params/network.go
@@ -13,7 +13,6 @@ const (
 	// Mamaki testnet. See: celestiaorg/networks.
 	Mamaki Network = "mamaki"
 	// Private can be used to set up any private network, including local testing setups.
-	// Use CELESTIA_PRIVATE_GENESIS env var to enable Private by specifying its genesis block hash.
 	Private Network = "private"
 )
 

--- a/params/network.go
+++ b/params/network.go
@@ -39,3 +39,16 @@ var networksList = map[Network]struct{}{
 	Mamaki:  {},
 	Private: {},
 }
+
+// ListProvidedNetworks provides a string listing all known long-standing networks for things like command hints.
+func ListProvidedNetworks() string {
+	var networks string
+	for net := range networksList {
+		// "private" network isn't really a choosable option, so skip
+		if net != Private {
+			networks += string(net) + ", "
+		}
+	}
+	// chop off trailing ", "
+	return networks[:len(networks)-2]
+}


### PR DESCRIPTION
Closes #1066 .

- node store, extend home directory with network name
- Keep CELESTIA_CUSTOM, deprecate CELESTIA_PRIVATE_GENESIS
    - panic will be taken care of by the node store naming extension
- Add `--node.network < arabica || mamaki || ... >`
- Fixes cel-shed and cel-key packages