### PR TITLE
fix(nodebuilder/p2p): Fail out on init if invalid network specified through flag

### DIFF
--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -79,7 +79,7 @@ func ParseNetwork(cmd *cobra.Command) (Network, error) {
 	}
 	parsed := Network(parsedNetwork)
 	if err := parsed.Validate(); err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid network specified: %w", err)
 	}
 	return parsed, nil
 }

--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -77,7 +77,11 @@ func ParseNetwork(cmd *cobra.Command) (Network, error) {
 		}
 		return envNetwork, err
 	}
-	return Network(parsedNetwork), nil
+	parsed := Network(parsedNetwork)
+	if err := parsed.Validate(); err != nil {
+		return "", err
+	}
+	return parsed, nil
 }
 
 // parseNetworkFromEnv tries to parse the network from the environment.


### PR DESCRIPTION
Found during debugging. Self-explanatory.