### PR TITLE
feat(share): Supplying `eds.Store` to bridge and full nodes

### DIFF
--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -30,6 +30,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		fx.Supply(store.Config),
 		fx.Provide(store.Datastore),
 		fx.Provide(store.Keystore),
+		fx.Supply(node.ConfigPath(store.Path())),
 		// modules provided by the node
 		p2p.ConstructModule(tp, &cfg.P2P),
 		state.ConstructModule(tp, &cfg.State),

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -30,7 +30,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		fx.Supply(store.Config),
 		fx.Provide(store.Datastore),
 		fx.Provide(store.Keystore),
-		fx.Supply(node.ConfigPath(store.Path())),
+		fx.Supply(node.StorePath(store.Path())),
 		// modules provided by the node
 		p2p.ConstructModule(tp, &cfg.P2P),
 		state.ConstructModule(tp, &cfg.State),

--- a/nodebuilder/node/type.go
+++ b/nodebuilder/node/type.go
@@ -4,6 +4,9 @@ package node
 // The zero value for Type is invalid.
 type Type uint8
 
+// ConfigPath is an alias used in order to pass the base path of the node store to nodebuilder modules.
+type ConfigPath string
+
 const (
 	// Bridge is a Celestia Node that bridges the Celestia consensus network and data availability
 	// network. It maintains a trusted channel/connection to a Celestia Core node via the core.Client

--- a/nodebuilder/node/type.go
+++ b/nodebuilder/node/type.go
@@ -4,8 +4,8 @@ package node
 // The zero value for Type is invalid.
 type Type uint8
 
-// ConfigPath is an alias used in order to pass the base path of the node store to nodebuilder modules.
-type ConfigPath string
+// StorePath is an alias used in order to pass the base path of the node store to nodebuilder modules.
+type StorePath string
 
 const (
 	// Bridge is a Celestia Node that bridges the Celestia consensus network and data availability

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -59,6 +59,9 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 					return eds.Stop(ctx)
 				}),
 			)),
+			// this invoke is required until the eds.Store is referenced elsewhere, otherwise it
+			// will not be added to the application.
+			fx.Invoke(func(*eds.Store) {}),
 			fx.Provide(fx.Annotate(
 				full.NewShareAvailability,
 				fx.OnStart(func(ctx context.Context, avail *full.ShareAvailability) error {

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -59,9 +59,6 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 					return eds.Stop(ctx)
 				}),
 			)),
-			// this invoke is required until the eds.Store is referenced elsewhere, otherwise it
-			// will not be added to the application.
-			fx.Invoke(func(*eds.Store) {}),
 			fx.Provide(fx.Annotate(
 				full.NewShareAvailability,
 				fx.OnStart(func(ctx context.Context, avail *full.ShareAvailability) error {

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -49,7 +49,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			"share",
 			baseComponents,
 			fx.Provide(fx.Annotate(
-				func(path node.ConfigPath, ds datastore.Batching) (*eds.Store, error) {
+				func(path node.StorePath, ds datastore.Batching) (*eds.Store, error) {
 					return eds.NewStore(string(path), ds)
 				},
 				fx.OnStart(func(ctx context.Context, eds *eds.Store) error {

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -48,8 +48,11 @@ func TestNodeWithConfig(t *testing.T, tp node.Type, cfg *Config, opts ...fx.Opti
 	cfg.Core.RPCPort = port
 	cfg.RPC.Port = "0"
 
+	// storePath is used for the eds blockstore
+	storePath := t.TempDir()
 	opts = append(opts,
 		state.WithKeyringSigner(TestKeyringSigner(t)),
+		fx.Replace(node.StorePath(storePath)),
 	)
 	nd, err := New(tp, p2p.Private, store, opts...)
 	require.NoError(t, err)

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -259,8 +259,12 @@ func (s *Swamp) newNode(t node.Type, store nodebuilder.Store, options ...fx.Opti
 	cfg, _ := store.Config()
 	cfg.Header.TrustedHash = s.trustedHash
 	cfg.RPC.Port = "0"
+
+	// tempDir is used for the eds.Store
+	tempDir := s.t.TempDir()
 	options = append(options,
 		p2p.WithHost(s.createPeer(ks)),
+		fx.Replace(node.StorePath(tempDir)),
 	)
 
 	node, err := nodebuilder.New(t, p2p.Private, store, options...)

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -213,16 +213,15 @@ func (s *Store) Has(ctx context.Context, root share.Root) (bool, error) {
 }
 
 func setupPath(basepath string) error {
-	perms := os.FileMode(0755)
-	err := os.Mkdir(basepath+blocksPath, perms)
+	err := os.MkdirAll(basepath+blocksPath, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create blocks directory: %w", err)
 	}
-	err = os.Mkdir(basepath+transientsPath, perms)
+	err = os.MkdirAll(basepath+transientsPath, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create transients directory: %w", err)
 	}
-	err = os.Mkdir(basepath+indexPath, perms)
+	err = os.MkdirAll(basepath+indexPath, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create index directory: %w", err)
 	}

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -214,7 +214,6 @@ func (s *Store) Has(ctx context.Context, root share.Root) (bool, error) {
 }
 
 func setupPath(basepath string) error {
-	fmt.Println(basepath)
 	err := os.MkdirAll(basepath+blocksPath, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create blocks directory: %w", err)

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -213,15 +213,16 @@ func (s *Store) Has(ctx context.Context, root share.Root) (bool, error) {
 }
 
 func setupPath(basepath string) error {
-	err := os.MkdirAll(basepath+blocksPath, os.ModePerm)
+	perms := os.FileMode(0755)
+	err := os.MkdirAll(basepath+blocksPath, perms)
 	if err != nil {
 		return fmt.Errorf("failed to create blocks directory: %w", err)
 	}
-	err = os.MkdirAll(basepath+transientsPath, os.ModePerm)
+	err = os.MkdirAll(basepath+transientsPath, perms)
 	if err != nil {
 		return fmt.Errorf("failed to create transients directory: %w", err)
 	}
-	err = os.MkdirAll(basepath+indexPath, os.ModePerm)
+	err = os.MkdirAll(basepath+indexPath, perms)
 	if err != nil {
 		return fmt.Errorf("failed to create index directory: %w", err)
 	}

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -79,7 +79,8 @@ func NewStore(basepath string, ds datastore.Batching) (*Store, error) {
 }
 
 // Start starts the underlying DAGStore.
-func (s *Store) Start(ctx context.Context) error {
+func (s *Store) Start(context.Context) error {
+	ctx := context.Background()
 	return s.dgstr.Start(ctx)
 }
 
@@ -213,16 +214,16 @@ func (s *Store) Has(ctx context.Context, root share.Root) (bool, error) {
 }
 
 func setupPath(basepath string) error {
-	perms := os.FileMode(0755)
-	err := os.MkdirAll(basepath+blocksPath, perms)
+	fmt.Println(basepath)
+	err := os.MkdirAll(basepath+blocksPath, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create blocks directory: %w", err)
 	}
-	err = os.MkdirAll(basepath+transientsPath, perms)
+	err = os.MkdirAll(basepath+transientsPath, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create transients directory: %w", err)
 	}
-	err = os.MkdirAll(basepath+indexPath, perms)
+	err = os.MkdirAll(basepath+indexPath, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create index directory: %w", err)
 	}

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -84,7 +84,7 @@ func (s *Store) Start(ctx context.Context) error {
 }
 
 // Stop stops the underlying DAGStore.
-func (s *Store) Stop() error {
+func (s *Store) Stop(context.Context) error {
 	return s.dgstr.Close()
 }
 


### PR DESCRIPTION
# PULL REQUEST

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
This PR is based on #1232 and closes #1114. It supplies bridge and full nodes with an instance of EDSStore. The base path is provided by FX from `nodebuilder.Store` through a string alias.

It also fixes a bug that occurred when initializing the eds.Store twice, where the directories already existed. I have swapped MkDir out for MkDirAll, which does not err if the directory already exists.

No test modifications are done, but the Lifecycle tests would fail if it were to fail building or not be able to provide the EDSStore to the nodes.  
<!-- 
Please provide an explanation of the PR, including the apprioprate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [X] New and updated code has appropriate documentation
- [X] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [X] Visual proof for any user facing features like CLI or documentation updates
- [X] Linked issues closed with keywords
