### PR TITLE
feat(api/rpc): Implement auth middleware on `Server`

### DIFF
--- a/api/rpc/permissions/permissions.go
+++ b/api/rpc/permissions/permissions.go
@@ -3,9 +3,9 @@ package permissions
 import "github.com/filecoin-project/go-jsonrpc/auth"
 
 var (
-	DefaultPerms   = []auth.Permission{"read"}
-	ReadWritePerms = []auth.Permission{"read", "write"}
-	AllPerms       = []auth.Permission{"read", "write", "admin"}
+	DefaultPerms   = []auth.Permission{"public"}
+	ReadWritePerms = []auth.Permission{"public", "read", "write"}
+	AllPerms       = []auth.Permission{"public", "read", "write", "admin"}
 )
 
 // JWTPayload is a utility struct for marshaling/unmarshalling

--- a/api/rpc/permissions/permissions.go
+++ b/api/rpc/permissions/permissions.go
@@ -1,0 +1,15 @@
+package permissions
+
+import "github.com/filecoin-project/go-jsonrpc/auth"
+
+var (
+	DefaultPerms   = []auth.Permission{"read"}
+	ReadWritePerms = []auth.Permission{"read", "write"}
+	AllPerms       = []auth.Permission{"read", "write", "admin"}
+)
+
+// JWTPayload is a utility struct for marshaling/unmarshalling
+// permissions into for token signing/verifying.
+type JWTPayload struct {
+	Allow []auth.Permission
+}

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -56,7 +56,7 @@ func (s *Server) verifyAuth(_ context.Context, token string) ([]auth.Permission,
 		return nil, err
 	}
 	p := new(permissions.JWTPayload)
-	err = json.Unmarshal(tk.Payload(), p)
+	err = json.Unmarshal(tk.RawClaims(), p)
 	if err != nil {
 		return nil, err
 	}

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -2,23 +2,22 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"net/http"
 	"reflect"
 	"sync/atomic"
 	"time"
 
+	"github.com/cristalhq/jwt"
 	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-jsonrpc/auth"
 	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/celestiaorg/celestia-node/api/rpc/permissions"
 )
 
 var log = logging.Logger("rpc")
-
-var (
-	AllPerms     = []auth.Permission{"public", "read", "write", "admin"}
-	DefaultPerms = []auth.Permission{"public"}
-)
 
 type Server struct {
 	srv      *http.Server
@@ -26,27 +25,43 @@ type Server struct {
 	listener net.Listener
 
 	started atomic.Bool
+
+	auth jwt.Signer
 }
 
-func NewServer(address, port string) *Server {
+func NewServer(address, port string, secret jwt.Signer) *Server {
 	rpc := jsonrpc.NewServer()
-	authHandler := &auth.Handler{
-		Verify: func(ctx context.Context, token string) ([]auth.Permission, error) {
-			// TODO(distractedm1nd/renaynay): implement auth
-			log.Warn("auth not implemented, token: ", token)
-			return DefaultPerms, nil
-		},
-		Next: rpc.ServeHTTP,
-	}
-	return &Server{
+	srv := &Server{
 		rpc: rpc,
 		srv: &http.Server{
-			Addr:    address + ":" + port,
-			Handler: authHandler,
+			Addr: address + ":" + port,
 			// the amount of time allowed to read request headers. set to the default 2 seconds
 			ReadHeaderTimeout: 2 * time.Second,
 		},
+		auth: secret,
 	}
+	srv.srv.Handler = &auth.Handler{
+		Verify: srv.verifyAuth,
+		Next:   rpc.ServeHTTP,
+	}
+	return srv
+}
+
+// verifyAuth is the RPC server's auth middleware. This middleware is only
+// reached if a token is provided in the header of the request, otherwise only
+// methods with `read` permissions are accessible.
+func (s *Server) verifyAuth(_ context.Context, token string) ([]auth.Permission, error) {
+	tk, err := jwt.ParseAndVerifyString(token, s.auth)
+	if err != nil {
+		return nil, err
+	}
+	p := new(permissions.JWTPayload)
+	err = json.Unmarshal(tk.Payload(), p)
+	if err != nil {
+		return nil, err
+	}
+	// check permissions
+	return p.Allow, nil
 }
 
 // RegisterService registers a service onto the RPC server. All methods on the service will then be
@@ -58,7 +73,7 @@ func (s *Server) RegisterService(namespace string, service interface{}) {
 // RegisterAuthedService registers a service onto the RPC server. All methods on the service will
 // then be exposed over the RPC.
 func (s *Server) RegisterAuthedService(namespace string, service interface{}, out interface{}) {
-	auth.PermissionedProxy(AllPerms, DefaultPerms, service, getInternalStruct(out))
+	auth.PermissionedProxy(permissions.AllPerms, permissions.DefaultPerms, service, getInternalStruct(out))
 	s.RegisterService(namespace, out)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/celestiaorg/rsmt2d v0.7.0
 	github.com/cosmos/cosmos-sdk v0.46.0
 	github.com/cosmos/cosmos-sdk/api v0.1.0
+	github.com/cristalhq/jwt v1.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/etclabscore/go-openrpc-reflect v0.0.37
 	github.com/filecoin-project/dagstore v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,8 @@ github.com/creachadair/taskgroup v0.3.2 h1:zlfutDS+5XG40AOxcHDSThxKzns8Tnr9jnr6V
 github.com/creachadair/taskgroup v0.3.2/go.mod h1:wieWwecHVzsidg2CsUnFinW1faVN4+kq+TDlRJQ0Wbk=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cristalhq/jwt v1.2.0 h1:fHmMkFJvEbS4o04aQP8BmtJg7fqkYvd7r8er3sUdS4Q=
+github.com/cristalhq/jwt v1.2.0/go.mod h1:QQFazsDzoqeucUEEV0h16uPTZXBAi2SVA8cQ9JEDuFw=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/nodebuilder/node/auth.go
+++ b/nodebuilder/node/auth.go
@@ -1,0 +1,23 @@
+package node
+
+import (
+	"crypto/rand"
+	"io"
+
+	"github.com/cristalhq/jwt"
+)
+
+// secret returns the node's JWT secret if it exists, or generates
+// and saves a new one if it does not.
+//
+// TODO @renaynay:
+//  1. implement checking for existing key
+//  2. implement saving the generated key to disk
+//     (if the secret needs to be generated)
+func secret() (jwt.Signer, error) {
+	sk, err := io.ReadAll(io.LimitReader(rand.Reader, 32))
+	if err != nil {
+		return nil, err
+	}
+	return jwt.NewHS256(sk)
+}

--- a/nodebuilder/node/module.go
+++ b/nodebuilder/node/module.go
@@ -1,14 +1,16 @@
 package node
 
 import (
+	"github.com/cristalhq/jwt"
 	"go.uber.org/fx"
 )
 
 func ConstructModule(tp Type) fx.Option {
 	return fx.Module(
 		"node",
-		fx.Provide(func() Module {
+		fx.Provide(func(secret jwt.Signer) Module {
 			return newModule(tp)
 		}),
+		fx.Provide(secret),
 	)
 }

--- a/nodebuilder/rpc/constructors.go
+++ b/nodebuilder/rpc/constructors.go
@@ -1,6 +1,8 @@
 package rpc
 
 import (
+	"github.com/cristalhq/jwt"
+
 	"github.com/celestiaorg/celestia-node/api/rpc"
 	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/fraud"
@@ -31,6 +33,6 @@ func RegisterEndpoints(
 	serv.RegisterAuthedService("node", nodeMod, &node.API{})
 }
 
-func Server(cfg *Config) *rpc.Server {
-	return rpc.NewServer(cfg.Address, cfg.Port)
+func Server(cfg *Config, auth jwt.Signer) *rpc.Server {
+	return rpc.NewServer(cfg.Address, cfg.Port, auth)
 }


### PR DESCRIPTION
Related to #1187 

**This PR is based on #1313** 

**It implements:** 
* providing a new JWT secret from the `nodebuilder/node` module to both the node module and the rpc server.
* auth middleware for the `rpc.Server` that verifies the given token with the server's secret

In a follow-up PR will come the ability to create an rpc client with elevated permissions (this branch restricts client access to read-only API methods).