### PR TITLE
refactor(nodebuilder): Allow custom networks to work over already-initialised store

### DIFF
--- a/nodebuilder/init.go
+++ b/nodebuilder/init.go
@@ -1,14 +1,12 @@
 package nodebuilder
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/celestiaorg/celestia-node/libs/fslock"
 	"github.com/celestiaorg/celestia-node/libs/utils"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
-	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 // Init initializes the Node FileSystem Store for the given Node Type 'tp' in the directory under 'path'.
@@ -102,11 +100,6 @@ func initRoot(path string) error {
 // initDir creates a dir if not exist
 func initDir(path string) error {
 	if utils.Exists(path) {
-		// if the dir already exists and `CELESTIA_CUSTOM` env var is set,
-		// fail out to prevent store corruption
-		if _, ok := os.LookupEnv(p2p.EnvCustomNetwork); ok {
-			return fmt.Errorf("cannot run a custom network over an already-existing node store")
-		}
 		return nil
 	}
 	return os.Mkdir(path, perms)


### PR DESCRIPTION
After conversation with @jbowen93 , we decided to allow using custom networks over an already-initialised node store. 

The issue this was originally attempting to prevent is accidental corruption of chain data in the case that a user accidentally leaves their environment variable set up and connects to another network over an old node store.

This issue is actually currently prevented thanks to #1073 extending the node store name with the network name.