### PR TITLE
chore: remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
 linters:
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -33,13 +32,11 @@ linters:
     # - scopelint - deprecated since v1.39. exportloopref will be used instead
     - exportloopref
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     # - unparam
     - unused
-    - varcheck
     # - whitespace
     # - wsl
     # - gocognit


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-node/issues/1149

The `unused` linter is already enabled: https://github.com/celestiaorg/celestia-node/blob/a036bc6a0ef121d15c394d44900da0ec16077b80/.golangci.yml#L41