### PR TITLE
fix: returning nil sum when hasher receives data with incorrect length

### DIFF
--- a/share/ipld/namespace_hasher.go
+++ b/share/ipld/namespace_hasher.go
@@ -58,7 +58,8 @@ func (n *namespaceHasher) Write(data []byte) (int, error) {
 // Sum computes the hash.
 // Does not append the given suffix and violating the interface.
 func (n *namespaceHasher) Sum([]byte) []byte {
-	// if n.data is empty, it hit the default case in Write
+	// if n.data is empty, it hit the default case in Write.
+	// this will be seen by multihash.encodeHash, where it will be caught and an error will be returned.
 	if len(n.data) == 0 {
 		return nil
 	}

--- a/share/ipld/namespace_hasher.go
+++ b/share/ipld/namespace_hasher.go
@@ -43,7 +43,7 @@ func (n *namespaceHasher) Write(data []byte) (int, error) {
 	ln := len(data)
 	switch ln {
 	default:
-		log.Warnf("ipld: unexpected data size: %d", ln)
+		log.Warnf("unexpected data size: %d", ln)
 		return 0, fmt.Errorf("ipld: wrong sized data written to the hasher, len: %v", ln)
 	case innerNodeSize:
 		n.tp = nmt.NodePrefix

--- a/share/ipld/namespace_hasher.go
+++ b/share/ipld/namespace_hasher.go
@@ -43,6 +43,7 @@ func (n *namespaceHasher) Write(data []byte) (int, error) {
 	ln := len(data)
 	switch ln {
 	default:
+		log.Warnf("ipld: unexpected data size: %d", ln)
 		return 0, fmt.Errorf("ipld: wrong sized data written to the hasher, len: %v", ln)
 	case innerNodeSize:
 		n.tp = nmt.NodePrefix
@@ -57,6 +58,11 @@ func (n *namespaceHasher) Write(data []byte) (int, error) {
 // Sum computes the hash.
 // Does not append the given suffix and violating the interface.
 func (n *namespaceHasher) Sum([]byte) []byte {
+	// if n.data is empty, it hit the default case in Write
+	if len(n.data) == 0 {
+		return nil
+	}
+
 	isLeafData := n.tp == nmt.LeafPrefix
 	if isLeafData {
 		return n.Hasher.HashLeaf(n.data)

--- a/share/ipld/namespace_hasher_test.go
+++ b/share/ipld/namespace_hasher_test.go
@@ -56,3 +56,43 @@ func TestNamespaceHasherWrite(t *testing.T) {
 		assert.Equal(t, 0, n)
 	})
 }
+
+func TestNamespaceHasherSum(t *testing.T) {
+	leafSize := appconsts.ShareSize + appconsts.NamespaceSize
+	innerSize := nmtHashSize * 2
+	tt := []struct {
+		name         string
+		expectedSize int
+		writtenSize  int
+	}{
+		{
+			"Leaf",
+			nmtHashSize,
+			leafSize,
+		},
+		{
+			"Inner",
+			nmtHashSize,
+			innerSize,
+		},
+		{
+			"ShortGarbage",
+			0,
+			13,
+		},
+		{
+			"LongGarbage",
+			0,
+			500,
+		},
+	}
+
+	for _, ts := range tt {
+		t.Run("Success"+ts.name, func(t *testing.T) {
+			h := defaultHasher()
+			_, _ = h.Write(make([]byte, ts.writtenSize))
+			sum := h.Sum(nil)
+			assert.Equal(t, len(sum), ts.expectedSize)
+		})
+	}
+}


### PR DESCRIPTION
@walldiss Does this look okay to you?

The nodes sync successfully now, even without explicitly handling the legacy case. 