### PR TITLE
bugfix: fix flakiness in TestFullReconstructFromLights

### DIFF
--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -102,7 +102,7 @@ func TestFullReconstructFromLights(t *testing.T) {
 		lnodes = 69
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	t.Cleanup(cancel)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
 	errCh := make(chan error)


### PR DESCRIPTION
The main root cause was in timeout duration.
Discovery takes 7-10 seconds. 
` reconstruct_test.go:160: discovery done after: 7.190291886`
Syncing blocks ~15
`sync/sync.go:197	finished syncing	{"from": 19, "to": 58, "elapsed time": 15.208134365}`

So, sometimes the 30 Seconds timeout was not enough to discover full node, sync headers and reconstruct 20 headers.
 ```
    reconstruct_test.go:181: fill blocks finished
    reconstruct_test.go:170: retreiving header with height 1
    reconstruct_test.go:174: retreiving header with height 1 finished in 0.000001
    reconstruct_test.go:170: retreiving header with height 2
    reconstruct_test.go:174: retreiving header with height 2 finished in 0.000000
    reconstruct_test.go:170: retreiving header with height 3
    reconstruct_test.go:170: retreiving header with height 4
    reconstruct_test.go:170: retreiving header with height 5
    reconstruct_test.go:170: retreiving header with height 6
    reconstruct_test.go:170: retreiving header with height 7
    reconstruct_test.go:170: retreiving header with height 8
    reconstruct_test.go:170: retreiving header with height 9
    reconstruct_test.go:170: retreiving header with height 10
    reconstruct_test.go:170: retreiving header with height 11
    reconstruct_test.go:170: retreiving header with height 12
    reconstruct_test.go:174: retreiving header with height 3 finished in 6.850856
    reconstruct_test.go:174: retreiving header with height 11 finished in 7.600257
    reconstruct_test.go:170: retreiving header with height 13
    reconstruct_test.go:174: retreiving header with height 5 finished in 11.732598
    reconstruct_test.go:174: retreiving header with height 8 finished in 11.904563
    reconstruct_test.go:170: retreiving header with height 14
    reconstruct_test.go:174: retreiving header with height 14 finished in 0.000004
    reconstruct_test.go:174: retreiving header with height 7 finished in 13.274618
    reconstruct_test.go:170: retreiving header with height 15
    reconstruct_test.go:174: retreiving header with height 15 finished in 0.000004
    reconstruct_test.go:170: retreiving header with height 16
    reconstruct_test.go:174: retreiving header with height 16 finished in 0.000005
    reconstruct_test.go:174: retreiving header with height 12 finished in 11.199466
    reconstruct_test.go:174: retreiving header with height 10 finished in 16.013471
    reconstruct_test.go:170: retreiving header with height 17
    reconstruct_test.go:174: retreiving header with height 17 finished in 0.000004
    reconstruct_test.go:174: retreiving header with height 6 finished in 16.747109
    reconstruct_test.go:174: retreiving header with height 4 finished in 16.903462
    reconstruct_test.go:174: retreiving header with height 9 finished in 17.053828
    reconstruct_test.go:174: retreiving header with height 13 finished in 6.086634
    reconstruct_test.go:170: retreiving header with height 18
    reconstruct_test.go:174: retreiving header with height 18 finished in 0.000004
```