### PR TITLE
Fix markdown lint workflow to run on directories

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,4 +19,4 @@ jobs:
           node-version: 18
       - run: |
           npm install -g markdownlint-cli@0.32.1
-          markdownlint --config .markdownlint.yaml **/*.md
+          markdownlint --config .markdownlint.yaml '**/*.md'


### PR DESCRIPTION
Ref https://github.com/celestiaorg/celestia-app/pull/794

Apparently quotes are needed if you have some subdirectory structure. Note that official examples use quotes: https://github.com/igorshubovych/markdownlint-cli/tree/f891b45ee50f621330160e5dcfa47435ac2220f8#globbing-examples