### PR TITLE
chore!(nodebuilder/p2p): increment the chain-id for arabica

### DIFF
--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -12,7 +12,7 @@ const (
 	// DefaultNetwork is the default network of the current build.
 	DefaultNetwork = Arabica
 	// Arabica testnet. See: celestiaorg/networks.
-	Arabica Network = "arabica-1"
+	Arabica Network = "arabica-2"
 	// Mamaki testnet. See: celestiaorg/networks.
 	Mamaki Network = "mamaki"
 	// Private can be used to set up any private network, including local testing setups.


### PR DESCRIPTION
## Overview

we changed the codec in v0.5.0-rc3, and unless we want to support the old codec forever, we have to reset the block data and therefore increment the chain-id for arabica.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
