### PR TITLE
fix(nodebuilder): fix ordering of modules according to new fx upgrade to 1.18.2

### DIFF
--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -30,10 +30,10 @@ func ConstructModule(tp node.Type, cfg *Config, store Store) fx.Option {
 		// modules provided by the node
 		p2p.ConstructModule(tp, &cfg.P2P),
 		state.ConstructModule(tp, &cfg.State),
-		header.ConstructModule(tp, &cfg.Header),
 		share.ConstructModule(tp, &cfg.Share),
 		rpc.ConstructModule(tp, &cfg.RPC),
 		core.ConstructModule(tp, &cfg.Core),
+		header.ConstructModule(tp, &cfg.Header),
 		daser.ConstructModule(tp),
 		fraud.ConstructModule(tp),
 	)


### PR DESCRIPTION
Ordering of invokes inside of modules matters now due to fx 1.18.2 upgrade which was impacting integration tests - now fixed

TODO: 
- [ ] unit tests for ensuring all components are built and running properly **per node type**
- [ ] if can't figure out by EOD (10.10.22), downgrade fx and include upgrade in this PR