### PR TITLE
chore: disable debug log in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,25 +82,25 @@ lint:
 ## test-unit: Running unit tests
 test-unit:
 	@echo "--> Running unit tests"
-	@go test -v `go list ./... | grep -v nodebuilder/tests` -covermode=atomic -coverprofile=coverage.out
+	@go test `go list ./... | grep -v nodebuilder/tests` -covermode=atomic -coverprofile=coverage.out
 .PHONY: test-unit
 
 ## test-unit-race: Running unit tests with data race detector
 test-unit-race:
 	@echo "--> Running unit tests with data race detector"
-	@go test -v -race `go list ./... | grep -v nodebuilder/tests`
+	@go test -race `go list ./... | grep -v nodebuilder/tests`
 .PHONY: test-unit-race
 
 ## test-swamp: Running swamp tests located in nodebuilder/tests
 test-swamp:
 	@echo "--> Running swamp tests"
-	@go test -v ./nodebuilder/tests
+	@go test ./nodebuilder/tests
 .PHONY: test-swamp
 
 ## test-swamp: Running swamp tests with data race detector located in node/tests
 test-swamp-race:
 	@echo "--> Running swamp tests with data race detector"
-	@go test -v -race ./nodebuilder/tests
+	@go test -race ./nodebuilder/tests
 .PHONY: test-swamp-race
 
 ## test-all: Running both unit and swamp tests


### PR DESCRIPTION
The motivation here is to solve debug logs overload on the CI. In practice, they are not useful in any way for debugging issues on CI, which are usually flaky. Debug logs only clog the output requiring devs to download the log archive and analyze what test did fail locally, which is a lot of unnecessary friction. 

Removing the debug log keeps logging failed tests and error logs, allowing devs to identify and resolve the problem locally. Furthermore, it reduces the action run execution time by ___2 minutes___.

Also, we keep existing Makefile commands untouched and introduce new ones that CI can depend on. 