### PR TITLE
fix(state): returning CoreAccessor from nodebuilder for state.WithMetrics

### DIFF
--- a/nodebuilder/settings.go
+++ b/nodebuilder/settings.go
@@ -90,7 +90,9 @@ func initializeMetrics(
 	)
 
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		// here we take the context from fx.Invoke because pusher uses it for its entire lifetime,
+		// instead of only for the Start operation
+		OnStart: func(context.Context) error {
 			return pusher.Start(ctx)
 		},
 		OnStop: func(ctx context.Context) error {

--- a/nodebuilder/state/core.go
+++ b/nodebuilder/state/core.go
@@ -23,7 +23,7 @@ func CoreAccessor(
 	corecfg core.Config,
 	signer *apptypes.KeyringSigner,
 	sync *sync.Syncer,
-) Module {
+) (Module, *state.CoreAccessor) {
 	service := state.NewCoreAccessor(signer, sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort)
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -34,5 +34,5 @@ func CoreAccessor(
 			return service.Stop(ctx)
 		},
 	})
-	return service
+	return service, service
 }

--- a/nodebuilder/state/core.go
+++ b/nodebuilder/state/core.go
@@ -1,15 +1,7 @@
 package state
 
 import (
-	"context"
-
-	"go.uber.org/fx"
-
 	apptypes "github.com/celestiaorg/celestia-app/x/payment/types"
-	"github.com/celestiaorg/celestia-node/fraud"
-	"github.com/celestiaorg/celestia-node/libs/fxutil"
-	fraudServ "github.com/celestiaorg/celestia-node/nodebuilder/fraud"
-
 	"github.com/celestiaorg/celestia-node/header/sync"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
 	"github.com/celestiaorg/celestia-node/state"
@@ -18,21 +10,9 @@ import (
 // CoreAccessor constructs a new instance of state.Module over
 // a celestia-core connection.
 func CoreAccessor(
-	lc fx.Lifecycle,
-	fService fraudServ.Module,
 	corecfg core.Config,
 	signer *apptypes.KeyringSigner,
 	sync *sync.Syncer,
-) (Module, *state.CoreAccessor) {
-	service := state.NewCoreAccessor(signer, sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort)
-	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
-			lifecycleCtx := fxutil.WithLifecycle(ctx, lc)
-			return fraudServ.Lifecycle(ctx, lifecycleCtx, fraud.BadEncoding, fService, service.Start, service.Stop)
-		},
-		OnStop: func(ctx context.Context) error {
-			return service.Stop(ctx)
-		},
-	})
-	return service, service
+) *state.CoreAccessor {
+	return state.NewCoreAccessor(signer, sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort)
 }


### PR DESCRIPTION
#1083 introduced `state.WithMetrics` that takes a `CoreAccessor` instead of the `Module`, so the DI currently fails to build.  This fixes the DI for nodes running metrics