### PR TITLE
chore(share/eds): adding test utility for generating embedded test data

### DIFF
--- a/share/eds/testdata/README.md
+++ b/share/eds/testdata/README.md
@@ -1,0 +1,3 @@
+This directory contains an example CARv1 file of an EDS and its matching data availability header.
+
+They might need to be regenerated when modifying constants such as the default share size. This can be done by running the test utility in `eds_test.go` called `createTestData`.


### PR DESCRIPTION
Self explanatory. Noticed this gap thanks to @walldiss 