### PR TITLE
refactor(service/state): Use DefaultProofRuntime instead of ibc-go `VerifyMembership` endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/celestiaorg/rsmt2d v0.6.0
 	github.com/cosmos/cosmos-sdk v0.46.0-beta2.0.20220418184507-c53157dd63f6
 	github.com/cosmos/cosmos-sdk/api v0.1.0
-	github.com/cosmos/ibc-go/v4 v4.0.0
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/gammazero/workerpool v1.1.3
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,6 @@ github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.19.0 h1:sgyrjqOkycXiN7Tuupuo4QAldKFg7Sipyfeg/IL7cps=
 github.com/cosmos/iavl v0.19.0/go.mod h1:l5h9pAB3m5fihB3pXVgwYqdY8aBsMagqz7T0MUjxZeA=
-github.com/cosmos/ibc-go/v4 v4.0.0 h1:kqbbRDFB9bNLVfxImZ1wIsXZKjbS5NZ5xvnv/MoX138=
-github.com/cosmos/ibc-go/v4 v4.0.0/go.mod h1:qxfXOjgJKDzdJeTTDFowrFxxI1KD3x1k0pZifdf9fOg=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
 github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
 github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -3,13 +3,12 @@ package state
 import (
 	"context"
 	"fmt"
-
 	"github.com/cosmos/cosmos-sdk/api/tendermint/abci"
+	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	proofutils "github.com/cosmos/ibc-go/v4/modules/core/23-commitment/types"
 	logging "github.com/ipfs/go-log/v2"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/client/http"
@@ -178,19 +177,14 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr AccAddress) 
 	if !ok {
 		return nil, fmt.Errorf("cannot convert %s into sdktypes.Int", string(value))
 	}
-	// convert proofs into a more digestible format
-	merkleproof, err := proofutils.ConvertProofs(result.Response.GetProofOps())
+	// verify balance
+	path := fmt.Sprintf("/%s/%s", banktypes.StoreKey, string(prefixedAccountKey))
+	prt := rootmulti.DefaultProofRuntime()
+	err = prt.VerifyValue(result.Response.GetProofOps(), head.AppHash, path, value)
 	if err != nil {
 		return nil, err
 	}
-	root := proofutils.NewMerkleRoot(head.AppHash)
-	// VerifyMembership expects the path as:
-	// []string{<store key of module>, <actual key corresponding to requested value>}
-	path := proofutils.NewMerklePath(banktypes.StoreKey, string(prefixedAccountKey))
-	err = merkleproof.VerifyMembership(proofutils.GetSDKSpecs(), root, path, value)
-	if err != nil {
-		return nil, err
-	}
+
 	return &Balance{
 		Denom:  app.BondDenom,
 		Amount: coin,

--- a/service/state/core_access.go
+++ b/service/state/core_access.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/api/tendermint/abci"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"


### PR DESCRIPTION
Removes ibc-go as a dependency of node and uses cosmos-sdk DefaultProofRuntime instead.