### PR TITLE
feat(api/client): Implement RPC client authentication

### DIFF
--- a/api/rpc/client/client.go
+++ b/api/rpc/client/client.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/filecoin-project/go-jsonrpc"
 
-	"github.com/celestiaorg/celestia-node/api/rpc/permissions"
+	"github.com/celestiaorg/celestia-node/api/rpc/perms"
 	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/fraud"
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
@@ -51,15 +51,15 @@ func (c *Client) Close() {
 	c.closer.closeAll()
 }
 
-// NewReadOnlyClient creates a new Client with one connection per namespace.
-func NewReadOnlyClient(ctx context.Context, addr string) (*Client, error) {
+// NewPublicClient creates a new Client with one connection per namespace.
+func NewPublicClient(ctx context.Context, addr string) (*Client, error) {
 	return newClient(ctx, addr, nil)
 }
 
 // NewClient creates a new Client with one connection per namespace with the
 // given token as the authorization token.
 func NewClient(ctx context.Context, addr string, token string) (*Client, error) {
-	authHeader := http.Header{permissions.AuthKey: []string{fmt.Sprintf("Bearer %s", token)}}
+	authHeader := http.Header{perms.AuthKey: []string{fmt.Sprintf("Bearer %s", token)}}
 	return newClient(ctx, addr, authHeader)
 }
 

--- a/api/rpc/permissions/permissions.go
+++ b/api/rpc/permissions/permissions.go
@@ -1,6 +1,11 @@
 package permissions
 
-import "github.com/filecoin-project/go-jsonrpc/auth"
+import (
+	"encoding/json"
+
+	"github.com/cristalhq/jwt"
+	"github.com/filecoin-project/go-jsonrpc/auth"
+)
 
 var (
 	DefaultPerms   = []auth.Permission{"public"}
@@ -8,8 +13,23 @@ var (
 	AllPerms       = []auth.Permission{"public", "read", "write", "admin"}
 )
 
+var AuthKey = "Authorization"
+
 // JWTPayload is a utility struct for marshaling/unmarshalling
 // permissions into for token signing/verifying.
 type JWTPayload struct {
 	Allow []auth.Permission
+}
+
+func (j *JWTPayload) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(j)
+}
+
+// NewTokenWithPerms generates and signs a new JWT token with the given secret
+// and given permissions.
+func NewTokenWithPerms(secret jwt.Signer, perms []auth.Permission) ([]byte, error) {
+	p := &JWTPayload{
+		Allow: perms,
+	}
+	return jwt.NewTokenBuilder(secret).BuildBytes(p)
 }

--- a/api/rpc/perms/permissions.go
+++ b/api/rpc/perms/permissions.go
@@ -1,4 +1,4 @@
-package permissions
+package perms
 
 import (
 	"encoding/json"

--- a/api/rpc/perms/permissions.go
+++ b/api/rpc/perms/permissions.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	DefaultPerms   = []auth.Permission{"public"}
+	ReadPerms      = []auth.Permission{"public", "read"}
 	ReadWritePerms = []auth.Permission{"public", "read", "write"}
 	AllPerms       = []auth.Permission{"public", "read", "write", "admin"}
 )

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/filecoin-project/go-jsonrpc/auth"
 	logging "github.com/ipfs/go-log/v2"
 
-	"github.com/celestiaorg/celestia-node/api/rpc/permissions"
+	"github.com/celestiaorg/celestia-node/api/rpc/perms"
 )
 
 var log = logging.Logger("rpc")
@@ -55,7 +55,7 @@ func (s *Server) verifyAuth(_ context.Context, token string) ([]auth.Permission,
 	if err != nil {
 		return nil, err
 	}
-	p := new(permissions.JWTPayload)
+	p := new(perms.JWTPayload)
 	err = json.Unmarshal(tk.RawClaims(), p)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (s *Server) RegisterService(namespace string, service interface{}) {
 // RegisterAuthedService registers a service onto the RPC server. All methods on the service will
 // then be exposed over the RPC.
 func (s *Server) RegisterAuthedService(namespace string, service interface{}, out interface{}) {
-	auth.PermissionedProxy(permissions.AllPerms, permissions.DefaultPerms, service, getInternalStruct(out))
+	auth.PermissionedProxy(perms.AllPerms, perms.DefaultPerms, service, getInternalStruct(out))
 	s.RegisterService(namespace, out)
 }
 

--- a/api/rpc_test.go
+++ b/api/rpc_test.go
@@ -8,12 +8,16 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cristalhq/jwt"
 	"github.com/golang/mock/gomock"
+	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/api/rpc"
 	"github.com/celestiaorg/celestia-node/api/rpc/client"
+	"github.com/celestiaorg/celestia-node/api/rpc/permissions"
+	daspkg "github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	dasMock "github.com/celestiaorg/celestia-node/nodebuilder/das/mocks"
@@ -44,7 +48,7 @@ func TestRPCCallsUnderlyingNode(t *testing.T) {
 	)
 	for i := 0; i < 3; i++ {
 		time.Sleep(time.Second * 1)
-		rpcClient, err = client.NewClient(ctx, "http://"+url)
+		rpcClient, err = client.NewReadOnlyClient(ctx, "http://"+url)
 		if err == nil {
 			t.Cleanup(rpcClient.Close)
 			break
@@ -108,6 +112,181 @@ func TestModulesImplementFullAPI(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestAuthedRPC tests whether a client with admin permissions can access all
+// methods at all permission levels via RPC.
+func TestAuthedRPC(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// generate dummy signer and sign admin perms token with it
+	signer, err := jwt.NewHS256(make([]byte, 32))
+	require.NoError(t, err)
+	token, err := permissions.NewTokenWithPerms(signer, permissions.AllPerms)
+	require.NoError(t, err)
+
+	nd, server := setupNodeWithAuthedRPC(t, signer)
+	url := nd.RPCServer.ListenAddr()
+
+	// we need to run this a few times to prevent the race where the server is not yet started
+	var rpcClient *client.Client
+	require.NoError(t, err)
+	for i := 0; i < 3; i++ {
+		time.Sleep(time.Second * 1)
+		rpcClient, err = client.NewClient(ctx, "http://"+url, string(token))
+		if err == nil {
+			t.Cleanup(rpcClient.Close)
+			break
+		}
+	}
+	require.NotNil(t, rpcClient)
+	require.NoError(t, err)
+
+	// 1. Test method with read-level permissions
+	expected := daspkg.SamplingStats{
+		SampledChainHead: 100,
+		CatchupHead:      100,
+		NetworkHead:      1000,
+		Failed:           nil,
+		Workers:          nil,
+		Concurrency:      0,
+		CatchUpDone:      true,
+		IsRunning:        false,
+	}
+	server.Das.EXPECT().SamplingStats(gomock.Any()).Return(expected, nil).Times(1)
+	stats, err := rpcClient.DAS.SamplingStats(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expected, stats)
+
+	// 2. Test method with write-level permissions
+	expectedResp := &state.TxResponse{}
+	server.State.EXPECT().SubmitTx(gomock.Any(), gomock.Any()).Return(expectedResp, nil).Times(1)
+	txResp, err := rpcClient.State.SubmitTx(ctx, []byte{})
+	require.NoError(t, err)
+	require.Equal(t, expectedResp, txResp)
+
+	// 3. Test method with admin-level permissions
+	expectedReachability := network.Reachability(3)
+	server.P2P.EXPECT().NATStatus(gomock.Any()).Return(expectedReachability, nil).Times(1)
+	natstatus, err := rpcClient.P2P.NATStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expectedReachability, natstatus)
+}
+
+// TestRWAuthRPC tests whether a client with RW permissions can access read and write-level
+// methods via RPC, but not admin-level.
+func TestRWAuthRPC(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// generate dummy signer and sign RW perms token with it
+	signer, err := jwt.NewHS256(make([]byte, 32))
+	require.NoError(t, err)
+	token, err := permissions.NewTokenWithPerms(signer, permissions.ReadWritePerms)
+	require.NoError(t, err)
+
+	nd, server := setupNodeWithAuthedRPC(t, signer)
+	url := nd.RPCServer.ListenAddr()
+
+	// we need to run this a few times to prevent the race where the server is not yet started
+	var rpcClient *client.Client
+	require.NoError(t, err)
+	for i := 0; i < 3; i++ {
+		time.Sleep(time.Second * 1)
+		rpcClient, err = client.NewClient(ctx, "http://"+url, string(token))
+		if err == nil {
+			t.Cleanup(rpcClient.Close)
+			break
+		}
+	}
+	require.NotNil(t, rpcClient)
+	require.NoError(t, err)
+
+	// 1. Test method with read-level permissions
+	expected := daspkg.SamplingStats{
+		SampledChainHead: 100,
+		CatchupHead:      100,
+		NetworkHead:      1000,
+		Failed:           nil,
+		Workers:          nil,
+		Concurrency:      0,
+		CatchUpDone:      true,
+		IsRunning:        false,
+	}
+	server.Das.EXPECT().SamplingStats(gomock.Any()).Return(expected, nil).Times(1)
+	stats, err := rpcClient.DAS.SamplingStats(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expected, stats)
+
+	// 2. Test method with write-level permissions
+	expectedResp := &state.TxResponse{}
+	server.State.EXPECT().SubmitTx(gomock.Any(), gomock.Any()).Return(expectedResp, nil).Times(1)
+	txResp, err := rpcClient.State.SubmitTx(ctx, []byte{})
+	require.NoError(t, err)
+	require.Equal(t, expectedResp, txResp)
+
+	// 3. Ensure method with admin-level permissions fails and does not get called
+	server.P2P.EXPECT().NATStatus(gomock.Any()).Return(network.ReachabilityUnknown, nil).Times(0)
+	_, err = rpcClient.P2P.NATStatus(ctx)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing permission")
+}
+
+// TestUnauthedRPC tests whether a client with no (read-only) permissions can access only
+// read-only methods.
+func TestUnauthedRPC(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// generate dummy signer and sign RW perms token with it
+	signer, err := jwt.NewHS256(make([]byte, 32))
+	require.NoError(t, err)
+
+	nd, server := setupNodeWithAuthedRPC(t, signer)
+	url := nd.RPCServer.ListenAddr()
+
+	// we need to run this a few times to prevent the race where the server is not yet started
+	var rpcClient *client.Client
+	require.NoError(t, err)
+	for i := 0; i < 3; i++ {
+		time.Sleep(time.Second * 1)
+		rpcClient, err = client.NewReadOnlyClient(ctx, "http://"+url)
+		if err == nil {
+			t.Cleanup(rpcClient.Close)
+			break
+		}
+	}
+	require.NotNil(t, rpcClient)
+	require.NoError(t, err)
+
+	// 1. Test method with read-level permissions
+	expected := daspkg.SamplingStats{
+		SampledChainHead: 100,
+		CatchupHead:      100,
+		NetworkHead:      1000,
+		Failed:           nil,
+		Workers:          nil,
+		Concurrency:      0,
+		CatchUpDone:      true,
+		IsRunning:        false,
+	}
+	server.Das.EXPECT().SamplingStats(gomock.Any()).Return(expected, nil).Times(1)
+	stats, err := rpcClient.DAS.SamplingStats(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expected, stats)
+
+	// 2. Ensure method with write-level permissions fails and doesn't get called
+	server.State.EXPECT().SubmitTx(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
+	_, err = rpcClient.State.SubmitTx(ctx, []byte{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing permission")
+
+	// 3. Ensure method with admin-level permissions fails and does not get called
+	server.P2P.EXPECT().NATStatus(gomock.Any()).Return(network.ReachabilityUnknown, nil).Times(0)
+	_, err = rpcClient.P2P.NATStatus(ctx)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing permission")
 }
 
 func TestAllReturnValuesAreMarshalable(t *testing.T) {
@@ -201,6 +380,49 @@ func setupNodeWithModifiedRPC(t *testing.T) (*nodebuilder.Node, *mockAPI) {
 		srv.RegisterService("node", mockAPI.Node)
 	})
 	nd := nodebuilder.TestNode(t, node.Full, invokeRPC)
+	// start node
+	err := nd.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err = nd.Stop(ctx)
+		require.NoError(t, err)
+	})
+	return nd, mockAPI
+}
+
+// setupNodeWithAuthedRPC sets up a node and overrides its JWT
+// signer with the given signer.
+func setupNodeWithAuthedRPC(t *testing.T, auth jwt.Signer) (*nodebuilder.Node, *mockAPI) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ctrl := gomock.NewController(t)
+
+	mockAPI := &mockAPI{
+		stateMock.NewMockModule(ctrl),
+		shareMock.NewMockModule(ctrl),
+		fraudMock.NewMockModule(ctrl),
+		headerMock.NewMockModule(ctrl),
+		dasMock.NewMockModule(ctrl),
+		p2pMock.NewMockModule(ctrl),
+		nodeMock.NewMockModule(ctrl),
+	}
+
+	// given the behavior of fx.Invoke, this invoke will be called last as it is added at the root
+	// level module. For further information, check the documentation on fx.Invoke.
+	invokeRPC := fx.Invoke(func(srv *rpc.Server) {
+		srv.RegisterAuthedService("state", mockAPI.State, &statemod.API{})
+		srv.RegisterAuthedService("share", mockAPI.Share, &share.API{})
+		srv.RegisterAuthedService("fraud", mockAPI.Fraud, &fraud.API{})
+		srv.RegisterAuthedService("header", mockAPI.Header, &header.API{})
+		srv.RegisterAuthedService("das", mockAPI.Das, &das.API{})
+		srv.RegisterAuthedService("p2p", mockAPI.P2P, &p2p.API{})
+		srv.RegisterAuthedService("node", mockAPI.Node, &node.API{})
+	})
+	// fx.Replace does not work here, but fx.Decorate does
+	nd := nodebuilder.TestNode(t, node.Full, invokeRPC, fx.Decorate(func() (jwt.Signer, error) {
+		return auth, nil
+	}))
 	// start node
 	err := nd.Start(ctx)
 	require.NoError(t, err)

--- a/nodebuilder/node/mocks/api.go
+++ b/nodebuilder/node/mocks/api.go
@@ -8,10 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
+	node "github.com/celestiaorg/celestia-node/nodebuilder/node"
 	auth "github.com/filecoin-project/go-jsonrpc/auth"
 	gomock "github.com/golang/mock/gomock"
-
-	node "github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
 // MockModule is a mock of Module interface.


### PR DESCRIPTION
Resolves #1187

* Adds `NewClientWithPerms` which takes a token and adds it to the request header for rpc calls
* Adds tests for authenticated methods