### PR TITLE
fix: README link for header doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ celestia <node_type> start
 
 ## Package-specific documentation
 
-- [Header](./service/header/doc.go)
+- [Header](./header/doc.go)
 - [Share](./share/doc.go)
 - [DAS](./das/doc.go)
 


### PR DESCRIPTION
This doc was moved in https://github.com/celestiaorg/celestia-node/commit/a0232625250c9128c0d6fa74d27329c113603138