### PR TITLE
Refactor: deprecated global const variables in favor of configurable functional options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ clean:
 	@echo "--> Cleaning up ./build"
 	@rm -rf build/*
 
+## clean-cache: removes all go cache, useful for when your tests aren't passing due to cached old code
+clean-cache:
+	@go clean -r -testcache -cache -modcache .
+.PHONY: clean-cache
+
 ## install: Build and install the celestia-node binary into the $PREFIX (/usr/local/ by default) directory.
 install: build
 	@echo "--> Installing Celestia"

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,6 @@ clean:
 	@echo "--> Cleaning up ./build"
 	@rm -rf build/*
 
-## clean-cache: removes all go cache, useful for when your tests aren't passing due to cached old code
-clean-cache:
-	@go clean -r -testcache -cache -modcache .
-.PHONY: clean-cache
-
 ## install: Build and install the celestia-node binary into the $PREFIX (/usr/local/ by default) directory.
 install: build
 	@echo "--> Installing Celestia"

--- a/das/coordinator_test.go
+++ b/das/coordinator_test.go
@@ -14,10 +14,15 @@ import (
 )
 
 func TestCoordinator(t *testing.T) {
-	concurrency := 10
-	samplingRange := uint64(10)
+
+	config := DefaultConfig()
+
+	config.ConcurrencyLimit = 10
+	config.SamplingRange = uint64(10)
+	config.GenesisHeight = 1
+
 	networkHead := uint64(500)
-	sampleFrom := uint64(genesisHeight)
+	sampleFrom := uint64(config.GenesisHeight)
 	timeoutDelay := 125 * time.Second
 
 	t.Run("test run", func(t *testing.T) {
@@ -25,7 +30,7 @@ func TestCoordinator(t *testing.T) {
 
 		sampler := newMockSampler(sampleFrom, networkHead)
 
-		coordinator := newSamplingCoordinator(concurrency, samplingRange, getterStub{}, onceMiddleWare(sampler.sample))
+		coordinator := newSamplingCoordinator(config, getterStub{}, onceMiddleWare(sampler.sample))
 		go coordinator.run(ctx, sampler.checkpoint)
 
 		// check if all jobs were sampled successfully
@@ -47,7 +52,7 @@ func TestCoordinator(t *testing.T) {
 
 		sampler := newMockSampler(sampleFrom, networkHead)
 
-		coordinator := newSamplingCoordinator(concurrency, samplingRange, getterStub{}, sampler.sample)
+		coordinator := newSamplingCoordinator(config, getterStub{}, sampler.sample)
 		go coordinator.run(ctx, sampler.checkpoint)
 
 		time.Sleep(50 * time.Millisecond)
@@ -72,11 +77,14 @@ func TestCoordinator(t *testing.T) {
 	})
 
 	t.Run("prioritize newly discovered over known", func(t *testing.T) {
+
+		config := DefaultConfig()
+		config.ConcurrencyLimit = 1
+		config.SamplingRange = 4
+
 		sampleFrom := uint64(1)
 		networkHead := uint64(10)
 		toBeDiscovered := uint64(20)
-		samplingRange := uint64(4)
-		concurrency := 1
 
 		sampler := newMockSampler(sampleFrom, networkHead)
 
@@ -86,15 +94,15 @@ func TestCoordinator(t *testing.T) {
 		lk := newLock(sampleFrom, sampleFrom)
 
 		// expect worker to prioritize newly discovered  (20 -> 10) and then old (0 -> 10)
-		order := newCheckOrder().addInterval(sampleFrom, samplingRange) // worker will pick up first job before discovery
-		order.addStacks(networkHead+1, toBeDiscovered, samplingRange)
-		order.addInterval(samplingRange+1, toBeDiscovered)
+		order := newCheckOrder().addInterval(sampleFrom, config.SamplingRange) // worker will pick up first job before discovery
+		order.addStacks(networkHead+1, toBeDiscovered, config.SamplingRange)
+		order.addInterval(config.SamplingRange+1, toBeDiscovered)
 
 		// start coordinator
-		coordinator := newSamplingCoordinator(concurrency, samplingRange, getterStub{},
+		coordinator := newSamplingCoordinator(config, getterStub{},
 			lk.middleWare(
-				order.middleWare(
-					sampler.sample)),
+				order.middleWare(sampler.sample),
+			),
 		)
 		go coordinator.run(ctx, sampler.checkpoint)
 
@@ -131,7 +139,7 @@ func TestCoordinator(t *testing.T) {
 		sampler := newMockSampler(sampleFrom, networkHead)
 
 		lk := newLock(sampleFrom, networkHead) // lock all workers before start
-		coordinator := newSamplingCoordinator(concurrency, samplingRange, getterStub{},
+		coordinator := newSamplingCoordinator(config, getterStub{},
 			lk.middleWare(sampler.sample))
 		go coordinator.run(ctx, sampler.checkpoint)
 
@@ -178,7 +186,7 @@ func TestCoordinator(t *testing.T) {
 		bornToFail := []uint64{4, 8, 15, 16, 23, 42}
 		sampler := newMockSampler(sampleFrom, networkHead, bornToFail...)
 
-		coordinator := newSamplingCoordinator(concurrency, samplingRange, getterStub{}, onceMiddleWare(sampler.sample))
+		coordinator := newSamplingCoordinator(config, getterStub{}, onceMiddleWare(sampler.sample))
 		go coordinator.run(ctx, sampler.checkpoint)
 
 		// wait for coordinator to indicateDone catchup
@@ -207,7 +215,7 @@ func TestCoordinator(t *testing.T) {
 		sampler := newMockSampler(sampleFrom, networkHead, failedAgain...)
 		sampler.checkpoint.Failed = failedLastRun
 
-		coordinator := newSamplingCoordinator(concurrency, samplingRange, getterStub{}, onceMiddleWare(sampler.sample))
+		coordinator := newSamplingCoordinator(config, getterStub{}, onceMiddleWare(sampler.sample))
 		go coordinator.run(ctx, sampler.checkpoint)
 
 		// check if all jobs were sampled successfully
@@ -231,13 +239,14 @@ func TestCoordinator(t *testing.T) {
 }
 
 func BenchmarkCoordinator(b *testing.B) {
-	concurrency := 100
-	samplingRange := uint64(10)
 	timeoutDelay := 5 * time.Second
+	config := DefaultConfig()
+	config.ConcurrencyLimit = 100
+	config.SamplingRange = uint64(10)
 
 	b.Run("bench run", func(b *testing.B) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeoutDelay)
-		coordinator := newSamplingCoordinator(concurrency, samplingRange, newBenchGetter(),
+		coordinator := newSamplingCoordinator(config, newBenchGetter(),
 			func(ctx context.Context, h *header.ExtendedHeader) error { return nil })
 		go coordinator.run(ctx, checkpoint{
 			SampleFrom:  1,

--- a/das/state.go
+++ b/das/state.go
@@ -6,7 +6,7 @@ import (
 
 // coordinatorState represents the current state of sampling
 type coordinatorState struct {
-	rangeSize uint64
+	daserCfg Config
 
 	priority   []job                      // list of headers heights that will be sampled with higher priority
 	inProgress map[int]func() workerState // keeps track of running workers
@@ -21,15 +21,15 @@ type coordinatorState struct {
 }
 
 // newCoordinatorState initiates state for samplingCoordinator
-func newCoordinatorState(samplingRangeSize uint64) coordinatorState {
+func newCoordinatorState(daserCfg Config) coordinatorState {
 	return coordinatorState{
-		rangeSize:     samplingRangeSize,
+		daserCfg:      daserCfg,
 		priority:      make([]job, 0),
 		inProgress:    make(map[int]func() workerState),
 		failed:        make(map[uint64]int),
 		nextJobID:     0,
-		next:          genesisHeight,
-		networkHead:   genesisHeight,
+		next:          uint64(daserCfg.GenesisHeight),
+		networkHead:   uint64(daserCfg.GenesisHeight),
 		catchUpDone:   false,
 		catchUpDoneCh: make(chan struct{}),
 	}
@@ -77,7 +77,7 @@ func (s *coordinatorState) updateHead(last uint64) bool {
 		return false
 	}
 
-	if s.networkHead == genesisHeight {
+	if s.networkHead == uint64(s.daserCfg.GenesisHeight) {
 		s.networkHead = last
 		log.Infow("found first header, starting sampling")
 		return true
@@ -85,9 +85,9 @@ func (s *coordinatorState) updateHead(last uint64) bool {
 
 	// add most recent headers into priority queue
 	from := s.networkHead + 1
-	for from <= last && len(s.priority) < priorityQueueSize {
+	for from <= last && len(s.priority) < int(s.daserCfg.PriorityQueueSize) {
 		s.priority = append(s.priority, s.newJob(from, last))
-		from += s.rangeSize
+		from += s.daserCfg.SamplingRange
 	}
 
 	log.Debugw("added recent headers to DASer priority queue", "from_height", s.networkHead, "to_height", last)
@@ -110,7 +110,7 @@ func (s *coordinatorState) nextJob() (next job, found bool) {
 
 	j := s.newJob(s.next, s.networkHead)
 
-	s.next += s.rangeSize
+	s.next += s.daserCfg.SamplingRange
 	if s.next > s.networkHead {
 		s.next = s.networkHead + 1
 	}
@@ -139,7 +139,7 @@ func (s *coordinatorState) putInProgress(jobID int, getState func() workerState)
 
 func (s *coordinatorState) newJob(from, max uint64) job {
 	s.nextJobID++
-	to := from + s.rangeSize - 1
+	to := from + s.daserCfg.SamplingRange - 1
 	if to > max {
 		to = max
 	}

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -27,6 +28,7 @@ type Config struct {
 	RPC    rpc.Config
 	Share  share.Config
 	Header header.Config
+	DASer  das.Config
 }
 
 // DefaultConfig provides a default Config for a given Node Type 'tp'.
@@ -41,6 +43,7 @@ func DefaultConfig(tp node.Type) *Config {
 			RPC:    rpc.DefaultConfig(),
 			Share:  share.DefaultConfig(),
 			Header: header.DefaultConfig(),
+			DASer:  das.DefaultConfig(),
 		}
 	default:
 		panic("node: invalid node type")

--- a/nodebuilder/daser/daser.go
+++ b/nodebuilder/daser/daser.go
@@ -15,6 +15,7 @@ func NewDASer(
 	store header.Store,
 	batching datastore.Batching,
 	fraudService fraud.Module,
+	options ...das.Option,
 ) *das.DASer {
-	return das.NewDASer(da, hsub, store, batching, fraudService)
+	return das.NewDASer(da, hsub, store, batching, fraudService, options...)
 }

--- a/nodebuilder/daser/module.go
+++ b/nodebuilder/daser/module.go
@@ -12,22 +12,46 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
-func ConstructModule(tp node.Type) fx.Option {
+func ConstructModule(tp node.Type, cfg *das.Config) fx.Option {
+	baseComponents := fx.Options(
+		fx.Provide(
+			fx.Annotate(
+				// provide DASer configuration in here
+				// example:
+				//
+				//	return []das.Option{
+				//			das.WithParamBackgroundStoreInterval(10*100*time.Nanosecond),
+				//			das.WithParamConcurrencyLimit(32)
+				//	}
+				func() []das.Option {
+					return []das.Option{
+						das.WithParamSamplingRange(int(300)),
+						das.WithParamConcurrencyLimit(int(32)),
+					}
+				},
+				fx.ResultTags(`name:"DASOptions"`),
+			),
+		),
+	)
+
 	switch tp {
 	case node.Light, node.Full:
 		return fx.Module(
 			"daser",
-			fx.Provide(fx.Annotate(
-				NewDASer,
-				fx.OnStart(func(ctx context.Context, lc fx.Lifecycle, fservice fraudServ.Module, das *das.DASer) error {
-					lifecycleCtx := fxutil.WithLifecycle(ctx, lc)
-					return fraudServ.Lifecycle(ctx, lifecycleCtx, fraud.BadEncoding, fservice,
-						das.Start, das.Stop)
-				}),
-				fx.OnStop(func(ctx context.Context, das *das.DASer) error {
-					return das.Stop(ctx)
-				}),
-			)),
+			baseComponents,
+			fx.Provide(
+				fx.Annotate(
+					NewDASer,
+					fx.ParamTags(``, ``, ``, ``, ``, `name:"DASOptions"`),
+					fx.OnStart(func(ctx context.Context, lc fx.Lifecycle, fservice fraudServ.Module, das *das.DASer) error {
+						lifecycleCtx := fxutil.WithLifecycle(ctx, lc)
+						return fraudServ.Lifecycle(ctx, lifecycleCtx, fraud.BadEncoding, fservice, das.Start, das.Stop)
+					}),
+					fx.OnStop(func(ctx context.Context, das *das.DASer) error {
+						return das.Stop(ctx)
+					}),
+				),
+			),
 		)
 	case node.Bridge:
 		return fx.Options()

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -18,6 +18,7 @@ import (
 )
 
 func ConstructModule(tp node.Type, cfg *Config, store Store) fx.Option {
+
 	baseComponents := fx.Options(
 		fx.Provide(params.DefaultNetwork),
 		fx.Provide(params.BootstrappersFor),

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -35,7 +35,7 @@ func ConstructModule(tp node.Type, cfg *Config, store Store) fx.Option {
 		share.ConstructModule(tp, &cfg.Share),
 		rpc.ConstructModule(tp, &cfg.RPC),
 		core.ConstructModule(tp, &cfg.Core),
-		daser.ConstructModule(tp),
+		daser.ConstructModule(tp, &cfg.DASer),
 		fraud.ConstructModule(tp),
 	)
 

--- a/nodebuilder/share/config.go
+++ b/nodebuilder/share/config.go
@@ -18,19 +18,25 @@ type Config struct {
 	// AdvertiseInterval is a interval between advertising sessions.
 	// NOTE: only full and bridge can advertise themselves.
 	AdvertiseInterval time.Duration
+	// Availability Timeout Duration
+	AvailabilityTimeout time.Duration // TODO(team): should we define a unique timeout for each type of availability?
+	// Amount of Samples to perform
+	SampleAmount uint
 }
 
 func DefaultConfig() Config {
 	return Config{
-		PeersLimit:        3,
-		DiscoveryInterval: time.Second * 30,
-		AdvertiseInterval: time.Second * 30,
+		PeersLimit:          3,
+		DiscoveryInterval:   time.Second * 30,
+		AdvertiseInterval:   time.Second * 30,
+		AvailabilityTimeout: time.Minute * 20,
+		SampleAmount:        16,
 	}
 }
 
 // Validate performs basic validation of the config.
 func (cfg *Config) Validate() error {
-	if cfg.DiscoveryInterval <= 0 || cfg.AdvertiseInterval <= 0 {
+	if cfg.DiscoveryInterval <= 0 || cfg.AdvertiseInterval <= 0 || cfg.AvailabilityTimeout <= 0 {
 		return fmt.Errorf("nodebuilder/share: %s", ErrNegativeInterval)
 	}
 	return nil

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -19,6 +19,21 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 		fx.Options(options...),
 		fx.Invoke(share.EnsureEmptySquareExists),
 		fx.Provide(Discovery(*cfg)),
+		fx.Provide(
+			fx.Annotate(func() []share.LAOption {
+				return []share.LAOption{
+					share.WithLightAvailabilityTimeout(cfg.AvailabilityTimeout),
+					share.WithSampleAmount(int(cfg.SampleAmount)),
+				}
+			}, fx.ResultTags(`group:"LAOptions"`)),
+		),
+		fx.Provide(
+			fx.Annotate(func() []share.FAOption {
+				return []share.FAOption{
+					share.WithFullAvailabilityTimeout(cfg.AvailabilityTimeout),
+				}
+			}, fx.ResultTags(`group:"FAOptions"`)),
+		),
 		fx.Provide(NewModule),
 	)
 
@@ -29,6 +44,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			baseComponents,
 			fx.Provide(fx.Annotate(
 				share.NewLightAvailability,
+				fx.ParamTags(``, ``, `group:"LAOptions"`),
 				fx.OnStart(func(ctx context.Context, avail *share.LightAvailability) error {
 					return avail.Start(ctx)
 				}),
@@ -46,6 +62,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			baseComponents,
 			fx.Provide(fx.Annotate(
 				share.NewFullAvailability,
+				fx.ParamTags(``, ``, `group:"FAOptions"`),
 				fx.OnStart(func(ctx context.Context, avail *share.FullAvailability) error {
 					return avail.Start(ctx)
 				}),

--- a/share/full_availability.go
+++ b/share/full_availability.go
@@ -60,8 +60,8 @@ func NewFullAvailability(
 	}
 
 	// assign options if applicable
-	for _, opt := range options {
-		opt(fa)
+	for _, applyOpt := range options {
+		applyOpt(fa)
 	}
 
 	return fa

--- a/share/interface.go
+++ b/share/interface.go
@@ -12,7 +12,7 @@ var ErrNotAvailable = errors.New("da: data not available")
 // AvailabilityTimeout specifies timeout for DA validation during which data have to be found on the network,
 // otherwise ErrNotAvailable is fired.
 // TODO: https://github.com/celestiaorg/celestia-node/issues/10
-const AvailabilityTimeout = 20 * time.Minute
+const DefaultAvailabilityTimeout = 20 * time.Minute
 
 // Availability defines interface for validation of Shares' availability.
 type Availability interface {

--- a/share/testing.go
+++ b/share/testing.go
@@ -269,12 +269,17 @@ func (b *TestBrokenAvailability) ProbabilityOfAvailability() float64 {
 
 func TestLightAvailability(bServ blockservice.BlockService) *LightAvailability {
 	disc := NewDiscovery(nil, routing.NewRoutingDiscovery(routinghelpers.Null{}), 0, time.Second, time.Second)
-	return NewLightAvailability(bServ, disc)
+	return NewLightAvailability(bServ, disc, []LAOption{
+		WithDefaultSampleAmount(),
+		WithLightAvailabilityTimeoutDefault(),
+	}...)
 }
 
 func TestFullAvailability(bServ blockservice.BlockService) *FullAvailability {
 	disc := NewDiscovery(nil, routing.NewRoutingDiscovery(routinghelpers.Null{}), 0, time.Second, time.Second)
-	return NewFullAvailability(bServ, disc)
+	return NewFullAvailability(bServ, disc, []FAOption{
+		WithFullAvailabilityTimeoutDefault(),
+	}...)
 }
 
 type TestSuccessfulAvailability struct {


### PR DESCRIPTION
# Overview

The codebase is currently littered with default constant global variables acting as configuration variables.
This makes changing configuration values for the Celestia node non-trivial, as it requires code changes and binary re-building.

In this PR, we refactor the global configuration variables logic to use the functional options pattern, which will trivialize the process of configuring a Celestia node.

# References

#709 
#1063 
#912 

## Impact

- [x] the `share` module
- [ ] the `nodebuilder` module
- [x] the `das` module
- [ ] the `fraud` module
- [ ] the `header` module
- [ ] the `ipld` module
- [ ] the `params` module
- [ ] the `rpc` module


