### PR TITLE
feat(gateway): reenabling gateway, adding flag to enable

### DIFF
--- a/api/gateway/server_test.go
+++ b/api/gateway/server_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	address, port := "0.0.0.0", "0"
+	address, port := "localhost", "0"
 	server := NewServer(address, port)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -25,7 +25,7 @@ func TestServer(t *testing.T) {
 	ping := new(ping)
 	server.RegisterHandlerFunc("/ping", ping.ServeHTTP, http.MethodGet)
 
-	url := fmt.Sprintf("http://%s/ping", server.listener.Addr().String())
+	url := fmt.Sprintf("http://%s/ping", server.ListenAddr())
 
 	resp, err := http.Get(url)
 	require.NoError(t, err)

--- a/api/gateway/server_test.go
+++ b/api/gateway/server_test.go
@@ -12,10 +12,8 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	server := NewServer(Config{
-		Address: "0.0.0.0",
-		Port:    "0",
-	})
+	address, port := "0.0.0.0", "0"
+	server := NewServer(address, port)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/filecoin-project/go-jsonrpc"
@@ -12,8 +13,9 @@ import (
 var log = logging.Logger("rpc")
 
 type Server struct {
-	http *http.Server
-	rpc  *jsonrpc.RPCServer
+	http    *http.Server
+	rpc     *jsonrpc.RPCServer
+	started atomic.Bool
 }
 
 func NewServer(address string, port string) *Server {
@@ -37,20 +39,29 @@ func (s *Server) RegisterService(namespace string, service interface{}) {
 
 // Start starts the RPC Server.
 func (s *Server) Start(context.Context) error {
-	//nolint:errcheck
-	go s.http.ListenAndServe()
-	log.Infow("RPC server started", "listening on", s.http.Addr)
+	if s.started.CompareAndSwap(false, true) {
+		//nolint:errcheck
+		go s.http.ListenAndServe()
+		s.started.Store(true)
+		log.Infow("rpc: server started", "listening on", s.http.Addr)
+		return nil
+	}
+	log.Warn("rpc: cannot start server: already started")
 	return nil
 }
 
 // Stop stops the RPC Server.
 func (s *Server) Stop(ctx context.Context) error {
-	// if server already stopped, return
-	err := s.http.Shutdown(ctx)
-	if err != nil {
-		return err
+	if s.started.CompareAndSwap(true, false) {
+		err := s.http.Shutdown(ctx)
+		if err != nil {
+			return err
+		}
+		log.Info("rpc: server stopped")
+		s.started.Store(false)
+		return nil
 	}
-	log.Info("RPC server stopped")
+	log.Warn("rpc: cannot stop server: already stopped")
 	return nil
 }
 

--- a/cmd/celestia/bridge.go
+++ b/cmd/celestia/bridge.go
@@ -5,6 +5,7 @@ import (
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
+	"github.com/celestiaorg/celestia-node/nodebuilder/gateway"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/nodebuilder/rpc"
@@ -22,6 +23,7 @@ func init() {
 			core.Flags(),
 			cmdnode.MiscFlags(),
 			rpc.Flags(),
+			gateway.Flags(),
 			state.Flags(),
 		),
 		cmdnode.Start(
@@ -30,6 +32,7 @@ func init() {
 			core.Flags(),
 			cmdnode.MiscFlags(),
 			rpc.Flags(),
+			gateway.Flags(),
 			state.Flags(),
 		),
 	)
@@ -76,6 +79,7 @@ var bridgeCmd = &cobra.Command{
 		}
 
 		rpc.ParseFlags(cmd, &cfg.RPC)
+		gateway.ParseFlags(cmd, &cfg.Gateway)
 		state.ParseFlags(cmd, &cfg.State)
 
 		// set config

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -6,6 +6,7 @@ import (
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
+	"github.com/celestiaorg/celestia-node/nodebuilder/gateway"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
@@ -27,6 +28,7 @@ func init() {
 			// over an RPC connection with a celestia-core node.
 			core.Flags(),
 			rpc.Flags(),
+			gateway.Flags(),
 			state.Flags(),
 		),
 		cmdnode.Start(
@@ -38,6 +40,7 @@ func init() {
 			// over an RPC connection with a celestia-core node.
 			core.Flags(),
 			rpc.Flags(),
+			gateway.Flags(),
 			state.Flags(),
 		),
 	)
@@ -89,6 +92,7 @@ var fullCmd = &cobra.Command{
 		}
 
 		rpc.ParseFlags(cmd, &cfg.RPC)
+		gateway.ParseFlags(cmd, &cfg.Gateway)
 		state.ParseFlags(cmd, &cfg.State)
 
 		// set config

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -6,6 +6,7 @@ import (
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
+	"github.com/celestiaorg/celestia-node/nodebuilder/gateway"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
@@ -27,6 +28,7 @@ func init() {
 			// over an RPC connection with a celestia-core node.
 			core.Flags(),
 			rpc.Flags(),
+			gateway.Flags(),
 			state.Flags(),
 		),
 		cmdnode.Start(
@@ -38,6 +40,7 @@ func init() {
 			// over an RPC connection with a celestia-core node.
 			core.Flags(),
 			rpc.Flags(),
+			gateway.Flags(),
 			state.Flags(),
 		),
 	)
@@ -88,7 +91,9 @@ var lightCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
 		rpc.ParseFlags(cmd, &cfg.RPC)
+		gateway.ParseFlags(cmd, &cfg.Gateway)
 		state.ParseFlags(cmd, &cfg.State)
 
 		// set config

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
+	"github.com/celestiaorg/celestia-node/nodebuilder/gateway"
 	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -26,6 +27,7 @@ type Config struct {
 	State  state.Config
 	P2P    p2p.Config
 	RPC    rpc.Config
+	Gateway gateway.Config
 	Share  share.Config
 	Header header.Config
 	DASer  das.Config
@@ -41,6 +43,7 @@ func DefaultConfig(tp node.Type) *Config {
 			State:  state.DefaultConfig(),
 			P2P:    p2p.DefaultConfig(),
 			RPC:    rpc.DefaultConfig(),
+			Gateway: gateway.DefaultConfig(),
 			Share:  share.DefaultConfig(),
 			Header: header.DefaultConfig(),
 			DASer:  das.DefaultConfig(),

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -7,8 +7,8 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
-	"github.com/celestiaorg/celestia-node/nodebuilder/gateway"
 	"github.com/celestiaorg/celestia-node/nodebuilder/das"
+	"github.com/celestiaorg/celestia-node/nodebuilder/gateway"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
@@ -23,14 +23,14 @@ type ConfigLoader func() (*Config, error)
 // Config is main configuration structure for a Node.
 // It combines configuration units for all Node subsystems.
 type Config struct {
-	Core   core.Config
-	State  state.Config
-	P2P    p2p.Config
-	RPC    rpc.Config
+	Core    core.Config
+	State   state.Config
+	P2P     p2p.Config
+	RPC     rpc.Config
 	Gateway gateway.Config
-	Share  share.Config
-	Header header.Config
-	DASer  das.Config
+	Share   share.Config
+	Header  header.Config
+	DASer   das.Config
 }
 
 // DefaultConfig provides a default Config for a given Node Type 'tp'.
@@ -39,14 +39,14 @@ func DefaultConfig(tp node.Type) *Config {
 	switch tp {
 	case node.Bridge, node.Light, node.Full:
 		return &Config{
-			Core:   core.DefaultConfig(),
-			State:  state.DefaultConfig(),
-			P2P:    p2p.DefaultConfig(),
-			RPC:    rpc.DefaultConfig(),
+			Core:    core.DefaultConfig(),
+			State:   state.DefaultConfig(),
+			P2P:     p2p.DefaultConfig(),
+			RPC:     rpc.DefaultConfig(),
 			Gateway: gateway.DefaultConfig(),
-			Share:  share.DefaultConfig(),
-			Header: header.DefaultConfig(),
-			DASer:  das.DefaultConfig(),
+			Share:   share.DefaultConfig(),
+			Header:  header.DefaultConfig(),
+			DASer:   das.DefaultConfig(),
 		}
 	default:
 		panic("node: invalid node type")

--- a/nodebuilder/gateway/config.go
+++ b/nodebuilder/gateway/config.go
@@ -1,0 +1,33 @@
+package gateway
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+type Config struct {
+	Address string
+	Port    string
+	Enabled bool
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Address: "0.0.0.0",
+		// do NOT expose the same port as celestia-core by default so that both can run on the same machine
+		Port:    "26659",
+		Enabled: false,
+	}
+}
+
+func (cfg *Config) Validate() error {
+	if ip := net.ParseIP(cfg.Address); ip == nil {
+		return fmt.Errorf("service/rpc: invalid listen address format: %s", cfg.Address)
+	}
+	_, err := strconv.Atoi(cfg.Port)
+	if err != nil {
+		return fmt.Errorf("service/rpc: invalid port: %s", err.Error())
+	}
+	return nil
+}

--- a/nodebuilder/gateway/config.go
+++ b/nodebuilder/gateway/config.go
@@ -23,11 +23,11 @@ func DefaultConfig() Config {
 
 func (cfg *Config) Validate() error {
 	if ip := net.ParseIP(cfg.Address); ip == nil {
-		return fmt.Errorf("service/rpc: invalid listen address format: %s", cfg.Address)
+		return fmt.Errorf("gateway: invalid listen address format: %s", cfg.Address)
 	}
 	_, err := strconv.Atoi(cfg.Port)
 	if err != nil {
-		return fmt.Errorf("service/rpc: invalid port: %s", err.Error())
+		return fmt.Errorf("gateway: invalid port: %s", err.Error())
 	}
 	return nil
 }

--- a/nodebuilder/gateway/flags.go
+++ b/nodebuilder/gateway/flags.go
@@ -45,7 +45,7 @@ func ParseFlags(cmd *cobra.Command, cfg *Config) {
 	}
 	addr, port := cmd.Flag(addrFlag), cmd.Flag(portFlag)
 	if !enabled && (addr.Changed || port.Changed) {
-		log.Warn("gateway: cannot set custom address or port: gateway is disabled")
+		log.Warn("custom address or port provided without enabling gateway, setting config values")
 	}
 	addrVal := addr.Value.String()
 	if addrVal != "" {

--- a/nodebuilder/gateway/flags.go
+++ b/nodebuilder/gateway/flags.go
@@ -28,7 +28,7 @@ func Flags() *flag.FlagSet {
 	flags.String(
 		portFlag,
 		"",
-		"Set a custom gateway port (default: 26658)",
+		"Set a custom gateway port (default: 26659)",
 	)
 
 	return flags

--- a/nodebuilder/gateway/flags.go
+++ b/nodebuilder/gateway/flags.go
@@ -1,0 +1,51 @@
+package gateway
+
+import (
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+)
+
+var (
+	enabledFlag = "gateway"
+	addrFlag    = "gateway.addr"
+	portFlag    = "gateway.port"
+)
+
+// Flags gives a set of hardcoded node/gateway package flags.
+func Flags() *flag.FlagSet {
+	flags := &flag.FlagSet{}
+
+	flags.Bool(
+		enabledFlag,
+		false,
+		"Enables the REST gateway",
+	)
+	flags.String(
+		addrFlag,
+		"",
+		"Set a custom gateway listen address (default: localhost)",
+	)
+	flags.String(
+		portFlag,
+		"",
+		"Set a custom gateway port (default: 26658)",
+	)
+
+	return flags
+}
+
+// ParseFlags parses gateway flags from the given cmd and saves them to the passed config.
+func ParseFlags(cmd *cobra.Command, cfg *Config) {
+	addr := cmd.Flag(addrFlag).Value.String()
+	if addr != "" {
+		cfg.Address = addr
+	}
+	port := cmd.Flag(portFlag).Value.String()
+	if port != "" {
+		cfg.Port = port
+	}
+	enabled, err := cmd.Flags().GetBool(enabledFlag)
+	if err == nil {
+		cfg.Enabled = enabled
+	}
+}

--- a/nodebuilder/gateway/flags.go
+++ b/nodebuilder/gateway/flags.go
@@ -1,9 +1,12 @@
 package gateway
 
 import (
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 )
+
+var log = logging.Logger("gateway-module")
 
 var (
 	enabledFlag = "gateway"
@@ -36,16 +39,20 @@ func Flags() *flag.FlagSet {
 
 // ParseFlags parses gateway flags from the given cmd and saves them to the passed config.
 func ParseFlags(cmd *cobra.Command, cfg *Config) {
-	addr := cmd.Flag(addrFlag).Value.String()
-	if addr != "" {
-		cfg.Address = addr
-	}
-	port := cmd.Flag(portFlag).Value.String()
-	if port != "" {
-		cfg.Port = port
-	}
 	enabled, err := cmd.Flags().GetBool(enabledFlag)
 	if err == nil {
 		cfg.Enabled = enabled
+	}
+	addr, port := cmd.Flag(addrFlag), cmd.Flag(portFlag)
+	if !enabled && (addr.Changed || port.Changed) {
+		log.Warn("gateway: cannot set custom address or port: gateway is disabled")
+	}
+	addrVal := addr.Value.String()
+	if addrVal != "" {
+		cfg.Address = addrVal
+	}
+	portVal := port.Value.String()
+	if portVal != "" {
+		cfg.Port = portVal
 	}
 }

--- a/nodebuilder/gateway/gateway.go
+++ b/nodebuilder/gateway/gateway.go
@@ -13,8 +13,8 @@ func Handler(
 	state state.Module,
 	share share.Module,
 	header header.Module,
-	serv *gateway.Server,
 	daser *das.DASer,
+	serv *gateway.Server,
 ) {
 	handler := gateway.NewHandler(state, share, header, daser)
 	handler.RegisterEndpoints(serv)

--- a/nodebuilder/gateway/module.go
+++ b/nodebuilder/gateway/module.go
@@ -15,7 +15,6 @@ import (
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	// sanitize config values before constructing module
 	cfgErr := cfg.Validate()
-
 	if !cfg.Enabled {
 		return fx.Options()
 	}
@@ -51,7 +50,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 				header headerServ.Module,
 				serv *gateway.Server,
 			) {
-				Handler(state, share, header, serv, nil)
+				Handler(state, share, header, nil, serv)
 			}),
 		)
 	default:

--- a/nodebuilder/gateway/module.go
+++ b/nodebuilder/gateway/module.go
@@ -1,0 +1,60 @@
+package gateway
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+
+	"github.com/celestiaorg/celestia-node/api/gateway"
+	headerServ "github.com/celestiaorg/celestia-node/nodebuilder/header"
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	shareServ "github.com/celestiaorg/celestia-node/nodebuilder/share"
+	stateServ "github.com/celestiaorg/celestia-node/nodebuilder/state"
+)
+
+func ConstructModule(tp node.Type, cfg *Config) fx.Option {
+	// sanitize config values before constructing module
+	cfgErr := cfg.Validate()
+
+	if !cfg.Enabled {
+		return fx.Options()
+	}
+
+	baseComponents := fx.Options(
+		fx.Supply(cfg),
+		fx.Error(cfgErr),
+		fx.Provide(fx.Annotate(
+			Server,
+			fx.OnStart(func(ctx context.Context, server *gateway.Server) error {
+				return server.Start(ctx)
+			}),
+			fx.OnStop(func(ctx context.Context, server *gateway.Server) error {
+				return server.Stop(ctx)
+			}),
+		)),
+	)
+
+	switch tp {
+	case node.Light, node.Full:
+		return fx.Module(
+			"gateway",
+			baseComponents,
+			fx.Invoke(Handler),
+		)
+	case node.Bridge:
+		return fx.Module(
+			"gateway",
+			baseComponents,
+			fx.Invoke(func(
+				state stateServ.Module,
+				share shareServ.Module,
+				header headerServ.Module,
+				serv *gateway.Server,
+			) {
+				Handler(state, share, header, serv, nil)
+			}),
+		)
+	default:
+		panic("invalid node type")
+	}
+}

--- a/nodebuilder/gateway/rpc.go
+++ b/nodebuilder/gateway/rpc.go
@@ -1,0 +1,26 @@
+package gateway
+
+import (
+	"github.com/celestiaorg/celestia-node/api/gateway"
+	"github.com/celestiaorg/celestia-node/das"
+	"github.com/celestiaorg/celestia-node/nodebuilder/header"
+	"github.com/celestiaorg/celestia-node/nodebuilder/share"
+	"github.com/celestiaorg/celestia-node/nodebuilder/state"
+)
+
+// Handler constructs a new RPC Handler from the given services.
+func Handler(
+	state state.Module,
+	share share.Module,
+	header header.Module,
+	serv *gateway.Server,
+	daser *das.DASer,
+) {
+	handler := gateway.NewHandler(state, share, header, daser)
+	handler.RegisterEndpoints(serv)
+	handler.RegisterMiddleware(serv)
+}
+
+func Server(cfg *Config) *gateway.Server {
+	return gateway.NewServer(cfg.Address, cfg.Port)
+}

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -9,6 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
 	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/fraud"
+	"github.com/celestiaorg/celestia-node/nodebuilder/gateway"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
@@ -35,6 +36,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		header.ConstructModule(tp, &cfg.Header),
 		share.ConstructModule(tp, &cfg.Share),
 		rpc.ConstructModule(tp, &cfg.RPC),
+		gateway.ConstructModule(tp, &cfg.Gateway),
 		core.ConstructModule(tp, &cfg.Core),
 		das.ConstructModule(tp, &cfg.DASer),
 		fraud.ConstructModule(tp),

--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"go.uber.org/fx"
 
+	"github.com/celestiaorg/celestia-node/api/gateway"
 	"github.com/celestiaorg/celestia-node/api/rpc"
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/fraud"
@@ -45,7 +46,9 @@ type Node struct {
 	Config        *Config
 
 	// rpc components
-	RPCServer *rpc.Server // not optional
+	RPCServer     *rpc.Server     // not optional
+	GatewayServer *gateway.Server `optional:"true"`
+
 	// p2p components
 	Host         host.Host
 	ConnGater    *conngater.BasicConnectionGater


### PR DESCRIPTION
It adds the gateway back onto the node (closes #1182) with it's own config, disabled by default, which is activated by the flag `--gateway` (closes #1183).