### PR TITLE
fix(nodebuilder): Use test node for tests instead of New

### DIFF
--- a/nodebuilder/node_bridge_test.go
+++ b/nodebuilder/node_bridge_test.go
@@ -35,22 +35,19 @@ func TestBridge_WithMockedCoreClient(t *testing.T) {
 // TestBridge_HasStubDaser verifies that a bridge node implements a stub daser that returns an
 // error and empty das.SamplingStats
 func TestBridge_HasStubDaser(t *testing.T) {
-	repo := MockStore(t, DefaultConfig(node.Bridge))
-
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	_, client := core.StartTestClient(ctx, t)
-	node, err := New(node.Bridge, p2p.Private, repo, coremodule.WithClient(client))
-	require.NoError(t, err)
-	require.NotNil(t, node)
-	err = node.Start(ctx)
+	nd := TestNode(t, node.Bridge, coremodule.WithClient(client))
+	require.NotNil(t, nd)
+	err := nd.Start(ctx)
 	require.NoError(t, err)
 
-	stats, err := node.DASer.SamplingStats(ctx)
+	stats, err := nd.DASer.SamplingStats(ctx)
 	assert.EqualError(t, err, "moddas: dasing is not available on bridge nodes")
 	assert.Equal(t, stats, das.SamplingStats{})
 
-	err = node.Stop(ctx)
+	err = nd.Stop(ctx)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Fixes issue with this test not using in-memory keyring. 