### PR TITLE
refactor(nodebuilder/p2p): Allow specifying network alias with `--p2p.network` flag

### DIFF
--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -79,14 +79,14 @@ func ParseNetwork(cmd *cobra.Command) (Network, error) {
 	}
 	// check if user provided an alias
 	parsedNetwork, ok := networkAliases[parsed]
-	if !ok {
-		// check if user provided the actual network value
-		if err := Network(parsed).Validate(); err == nil {
-			return Network(parsed), nil
-		}
-		return "", fmt.Errorf("invalid network specified: %s", parsed)
+	if ok {
+		return parsedNetwork, nil
 	}
-	return parsedNetwork, nil
+	// check if user provided the actual network value
+	if err := Network(parsed).Validate(); err == nil {
+		return Network(parsed), nil
+	}
+	return "", fmt.Errorf("invalid network specified: %s", parsed)
 }
 
 // parseNetworkFromEnv tries to parse the network from the environment.

--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -67,9 +67,9 @@ func ParseFlags(
 // ParseNetwork tries to parse the network from the flags and environment,
 // and returns either the parsed network or the build's default network
 func ParseNetwork(cmd *cobra.Command) (Network, error) {
-	parsedNetwork := cmd.Flag(networkFlag).Value.String()
+	parsed := cmd.Flag(networkFlag).Value.String()
 	// no network set through the flags, so check if there is an override in the env
-	if parsedNetwork == "" {
+	if parsed == "" {
 		envNetwork, err := parseNetworkFromEnv()
 		// no network found in env, so use the default network
 		if envNetwork == "" {
@@ -77,7 +77,16 @@ func ParseNetwork(cmd *cobra.Command) (Network, error) {
 		}
 		return envNetwork, err
 	}
-	return Network(parsedNetwork), nil
+	// check if user provided an alias
+	parsedNetwork, ok := networkAliases[parsed]
+	if !ok {
+		// check if user provided the actual network value
+		if err := Network(parsed).Validate(); err == nil {
+			return Network(parsed), nil
+		}
+		return "", fmt.Errorf("invalid network specified: %s", parsed)
+	}
+	return parsedNetwork, nil
 }
 
 // parseNetworkFromEnv tries to parse the network from the environment.

--- a/nodebuilder/p2p/flags_test.go
+++ b/nodebuilder/p2p/flags_test.go
@@ -1,0 +1,71 @@
+package p2p
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseNetwork_matchesByAlias checks to ensure flag parsing
+// correctly matches the network's alias to the network name.
+func TestParseNetwork_matchesByAlias(t *testing.T) {
+	cmd := createCmdWithNetworkFlag()
+
+	err := cmd.Flags().Set(networkFlag, "arabica")
+	require.NoError(t, err)
+
+	net, err := ParseNetwork(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, Arabica, net)
+}
+
+// TestParseNetwork_matchesByValue checks to ensure flag parsing
+// correctly matches the network's actual value to the network name.
+func TestParseNetwork_matchesByValue(t *testing.T) {
+	cmd := createCmdWithNetworkFlag()
+
+	err := cmd.Flags().Set(networkFlag, string(Arabica))
+	require.NoError(t, err)
+
+	net, err := ParseNetwork(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, Arabica, net)
+}
+
+// TestParseNetwork_parsesFromEnv checks to ensure flag parsing
+// correctly fetches the value from the environment variable.
+func TestParseNetwork_parsesFromEnv(t *testing.T) {
+	cmd := createCmdWithNetworkFlag()
+
+	t.Setenv(EnvCustomNetwork, "testing")
+
+	net, err := ParseNetwork(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, Network("testing"), net)
+}
+
+func TestParsedNetwork_invalidNetwork(t *testing.T) {
+	cmd := createCmdWithNetworkFlag()
+
+	err := cmd.Flags().Set(networkFlag, "invalid")
+	require.NoError(t, err)
+
+	net, err := ParseNetwork(cmd)
+	assert.Error(t, err)
+	assert.Equal(t, Network(""), net)
+}
+
+func createCmdWithNetworkFlag() *cobra.Command {
+	cmd := &cobra.Command{}
+	flags := &flag.FlagSet{}
+	flags.String(
+		networkFlag,
+		"",
+		"",
+	)
+	cmd.Flags().AddFlagSet(flags)
+	return cmd
+}

--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -46,6 +46,15 @@ var networksList = map[Network]struct{}{
 	Private: {},
 }
 
+// networkAliases is a strict list of all known long-standing networks
+// mapped from the string representation of their *alias* (rather than
+// their actual value) to the Network.
+var networkAliases = map[string]Network{
+	"arabica": Arabica,
+	"mamaki":  Mamaki,
+	"private": Private,
+}
+
 // listProvidedNetworks provides a string listing all known long-standing networks for things like
 // command hints.
 func listProvidedNetworks() string {


### PR DESCRIPTION
* Allows users to specify the network alias rather than the actual value of the network ID when passing `--p2p.network`
* Fails out on init if invalid network specified via `--p2p.network`

Supersedes https://github.com/celestiaorg/celestia-node/pull/1353

Ensures https://github.com/celestiaorg/docs/pull/304 does not need to happen.
