### PR TITLE
fix: removing protocolIDs from global namespace in p2p and fraud

### DIFF
--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/celestiaorg/celestia-node/fraud"
 	"github.com/celestiaorg/celestia-node/header"
-	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 var timeout = time.Second * 15
@@ -141,7 +140,7 @@ func TestDASer_stopsAfter_BEFP(t *testing.T) {
 	mockGet, sub, _ := createDASerSubcomponents(t, bServ, 15, 15)
 
 	// create fraud service and break one header
-	f := fraud.NewProofService(ps, net.Hosts()[0], mockGet.GetByHeight, ds, false, string(p2p.Private))
+	f := fraud.NewProofService(ps, net.Hosts()[0], mockGet.GetByHeight, ds, false, "private")
 	require.NoError(t, f.Start(ctx))
 	mockGet.headers[1] = header.CreateFraudExtHeader(t, mockGet.headers[1], bServ)
 	newCtx := context.Background()

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/fraud"
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 var timeout = time.Second * 15
@@ -140,7 +141,7 @@ func TestDASer_stopsAfter_BEFP(t *testing.T) {
 	mockGet, sub, _ := createDASerSubcomponents(t, bServ, 15, 15)
 
 	// create fraud service and break one header
-	f := fraud.NewProofService(ps, net.Hosts()[0], mockGet.GetByHeight, ds, false, "private")
+	f := fraud.NewProofService(ps, net.Hosts()[0], mockGet.GetByHeight, ds, false, string(p2p.Private))
 	require.NoError(t, f.Start(ctx))
 	mockGet.headers[1] = header.CreateFraudExtHeader(t, mockGet.headers[1], bServ)
 	newCtx := context.Background()

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -140,7 +140,7 @@ func TestDASer_stopsAfter_BEFP(t *testing.T) {
 	mockGet, sub, _ := createDASerSubcomponents(t, bServ, 15, 15)
 
 	// create fraud service and break one header
-	f := fraud.NewProofService(ps, net.Hosts()[0], mockGet.GetByHeight, ds, false)
+	f := fraud.NewProofService(ps, net.Hosts()[0], mockGet.GetByHeight, ds, false, "private")
 	require.NoError(t, f.Start(ctx))
 	mockGet.headers[1] = header.CreateFraudExtHeader(t, mockGet.headers[1], bServ)
 	newCtx := context.Background()

--- a/fraud/requester.go
+++ b/fraud/requester.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/celestiaorg/go-libp2p-messenger/serde"
@@ -19,14 +18,13 @@ const (
 	readDeadline = time.Minute
 )
 
-func requestProofs(
+func (f *ProofService) requestProofs(
 	ctx context.Context,
-	host host.Host,
 	pid peer.ID,
 	proofTypes []string,
 ) ([]*pb.ProofResponse, error) {
 	msg := &pb.FraudMessageRequest{RequestedProofType: proofTypes}
-	stream, err := host.NewStream(ctx, pid, fraudProtocolID)
+	stream, err := f.host.NewStream(ctx, pid, f.protocolID)
 	if err != nil {
 		return nil, err
 	}

--- a/fraud/service_test.go
+++ b/fraud/service_test.go
@@ -133,6 +133,7 @@ func TestService_ReGossiping(t *testing.T) {
 		},
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		false,
+		"private",
 	)
 	addrB := host.InfoFromHost(net.Hosts()[1]) // -> B
 
@@ -148,6 +149,7 @@ func TestService_ReGossiping(t *testing.T) {
 		},
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		false,
+		"private",
 	)
 	// establish connections
 	// connect peers: A -> B -> C, so A and C are not connected to each other
@@ -263,5 +265,6 @@ func createServiceWithHost(
 		store.GetByHeight,
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		enabledSyncer,
+		"private",
 	), store
 }

--- a/fraud/service_test.go
+++ b/fraud/service_test.go
@@ -17,6 +17,7 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 func TestService_Subscribe(t *testing.T) {
@@ -133,7 +134,7 @@ func TestService_ReGossiping(t *testing.T) {
 		},
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		false,
-		"private",
+		string(p2p.Private),
 	)
 	addrB := host.InfoFromHost(net.Hosts()[1]) // -> B
 
@@ -149,7 +150,7 @@ func TestService_ReGossiping(t *testing.T) {
 		},
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		false,
-		"private",
+		string(p2p.Private),
 	)
 	// establish connections
 	// connect peers: A -> B -> C, so A and C are not connected to each other
@@ -265,6 +266,6 @@ func createServiceWithHost(
 		store.GetByHeight,
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		enabledSyncer,
-		"private",
+		string(p2p.Private),
 	), store
 }

--- a/fraud/service_test.go
+++ b/fraud/service_test.go
@@ -17,7 +17,6 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 
 	"github.com/celestiaorg/celestia-node/header"
-	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 func TestService_Subscribe(t *testing.T) {
@@ -134,7 +133,7 @@ func TestService_ReGossiping(t *testing.T) {
 		},
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		false,
-		string(p2p.Private),
+		"private",
 	)
 	addrB := host.InfoFromHost(net.Hosts()[1]) // -> B
 
@@ -150,7 +149,7 @@ func TestService_ReGossiping(t *testing.T) {
 		},
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		false,
-		string(p2p.Private),
+		"private",
 	)
 	// establish connections
 	// connect peers: A -> B -> C, so A and C are not connected to each other
@@ -266,6 +265,6 @@ func createServiceWithHost(
 		store.GetByHeight,
 		sync.MutexWrap(datastore.NewMapDatastore()),
 		enabledSyncer,
-		string(p2p.Private),
+		"private",
 	), store
 }

--- a/fraud/sync.go
+++ b/fraud/sync.go
@@ -67,7 +67,7 @@ func (f *ProofService) syncFraudProofs(ctx context.Context) {
 				attribute.StringSlice("proof_types", proofTypes),
 			)
 			log.Debugw("requesting proofs from peer", "pid", pid)
-			respProofs, err := requestProofs(ctx, f.host, pid, proofTypes)
+			respProofs, err := f.requestProofs(ctx, pid, proofTypes)
 			if err != nil {
 				log.Errorw("error while requesting fraud proofs", "err", err, "peer", pid)
 				span.RecordError(err)

--- a/header/p2p/exchange_test.go
+++ b/header/p2p/exchange_test.go
@@ -17,7 +17,10 @@ import (
 
 	"github.com/celestiaorg/celestia-node/header"
 	p2p_pb "github.com/celestiaorg/celestia-node/header/p2p/pb"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
+
+var privateProtocolID = protocolID(string(p2p.Private))
 
 func TestExchange_RequestHead(t *testing.T) {
 	host, peer := createMocknet(t)
@@ -99,7 +102,7 @@ func TestExchange_RequestByHash(t *testing.T) {
 	host, peer := net.Hosts()[0], net.Hosts()[1]
 	// create and start the ExchangeServer
 	store := createStore(t, 5)
-	serv := NewExchangeServer(host, store, "private")
+	serv := NewExchangeServer(host, store, string(p2p.Private))
 	err = serv.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -107,7 +110,7 @@ func TestExchange_RequestByHash(t *testing.T) {
 	})
 
 	// start a new stream via Peer to see if Host can handle inbound requests
-	stream, err := peer.NewStream(context.Background(), libhost.InfoFromHost(host).ID, protocolID("private"))
+	stream, err := peer.NewStream(context.Background(), libhost.InfoFromHost(host).ID, privateProtocolID)
 	require.NoError(t, err)
 	// create request for a header at a random height
 	reqHeight := store.headHeight - 2
@@ -205,14 +208,14 @@ func TestExchange_RequestByHashFails(t *testing.T) {
 	require.NoError(t, err)
 	// get host and peer
 	host, peer := net.Hosts()[0], net.Hosts()[1]
-	serv := NewExchangeServer(host, createStore(t, 0), "private")
+	serv := NewExchangeServer(host, createStore(t, 0), string(p2p.Private))
 	err = serv.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		serv.Stop(context.Background()) //nolint:errcheck
 	})
 
-	stream, err := peer.NewStream(context.Background(), libhost.InfoFromHost(host).ID, protocolID("private"))
+	stream, err := peer.NewStream(context.Background(), libhost.InfoFromHost(host).ID, privateProtocolID)
 	require.NoError(t, err)
 	req := &p2p_pb.ExtendedHeaderRequest{
 		Data:   &p2p_pb.ExtendedHeaderRequest_Hash{Hash: []byte("dummy_hash")},
@@ -238,7 +241,7 @@ func createMocknet(t *testing.T) (libhost.Host, libhost.Host) {
 // createP2PExAndServer creates a Exchange with 5 headers already in its store.
 func createP2PExAndServer(t *testing.T, host, tpeer libhost.Host) (header.Exchange, *mockStore) {
 	store := createStore(t, 5)
-	serverSideEx := NewExchangeServer(tpeer, store, "private")
+	serverSideEx := NewExchangeServer(tpeer, store, string(p2p.Private))
 	err := serverSideEx.Start(context.Background())
 	require.NoError(t, err)
 
@@ -246,7 +249,7 @@ func createP2PExAndServer(t *testing.T, host, tpeer libhost.Host) (header.Exchan
 		serverSideEx.Stop(context.Background()) //nolint:errcheck
 	})
 
-	return NewExchange(host, []peer.ID{tpeer.ID()}, "private"), store
+	return NewExchange(host, []peer.ID{tpeer.ID()}, string(p2p.Private)), store
 }
 
 type mockStore struct {

--- a/header/p2p/exchange_test.go
+++ b/header/p2p/exchange_test.go
@@ -17,10 +17,9 @@ import (
 
 	"github.com/celestiaorg/celestia-node/header"
 	p2p_pb "github.com/celestiaorg/celestia-node/header/p2p/pb"
-	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
-var privateProtocolID = protocolID(string(p2p.Private))
+var privateProtocolID = protocolID("private")
 
 func TestExchange_RequestHead(t *testing.T) {
 	host, peer := createMocknet(t)
@@ -102,7 +101,7 @@ func TestExchange_RequestByHash(t *testing.T) {
 	host, peer := net.Hosts()[0], net.Hosts()[1]
 	// create and start the ExchangeServer
 	store := createStore(t, 5)
-	serv := NewExchangeServer(host, store, string(p2p.Private))
+	serv := NewExchangeServer(host, store, "private")
 	err = serv.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -208,7 +207,7 @@ func TestExchange_RequestByHashFails(t *testing.T) {
 	require.NoError(t, err)
 	// get host and peer
 	host, peer := net.Hosts()[0], net.Hosts()[1]
-	serv := NewExchangeServer(host, createStore(t, 0), string(p2p.Private))
+	serv := NewExchangeServer(host, createStore(t, 0), "private")
 	err = serv.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -241,7 +240,7 @@ func createMocknet(t *testing.T) (libhost.Host, libhost.Host) {
 // createP2PExAndServer creates a Exchange with 5 headers already in its store.
 func createP2PExAndServer(t *testing.T, host, tpeer libhost.Host) (header.Exchange, *mockStore) {
 	store := createStore(t, 5)
-	serverSideEx := NewExchangeServer(tpeer, store, string(p2p.Private))
+	serverSideEx := NewExchangeServer(tpeer, store, "private")
 	err := serverSideEx.Start(context.Background())
 	require.NoError(t, err)
 
@@ -249,7 +248,7 @@ func createP2PExAndServer(t *testing.T, host, tpeer libhost.Host) (header.Exchan
 		serverSideEx.Stop(context.Background()) //nolint:errcheck
 	})
 
-	return NewExchange(host, []peer.ID{tpeer.ID()}, string(p2p.Private)), store
+	return NewExchange(host, []peer.ID{tpeer.ID()}, "private"), store
 }
 
 type mockStore struct {

--- a/header/p2p/exchange_test.go
+++ b/header/p2p/exchange_test.go
@@ -99,7 +99,7 @@ func TestExchange_RequestByHash(t *testing.T) {
 	host, peer := net.Hosts()[0], net.Hosts()[1]
 	// create and start the ExchangeServer
 	store := createStore(t, 5)
-	serv := NewExchangeServer(host, store)
+	serv := NewExchangeServer(host, store, "private")
 	err = serv.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -107,7 +107,7 @@ func TestExchange_RequestByHash(t *testing.T) {
 	})
 
 	// start a new stream via Peer to see if Host can handle inbound requests
-	stream, err := peer.NewStream(context.Background(), libhost.InfoFromHost(host).ID, exchangeProtocolID)
+	stream, err := peer.NewStream(context.Background(), libhost.InfoFromHost(host).ID, protocolID("private"))
 	require.NoError(t, err)
 	// create request for a header at a random height
 	reqHeight := store.headHeight - 2
@@ -205,14 +205,14 @@ func TestExchange_RequestByHashFails(t *testing.T) {
 	require.NoError(t, err)
 	// get host and peer
 	host, peer := net.Hosts()[0], net.Hosts()[1]
-	serv := NewExchangeServer(host, createStore(t, 0))
+	serv := NewExchangeServer(host, createStore(t, 0), "private")
 	err = serv.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		serv.Stop(context.Background()) //nolint:errcheck
 	})
 
-	stream, err := peer.NewStream(context.Background(), libhost.InfoFromHost(host).ID, exchangeProtocolID)
+	stream, err := peer.NewStream(context.Background(), libhost.InfoFromHost(host).ID, protocolID("private"))
 	require.NoError(t, err)
 	req := &p2p_pb.ExtendedHeaderRequest{
 		Data:   &p2p_pb.ExtendedHeaderRequest_Hash{Hash: []byte("dummy_hash")},
@@ -238,7 +238,7 @@ func createMocknet(t *testing.T) (libhost.Host, libhost.Host) {
 // createP2PExAndServer creates a Exchange with 5 headers already in its store.
 func createP2PExAndServer(t *testing.T, host, tpeer libhost.Host) (header.Exchange, *mockStore) {
 	store := createStore(t, 5)
-	serverSideEx := NewExchangeServer(tpeer, store)
+	serverSideEx := NewExchangeServer(tpeer, store, "private")
 	err := serverSideEx.Start(context.Background())
 	require.NoError(t, err)
 
@@ -246,7 +246,7 @@ func createP2PExAndServer(t *testing.T, host, tpeer libhost.Host) (header.Exchan
 		serverSideEx.Stop(context.Background()) //nolint:errcheck
 	})
 
-	return NewExchange(host, []peer.ID{tpeer.ID()}), store
+	return NewExchange(host, []peer.ID{tpeer.ID()}, "private"), store
 }
 
 type mockStore struct {

--- a/nodebuilder/fraud/fraud.go
+++ b/nodebuilder/fraud/fraud.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/fraud"
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 // NewModule constructs a fraud proof service with the syncer disabled.
@@ -19,8 +20,9 @@ func NewModule(
 	host host.Host,
 	hstore header.Store,
 	ds datastore.Batching,
+	network p2p.Network,
 ) (Module, error) {
-	return newFraudService(lc, sub, host, hstore, ds, false)
+	return newFraudService(lc, sub, host, hstore, ds, false, string(network))
 }
 
 // ModuleWithSyncer constructs fraud proof service with enabled syncer.
@@ -30,8 +32,9 @@ func ModuleWithSyncer(
 	host host.Host,
 	hstore header.Store,
 	ds datastore.Batching,
+	network p2p.Network,
 ) (Module, error) {
-	return newFraudService(lc, sub, host, hstore, ds, true)
+	return newFraudService(lc, sub, host, hstore, ds, true, string(network))
 }
 
 func newFraudService(
@@ -40,8 +43,9 @@ func newFraudService(
 	host host.Host,
 	hstore header.Store,
 	ds datastore.Batching,
-	isEnabled bool) (Module, error) {
-	pservice := fraud.NewProofService(sub, host, hstore.GetByHeight, ds, isEnabled)
+	isEnabled bool,
+	protocolSuffix string) (Module, error) {
+	pservice := fraud.NewProofService(sub, host, hstore.GetByHeight, ds, isEnabled, protocolSuffix)
 	lc.Append(fx.Hook{
 		OnStart: pservice.Start,
 		OnStop:  pservice.Stop,

--- a/nodebuilder/fraud/fraud.go
+++ b/nodebuilder/fraud/fraud.go
@@ -44,7 +44,8 @@ func newFraudService(
 	hstore header.Store,
 	ds datastore.Batching,
 	isEnabled bool,
-	protocolSuffix string) (Module, error) {
+	protocolSuffix string,
+) (Module, error) {
 	pservice := fraud.NewProofService(sub, host, hstore.GetByHeight, ds, isEnabled, protocolSuffix)
 	lc.Append(fx.Hook{
 		OnStart: pservice.Start,

--- a/nodebuilder/header/header.go
+++ b/nodebuilder/header/header.go
@@ -16,9 +16,14 @@ import (
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
-// newP2PExchange constructs new Exchange for headers.
-func newP2PExchange(cfg Config) func(modp2p.Bootstrappers, host.Host) (header.Exchange, error) {
-	return func(bpeers modp2p.Bootstrappers, host host.Host) (header.Exchange, error) {
+// newP2PServer constructs a new ExchangeServer using the given Network as a protocolID suffix.
+func newP2PServer(host host.Host, store header.Store, network modp2p.Network) *p2p.ExchangeServer {
+	return p2p.NewExchangeServer(host, store, string(network))
+}
+
+// newP2PExchange constructs a new Exchange for headers.
+func newP2PExchange(cfg Config) func(modp2p.Bootstrappers, modp2p.Network, host.Host) (header.Exchange, error) {
+	return func(bpeers modp2p.Bootstrappers, network modp2p.Network, host host.Host) (header.Exchange, error) {
 		peers, err := cfg.trustedPeers(bpeers)
 		if err != nil {
 			return nil, err
@@ -28,7 +33,7 @@ func newP2PExchange(cfg Config) func(modp2p.Bootstrappers, host.Host) (header.Ex
 			ids[index] = peer.ID
 			host.Peerstore().AddAddrs(peer.ID, peer.Addrs, peerstore.PermanentAddrTTL)
 		}
-		return p2p.NewExchange(host, ids), nil
+		return p2p.NewExchange(host, ids, string(network)), nil
 	}
 }
 

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -71,7 +71,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 			}),
 		)),
 		fx.Provide(fx.Annotate(
-			p2p.NewExchangeServer,
+			newP2PServer,
 			fx.OnStart(func(ctx context.Context, server *p2p.ExchangeServer) error {
 				return server.Start(ctx)
 			}),


### PR DESCRIPTION
Based on #1168 
Closes #1189 