### PR TITLE
bugfix(nodebuilder/fraud): remove fraud.Subscriber from module

### DIFF
--- a/nodebuilder/fraud/module.go
+++ b/nodebuilder/fraud/module.go
@@ -4,8 +4,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"
 
-	"github.com/celestiaorg/celestia-node/fraud"
-	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
@@ -16,12 +14,12 @@ func Module(tp node.Type) fx.Option {
 	case node.Light:
 		return fx.Module(
 			"fraud",
-			fxutil.ProvideAs(ServiceWithSyncer, new(fraud.Service), new(fraud.Subscriber)),
+			fx.Provide(ServiceWithSyncer),
 		)
 	case node.Full, node.Bridge:
 		return fx.Module(
 			"fraud",
-			fxutil.ProvideAs(Service, new(fraud.Service), new(fraud.Subscriber)),
+			fx.Provide(Service),
 		)
 	default:
 		panic("invalid node type")


### PR DESCRIPTION
It's not nessesary to invoke `new(fraud.Subscriber)` in the Module creation because this instances of fraud.Subscriber is not used anywhere. According to our logic it should be passed to [OnProof](https://github.com/celestiaorg/celestia-node/blob/b95d48647a3a1da2de7a69c4a071ae85ef9159e3/fraud/proof.go#L52) and OnProof is invoked from [Lifecycle](https://github.com/celestiaorg/celestia-node/blob/b95d48647a3a1da2de7a69c4a071ae85ef9159e3/nodebuilder/fraud/fraud.go#L74) that receives fraud.Service as an input parameter.