### PR TITLE
fix(state): `CoreAccessor` manages its own context

### DIFF
--- a/nodebuilder/node_test.go
+++ b/nodebuilder/node_test.go
@@ -36,8 +36,14 @@ func TestLifecycle(t *testing.T) {
 			err := node.Start(ctx)
 			require.NoError(t, err)
 
+			// ensure the state service is running
+			require.False(t, node.StateServ.IsStopped())
+
 			err = node.Stop(ctx)
 			require.NoError(t, err)
+
+			// ensure the state service is stopped
+			require.True(t, node.StateServ.IsStopped())
 		})
 	}
 }

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -109,10 +109,7 @@ func (ca *CoreAccessor) Stop(context.Context) error {
 		log.Warn("no connection found to close")
 		return nil
 	}
-	defer func() {
-		ca.cancel()
-		ca.cancel = nil
-	}()
+	defer ca.cancelCtx()
 
 	// close out core connection
 	err := ca.coreConn.Close()
@@ -123,6 +120,11 @@ func (ca *CoreAccessor) Stop(context.Context) error {
 	ca.coreConn = nil
 	ca.queryCli = nil
 	return nil
+}
+
+func (ca *CoreAccessor) cancelCtx() {
+	ca.cancel()
+	ca.cancel = nil
 }
 
 func (ca *CoreAccessor) constructSignedTx(

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -1,0 +1,33 @@
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLifecycle(t *testing.T) {
+	ca := NewCoreAccessor(nil, nil, "", "", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	// start the accessor
+	err := ca.Start(ctx)
+	require.NoError(t, err)
+	// ensure accessor isn't stopped
+	require.False(t, ca.IsStopped())
+	// cancel the top level context (this should not affect the lifecycle of the
+	// accessor as it should manage its own internal context)
+	cancel()
+	// ensure accessor was unaffected by top-level context cancellation
+	require.False(t, ca.IsStopped())
+	// stop the accessor
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	t.Cleanup(stopCancel)
+	err = ca.Stop(stopCtx)
+	require.NoError(t, err)
+	// ensure accessor is stopped
+	require.True(t, ca.IsStopped())
+	// ensure that stopping the accessor again does not return an error
+	err = ca.Stop(stopCtx)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Resolves https://github.com/celestiaorg/celestia-node/issues/1248 and https://github.com/celestiaorg/celestia-node/issues/1246