### PR TITLE
.github: add triggering on versioned tags

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    # Trigger on version tags
+    tags:
+      - "v*"
   pull_request:
   workflow_dispatch:
     # Inputs the workflow accepts.


### PR DESCRIPTION
Small update to include running the CI on versioned tags, i.e. any tag starting with a `v`. 

This allows for tagging release candidates manually. 