### PR TITLE
fix(eds/byzantine): trim `NMTWrapper`'s namespace during BEFP validation

### DIFF
--- a/share/eds/byzantine/bad_encoding.go
+++ b/share/eds/byzantine/bad_encoding.go
@@ -138,10 +138,13 @@ func (p *BadEncodingProof) Validate(header *header.ExtendedHeader) error {
 		if share == nil {
 			continue
 		}
-		shares[index] = share.Share
+		// validate inclusion of the share into one of the DAHeader roots
 		if ok := share.Validate(ipld.MustCidFromNamespacedSha256(root)); !ok {
 			return fmt.Errorf("fraud: invalid proof: incorrect share received at index %d", index)
 		}
+		// NMTree commits the additional namespace while rsmt2d does not know about, so we trim it
+		// this is ugliness from NMTWrapper that we have to embrace ¯\_(ツ)_/¯
+		shares[index] = share.Share[ipld.NamespaceSize:]
 	}
 
 	codec := appconsts.DefaultCodec()

--- a/share/eds/byzantine/bad_encoding_test.go
+++ b/share/eds/byzantine/bad_encoding_test.go
@@ -7,14 +7,15 @@ import (
 	"sort"
 	"testing"
 
+	mdutils "github.com/ipfs/go-merkledag/test"
+	"github.com/stretchr/testify/require"
+	core "github.com/tendermint/tendermint/types"
+
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/ipld"
 	"github.com/celestiaorg/rsmt2d"
-	mdutils "github.com/ipfs/go-merkledag/test"
-	"github.com/stretchr/testify/require"
-	core "github.com/tendermint/tendermint/types"
 )
 
 func TestFalsePositiveBadEncodingFraudProof(t *testing.T) {
@@ -31,12 +32,13 @@ func TestFalsePositiveBadEncodingFraudProof(t *testing.T) {
 
 	dah := da.NewDataAvailabilityHeader(eds)
 
-	// get an arbitary row
+	// get an arbitrary row
 	row := uint(squareSize / 2)
 	rowShares := eds.Row(row)
 	rowRoot := dah.RowsRoots[row]
 
 	shareProofs, err := GetProofsForShares(ctx, bServ, ipld.MustCidFromNamespacedSha256(rowRoot), rowShares)
+	require.NoError(t, err)
 
 	// create a fake error for data that was encoded correctly
 	fakeError := ErrByzantine{
@@ -71,14 +73,14 @@ func generateRandNamespacedRawData(total, nidSize, leafSize uint32) [][]byte {
 	for i := uint32(0); i < total; i++ {
 		nid := make([]byte, nidSize)
 
-		rand.Read(nid)
+		_, _ = rand.Read(nid)
 		data[i] = nid
 	}
 	sortByteArrays(data)
 	for i := uint32(0); i < total; i++ {
 		d := make([]byte, leafSize)
 
-		rand.Read(d)
+		_, _ = rand.Read(d)
 		data[i] = append(data[i], d...)
 	}
 

--- a/share/eds/byzantine/bad_encoding_test.go
+++ b/share/eds/byzantine/bad_encoding_test.go
@@ -1,10 +1,7 @@
 package byzantine
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"sort"
 	"testing"
 
 	mdutils "github.com/ipfs/go-merkledag/test"
@@ -25,9 +22,9 @@ func TestFalsePositiveBadEncodingFraudProof(t *testing.T) {
 	bServ := mdutils.Bserv()
 
 	squareSize := 8
-	ss := generateRandNamespacedRawData(uint32(squareSize*squareSize), 8, 504)
+	shares := share.RandShares(t, squareSize*squareSize)
 
-	eds, err := share.AddShares(ctx, ss, bServ)
+	eds, err := share.AddShares(ctx, shares, bServ)
 	require.NoError(t, err)
 
 	dah := da.NewDataAvailabilityHeader(eds)
@@ -65,28 +62,4 @@ func TestFalsePositiveBadEncodingFraudProof(t *testing.T) {
 
 	err = proof.Validate(&h)
 	require.Error(t, err)
-}
-
-// generateRandNamespacedRawData returns random namespaced raw data for testing purposes.
-func generateRandNamespacedRawData(total, nidSize, leafSize uint32) [][]byte {
-	data := make([][]byte, total)
-	for i := uint32(0); i < total; i++ {
-		nid := make([]byte, nidSize)
-
-		_, _ = rand.Read(nid)
-		data[i] = nid
-	}
-	sortByteArrays(data)
-	for i := uint32(0); i < total; i++ {
-		d := make([]byte, leafSize)
-
-		_, _ = rand.Read(d)
-		data[i] = append(data[i], d...)
-	}
-
-	return data
-}
-
-func sortByteArrays(src [][]byte) {
-	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i], src[j]) < 0 })
 }

--- a/share/eds/byzantine/bad_encoding_test.go
+++ b/share/eds/byzantine/bad_encoding_test.go
@@ -15,7 +15,8 @@ import (
 	"github.com/celestiaorg/rsmt2d"
 )
 
-func TestFalsePositiveBadEncodingFraudProof(t *testing.T) {
+// TestIncorrectBadEncodingFraudProof asserts that BEFP is not generated for the correct data
+func TestIncorrectBadEncodingFraudProof(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -44,7 +45,7 @@ func TestFalsePositiveBadEncodingFraudProof(t *testing.T) {
 		Axis:   rsmt2d.Row,
 	}
 
-	h := header.ExtendedHeader{
+	h := &header.ExtendedHeader{
 		RawHeader: core.Header{
 			Height: 420,
 		},
@@ -56,10 +57,7 @@ func TestFalsePositiveBadEncodingFraudProof(t *testing.T) {
 		},
 	}
 
-	hhash := h.Hash()
-
-	proof := CreateBadEncodingProof(hhash, uint64(h.Height), &fakeError)
-
-	err = proof.Validate(&h)
+	proof := CreateBadEncodingProof(h.Hash(), uint64(h.Height), &fakeError)
+	err = proof.Validate(h)
 	require.Error(t, err)
 }

--- a/share/eds/byzantine/bad_encoding_test.go
+++ b/share/eds/byzantine/bad_encoding_test.go
@@ -1,0 +1,90 @@
+package byzantine
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"sort"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/pkg/da"
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/ipld"
+	"github.com/celestiaorg/rsmt2d"
+	mdutils "github.com/ipfs/go-merkledag/test"
+	"github.com/stretchr/testify/require"
+	core "github.com/tendermint/tendermint/types"
+)
+
+func TestFalsePositiveBadEncodingFraudProof(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bServ := mdutils.Bserv()
+
+	squareSize := 8
+	ss := generateRandNamespacedRawData(uint32(squareSize*squareSize), 8, 504)
+
+	eds, err := share.AddShares(ctx, ss, bServ)
+	require.NoError(t, err)
+
+	dah := da.NewDataAvailabilityHeader(eds)
+
+	// get an arbitary row
+	row := uint(squareSize / 2)
+	rowShares := eds.Row(row)
+	rowRoot := dah.RowsRoots[row]
+
+	shareProofs, err := GetProofsForShares(ctx, bServ, ipld.MustCidFromNamespacedSha256(rowRoot), rowShares)
+
+	// create a fake error for data that was encoded correctly
+	fakeError := ErrByzantine{
+		Index:  uint32(row),
+		Shares: shareProofs,
+		Axis:   rsmt2d.Row,
+	}
+
+	h := header.ExtendedHeader{
+		RawHeader: core.Header{
+			Height: 420,
+		},
+		DAH: &dah,
+		Commit: &core.Commit{
+			BlockID: core.BlockID{
+				Hash: []byte("made up hash"),
+			},
+		},
+	}
+
+	hhash := h.Hash()
+
+	proof := CreateBadEncodingProof(hhash, uint64(h.Height), &fakeError)
+
+	err = proof.Validate(&h)
+	require.Error(t, err)
+}
+
+// generateRandNamespacedRawData returns random namespaced raw data for testing purposes.
+func generateRandNamespacedRawData(total, nidSize, leafSize uint32) [][]byte {
+	data := make([][]byte, total)
+	for i := uint32(0); i < total; i++ {
+		nid := make([]byte, nidSize)
+
+		rand.Read(nid)
+		data[i] = nid
+	}
+	sortByteArrays(data)
+	for i := uint32(0); i < total; i++ {
+		d := make([]byte, leafSize)
+
+		rand.Read(d)
+		data[i] = append(data[i], d...)
+	}
+
+	return data
+}
+
+func sortByteArrays(src [][]byte) {
+	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i], src[j]) < 0 })
+}


### PR DESCRIPTION
## Overview
Fixes https://github.com/celestiaorg/celestia-node/issues/1355
Adds a test for a false positive for BEFPs. 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
