### PR TITLE
fix: pointing `make openrpc-gen` to the correct cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,6 @@ pb-gen:
 ## openrpc-gen: Generate OpenRPC spec for Celestia-Node's RPC api
 openrpc-gen:
 	@echo "--> Generating OpenRPC spec"
-	@go run ./api/docgen/cmd fraud header state share daser
+	@go run ./cmd/docgen fraud header state share das
 .PHONY: openrpc-gen
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
The command `make openrpc-gen` was pointing to the incorrect command path, and using the deprecated `daser` path.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- ~~New and updated code has appropriate documentation~~ NA
- ~~New and updated code has new and/or updated testing~~ NA
- [x] Required CI checks are passing
- ~~Visual proof for any user facing features like CLI or documentation updates~~ NA
- ~~Linked issues closed with keywords~~ NA
