### PR TITLE
feat(rpc): Allowing for `ValAddr` on `/transfer` and `/balance/$ADDRESS`

### DIFF
--- a/service/rpc/state.go
+++ b/service/rpc/state.go
@@ -26,8 +26,9 @@ const (
 	queryRedelegationsEndpoint = "/query_redelegations"
 )
 
+const addrKey = "address"
+
 var (
-	addrKey                 = "address"
 	ErrInvalidAddressFormat = errors.New("address must be a valid account or validator address")
 	ErrMissingAddress       = errors.New("address not specified")
 	ErrInvalidAmount        = errors.New("amount must be greater than zero")
@@ -99,7 +100,8 @@ func (h *Handler) handleBalanceRequest(w http.ResponseWriter, r *http.Request) {
 	addrStr, exists := vars[addrKey]
 	if exists {
 		// convert address to Address type
-		addr, err := types.AccAddressFromBech32(addrStr)
+		var addr state.AccAddress
+		addr, err = types.AccAddressFromBech32(addrStr)
 		if err != nil {
 			// first check if it is a validator address and can be converted
 			valAddr, err := types.ValAddressFromBech32(addrStr)

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -136,7 +136,7 @@ func (ca *CoreAccessor) Balance(ctx context.Context) (*Balance, error) {
 	return ca.BalanceForAddress(ctx, addr)
 }
 
-func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr AccAddress) (*Balance, error) {
+func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*Balance, error) {
 	head, err := ca.getter.Head(ctx)
 	if err != nil {
 		return nil, err

--- a/service/state/interface.go
+++ b/service/state/interface.go
@@ -27,7 +27,7 @@ type Accessor interface {
 	// NOTE: the balance returned is the balance reported by the block right before
 	// the node's current head (head-1). This is due to the fact that for block N, the block's
 	// `AppHash` is the result of applying the previous block's transaction list.
-	BalanceForAddress(ctx context.Context, addr AccAddress) (*Balance, error)
+	BalanceForAddress(ctx context.Context, addr Address) (*Balance, error)
 
 	// Transfer sends the given amount of coins from default wallet of the node to the given account address.
 	Transfer(ctx context.Context, to AccAddress, amount math.Int, gasLimit uint64) (*TxResponse, error)

--- a/service/state/service.go
+++ b/service/state/service.go
@@ -37,7 +37,7 @@ func (s *Service) Balance(ctx context.Context) (*Balance, error) {
 	return s.accessor.Balance(ctx)
 }
 
-func (s *Service) BalanceForAddress(ctx context.Context, addr AccAddress) (*Balance, error) {
+func (s *Service) BalanceForAddress(ctx context.Context, addr Address) (*Balance, error) {
 	return s.accessor.BalanceForAddress(ctx, addr)
 }
 

--- a/service/state/state.go
+++ b/service/state/state.go
@@ -15,6 +15,9 @@ type Tx = coretypes.Tx
 // TxResponse is an alias to the TxResponse type from Cosmos-SDK.
 type TxResponse = sdk.TxResponse
 
+// Address is an alias to the Address type from Cosmos-SDK.
+type Address = sdk.Address
+
 // ValAddress is an alias to the ValAddress type from Cosmos-SDK.
 type ValAddress = sdk.ValAddress
 


### PR DESCRIPTION
Closes #1085 

Notes:
- The `Accessor` interface still requires an `AccAddress` in Transfer. This is because the transfer does in fact need an account address. However: We can convert a `ValAddr` to an `AccAddr` while handling the request.
- BalanceForAddress does take ANY address type again (so `sdk.Address`), and the RPC handles only `AccAddress` and `ValAddress`.
- When querying the balance of validators, something blows up with retrieving proofs. For example try querying the balance of `celestiavaloper1t5x0tdfepqjnez24keew4p46v89a0wn0s7fmup` on Arabica.

Good insight to keep:
The underlying bytes of an `sdk.Address` do not include the HRP or checksum, so we can convert between all address types using it. But we need at least one valid Bech32 address first to convert from (which is why for example BalanceForAddress takes all address types, but we only try decoding from `AccAddr` and `ValAddr`)