### PR TITLE
feat(blocksync): Benchmarks for `ReadEDS` and `WriteEDS`

### DIFF
--- a/share/eds/eds_test.go
+++ b/share/eds/eds_test.go
@@ -176,6 +176,8 @@ func TestReadEDSContentIntegrityMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "share: content integrity mismatch: imported root")
 }
 
+// BenchmarkReadWriteEDS benchmarks the time it takes to write and read an EDS from disk.
+// The benchmark is run with a 4x4 ODS to a 64x64 ODS - a higher value can be used but it will run for much longer.
 func BenchmarkReadWriteEDS(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	b.Cleanup(cancel)

--- a/share/eds/eds_test.go
+++ b/share/eds/eds_test.go
@@ -183,9 +183,6 @@ func BenchmarkReadWriteEDS(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	b.Cleanup(cancel)
 	for originalDataWidth := 4; originalDataWidth <= 64; originalDataWidth *= 2 {
-		tmpDir := b.TempDir()
-		err := os.Chdir(tmpDir)
-		require.NoError(b, err)
 		eds := share.RandEDS(b, originalDataWidth)
 		dah := da.NewDataAvailabilityHeader(eds)
 		b.Run(fmt.Sprintf("Writing %dx%d", originalDataWidth, originalDataWidth), func(b *testing.B) {
@@ -203,7 +200,7 @@ func BenchmarkReadWriteEDS(b *testing.B) {
 				f := new(bytes.Buffer)
 				_ = WriteEDS(ctx, eds, f)
 				b.StartTimer()
-				_, err = ReadEDS(ctx, f, dah)
+				_, err := ReadEDS(ctx, f, dah)
 				require.NoError(b, err)
 			}
 		})

--- a/share/eds/eds_test.go
+++ b/share/eds/eds_test.go
@@ -178,6 +178,7 @@ func TestReadEDSContentIntegrityMismatch(t *testing.T) {
 
 func BenchmarkReadWriteEDS(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
 	for originalDataWidth := 4; originalDataWidth <= 64; originalDataWidth *= 2 {
 		tmpDir := b.TempDir()
 		err := os.Chdir(tmpDir)
@@ -201,7 +202,6 @@ func BenchmarkReadWriteEDS(b *testing.B) {
 			}
 		})
 	}
-	b.Cleanup(cancel)
 }
 
 func writeRandomEDS(t *testing.T) *rsmt2d.ExtendedDataSquare {

--- a/share/eds/eds_test.go
+++ b/share/eds/eds_test.go
@@ -177,8 +177,8 @@ func TestReadEDSContentIntegrityMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "share: content integrity mismatch: imported root")
 }
 
-// BenchmarkReadWriteEDS benchmarks the time it takes to write and read an EDS from disk.
-// The benchmark is run with a 4x4 ODS to a 64x64 ODS - a higher value can be used but it will run for much longer.
+// BenchmarkReadWriteEDS benchmarks the time it takes to write and read an EDS from disk. The benchmark is run with a
+// 4x4 ODS to a 64x64 ODS - a higher value can be used, but it will run for much longer.
 func BenchmarkReadWriteEDS(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	b.Cleanup(cancel)

--- a/share/test_helpers.go
+++ b/share/test_helpers.go
@@ -66,6 +66,8 @@ func RandShares(t *testing.T, total int) []Share {
 	return shares
 }
 
+// RandBenchmarkEDS generates an EDS filled with random data using size as the ODS width.
+// It is used for benchmarking purposes, and does not check any errors.
 func RandBenchmarkEDS(b *testing.B, size int) *rsmt2d.ExtendedDataSquare {
 	total := size * size
 

--- a/share/test_helpers.go
+++ b/share/test_helpers.go
@@ -65,3 +65,24 @@ func RandShares(t *testing.T, total int) []Share {
 
 	return shares
 }
+
+func RandBenchmarkEDS(b *testing.B, size int) *rsmt2d.ExtendedDataSquare {
+	total := size * size
+
+	shares := make([]Share, total)
+	for i := range shares {
+		nid := make([]byte, Size)
+		mrand.Read(nid[:NamespaceSize])
+		shares[i] = nid
+	}
+	sort.Slice(shares, func(i, j int) bool { return bytes.Compare(shares[i], shares[j]) < 0 })
+
+	for i := range shares {
+		mrand.Read(shares[i][NamespaceSize:])
+	}
+	// create the nmt wrapper to generate row and col commitments
+	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(size))
+	// recompute the eds
+	eds, _ := rsmt2d.ComputeExtendedDataSquare(shares, DefaultRSMT2DCodec(), tree.Constructor)
+	return eds
+}

--- a/share/test_helpers.go
+++ b/share/test_helpers.go
@@ -31,7 +31,8 @@ func EqualEDS(a *rsmt2d.ExtendedDataSquare, b *rsmt2d.ExtendedDataSquare) bool {
 	return true
 }
 
-// RandEDS generates EDS filled with the random data with the given size for original square.
+// RandEDS generates EDS filled with the random data with the given size for original square. It uses require.TestingT
+// to be able to take both a *testing.T and a *testing.B.
 func RandEDS(t require.TestingT, size int) *rsmt2d.ExtendedDataSquare {
 	shares := RandShares(t, size*size)
 	// create the nmt wrapper to generate row and col commitments
@@ -42,10 +43,11 @@ func RandEDS(t require.TestingT, size int) *rsmt2d.ExtendedDataSquare {
 	return eds
 }
 
-// RandShares generate 'total' amount of shares filled with random data.
+// RandShares generate 'total' amount of shares filled with random data. It uses require.TestingT to be able to take
+// both a *testing.T and a *testing.B.
 func RandShares(t require.TestingT, total int) []Share {
 	if total&(total-1) != 0 {
-		t.Errorf("Namespace total must be power of 2")
+		t.Errorf("Namespace total must be power of 2: %d", total)
 		t.FailNow()
 	}
 


### PR DESCRIPTION
Based on #1158 

Closes #1106 