### PR TITLE
refactor(service/state): `CoreAccessor` relies on `header.Head` instead of `header.Getter`

### DIFF
--- a/header/interface.go
+++ b/header/interface.go
@@ -104,8 +104,7 @@ type Store interface {
 // Getter contains the behavior necessary for a component to retrieve
 // headers that have been processed during header sync.
 type Getter interface {
-	// Head returns the ExtendedHeader of the chain head.
-	Head(context.Context) (*ExtendedHeader, error)
+	Head
 
 	// Get returns the ExtendedHeader corresponding to the given hash.
 	Get(context.Context, tmbytes.HexBytes) (*ExtendedHeader, error)
@@ -115,4 +114,12 @@ type Getter interface {
 
 	// GetRangeByHeight returns the given range [from:to) of ExtendedHeaders.
 	GetRangeByHeight(ctx context.Context, from, to uint64) ([]*ExtendedHeader, error)
+}
+
+// Head contains the behavior necessary for a component to retrieve
+// the chain head. Note that "chain head" is subjective to the component
+// reporting it.
+type Head interface {
+	// Head returns the latest known header.
+	Head(context.Context) (*ExtendedHeader, error)
 }

--- a/header/sync/sync_head.go
+++ b/header/sync/sync_head.go
@@ -9,6 +9,11 @@ import (
 	"github.com/celestiaorg/celestia-node/header"
 )
 
+// Head returns the Syncer's latest known header.
+func (s *Syncer) Head(ctx context.Context) (*header.ExtendedHeader, error) {
+	return s.networkHead(ctx)
+}
+
 // subjectiveHead returns the latest known local header that is not expired(within trusting period).
 // If the header is expired, it is retrieved from a trusted peer without validation;
 // in other words, an automatic subjective initialization is performed.

--- a/header/sync/sync_head.go
+++ b/header/sync/sync_head.go
@@ -9,7 +9,8 @@ import (
 	"github.com/celestiaorg/celestia-node/header"
 )
 
-// Head returns the Syncer's latest known header.
+// Head returns the Syncer's latest known header. It calls 'networkHead' in order to
+// either return or eagerly fetch the most recent header.
 func (s *Syncer) Head(ctx context.Context) (*header.ExtendedHeader, error) {
 	return s.networkHead(ctx)
 }

--- a/node/state/core.go
+++ b/node/state/core.go
@@ -4,7 +4,8 @@ import (
 	"go.uber.org/fx"
 
 	apptypes "github.com/celestiaorg/celestia-app/x/payment/types"
-	"github.com/celestiaorg/celestia-node/header"
+
+	"github.com/celestiaorg/celestia-node/header/sync"
 	"github.com/celestiaorg/celestia-node/service/state"
 )
 
@@ -14,9 +15,9 @@ func CoreAccessor(
 	coreIP,
 	coreRPC,
 	coreGRPC string,
-) func(fx.Lifecycle, *apptypes.KeyringSigner, header.Store) (state.Accessor, error) {
-	return func(lc fx.Lifecycle, signer *apptypes.KeyringSigner, getter header.Store) (state.Accessor, error) {
-		ca := state.NewCoreAccessor(signer, getter, coreIP, coreRPC, coreGRPC)
+) func(fx.Lifecycle, *apptypes.KeyringSigner, *sync.Syncer) (state.Accessor, error) {
+	return func(lc fx.Lifecycle, signer *apptypes.KeyringSigner, syncer *sync.Syncer) (state.Accessor, error) {
+		ca := state.NewCoreAccessor(signer, syncer, coreIP, coreRPC, coreGRPC)
 		lc.Append(fx.Hook{
 			OnStart: ca.Start,
 			OnStop:  ca.Stop,

--- a/node/state/state.go
+++ b/node/state/state.go
@@ -7,7 +7,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/fraud"
-	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/node/core"
 	"github.com/celestiaorg/celestia-node/node/key"
@@ -32,10 +31,9 @@ func Service(
 	ctx context.Context,
 	lc fx.Lifecycle,
 	accessor state.Accessor,
-	store header.Store,
 	fservice fraud.Service,
 ) *state.Service {
-	serv := state.NewService(accessor, store)
+	serv := state.NewService(accessor)
 	lifecycleCtx := fxutil.WithLifecycle(ctx, lc)
 	lc.Append(fx.Hook{
 		OnStart: func(startCtx context.Context) error {

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -30,7 +30,7 @@ var log = logging.Logger("state")
 // with a celestia-core node.
 type CoreAccessor struct {
 	signer *apptypes.KeyringSigner
-	getter header.Getter
+	getter header.Head
 
 	queryCli   banktypes.QueryClient
 	stakingCli stakingtypes.QueryClient
@@ -47,7 +47,7 @@ type CoreAccessor struct {
 // connection.
 func NewCoreAccessor(
 	signer *apptypes.KeyringSigner,
-	getter header.Getter,
+	getter header.Head,
 	coreIP,
 	rpcPort string,
 	grpcPort string,

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/nmt/namespace"
 )
 
@@ -16,15 +15,12 @@ type Service struct {
 	cancel context.CancelFunc
 
 	accessor Accessor
-
-	getter header.Getter
 }
 
 // NewService constructs a new state Service.
-func NewService(accessor Accessor, getter header.Getter) *Service {
+func NewService(accessor Accessor) *Service {
 	return &Service{
 		accessor: accessor,
-		getter:   getter,
 	}
 }
 


### PR DESCRIPTION
`CoreAccessor` relies on the `Syncer` implementation of `header.Head` instead of the `header.Store` implementation of `header.Getter` in order to provide access to more current network head, and consequently, balance information.