### PR TITLE
chore: gen less acounts to reduce test execution times

### DIFF
--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -67,8 +67,8 @@ func NewSwamp(t *testing.T, options ...Option) *Swamp {
 	ctx := context.Background()
 
 	// we create an arbitrary number of funded accounts
-	accounts := make([]string, 100)
-	for i := 0; i < 100; i++ {
+	accounts := make([]string, 10)
+	for i := range accounts {
 		accounts[i] = tmrand.Str(9)
 	}
 


### PR DESCRIPTION
Before: PASS: TestFraudProofSyncing (7.57s)

After: PASS: TestFraudProofSyncing (5.93s)

@evan-forbes, any clue why it takes so long to generate accounts? 