### PR TITLE
Makefile: update go-acc version due to errors and new release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ clean:
 ## cover: generate to code coverage report.
 cover:
 	@echo "--> Generating Code Coverage"
-	@go install github.com/ory/go-acc@v0.2.6
+	@go install github.com/ory/go-acc@latest
 	@go-acc -o coverage.txt `go list ./... | grep -v nodebuilder/tests` -- -v
 .PHONY: cover
 


### PR DESCRIPTION
I was getting the following errors on `v0.2.6` of `go-acc`. Updating to latest fixed these errors. 

```
celestia-node % make cover
--> Generating Code Coverage
go install github.com/ory/go-acc@v0.2.6
# golang.org/x/sys/unix
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20200602225109-6fdc65e7d980/unix/zsyscall_darwin_amd64.go:121:3: too many errors
make: *** [cover] Error 2
```