### PR TITLE
refactor(share/ipld): Use consts for node type determination

### DIFF
--- a/share/ipld/namespace_hasher.go
+++ b/share/ipld/namespace_hasher.go
@@ -7,7 +7,6 @@ import (
 	"github.com/minio/sha256-simd"
 	mhcore "github.com/multiformats/go-multihash/core"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/nmt"
 )
 
@@ -41,8 +40,7 @@ func (n *namespaceHasher) Write(data []byte) (int, error) {
 		return 0, fmt.Errorf("ipld: only one write to hasher is allowed")
 	}
 
-	ln, nln, hln := len(data), int(n.NamespaceLen), n.Hash.Size()
-	innerNodeSize, leafNodeSize := (nln*2+hln)*2, nln+appconsts.ShareSize
+	ln := len(data)
 	switch ln {
 	default:
 		return 0, fmt.Errorf("ipld: wrong sized data written to the hasher, len: %v", ln)

--- a/share/ipld/namespace_hasher.go
+++ b/share/ipld/namespace_hasher.go
@@ -28,7 +28,7 @@ type namespaceHasher struct {
 
 // defaultHasher constructs the namespaceHasher with default configuration
 func defaultHasher() *namespaceHasher {
-	return &namespaceHasher{Hasher: nmt.NewNmtHasher(sha256.New(), nmt.DefaultNamespaceIDLen, true)}
+	return &namespaceHasher{Hasher: nmt.NewNmtHasher(sha256.New(), NamespaceSize, true)}
 }
 
 // Write writes the namespaced data to be hashed.

--- a/share/ipld/namespace_hasher.go
+++ b/share/ipld/namespace_hasher.go
@@ -51,7 +51,7 @@ func (n *namespaceHasher) Write(data []byte) (int, error) {
 	}
 
 	n.data = data
-	return len(n.data), nil
+	return ln, nil
 }
 
 // Sum computes the hash.


### PR DESCRIPTION
Self-explanatory