### PR TITLE
feat(openrpc): adding example types

### DIFF
--- a/api/docgen/exampledata/extendedHeader.json
+++ b/api/docgen/exampledata/extendedHeader.json
@@ -1,0 +1,77 @@
+{
+  "validator_set": {
+    "validators": [
+      {
+        "address": "57DC09D28388DBF977CFC30EF50BE8B644CCC1FA",
+        "pub_key": {
+          "type": "tendermint/PubKeyEd25519",
+          "value": "aoB4xU9//HAqOP9ciyp0+PTdZxt/UGKgZOabU6JxW8o="
+        },
+        "voting_power": "5000000000",
+        "proposer_priority": "0"
+      }
+    ],
+    "proposer": {
+      "address": "57DC09D28388DBF977CFC30EF50BE8B644CCC1FA",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "aoB4xU9//HAqOP9ciyp0+PTdZxt/UGKgZOabU6JxW8o="
+      },
+      "voting_power": "5000000000",
+      "proposer_priority": "0"
+    }
+  },
+  "header": {
+    "version": {
+      "block": 11
+    },
+    "chain_id": "arabica-2",
+    "height": 42,
+    "time": "2022-11-15T17:04:04.364455555Z",
+    "last_block_id": {
+      "hash": "D35285797CB08451E8E85B97B0259A3C98E42BFCAEA5465152EE68DBD5760935",
+      "parts": {
+        "total": 1,
+        "hash": "EF5E90A836E5676B98177FB38B0C0BB7D957F71BBA6109B1D79C65344BC6C7FB"
+      }
+    },
+    "last_commit_hash": "DB5BB6A1518FD618D5B6607E9507E60E52BB9B532E5718D6D74F1F510FE5D10F",
+    "data_hash": "6F52DAC16545E45725BE6EA32AED55266E45034800EEE1D87C9428F4844EA47A",
+    "validators_hash": "883A0C92B8D976312B249C1397E73CF2981A9EB715717CBEE3800B8380C22C1D",
+    "next_validators_hash": "883A0C92B8D976312B249C1397E73CF2981A9EB715717CBEE3800B8380C22C1D",
+    "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
+    "app_hash": "9E52BD09B71043C25FBC7C8D928490E051811A10E978C66E3519A41352DD0699",
+    "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+    "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+    "proposer_address": "57DC09D28388DBF977CFC30EF50BE8B644CCC1FA"
+  },
+  "commit": {
+    "height": 42,
+    "round": 0,
+    "block_id": {
+      "hash": "F22BAEF4D99A835D9F2CA92C58E8AA48C589284B7916FF073A1D778C73EA4CC1",
+      "parts": {
+        "total": 1,
+        "hash": "9961CC7B6B9BE558D0FED40675232F4B37BEE75419C815240804C1A1801CF626"
+      }
+    },
+    "signatures": [
+      {
+        "block_id_flag": 2,
+        "validator_address": "57DC09D28388DBF977CFC30EF50BE8B644CCC1FA",
+        "timestamp": "2022-11-15T17:04:29.384867372Z",
+        "signature": "0+INXvvzUExQToNpmQhhvFySbQYFqoYTpgFACP+3lkSWGh48ukkMMqj2UnnAzqQhabuKeXx/5f8hiwEzeMM6Dg=="
+      }
+    ]
+  },
+  "dah": {
+    "row_roots": [
+      "//////////7//////////rr7xfWEpBugDbgBYmKPvIOGpNDJUjrMyS17ZyAnUvK7",
+      "/////////////////////zEUYTRl2BUUeFrpCh4OmiYKeTgtgYfn/tCeVNNVTMv4"
+    ],
+    "column_roots": [
+      "//////////7//////////rr7xfWEpBugDbgBYmKPvIOGpNDJUjrMyS17ZyAnUvK7",
+      "/////////////////////zEUYTRl2BUUeFrpCh4OmiYKeTgtgYfn/tCeVNNVTMv4"
+    ]
+  }
+}

--- a/api/docgen/exampledata/samplingStats.json
+++ b/api/docgen/exampledata/samplingStats.json
@@ -1,0 +1,90 @@
+{
+  "head_of_sampled_chain": 27499,
+  "head_of_catchup": 29101,
+  "network_head_height": 30483,
+  "workers": [
+    {
+      "current": 28806,
+      "from": 28802,
+      "to": 28901
+    },
+    {
+      "current": 28906,
+      "from": 28902,
+      "to": 29001
+    },
+    {
+      "current": 27794,
+      "from": 27702,
+      "to": 27801
+    },
+    {
+      "current": 28191,
+      "from": 28102,
+      "to": 28201
+    },
+    {
+      "current": 28420,
+      "from": 28402,
+      "to": 28501
+    },
+    {
+      "current": 28334,
+      "from": 28302,
+      "to": 28401
+    },
+    {
+      "current": 27691,
+      "from": 27602,
+      "to": 27701
+    },
+    {
+      "current": 27889,
+      "from": 27802,
+      "to": 27901
+    },
+    {
+      "current": 27990,
+      "from": 27902,
+      "to": 28001
+    },
+    {
+      "current": 28293,
+      "from": 28202,
+      "to": 28301
+    },
+    {
+      "current": 28092,
+      "from": 28002,
+      "to": 28101
+    },
+    {
+      "current": 29004,
+      "from": 29002,
+      "to": 29101
+    },
+    {
+      "current": 28708,
+      "from": 28702,
+      "to": 28801
+    },
+    {
+      "current": 28513,
+      "from": 28502,
+      "to": 28601
+    },
+    {
+      "current": 27500,
+      "from": 27402,
+      "to": 27501
+    },
+    {
+      "current": 28615,
+      "from": 28602,
+      "to": 28701
+    }
+  ],
+  "concurrency": 16,
+  "catch_up_done": false,
+  "is_running": true
+}

--- a/api/docgen/exampledata/txResponse.json
+++ b/api/docgen/exampledata/txResponse.json
@@ -1,0 +1,187 @@
+{
+  "height": 30497,
+  "txhash": "05D9016060072AA71B007A6CFB1B895623192D6616D513017964C3BFCD047282",
+  "data": "12260A242F636F736D6F732E62616E6B2E763162657461312E4D736753656E64526573706F6E7365",
+  "raw_log": "[{\"msg_index\":0,\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"celestia12les8l8gzsacjjxwum9wdy7me8x9xajqch4gyw\"},{\"key\":\"amount\",\"value\":\"30utia\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h\"},{\"key\":\"amount\",\"value\":\"30utia\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.bank.v1beta1.MsgSend\"},{\"key\":\"sender\",\"value\":\"celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h\"},{\"key\":\"module\",\"value\":\"bank\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"celestia12les8l8gzsacjjxwum9wdy7me8x9xajqch4gyw\"},{\"key\":\"sender\",\"value\":\"celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h\"},{\"key\":\"amount\",\"value\":\"30utia\"}]}]}]",
+  "logs": [
+    {
+      "msg_index": 0,
+      "events": [
+        {
+          "type": "coin_received",
+          "attributes": [
+            {
+              "key": "receiver",
+              "value": "celestia12les8l8gzsacjjxwum9wdy7me8x9xajqch4gyw"
+            },
+            {
+              "key": "amount",
+              "value": "30utia"
+            }
+          ]
+        },
+        {
+          "type": "coin_spent",
+          "attributes": [
+            {
+              "key": "spender",
+              "value": "celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h"
+            },
+            {
+              "key": "amount",
+              "value": "30utia"
+            }
+          ]
+        },
+        {
+          "type": "message",
+          "attributes": [
+            {
+              "key": "action",
+              "value": "/cosmos.bank.v1beta1.MsgSend"
+            },
+            {
+              "key": "sender",
+              "value": "celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h"
+            },
+            {
+              "key": "module",
+              "value": "bank"
+            }
+          ]
+        },
+        {
+          "type": "transfer",
+          "attributes": [
+            {
+              "key": "recipient",
+              "value": "celestia12les8l8gzsacjjxwum9wdy7me8x9xajqch4gyw"
+            },
+            {
+              "key": "sender",
+              "value": "celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h"
+            },
+            {
+              "key": "amount",
+              "value": "30utia"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "gas_wanted": 10000000,
+  "gas_used": 69085,
+  "events": [
+    {
+      "type": "tx",
+      "attributes": [
+        {
+          "key": "ZmVl",
+          "value": null,
+          "index": true
+        }
+      ]
+    },
+    {
+      "type": "tx",
+      "attributes": [
+        {
+          "key": "YWNjX3NlcQ==",
+          "value": "Y2VsZXN0aWExMzc3azVhbjNmOTR2Nnd5YWNldTBjZjRucTZnazJqdHBjNDZnN2gvMA==",
+          "index": true
+        }
+      ]
+    },
+    {
+      "type": "tx",
+      "attributes": [
+        {
+          "key": "c2lnbmF0dXJl",
+          "value": "R3NlVjhGNThFNGphR05LU0NicDBvNmRILytKK3BNQjNvUmtoNVpKNE8rVjdvNVVYQkJNNXpmNkdiYnN6OW9Takc1OUZkSHJRYzFvVVVBbnRBZW1wV0E9PQ==",
+          "index": true
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "attributes": [
+        {
+          "key": "YWN0aW9u",
+          "value": "L2Nvc21vcy5iYW5rLnYxYmV0YTEuTXNnU2VuZA==",
+          "index": true
+        }
+      ]
+    },
+    {
+      "type": "coin_spent",
+      "attributes": [
+        {
+          "key": "c3BlbmRlcg==",
+          "value": "Y2VsZXN0aWExMzc3azVhbjNmOTR2Nnd5YWNldTBjZjRucTZnazJqdHBjNDZnN2g=",
+          "index": true
+        },
+        {
+          "key": "YW1vdW50",
+          "value": "MzB1dGlh",
+          "index": true
+        }
+      ]
+    },
+    {
+      "type": "coin_received",
+      "attributes": [
+        {
+          "key": "cmVjZWl2ZXI=",
+          "value": "Y2VsZXN0aWExMmxlczhsOGd6c2Fjamp4d3VtOXdkeTdtZTh4OXhhanFjaDRneXc=",
+          "index": true
+        },
+        {
+          "key": "YW1vdW50",
+          "value": "MzB1dGlh",
+          "index": true
+        }
+      ]
+    },
+    {
+      "type": "transfer",
+      "attributes": [
+        {
+          "key": "cmVjaXBpZW50",
+          "value": "Y2VsZXN0aWExMmxlczhsOGd6c2Fjamp4d3VtOXdkeTdtZTh4OXhhanFjaDRneXc=",
+          "index": true
+        },
+        {
+          "key": "c2VuZGVy",
+          "value": "Y2VsZXN0aWExMzc3azVhbjNmOTR2Nnd5YWNldTBjZjRucTZnazJqdHBjNDZnN2g=",
+          "index": true
+        },
+        {
+          "key": "YW1vdW50",
+          "value": "MzB1dGlh",
+          "index": true
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "attributes": [
+        {
+          "key": "c2VuZGVy",
+          "value": "Y2VsZXN0aWExMzc3azVhbjNmOTR2Nnd5YWNldTBjZjRucTZnazJqdHBjNDZnN2g=",
+          "index": true
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "attributes": [
+        {
+          "key": "bW9kdWxl",
+          "value": "YmFuaw==",
+          "index": true
+        }
+      ]
+    }
+  ]
+}

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -1,26 +1,116 @@
 package docgen
 
 import (
+	_ "embed"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/fraud"
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
+	"github.com/celestiaorg/celestia-node/state"
+
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/rsmt2d"
 )
 
+//go:embed "exampledata/extendedHeader.json"
+var exampleExtendedHeader string
+
+//go:embed "exampledata/samplingStats.json"
+var exampleSamplingStats string
+
+//go:embed "exampledata/txResponse.json"
+var exampleTxResponse string
+
 var ExampleValues = map[reflect.Type]interface{}{
-	reflect.TypeOf(""):         "string value",
-	reflect.TypeOf(uint64(42)): uint64(42),
-	reflect.TypeOf(uint32(42)): uint32(42),
-	// reflect.TypeOf(int32(42)):   int32(42),
+	reflect.TypeOf(""):                "string value",
+	reflect.TypeOf(uint64(42)):        uint64(42),
+	reflect.TypeOf(uint32(42)):        uint32(42),
+	reflect.TypeOf(int32(42)):         int32(42),
 	reflect.TypeOf(int64(42)):         int64(42),
 	reflect.TypeOf(byte(7)):           byte(7),
 	reflect.TypeOf(float64(42)):       float64(42),
 	reflect.TypeOf(true):              true,
 	reflect.TypeOf([]byte{}):          []byte("byte array"),
 	reflect.TypeOf(fraud.BadEncoding): fraud.BadEncoding,
+	reflect.TypeOf((*fraud.Proof)(nil)).Elem(): byzantine.CreateBadEncodingProof(
+		[]byte("bad encoding proof"),
+		42,
+		&byzantine.ErrByzantine{
+			Index:  0,
+			Axis:   rsmt2d.Axis(0),
+			Shares: []*byzantine.ShareWithProof{},
+		},
+	),
+}
+
+func init() {
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
+	cfg.SetBech32PrefixForValidator(app.Bech32PrefixValAddr, app.Bech32PrefixValPub)
+	cfg.Seal()
+
+	fraudProof := byzantine.CreateBadEncodingProof(
+		[]byte("bad encoding proof"),
+		42,
+		&byzantine.ErrByzantine{
+			Index:  0,
+			Axis:   rsmt2d.Axis(0),
+			Shares: []*byzantine.ShareWithProof{},
+		},
+	)
+	// this trick lets us use an interface type as a key in the map
+	ExampleValues[reflect.TypeOf((*fraud.Proof)(nil)).Elem()] = fraudProof
+
+	var txResponse *state.TxResponse
+	err := json.Unmarshal([]byte(exampleTxResponse), &txResponse)
+	if err != nil {
+		panic(err)
+	}
+
+	var samplingStats das.SamplingStats
+	err = json.Unmarshal([]byte(exampleSamplingStats), &samplingStats)
+	if err != nil {
+		panic(err)
+	}
+
+	var extendedHeader *header.ExtendedHeader
+	err = json.Unmarshal([]byte(exampleExtendedHeader), &extendedHeader)
+	if err != nil {
+		panic(err)
+	}
+
+	addToExampleValues(txResponse)
+	addToExampleValues(samplingStats)
+	addToExampleValues(extendedHeader)
+
+	addr, err := sdk.AccAddressFromBech32("celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h")
+	if err != nil {
+		panic(err)
+	}
+	addToExampleValues(addr)
+	ExampleValues[reflect.TypeOf((*sdk.Address)(nil)).Elem()] = addr
+
+	valAddr, err := sdk.ValAddressFromBech32("celestiavaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u4q4gx4p")
+	if err != nil {
+		panic(err)
+	}
+	addToExampleValues(valAddr)
+
+	mathInt, _ := math.NewIntFromString("42")
+	addToExampleValues(mathInt)
+}
+
+func addToExampleValues(v interface{}) {
+	ExampleValues[reflect.TypeOf(v)] = v
 }
 
 func ExampleValue(t, parent reflect.Type) (interface{}, error) {

--- a/api/docgen/openrpc.go
+++ b/api/docgen/openrpc.go
@@ -179,7 +179,7 @@ func NewOpenRPCDocument(comments Comments) *go_openrpc_reflect.Document {
 	appReflector.FnSchemaExamples = func(ty reflect.Type) (examples *meta_schema.Examples, err error) {
 		v, err := ExampleValue(ty, ty) // This isn't ideal, but seems to work well enough.
 		if err != nil {
-			fmt.Println(err)
+			panic(err)
 		}
 		return &meta_schema.Examples{
 			meta_schema.AlwaysTrue(v),


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
WARNING: This PR still needs a lot of cleanup.
Closes #1358 
This PR adds enough example types to add coverage for the most important RPC methods.
I did not add all possible types because it would include adding more files which I think is a bit unnecessary.

Some missing types I will probably leave out:
- [ ] *types.QueryDelegationResponse
- [ ] *types.QueryUnbondingDelegationResponse
- [ ] *types.QueryRedelegationsResponse

Missing types to still add:
- [ ] *share.Root
- [ ] share.Share
- [ ] namespace.ID


In addition, the example values for the P2P module are not included yet.
- [ ] peer.AddrInfo
- [ ] []peer.ID
- [ ] network.Connectedness
- [ ] network.Reachability
- [ ] metrics.Stats
- [ ] rcmgr.ResourceManagerStat


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
