### PR TITLE
env: create new package and introduce build variables. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 cover:
 	@echo "--> Generating Code Coverage"
 	@go install github.com/ory/go-acc@latest
-	@go-acc -o coverage.txt -tags='testing' `go list ./... | grep -v nodebuilder/tests` -- -v
+	@go-acc -o coverage.txt `go list ./... | grep -v nodebuilder/tests` -- -v -tags='testing'
 .PHONY: cover
 
 ## deps: install dependencies.

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 cover:
 	@echo "--> Generating Code Coverage"
 	@go install github.com/ory/go-acc@latest
-	@go-acc -o coverage.txt `go list ./... | grep -v nodebuilder/tests` -- -v
+	@go-acc -o coverage.txt -tags='testing' `go list ./... | grep -v nodebuilder/tests` -- -v
 .PHONY: cover
 
 ## deps: install dependencies.

--- a/Makefile
+++ b/Makefile
@@ -95,39 +95,39 @@ lint:
 ## test-unit: Running unit tests
 test-unit:
 	@echo "--> Running unit tests"
-	@go test `go list ./... | grep -v nodebuilder/tests` -covermode=atomic -coverprofile=coverage.out
+	@go test -tags='testing' `go list ./... | grep -v nodebuilder/tests` -covermode=atomic -coverprofile=coverage.out
 .PHONY: test-unit
 
 ## test-unit-race: Running unit tests with data race detector
 test-unit-race:
 	@echo "--> Running unit tests with data race detector"
-	@go test -race `go list ./... | grep -v nodebuilder/tests`
+	@go test -tags='testing' -race `go list ./... | grep -v nodebuilder/tests`
 .PHONY: test-unit-race
 
 ## test-swamp: Running swamp tests located in nodebuilder/tests
 test-swamp:
 	@echo "--> Running swamp tests"
-	@go test ./nodebuilder/tests
+	@go test -tags='testing' ./nodebuilder/tests
 .PHONY: test-swamp
 
 ## test-swamp: Running swamp tests with data race detector located in node/tests
 test-swamp-race:
 	@echo "--> Running swamp tests with data race detector"
-	@go test -race ./nodebuilder/tests
+	@go test -tags='testing' -race ./nodebuilder/tests
 .PHONY: test-swamp-race
 
 ## test-all: Running both unit and swamp tests
 test:
 	@echo "--> Running all tests without data race detector"
-	@go test ./...
+	@go test -tags='testing' ./...
 	@echo "--> Running all tests with data race detector"
-	@go test -race ./...
+	@go test -tags='testing' -race ./...
 .PHONY: test
 
 ## benchmark: Running all benchmarks
 benchmark:
 	@echo "--> Running benchmarks"
-	@go test -run="none" -bench=. -benchtime=100x -benchmem ./...
+	@go test -tags='testing' -run="none" -bench=. -benchtime=100x -benchmem ./...
 .PHONY: benchmark
 
 PB_PKGS=$(shell find . -name 'pb' -type d)

--- a/env/release_standard.go
+++ b/env/release_standard.go
@@ -1,0 +1,7 @@
+//go:build !testing
+// +build !testing
+
+package env
+
+// Release refers to the standard release mode.
+const Release = "standard"

--- a/env/release_testing.go
+++ b/env/release_testing.go
@@ -1,0 +1,7 @@
+//go:build testing
+// +build testing
+
+package env
+
+// Release refers to the testing release mode.
+const Release = "testing"

--- a/env/var.go
+++ b/env/var.go
@@ -1,0 +1,45 @@
+package env
+
+import "reflect"
+
+// A Var represents a variable whose value depends on which Release is being
+// compiled. None of the fields may be nil, and all fields must have the same
+// type.
+type Var struct {
+	Standard interface{}
+	Testing  interface{}
+	// prevent unkeyed literals
+	_ struct{}
+}
+
+// Select returns the field of v that corresponds to the current Release.
+//
+// Since the caller typically makes a type assertion on the result, it is
+// important to point out that type assertions are stricter than conversions.
+// Specifically, you cannot write:
+//
+//	type myint int
+//	Select(Var{0, 0}).(myint)
+//
+// Because 0 will be interpreted as an int, which is not assignable to myint.
+// Instead, you must explicitly cast each field in the Var, or cast the return
+// value of Select after the type assertion. The former is preferred.
+func Select(v Var) interface{} {
+	if v.Standard == nil || v.Testing == nil {
+		panic("nil value in build variable")
+	}
+	st, tt := reflect.TypeOf(v.Standard), reflect.TypeOf(v.Testing)
+	if !tt.AssignableTo(st) {
+		// NOTE: we use AssignableTo instead of the more lenient
+		// ConvertibleTo because type assertions require the former.
+		panic("build variables must have a single type")
+	}
+	switch Release {
+	case "standard":
+		return v.Standard
+	case "testing":
+		return v.Testing
+	default:
+		panic("unrecognized Release: " + Release)
+	}
+}

--- a/env/var_test.go
+++ b/env/var_test.go
@@ -1,0 +1,73 @@
+package env
+
+import (
+	"testing"
+)
+
+// didPanic returns true if fn panicked.
+func didPanic(fn func()) (p bool) {
+	defer func() {
+		p = (recover() != nil)
+	}()
+	fn()
+	return
+}
+
+// TestSelect tests the Select function. Since we can't change the Release
+// constant during testing, we can only test the "testing" branches.
+func TestSelect(t *testing.T) {
+	var v Var
+	if !didPanic(func() { Select(v) }) {
+		t.Error("Select should panic with all nil fields")
+	}
+
+	v.Standard = 0
+	if !didPanic(func() { Select(v) }) {
+		t.Error("Select should panic with some nil fields")
+	}
+
+	v = Var{
+		Standard: 1,
+		Testing:  2,
+	}
+	if didPanic(func() { Select(v) }) {
+		t.Error("Select should not panic with valid fields")
+	}
+
+	if !didPanic(func() { _ = Select(v).(string) }) {
+		t.Error("improper type assertion should panic")
+	}
+
+	// Verify select returns
+	if Select(v) != v.Testing {
+		t.Errorf(`Expected Select to return v.Testing value %v, but found %v
+		Double check the -tags flag for the test command`,
+			Select(v), v.Testing)
+	}
+
+	// should fail even if types are convertible
+	type myint int
+	if !didPanic(func() { _ = Select(v).(myint) }) {
+		t.Error("improper type assertion should panic")
+	}
+
+	v.Standard = "foo"
+	if !didPanic(func() { Select(v) }) {
+		t.Error("Select should panic if field types do not match")
+	}
+
+	// Even though myint is convertible to int, it is not *assignable*. That
+	// means that this code will panic, as checked in a previous test:
+	//
+	// _ = Select(v).(myint)
+	//
+	// This is important because users of Select may assume that type
+	// assertions only require convertibility. To guard against this, we
+	// enforce that all Var fields must be assignable to each other;
+	// otherwise a type assertion may succeed for certain Release constants
+	// and fail for others.
+	v.Standard = myint(0)
+	if !didPanic(func() { Select(v) }) {
+		t.Error("Select should panic if field types are not mutually assignable")
+	}
+}

--- a/fraud/requester.go
+++ b/fraud/requester.go
@@ -8,12 +8,19 @@ import (
 
 	"github.com/celestiaorg/go-libp2p-messenger/serde"
 
+	"github.com/celestiaorg/celestia-node/env"
 	pb "github.com/celestiaorg/celestia-node/fraud/pb"
 )
 
-const (
+var (
 	// writeDeadline sets timeout for sending messages to the stream
-	writeDeadline = time.Second * 5
+	writeDeadline = env.Select(env.Var{
+		Standard: time.Second * 5,
+		Testing:  time.Millisecond * 100,
+	}).(time.Duration)
+)
+
+const (
 	// readDeadline sets timeout for reading messages from the stream
 	readDeadline = time.Minute
 )


### PR DESCRIPTION
## Proposal

I would like to introduce the concept of build time variables. These build time variables allow for switching between values based on the build, i.e. testing vs production. 

## Why?

One major benefit of build specific variables is in testing. Timeouts are a common variable to define, and the expectations of timeouts in testing and in production are usually quite different. For example on production, we might measure response time in seconds while in a virtualized test environment we measure in milliseconds.  

Ultimately this adds a more granular level of control over our variables. 

## PR Context

It would have been nice for the new package to be called `build` since these are build time variables, but we currently use the `build` directory as the output for `make build`.  I would be open to refactoring that in a follow up if others agree with the naming. 

To properly using the build variables, the `-tags` flag needs to be used in testing (see updates to the `Makefile`). 

I updated one variable in the `fraud` package to illustrate how this new variable interface can be used. 