### PR TITLE
fix(coreaccessor): pfd submission nil check

### DIFF
--- a/state/core_access.go
+++ b/state/core_access.go
@@ -153,7 +153,7 @@ func (ca *CoreAccessor) SubmitPayForData(
 ) (*TxResponse, error) {
 	response, err := payment.SubmitPayForData(ctx, ca.signer, ca.coreConn, nID, data, gasLim)
 	// metrics should only be counted on a successful PFD tx
-	if response.Code == 0 && err == nil {
+	if response != nil && response.Code == 0 && err == nil {
 		ca.lastPayForData = time.Now().UnixMilli()
 		ca.payForDataCount++
 	}

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -153,7 +153,7 @@ func (ca *CoreAccessor) SubmitPayForData(
 ) (*TxResponse, error) {
 	response, err := payment.SubmitPayForData(ctx, ca.signer, ca.coreConn, nID, data, gasLim)
 	// metrics should only be counted on a successful PFD tx
-	if response != nil && response.Code == 0 && err == nil {
+	if err == nil && response.Code == 0 {
 		ca.lastPayForData = time.Now().UnixMilli()
 		ca.payForDataCount++
 	}


### PR DESCRIPTION
# PULL REQUEST

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
PFD submissions collect metrics. I swapped the arguments to an && condition that ensures a struct is only accessed if the err != nil.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [X] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [X] Visual proof for any user facing features like CLI or documentation updates
- [X] Linked issues closed with keywords
