### PR TITLE
fix(nodebuider/header): initialize Store during start lifecycle instead of fx.Invoke

### DIFF
--- a/nodebuilder/header/header.go
+++ b/nodebuilder/header/header.go
@@ -2,19 +2,22 @@ package header
 
 import (
 	"context"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
+	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/p2p"
 	"github.com/celestiaorg/celestia-node/header/store"
+	"github.com/celestiaorg/celestia-node/header/sync"
 	"github.com/celestiaorg/celestia-node/params"
 )
 
-// P2PExchange constructs new Exchange for headers.
-func P2PExchange(cfg Config) func(params.Bootstrappers, host.Host) (header.Exchange, error) {
+// newP2PExchange constructs new Exchange for headers.
+func newP2PExchange(cfg Config) func(params.Bootstrappers, host.Host) (header.Exchange, error) {
 	return func(bpeers params.Bootstrappers, host host.Host) (header.Exchange, error) {
 		peers, err := cfg.trustedPeers(bpeers)
 		if err != nil {
@@ -29,22 +32,43 @@ func P2PExchange(cfg Config) func(params.Bootstrappers, host.Host) (header.Excha
 	}
 }
 
-// InitStore initializes the store.
-func InitStore(ctx context.Context, cfg Config, net params.Network, s header.Store, ex header.Exchange) error {
+// newSyncer constructs new Syncer for headers.
+func newSyncer(ex header.Exchange, store initStore, sub header.Subscriber, duration time.Duration) *sync.Syncer {
+	return sync.NewSyncer(ex, store, sub, duration)
+}
+
+// initStore is a type representing initialized header store.
+// NOTE: It is needed to ensure that Store is always initialized before Syncer is started.
+type initStore header.Store
+
+// newInitStore constructs an initialized store
+func newInitStore(
+	lc fx.Lifecycle,
+	cfg Config,
+	net params.Network,
+	s header.Store,
+	ex header.Exchange,
+) (initStore, error) {
 	trustedHash, err := cfg.trustedHash(net)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	err = store.Init(ctx, s, ex, trustedHash)
-	if err != nil {
-		// TODO(@Wondertan): Error is ignored, as otherwise unit tests for Node construction fail.
-		// 	This is due to requesting step of initialization, which fetches initial Header by trusted hash from
-		//  the network. The step can't be done during unit tests and fixing it would require either
-		//   * Having some test/dev/offline mode for Node that mocks out all the networking
-		//   * Hardcoding full extended header in params pkg, instead of hashes, so we avoid requesting step
-		log.Errorf("initializing store failed: %s", err)
-	}
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			err = store.Init(ctx, s, ex, trustedHash)
+			if err != nil {
+				// TODO(@Wondertan): Error is ignored, as otherwise unit tests for Node construction fail.
+				// 	This is due to requesting step of initialization, which fetches initial Header by trusted hash from
+				//  the network. The step can't be done during unit tests and fixing it would require either
+				//   * Having some test/dev/offline mode for Node that mocks out all the networking
+				//   * Hardcoding full extended header in params pkg, instead of hashes, so we avoid requesting step
+				//   * Or removing explicit initialization in favor of automated initialization by Syncer
+				log.Errorf("initializing store failed: %s", err)
+			}
+			return nil
+		},
+	})
 
-	return nil
+	return s, nil
 }

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -37,12 +37,12 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 				return store.Stop(ctx)
 			}),
 		)),
-		fx.Invoke(InitStore),
+		fx.Provide(newInitStore),
 		fx.Provide(func(subscriber *p2p.Subscriber) header.Subscriber {
 			return subscriber
 		}),
 		fx.Provide(fx.Annotate(
-			sync.NewSyncer,
+			newSyncer,
 			fx.OnStart(func(ctx context.Context, lc fx.Lifecycle, fservice fraudServ.Module, syncer *sync.Syncer) error {
 				syncerStartFunc := func(ctx context.Context) error {
 					err := syncer.Start(ctx)
@@ -88,7 +88,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 		return fx.Module(
 			"header",
 			baseComponents,
-			fx.Provide(P2PExchange(*cfg)),
+			fx.Provide(newP2PExchange(*cfg)),
 		)
 	case node.Bridge:
 		return fx.Module(


### PR DESCRIPTION
Here we solve two issues:
* Tests and red CI without downgrading FX while keeping node modules construction order independent
	*  The recent FX update(to 1.18.2) changed the order of fx.Invoke executions and uncovered an issue with order between connection to a trusted peer and joining the header-sub topic. Connection to the trusted peer happens implicitly during store initialization, and initialization happens during Invoke, hence it's ordering was changed after the update.
* Node constructor free from network calls
	* store.Init does a network call, and it was invoked during node construction. Now, we do this only during the Start, where network calls are acceptable.

Store initialization during the Start lifecycle goes after the Syncer is started, causing Syncer to error, as it requires initialized Store. To overcome this a private `initStore` proxy type is introduced, which explicitly chains the order of fx provides and, subsequently, Starts.