### PR TITLE
refactor(state): `CoreAccessor` restricts writes on fraud

### DIFF
--- a/nodebuilder/state/module.go
+++ b/nodebuilder/state/module.go
@@ -27,7 +27,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 		fx.Provide(fx.Annotate(
 			CoreAccessor,
 			fx.OnStart(func(startCtx, ctx context.Context, fservice fraudServ.Module, ca *state.CoreAccessor) error {
-				return fraudServ.Lifecycle(startCtx, ctx, fraud.BadEncoding, fservice, ca.Start, ca.Stop)
+				return fraudServ.Lifecycle(startCtx, ctx, fraud.BadEncoding, fservice, ca.Start, ca.RestrictWrites)
 			}),
 			fx.OnStop(func(ctx context.Context, ca *state.CoreAccessor) error {
 				return ca.Stop(ctx)

--- a/nodebuilder/state/service.go
+++ b/nodebuilder/state/service.go
@@ -17,6 +17,8 @@ import (
 type Module interface {
 	// IsStopped checks if the Module's context has been stopped
 	IsStopped() bool
+	// ReadOnly checks if the Module has disabled write access
+	ReadOnly() bool
 
 	// AccountAddress retrieves the address of the node's account/signer
 	AccountAddress(ctx context.Context) (state.Address, error)

--- a/service/rpc/middleware.go
+++ b/service/rpc/middleware.go
@@ -26,7 +26,7 @@ func checkPostDisabled(state state.Module) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// check if state service was halted and deny the transaction
-			if r.Method == http.MethodPost && state.IsStopped() {
+			if r.Method == http.MethodPost && state.ReadOnly() {
 				writeError(w, http.StatusMethodNotAllowed, r.URL.Path, errors.New("not possible to submit data"))
 				return
 			}

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -27,7 +27,7 @@ func TestLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	// ensure accessor is stopped
 	require.True(t, ca.IsStopped())
-	// ensure that stopping the accessor again does not return an error
+	// ensure that stopping the accessor again returns an error
 	err = ca.Stop(stopCtx)
-	require.NoError(t, err)
+	require.Error(t, err)
 }


### PR DESCRIPTION
This PR refactors `CoreAccessor` such that it contains a field that determines whether `CoreAccessor` is read-only: 

* implements `RestrictWrites()` method on core accessor (and state module) that gets called from fraud lifecycle in the case of fraud instead of calling stop 
* middleware now calls `ReadOnly()` on state module to check if state is read-only, and if so, restricts POST endpoints
* `CoreAccessor` `Stop` method now returns an error if stop is called twice (as it is now no longer expected).

Resolves #1235 

Tagging as a bug-fix as this is technically fixing a bug in specified behaviour.
