### PR TITLE
refactor(daser): use functional options pattern to configure daser

### DIFF
--- a/das/coordinator.go
+++ b/das/coordinator.go
@@ -10,8 +10,9 @@ import (
 // samplingCoordinator runs and coordinates sampling workers and updates current sampling state
 type samplingCoordinator struct {
 	concurrencyLimit int
-	getter           header.Getter
-	sampleFn         sampleFn
+
+	getter   header.Getter
+	sampleFn sampleFn
 
 	state coordinatorState
 
@@ -35,15 +36,15 @@ type result struct {
 }
 
 func newSamplingCoordinator(
-	concurrency int,
-	samplingRange uint64,
+	params Parameters,
 	getter header.Getter,
-	sample sampleFn) *samplingCoordinator {
+	sample sampleFn,
+) *samplingCoordinator {
 	return &samplingCoordinator{
-		concurrencyLimit: concurrency,
+		concurrencyLimit: params.ConcurrencyLimit,
 		getter:           getter,
 		sampleFn:         sample,
-		state:            newCoordinatorState(samplingRange),
+		state:            newCoordinatorState(params),
 		resultCh:         make(chan result),
 		updHeadCh:        make(chan uint64),
 		waitCh:           make(chan *sync.WaitGroup),

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -39,9 +39,10 @@ func TestDASerLifecycle(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)
 
-	daser := NewDASer(avail, sub, mockGet, ds, mockService)
+	daser, err := NewDASer(avail, sub, mockGet, ds, mockService)
+	require.NoError(t, err)
 
-	err := daser.Start(ctx)
+	err = daser.Start(ctx)
 	require.NoError(t, err)
 	defer func() {
 		err = daser.Stop(ctx)
@@ -73,9 +74,10 @@ func TestDASer_Restart(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)
 
-	daser := NewDASer(avail, sub, mockGet, ds, mockService)
+	daser, err := NewDASer(avail, sub, mockGet, ds, mockService)
+	require.NoError(t, err)
 
-	err := daser.Start(ctx)
+	err = daser.Start(ctx)
 	require.NoError(t, err)
 
 	// wait for dasing catch-up routine to indicateDone
@@ -100,7 +102,9 @@ func TestDASer_Restart(t *testing.T) {
 	restartCtx, restartCancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(restartCancel)
 
-	daser = NewDASer(avail, sub, mockGet, ds, mockService)
+	daser, err = NewDASer(avail, sub, mockGet, ds, mockService)
+	require.NoError(t, err)
+
 	err = daser.Start(restartCtx)
 	require.NoError(t, err)
 
@@ -146,7 +150,9 @@ func TestDASer_stopsAfter_BEFP(t *testing.T) {
 	newCtx := context.Background()
 
 	// create and start DASer
-	daser := NewDASer(avail, sub, mockGet, ds, f)
+	daser, dErr := NewDASer(avail, sub, mockGet, ds, f)
+	require.NoError(t, dErr)
+
 	resultCh := make(chan error)
 	go fraud.OnProof(newCtx, f, fraud.BadEncoding,
 		func(fraud.Proof) {

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -150,8 +150,8 @@ func TestDASer_stopsAfter_BEFP(t *testing.T) {
 	newCtx := context.Background()
 
 	// create and start DASer
-	daser, dErr := NewDASer(avail, sub, mockGet, ds, f)
-	require.NoError(t, dErr)
+	daser, err := NewDASer(avail, sub, mockGet, ds, f)
+	require.NoError(t, err)
 
 	resultCh := make(chan error)
 	go fraud.OnProof(newCtx, f, fraud.BadEncoding,

--- a/das/options.go
+++ b/das/options.go
@@ -5,18 +5,22 @@ import (
 	"time"
 )
 
-var (
-	ErrInvalidOption = fmt.Errorf("das: invalid option")
-)
+// ErrInvalidOption is an error that is returned by Parameters.Validate
+// when supplied with invalid values.
+// This error will also be returned by NewDASer if supplied with an invalid option
+var ErrInvalidOption = fmt.Errorf("das: invalid option")
 
+// errInvalidOptionValue is a utility function to dedup code for error-returning
+// when dealing with invalid parameter values
 func errInvalidOptionValue(optionName string, value string) error {
 	return fmt.Errorf("%w: value %s cannot be %s", ErrInvalidOption, optionName, value)
 }
 
-// Type Option is the functional option that is applied to the daser instance for parameters configuration.
+// Option is the functional option that is applied to the daser instance
+// to configure DASing parameters (the Parameters struct)
 type Option func(*DASer)
 
-// Type parameters is the set of parameters that must be configured for the daser
+// Parameters is the set of parameters that must be configured for the daser
 type Parameters struct {
 	//  SamplingRange is the maximum amount of headers processed in one job.
 	SamplingRange uint64
@@ -36,7 +40,7 @@ type Parameters struct {
 
 // DefaultParameters returns the default configuration values for the daser parameters
 func DefaultParameters() Parameters {
-	// TODO(@derrandz): parameters needs performance testing on real network to define optimal values
+	// TODO(@derrandz): parameters needs performance testing on real network to define optimal values (#1261)
 	return Parameters{
 		SamplingRange:           100,
 		ConcurrencyLimit:        16,
@@ -48,10 +52,9 @@ func DefaultParameters() Parameters {
 
 // Validate validates the values in Parameters
 //
-// All parameters must be positive and non-zero, except:
-//
-// BackgroundStoreInterval = 0 disables background storer,
-// PriorityQueueSize = 0 disables prioritization of recently produced blocks for sampling
+//	All parameters must be positive and non-zero, except:
+//		BackgroundStoreInterval = 0 disables background storer,
+//		PriorityQueueSize = 0 disables prioritization of recently produced blocks for sampling
 func (p *Parameters) Validate() error {
 	// SamplingRange = 0 will cause the jobs' queue to be empty
 	// Therefore no sampling jobs will be reserved and more importantly the DASer will break
@@ -84,18 +87,18 @@ func (p *Parameters) Validate() error {
 }
 
 // WithSamplingRange is a functional option to configure the daser's `SamplingRange` parameter
-// ```
 //
-//	WithSamplingRange(10)(daser)
-//
-// ```
+//	Usage:
+//	```
+//		WithSamplingRange(10)(daser)
+//	```
 //
 // or
-// ```
 //
-//	option := WithSamplingRange(10)
-//	// shenanigans to create daser
-//	option(daser)
+//	```
+//		option := WithSamplingRange(10)
+//		// shenanigans to create daser
+//		option(daser)
 //
 // ```
 func WithSamplingRange(samplingRange uint64) Option {

--- a/das/options.go
+++ b/das/options.go
@@ -1,0 +1,137 @@
+package das
+
+import (
+	"fmt"
+	"time"
+)
+
+var (
+	ErrInvalidOption = fmt.Errorf("das: invalid option")
+)
+
+func errInvalidOptionValue(optionName string, value string) error {
+	return fmt.Errorf("%w: value %s cannot be %s", ErrInvalidOption, optionName, value)
+}
+
+// Type Option is the functional option that is applied to the daser instance for parameters configuration.
+type Option func(*DASer)
+
+// Type parameters is the set of parameters that must be configured for the daser
+type Parameters struct {
+	//  SamplingRange is the maximum amount of headers processed in one job.
+	SamplingRange uint64
+
+	// ConcurrencyLimit defines the maximum amount of sampling workers running in parallel.
+	ConcurrencyLimit int
+
+	// BackgroundStoreInterval is the period of time for background checkpointStore to perform a checkpoint backup.
+	BackgroundStoreInterval time.Duration
+
+	// PriorityQueueSize defines the size limit of the priority queue
+	PriorityQueueSize int
+
+	// SampleFrom is the height sampling will start from
+	SampleFrom uint64
+}
+
+// DefaultParameters returns the default configuration values for the daser parameters
+func DefaultParameters() Parameters {
+	// TODO(@derrandz): parameters needs performance testing on real network to define optimal values
+	return Parameters{
+		SamplingRange:           100,
+		ConcurrencyLimit:        16,
+		BackgroundStoreInterval: 10 * time.Minute,
+		PriorityQueueSize:       16 * 4,
+		SampleFrom:              1,
+	}
+}
+
+// Validate validates the values in Parameters
+//
+// All parameters must be positive and non-zero, except:
+//
+// BackgroundStoreInterval = 0 disables background storer,
+// PriorityQueueSize = 0 disables prioritization of recently produced blocks for sampling
+func (p *Parameters) Validate() error {
+	// SamplingRange = 0 will cause the jobs' queue to be empty
+	// Therefore no sampling jobs will be reserved and more importantly the DASer will break
+	if p.SamplingRange <= 0 {
+		return errInvalidOptionValue(
+			"SamplingRange",
+			"negative or 0",
+		)
+	}
+
+	// ConcurrencyLimit = 0 will cause the number of workers to be 0 and
+	// Thus no threads will be assigned to the waiting jobs therefore breaking the DASer
+	if p.ConcurrencyLimit <= 0 {
+		return errInvalidOptionValue(
+			"ConcurrencyLimit",
+			"negative or 0",
+		)
+	}
+
+	// SampleFrom = 0 would tell the DASer to start sampling from block height 0
+	// which does not exist therefore breaking the DASer.
+	if p.SampleFrom <= 0 {
+		return errInvalidOptionValue(
+			"SampleFrome",
+			"negative or 0",
+		)
+	}
+
+	return nil
+}
+
+// WithSamplingRange is a functional option to configure the daser's `SamplingRange` parameter
+// ```
+//
+//	WithSamplingRange(10)(daser)
+//
+// ```
+//
+// or
+// ```
+//
+//	option := WithSamplingRange(10)
+//	// shenanigans to create daser
+//	option(daser)
+//
+// ```
+func WithSamplingRange(samplingRange uint64) Option {
+	return func(d *DASer) {
+		d.params.SamplingRange = samplingRange
+	}
+}
+
+// WithConcurrencyLimit is a functional option to configure the daser's `ConcurrencyLimit` parameter
+// Refer to WithSamplingRange documentation to see an example of how to use this
+func WithConcurrencyLimit(concurrencyLimit int) Option {
+	return func(d *DASer) {
+		d.params.ConcurrencyLimit = concurrencyLimit
+	}
+}
+
+// WithBackgroundStoreInterval is a functional option to configure the daser's `backgroundStoreInterval` parameter
+// Refer to WithSamplingRange documentation to see an example of how to use this
+func WithBackgroundStoreInterval(backgroundStoreInterval time.Duration) Option {
+	return func(d *DASer) {
+		d.params.BackgroundStoreInterval = backgroundStoreInterval
+	}
+}
+
+// WithPriorityQueueSize is a functional option to configure the daser's `priorityQueuSize` parameter
+// Refer to WithSamplingRange documentation to see an example of how to use this
+func WithPriorityQueueSize(priorityQueueSize int) Option {
+	return func(d *DASer) {
+		d.params.PriorityQueueSize = priorityQueueSize
+	}
+}
+
+// WithSampleFrom is a functional option to configure the daser's `SampleFrom` parameter
+// Refer to WithSamplingRange documentation to see an example of how to use this
+func WithSampleFrom(sampleFrom uint64) Option {
+	return func(d *DASer) {
+		d.params.SampleFrom = sampleFrom
+	}
+}

--- a/das/state.go
+++ b/das/state.go
@@ -6,7 +6,7 @@ import (
 
 // coordinatorState represents the current state of sampling
 type coordinatorState struct {
-	sampleFrom    uint64
+	sampleFrom    uint64 // is the height from which the DASer will start sampling
 	samplingRange uint64 // is the maximum amount of headers processed in one job.
 
 	priorityQueueSize int                        // the size of the priority queue
@@ -81,7 +81,6 @@ func (s *coordinatorState) updateHead(last uint64) bool {
 		return false
 	}
 
-	// TODO(@derrandz): question to @walldiss, why is networkHead uint64 to begin with?
 	if s.networkHead == s.sampleFrom {
 		s.networkHead = last
 		log.Infow("found first header, starting sampling")

--- a/das/state.go
+++ b/das/state.go
@@ -6,11 +6,13 @@ import (
 
 // coordinatorState represents the current state of sampling
 type coordinatorState struct {
-	rangeSize uint64
+	sampleFrom    uint64
+	samplingRange uint64 // is the maximum amount of headers processed in one job.
 
-	priority   []job                      // list of headers heights that will be sampled with higher priority
-	inProgress map[int]func() workerState // keeps track of running workers
-	failed     map[uint64]int             // stores heights of failed headers with amount of attempt as value
+	priorityQueueSize int                        // the size of the priority queue
+	priority          []job                      // list of headers heights that will be sampled with higher priority
+	inProgress        map[int]func() workerState // keeps track of running workers
+	failed            map[uint64]int             // stores heights of failed headers with amount of attempt as value
 
 	nextJobID   int
 	next        uint64 // all headers before next were sent to workers
@@ -21,17 +23,19 @@ type coordinatorState struct {
 }
 
 // newCoordinatorState initiates state for samplingCoordinator
-func newCoordinatorState(samplingRangeSize uint64) coordinatorState {
+func newCoordinatorState(params Parameters) coordinatorState {
 	return coordinatorState{
-		rangeSize:     samplingRangeSize,
-		priority:      make([]job, 0),
-		inProgress:    make(map[int]func() workerState),
-		failed:        make(map[uint64]int),
-		nextJobID:     0,
-		next:          genesisHeight,
-		networkHead:   genesisHeight,
-		catchUpDone:   false,
-		catchUpDoneCh: make(chan struct{}),
+		sampleFrom:        params.SampleFrom,
+		samplingRange:     params.SamplingRange,
+		priorityQueueSize: params.PriorityQueueSize,
+		priority:          make([]job, 0),
+		inProgress:        make(map[int]func() workerState),
+		failed:            make(map[uint64]int),
+		nextJobID:         0,
+		next:              params.SampleFrom,
+		networkHead:       params.SampleFrom,
+		catchUpDone:       false,
+		catchUpDoneCh:     make(chan struct{}),
 	}
 }
 
@@ -77,7 +81,8 @@ func (s *coordinatorState) updateHead(last uint64) bool {
 		return false
 	}
 
-	if s.networkHead == genesisHeight {
+	// TODO(@derrandz): question to @walldiss, why is networkHead uint64 to begin with?
+	if s.networkHead == s.sampleFrom {
 		s.networkHead = last
 		log.Infow("found first header, starting sampling")
 		return true
@@ -85,9 +90,9 @@ func (s *coordinatorState) updateHead(last uint64) bool {
 
 	// add most recent headers into priority queue
 	from := s.networkHead + 1
-	for from <= last && len(s.priority) < priorityQueueSize {
+	for from <= last && len(s.priority) < s.priorityQueueSize {
 		s.priority = append(s.priority, s.newJob(from, last))
-		from += s.rangeSize
+		from += s.samplingRange
 	}
 
 	log.Debugw("added recent headers to DASer priority queue", "from_height", s.networkHead, "to_height", last)
@@ -110,7 +115,7 @@ func (s *coordinatorState) nextJob() (next job, found bool) {
 
 	j := s.newJob(s.next, s.networkHead)
 
-	s.next += s.rangeSize
+	s.next += s.samplingRange
 	if s.next > s.networkHead {
 		s.next = s.networkHead + 1
 	}
@@ -139,7 +144,7 @@ func (s *coordinatorState) putInProgress(jobID int, getState func() workerState)
 
 func (s *coordinatorState) newJob(from, max uint64) job {
 	s.nextJobID++
-	to := from + s.rangeSize - 1
+	to := from + s.samplingRange - 1
 	if to > max {
 		to = max
 	}

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
+	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
@@ -27,6 +28,7 @@ type Config struct {
 	RPC    rpc.Config
 	Share  share.Config
 	Header header.Config
+	DASer  das.Config
 }
 
 // DefaultConfig provides a default Config for a given Node Type 'tp'.
@@ -41,6 +43,7 @@ func DefaultConfig(tp node.Type) *Config {
 			RPC:    rpc.DefaultConfig(),
 			Share:  share.DefaultConfig(),
 			Header: header.DefaultConfig(),
+			DASer:  das.DefaultConfig(),
 		}
 	default:
 		panic("node: invalid node type")

--- a/nodebuilder/das/config.go
+++ b/nodebuilder/das/config.go
@@ -6,20 +6,30 @@ import (
 	"github.com/celestiaorg/celestia-node/das"
 )
 
+// ErrMisConfig is an error that is returned by (*Config).Validate
+// when supplied with invalid values.
+var ErrMisConfig = fmt.Errorf("moddas misconfiguration")
+
 // Config contains configuration parameters for the DASer (or DASing process)
 type Config das.Parameters
 
 // TODO(@derrandz): parameters needs performance testing on real network to define optimal values
+// DefaultConfig provide the optimal default configuration per node type.
+// For the moment, there is only one default configuration for all node types
+// but this function will provide more once #1261 is addressed.
+//
+// TODO(@derrandz): Address #1261
 func DefaultConfig() Config {
 	return Config(das.DefaultParameters())
 }
 
 // Validate performs basic validation of the config.
+// Upon encountering an invalid value, Validate returns an error of type: ErrMisConfig
 func (cfg *Config) Validate() error {
 	err := (*das.Parameters)(cfg).Validate()
 
 	if err != nil {
-		return fmt.Errorf("moddas misconfiguration: %w", err)
+		return fmt.Errorf("%w: %s", ErrMisConfig, err)
 	}
 
 	return nil

--- a/nodebuilder/das/config.go
+++ b/nodebuilder/das/config.go
@@ -6,10 +6,6 @@ import (
 	"github.com/celestiaorg/celestia-node/das"
 )
 
-// ErrMisConfig is an error that is returned by (*Config).Validate
-// when supplied with invalid values.
-var ErrMisConfig = fmt.Errorf("moddas misconfiguration")
-
 // Config contains configuration parameters for the DASer (or DASing process)
 type Config das.Parameters
 
@@ -27,9 +23,8 @@ func DefaultConfig() Config {
 // Upon encountering an invalid value, Validate returns an error of type: ErrMisConfig
 func (cfg *Config) Validate() error {
 	err := (*das.Parameters)(cfg).Validate()
-
 	if err != nil {
-		return fmt.Errorf("%w: %s", ErrMisConfig, err)
+		return fmt.Errorf("moddas misconfiguration: %w", err)
 	}
 
 	return nil

--- a/nodebuilder/das/config.go
+++ b/nodebuilder/das/config.go
@@ -1,0 +1,26 @@
+package das
+
+import (
+	"fmt"
+
+	"github.com/celestiaorg/celestia-node/das"
+)
+
+// Config contains configuration parameters for the DASer (or DASing process)
+type Config das.Parameters
+
+// TODO(@derrandz): parameters needs performance testing on real network to define optimal values
+func DefaultConfig() Config {
+	return Config(das.DefaultParameters())
+}
+
+// Validate performs basic validation of the config.
+func (cfg *Config) Validate() error {
+	err := (*das.Parameters)(cfg).Validate()
+
+	if err != nil {
+		return fmt.Errorf("moddas misconfiguration: %w", err)
+	}
+
+	return nil
+}

--- a/nodebuilder/das/daser.go
+++ b/nodebuilder/das/daser.go
@@ -1,4 +1,4 @@
-package daser
+package das
 
 import (
 	"github.com/ipfs/go-datastore"
@@ -15,6 +15,7 @@ func NewDASer(
 	store header.Store,
 	batching datastore.Batching,
 	fraudService fraud.Module,
-) *das.DASer {
-	return das.NewDASer(da, hsub, store, batching, fraudService)
+	options ...das.Option,
+) (*das.DASer, error) {
+	return das.NewDASer(da, hsub, store, batching, fraudService, options...)
 }

--- a/nodebuilder/das/opts.go
+++ b/nodebuilder/das/opts.go
@@ -1,4 +1,4 @@
-package daser
+package das
 
 import (
 	"go.uber.org/fx"

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
-	"github.com/celestiaorg/celestia-node/nodebuilder/daser"
+	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/fraud"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -36,7 +36,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		share.ConstructModule(tp, &cfg.Share),
 		rpc.ConstructModule(tp, &cfg.RPC),
 		core.ConstructModule(tp, &cfg.Core),
-		daser.ConstructModule(tp),
+		das.ConstructModule(tp, &cfg.DASer),
 		fraud.ConstructModule(tp),
 	)
 

--- a/nodebuilder/settings.go
+++ b/nodebuilder/settings.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/fraud"
 	"github.com/celestiaorg/celestia-node/header"
-	"github.com/celestiaorg/celestia-node/nodebuilder/daser"
+	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/state"
@@ -49,7 +49,7 @@ func WithMetrics(metricOpts []otlpmetrichttp.Option, nodeType node.Type) fx.Opti
 	case node.Full, node.Light:
 		opts = fx.Options(
 			baseComponents,
-			fx.Invoke(daser.WithMetrics),
+			fx.Invoke(das.WithMetrics),
 			// add more monitoring here
 		)
 	case node.Bridge:


### PR DESCRIPTION
# Overview
The DAS module is currently reliant on default constant global variables acting as configuration variables.

This makes changing configuration values for the DAS module non-trivial, as it requires code changes and binary re-building.

In this PR, we refactor the global configuration variables used in the DAS module to use the functional options pattern, which will trivialize the process of configuring a Celestia node.

# Reference Issue
#1063 
#709 

# Impact / Change

The `das` package is now configurable using a set of functional options, namely:
```
WithSamplingRange(uint64)
WithConcurrencyLimit(int)
WithBackgroundStoreInterval(time.Duration)
WithPrioritySizeQueue(int)
WithGenesisHeight)
```

This allows the `das` package to be configured with values other than the default parameters defined in `das/options.go:29`

An example of the `das` package being configured with these options and instantiated with them is: `nodebuilder/das/module.go:22`

# Owners

@derrandz 