### PR TITLE
feat(nodebuilder): add AccountAddress to state's Module

### DIFF
--- a/nodebuilder/state/service.go
+++ b/nodebuilder/state/service.go
@@ -32,23 +32,13 @@ type Module interface {
 	BalanceForAddress(ctx context.Context, addr state.Address) (*state.Balance, error)
 
 	// Transfer sends the given amount of coins from default wallet of the node to the given account address.
-	Transfer(
-		ctx context.Context,
-		to state.AccAddress,
-		amount math.Int,
-		gasLimit uint64,
-	) (*state.TxResponse, error)
+	Transfer(ctx context.Context, to state.AccAddress, amount math.Int, gasLimit uint64) (*state.TxResponse, error)
 	// SubmitTx submits the given transaction/message to the
 	// Celestia network and blocks until the tx is included in
 	// a block.
 	SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, error)
 	// SubmitPayForData builds, signs and submits a PayForData transaction.
-	SubmitPayForData(
-		ctx context.Context,
-		nID namespace.ID,
-		data []byte,
-		gasLim uint64,
-	) (*state.TxResponse, error)
+	SubmitPayForData(ctx context.Context, nID namespace.ID, data []byte, gasLim uint64) (*state.TxResponse, error)
 
 	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
 	CancelUnbondingDelegation(
@@ -67,30 +57,14 @@ type Module interface {
 		gasLim uint64,
 	) (*state.TxResponse, error)
 	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.
-	Undelegate(
-		ctx context.Context,
-		delAddr state.ValAddress,
-		amount state.Int,
-		gasLim uint64,
-	) (*state.TxResponse, error)
+	Undelegate(ctx context.Context, delAddr state.ValAddress, amount state.Int, gasLim uint64) (*state.TxResponse, error)
 	// Delegate sends a user's liquid tokens to a validator for delegation.
-	Delegate(
-		ctx context.Context,
-		delAddr state.ValAddress,
-		amount state.Int,
-		gasLim uint64,
-	) (*state.TxResponse, error)
+	Delegate(ctx context.Context, delAddr state.ValAddress, amount state.Int, gasLim uint64) (*state.TxResponse, error)
 
 	// QueryDelegation retrieves the delegation information between a delegator and a validator.
-	QueryDelegation(
-		ctx context.Context,
-		valAddr state.ValAddress,
-	) (*types.QueryDelegationResponse, error)
+	QueryDelegation(ctx context.Context, valAddr state.ValAddress) (*types.QueryDelegationResponse, error)
 	// QueryUnbonding retrieves the unbonding status between a delegator and a validator.
-	QueryUnbonding(
-		ctx context.Context,
-		valAddr state.ValAddress,
-	) (*types.QueryUnbondingDelegationResponse, error)
+	QueryUnbonding(ctx context.Context, valAddr state.ValAddress) (*types.QueryUnbondingDelegationResponse, error)
 	// QueryRedelegations retrieves the status of the redelegations between a delegator and a validator.
 	QueryRedelegations(
 		ctx context.Context,

--- a/nodebuilder/state/service.go
+++ b/nodebuilder/state/service.go
@@ -18,6 +18,8 @@ type Module interface {
 	// IsStopped checks if the Module's context has been stopped
 	IsStopped() bool
 
+	// AccountAddress retrieves the address of the node's account/signer
+	AccountAddress(ctx context.Context) (state.Address, error)
 	// Balance retrieves the Celestia coin balance for the node's account/signer
 	// and verifies it against the corresponding block's AppHash.
 	Balance(ctx context.Context) (*state.Balance, error)
@@ -30,13 +32,23 @@ type Module interface {
 	BalanceForAddress(ctx context.Context, addr state.Address) (*state.Balance, error)
 
 	// Transfer sends the given amount of coins from default wallet of the node to the given account address.
-	Transfer(ctx context.Context, to state.AccAddress, amount math.Int, gasLimit uint64) (*state.TxResponse, error)
+	Transfer(
+		ctx context.Context,
+		to state.AccAddress,
+		amount math.Int,
+		gasLimit uint64,
+	) (*state.TxResponse, error)
 	// SubmitTx submits the given transaction/message to the
 	// Celestia network and blocks until the tx is included in
 	// a block.
 	SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, error)
 	// SubmitPayForData builds, signs and submits a PayForData transaction.
-	SubmitPayForData(ctx context.Context, nID namespace.ID, data []byte, gasLim uint64) (*state.TxResponse, error)
+	SubmitPayForData(
+		ctx context.Context,
+		nID namespace.ID,
+		data []byte,
+		gasLim uint64,
+	) (*state.TxResponse, error)
 
 	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
 	CancelUnbondingDelegation(
@@ -55,14 +67,30 @@ type Module interface {
 		gasLim uint64,
 	) (*state.TxResponse, error)
 	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.
-	Undelegate(ctx context.Context, delAddr state.ValAddress, amount state.Int, gasLim uint64) (*state.TxResponse, error)
+	Undelegate(
+		ctx context.Context,
+		delAddr state.ValAddress,
+		amount state.Int,
+		gasLim uint64,
+	) (*state.TxResponse, error)
 	// Delegate sends a user's liquid tokens to a validator for delegation.
-	Delegate(ctx context.Context, delAddr state.ValAddress, amount state.Int, gasLim uint64) (*state.TxResponse, error)
+	Delegate(
+		ctx context.Context,
+		delAddr state.ValAddress,
+		amount state.Int,
+		gasLim uint64,
+	) (*state.TxResponse, error)
 
 	// QueryDelegation retrieves the delegation information between a delegator and a validator.
-	QueryDelegation(ctx context.Context, valAddr state.ValAddress) (*types.QueryDelegationResponse, error)
+	QueryDelegation(
+		ctx context.Context,
+		valAddr state.ValAddress,
+	) (*types.QueryDelegationResponse, error)
 	// QueryUnbonding retrieves the unbonding status between a delegator and a validator.
-	QueryUnbonding(ctx context.Context, valAddr state.ValAddress) (*types.QueryUnbondingDelegationResponse, error)
+	QueryUnbonding(
+		ctx context.Context,
+		valAddr state.ValAddress,
+	) (*types.QueryUnbondingDelegationResponse, error)
 	// QueryRedelegations retrieves the status of the redelegations between a delegator and a validator.
 	QueryRedelegations(
 		ctx context.Context,

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -75,11 +75,7 @@ func (ca *CoreAccessor) Start(ctx context.Context) error {
 	}
 	// dial given celestia-core endpoint
 	endpoint := fmt.Sprintf("%s:%s", ca.coreIP, ca.grpcPort)
-	client, err := grpc.DialContext(
-		ctx,
-		endpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	client, err := grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}
@@ -168,9 +164,7 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 	// the AppHash contained in the head is actually the state root
 	// after applying the transactions contained in the previous block.
 	// TODO @renaynay: once https://github.com/cosmos/cosmos-sdk/pull/12674 is merged, use this method instead
-	prefixedAccountKey := append(
-		banktypes.CreateAccountBalancesPrefix(addr.Bytes()),
-		[]byte(app.BondDenom)...)
+	prefixedAccountKey := append(banktypes.CreateAccountBalancesPrefix(addr.Bytes()), []byte(app.BondDenom)...)
 	abciReq := abci.RequestQuery{
 		// TODO @renayay: once https://github.com/cosmos/cosmos-sdk/pull/12674 is merged, use const instead
 		Path:   fmt.Sprintf("store/%s/key", banktypes.StoreKey),
@@ -193,11 +187,7 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 	value := result.Response.Value
 	// if the value returned is empty, the account balance does not yet exist
 	if len(value) == 0 {
-		log.Errorf(
-			"balance for account %s does not exist at block height %d",
-			addr.String(),
-			head.Height-1,
-		)
+		log.Errorf("balance for account %s does not exist at block height %d", addr.String(), head.Height-1)
 		return &Balance{
 			Denom:  app.BondDenom,
 			Amount: sdktypes.NewInt(0),
@@ -222,12 +212,7 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 }
 
 func (ca *CoreAccessor) SubmitTx(ctx context.Context, tx Tx) (*TxResponse, error) {
-	txResp, err := apptypes.BroadcastTx(
-		ctx,
-		ca.coreConn,
-		sdktx.BroadcastMode_BROADCAST_MODE_BLOCK,
-		tx,
-	)
+	txResp, err := apptypes.BroadcastTx(ctx, ca.coreConn, sdktx.BroadcastMode_BROADCAST_MODE_BLOCK, tx)
 	if err != nil {
 		return nil, err
 	}

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -75,7 +75,11 @@ func (ca *CoreAccessor) Start(ctx context.Context) error {
 	}
 	// dial given celestia-core endpoint
 	endpoint := fmt.Sprintf("%s:%s", ca.coreIP, ca.grpcPort)
-	client, err := grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	client, err := grpc.DialContext(
+		ctx,
+		endpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	if err != nil {
 		return err
 	}
@@ -139,6 +143,14 @@ func (ca *CoreAccessor) SubmitPayForData(
 	return payment.SubmitPayForData(ctx, ca.signer, ca.coreConn, nID, data, gasLim)
 }
 
+func (ca *CoreAccessor) AccountAddress(ctx context.Context) (Address, error) {
+	addr, err := ca.signer.GetSignerInfo().GetAddress()
+	if err != nil {
+		return nil, err
+	}
+	return addr, nil
+}
+
 func (ca *CoreAccessor) Balance(ctx context.Context) (*Balance, error) {
 	addr, err := ca.signer.GetSignerInfo().GetAddress()
 	if err != nil {
@@ -156,7 +168,9 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 	// the AppHash contained in the head is actually the state root
 	// after applying the transactions contained in the previous block.
 	// TODO @renaynay: once https://github.com/cosmos/cosmos-sdk/pull/12674 is merged, use this method instead
-	prefixedAccountKey := append(banktypes.CreateAccountBalancesPrefix(addr.Bytes()), []byte(app.BondDenom)...)
+	prefixedAccountKey := append(
+		banktypes.CreateAccountBalancesPrefix(addr.Bytes()),
+		[]byte(app.BondDenom)...)
 	abciReq := abci.RequestQuery{
 		// TODO @renayay: once https://github.com/cosmos/cosmos-sdk/pull/12674 is merged, use const instead
 		Path:   fmt.Sprintf("store/%s/key", banktypes.StoreKey),
@@ -179,7 +193,11 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 	value := result.Response.Value
 	// if the value returned is empty, the account balance does not yet exist
 	if len(value) == 0 {
-		log.Errorf("balance for account %s does not exist at block height %d", addr.String(), head.Height-1)
+		log.Errorf(
+			"balance for account %s does not exist at block height %d",
+			addr.String(),
+			head.Height-1,
+		)
 		return &Balance{
 			Denom:  app.BondDenom,
 			Amount: sdktypes.NewInt(0),
@@ -204,7 +222,12 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 }
 
 func (ca *CoreAccessor) SubmitTx(ctx context.Context, tx Tx) (*TxResponse, error) {
-	txResp, err := apptypes.BroadcastTx(ctx, ca.coreConn, sdktx.BroadcastMode_BROADCAST_MODE_BLOCK, tx)
+	txResp, err := apptypes.BroadcastTx(
+		ctx,
+		ca.coreConn,
+		sdktx.BroadcastMode_BROADCAST_MODE_BLOCK,
+		tx,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Getting address from node's account
This is a handy feature that testground's tests are already utilising in upcoming PFD test-plans 

Tested on this PR https://github.com/celestiaorg/test-infra/pull/87

Ref: 
#1056 #506 

External Ref: https://github.com/celestiaorg/test-infra/issues/33

P.S. I've prettified the code-base with `golines`. Let me know if this should be opted out to a different PR 