### PR TITLE
refactor(nodebuilder): Logger names in subpackages to `constructor/<subpkg>`

### DIFF
--- a/nodebuilder/fraud/module.go
+++ b/nodebuilder/fraud/module.go
@@ -8,7 +8,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
-var log = logging.Logger("fraud-module")
+var log = logging.Logger("constructor/fraud")
 
 func ConstructModule(tp node.Type) fx.Option {
 	baseComponent := fx.Provide(func(module Module) fraud.Getter {

--- a/nodebuilder/fraud/module.go
+++ b/nodebuilder/fraud/module.go
@@ -8,7 +8,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
-var log = logging.Logger("constructor/fraud")
+var log = logging.Logger("module/fraud")
 
 func ConstructModule(tp node.Type) fx.Option {
 	baseComponent := fx.Provide(func(module Module) fraud.Getter {

--- a/nodebuilder/gateway/flags.go
+++ b/nodebuilder/gateway/flags.go
@@ -1,12 +1,9 @@
 package gateway
 
 import (
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 )
-
-var log = logging.Logger("constructor/gateway")
 
 var (
 	enabledFlag = "gateway"

--- a/nodebuilder/gateway/flags.go
+++ b/nodebuilder/gateway/flags.go
@@ -6,7 +6,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-var log = logging.Logger("gateway-module")
+var log = logging.Logger("constructor/gateway")
 
 var (
 	enabledFlag = "gateway"

--- a/nodebuilder/gateway/module.go
+++ b/nodebuilder/gateway/module.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 
+	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/api/gateway"
@@ -11,6 +12,8 @@ import (
 	shareServ "github.com/celestiaorg/celestia-node/nodebuilder/share"
 	stateServ "github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
+
+var log = logging.Logger("module/gateway")
 
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	// sanitize config values before constructing module

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -16,7 +16,7 @@ import (
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
-var log = logging.Logger("constructor/header")
+var log = logging.Logger("module/header")
 
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	// sanitize config values before constructing module

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -16,7 +16,7 @@ import (
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
-var log = logging.Logger("header-module")
+var log = logging.Logger("constructor/header")
 
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	// sanitize config values before constructing module

--- a/nodebuilder/p2p/module.go
+++ b/nodebuilder/p2p/module.go
@@ -1,10 +1,13 @@
 package p2p
 
 import (
+	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
+
+var log = logging.Logger("module/p2p")
 
 // ConstructModule collects all the components and services related to p2p.
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -5,14 +5,11 @@ import (
 	"fmt"
 
 	"github.com/ipfs/go-datastore"
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/libp2p/go-libp2p-core/routing"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"go.uber.org/fx"
 )
-
-var log = logging.Logger("constructor/p2p")
 
 // ContentRouting constructs nil content routing,
 // as for our use-case existing ContentRouting mechanisms, e.g DHT, are unsuitable

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/fx"
 )
 
-var log = logging.Logger("p2p-module")
+var log = logging.Logger("constructor/p2p")
 
 // ContentRouting constructs nil content routing,
 // as for our use-case existing ContentRouting mechanisms, e.g DHT, are unsuitable

--- a/nodebuilder/state/module.go
+++ b/nodebuilder/state/module.go
@@ -12,7 +12,7 @@ import (
 	"github.com/celestiaorg/celestia-node/state"
 )
 
-var log = logging.Logger("state-module")
+var log = logging.Logger("constructor/state")
 
 // ConstructModule provides all components necessary to construct the
 // state service.

--- a/nodebuilder/state/module.go
+++ b/nodebuilder/state/module.go
@@ -12,7 +12,7 @@ import (
 	"github.com/celestiaorg/celestia-node/state"
 )
 
-var log = logging.Logger("constructor/state")
+var log = logging.Logger("module/state")
 
 // ConstructModule provides all components necessary to construct the
 // state service.


### PR DESCRIPTION
Resolves #1288 