### PR TITLE
feat(das): make WaitCatchUp public

### DIFF
--- a/das/daser.go
+++ b/das/daser.go
@@ -169,3 +169,8 @@ func (d *DASer) sample(ctx context.Context, h *header.ExtendedHeader) error {
 func (d *DASer) SamplingStats(ctx context.Context) (SamplingStats, error) {
 	return d.sampler.stats(ctx)
 }
+
+// WaitCatchUp waits for DASer to indicate catchup is done
+func (d *DASer) WaitCatchUp(ctx context.Context) error {
+	return d.sampler.state.waitCatchUp(ctx)
+}

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -54,12 +54,17 @@ func TestDASerLifecycle(t *testing.T) {
 		// ensure checkpoint is stored at 30
 		assert.EqualValues(t, 30, checkpoint.SampleFrom-1)
 	}()
-	// wait for dasing catch-up routine to indicateDone
+
+	// wait for mock to indicate that catchup is done
 	select {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	case <-mockGet.doneCh:
 	}
+
+	// wait for DASer to indicate done
+	assert.NoError(t, daser.WaitCatchUp(ctx))
+
 	// give catch-up routine a second to finish up sampling last header
 	assert.NoError(t, daser.sampler.state.waitCatchUp(ctx))
 }
@@ -80,12 +85,15 @@ func TestDASer_Restart(t *testing.T) {
 	err = daser.Start(ctx)
 	require.NoError(t, err)
 
-	// wait for dasing catch-up routine to indicateDone
+	// wait for mock to indicate that catchup is done
 	select {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	case <-mockGet.doneCh:
 	}
+
+	// wait for DASer to indicate done
+	assert.NoError(t, daser.WaitCatchUp(ctx))
 
 	err = daser.Stop(ctx)
 	require.NoError(t, err)

--- a/das/state.go
+++ b/das/state.go
@@ -221,7 +221,7 @@ func (s *coordinatorState) checkDone() {
 	}
 }
 
-// waitCatchUp waits for sampling process to indicateDone catchup
+// waitCatchUp waits for sampling process to indicate catchup is done
 func (s *coordinatorState) waitCatchUp(ctx context.Context) error {
 	select {
 	case <-s.catchUpDoneCh:


### PR DESCRIPTION
## Overview

Exposes WaitCatchUp from DASer to subscribe to catchup event from external caller. Requested for https://github.com/celestiaorg/celestia-node/pull/1341

## Checklist
- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing

