### PR TITLE
core: Deprecate/remove StartTestClient in favour of StartTestCoreWithApp

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -13,7 +13,7 @@ func TestRemoteClient_Status(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	t.Cleanup(cancel)
 
-	_, client := StartTestClient(ctx, t)
+	_, client := StartTestCoreWithApp(t)
 	status, err := client.Status(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, status)
@@ -23,7 +23,7 @@ func TestRemoteClient_StartBlockSubscription_And_GetBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	t.Cleanup(cancel)
 
-	_, client := StartTestClient(ctx, t)
+	_, client := StartTestCoreWithApp(t)
 	eventChan, err := client.Subscribe(ctx, newBlockSubscriber, newBlockEventQuery)
 	require.NoError(t, err)
 

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRemoteClient_Status(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 	t.Cleanup(cancel)
 
 	_, client := StartTestCoreWithApp(t)
@@ -20,7 +20,7 @@ func TestRemoteClient_Status(t *testing.T) {
 }
 
 func TestRemoteClient_StartBlockSubscription_And_GetBlock(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 	t.Cleanup(cancel)
 
 	_, client := StartTestCoreWithApp(t)

--- a/core/fetcher_test.go
+++ b/core/fetcher_test.go
@@ -16,7 +16,7 @@ func TestBlockFetcher_GetBlock_and_SubscribeNewBlockEvent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 	t.Cleanup(cancel)
 
-	_, client := StartTestClient(ctx, t)
+	_, client := StartTestCoreWithApp(t)
 	fetcher := NewBlockFetcher(client)
 
 	// generate some blocks
@@ -44,7 +44,7 @@ func TestBlockFetcherHeaderValues(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 	t.Cleanup(cancel)
 
-	_, client := StartTestClient(ctx, t)
+	_, client := StartTestCoreWithApp(t)
 	fetcher := NewBlockFetcher(client)
 
 	// generate some blocks

--- a/core/testing.go
+++ b/core/testing.go
@@ -83,9 +83,7 @@ func StartTestCoreWithApp(t *testing.T) (tmservice.Service, Client) {
 	freePort, err := getFreePort()
 	require.NoError(t, err)
 	tmNode.Config().RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", freePort)
-	freePort, err = getFreePort()
-	require.NoError(t, err)
-	tmNode.Config().P2P.ListenAddress = fmt.Sprintf("tcp://0.0.0.0:%d", freePort)
+	tmNode.Config().P2P.ListenAddress = "tcp://0.0.0.0:0"
 
 	_, cleanupCoreNode, err := testnode.StartNode(tmNode, cctx)
 	require.NoError(t, err)

--- a/nodebuilder/node_bridge_test.go
+++ b/nodebuilder/node_bridge_test.go
@@ -19,7 +19,7 @@ func TestBridge_WithMockedCoreClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, client := core.StartTestClient(ctx, t)
+	_, client := core.StartTestCoreWithApp(t)
 	node, err := New(node.Bridge, p2p.Private, repo, coremodule.WithClient(client))
 	require.NoError(t, err)
 	require.NotNil(t, node)


### PR DESCRIPTION
Fixes #1365

## Overview

Replace StartTestClient with StartTestCoreWithApp within tests


