### PR TITLE
feat(share): Periodic GC over EDSStore

### DIFF
--- a/nodebuilder/p2p/p2p.go
+++ b/nodebuilder/p2p/p2p.go
@@ -67,7 +67,8 @@ type Module interface {
 	// BandwidthForPeer returns a Stats struct with bandwidth metrics associated with the given peer.ID.
 	// The metrics returned include all traffic sent / received for the peer, regardless of protocol.
 	BandwidthForPeer(id peer.ID) metrics.Stats
-	// BandwidthForProtocol returns a Stats struct with bandwidth metrics associated with the given protocol.ID.
+	// BandwidthForProtocol returns a Stats struct with bandwidth metrics associated with the given
+	// protocol.ID.
 	BandwidthForProtocol(proto protocol.ID) metrics.Stats
 
 	// ResourceState returns the state of the resource manager.

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -41,7 +41,8 @@ type Store struct {
 	topIdx index.Inverted
 	carIdx index.FullIndexRepo
 
-	basepath     string
+	basepath string
+	// lastGCResult is only stored on the store for testing purposes.
 	lastGCResult *dagstore.GCResult
 }
 
@@ -90,8 +91,7 @@ func NewStore(basepath string, ds datastore.Batching) (*Store, error) {
 	}, nil
 }
 
-// Start starts the underlying DAGStore and gc routine.
-func (s *Store) Start(context.Context) error {
+func (s *Store) Start(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
 

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -18,8 +18,8 @@ import (
 	"github.com/celestiaorg/rsmt2d"
 )
 
-// TODO(@distractedm1nd): this probably shouldn't be a var. it could be configured next to the blockstore's path and bs
-// cache size.
+// TODO(@distractedm1nd): this probably shouldn't be a var. it could be configured next to the
+// blockstore's path and bs cache size.
 var gcInterval = time.Hour
 
 const (
@@ -83,10 +83,10 @@ func NewStore(basepath string, ds datastore.Batching) (*Store, error) {
 		lastGCResult: &dagstore.GCResult{
 			Shards: make(map[shard.Key]error),
 		},
-		dgstr:    dagStore,
-		topIdx:   invertedRepo,
-		carIdx:   fsRepo,
-		mounts:   r,
+		dgstr:  dagStore,
+		topIdx: invertedRepo,
+		carIdx: fsRepo,
+		mounts: r,
 	}, nil
 }
 

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -20,9 +20,10 @@ import (
 )
 
 const (
-	blocksPath        = "/blocks/"
-	indexPath         = "/index/"
-	transientsPath    = "/transients/"
+	blocksPath     = "/blocks/"
+	indexPath      = "/index/"
+	transientsPath = "/transients/"
+
 	defaultGCInterval = time.Hour
 )
 
@@ -87,7 +88,7 @@ func NewStore(basepath string, ds datastore.Batching) (*Store, error) {
 	}, nil
 }
 
-func (s *Store) Start(ctx context.Context) error {
+func (s *Store) Start(context.Context) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
 

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -176,7 +176,13 @@ func TestEDSStore_GC(t *testing.T) {
 	// doesn't exist yet
 	assert.NotContains(t, edsStore.lastGCResult.Shards, shard.KeyFromString(dah.String()))
 
-	time.Sleep(time.Second)
+	// wait for gc to run, retry three times
+	for i := 0; i < 3; i++ {
+		time.Sleep(time.Second)
+		if _, ok := edsStore.lastGCResult.Shards[shard.KeyFromString(dah.String())]; ok {
+			break
+		}
+	}
 	assert.Contains(t, edsStore.lastGCResult.Shards, shard.KeyFromString(dah.String()))
 
 	// assert nil in this context means there was no error re-acquiring the shard during GC


### PR DESCRIPTION
# PULL REQUEST

## Overview
This PR implements a goroutine that runs during the lifetime of the `EDSStore`, which calls `dgstr.GC` periodically. This garbage collection cleans up shards from transient storage that are available but inactive or errored.

The PR is based on #1232 and closes #1116.
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [X] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [X] Visual proof for any user facing features like CLI or documentation updates
- [X] Linked issues closed with keywords
