### PR TITLE
feat(cmd/celestia): Add `auth` subcommand to bridge, full and light

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"
@@ -11,12 +11,11 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/celestiaorg/celestia-node/api/rpc/perms"
-	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/libs/keystore"
 	nodemod "github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
-func authCmd(fsets ...*flag.FlagSet) *cobra.Command {
+func AuthCmd(fsets ...*flag.FlagSet) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "auth [permission-level (e.g. read || write || admin)]",
 		Short: "Signs and outputs a hex-encoded JWT token with the given permissions.",
@@ -41,7 +40,7 @@ func newToken(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	expanded, err := homedir.Expand(filepath.Clean(cmdnode.StorePath(cmd.Context())))
+	expanded, err := homedir.Expand(filepath.Clean(StorePath(cmd.Context())))
 	if err != nil {
 		return err
 	}

--- a/cmd/celestia/auth.go
+++ b/cmd/celestia/auth.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/cristalhq/jwt"
+	"github.com/filecoin-project/go-jsonrpc/auth"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
+	"github.com/celestiaorg/celestia-node/api/rpc/perms"
+	cmdnode "github.com/celestiaorg/celestia-node/cmd"
+	"github.com/celestiaorg/celestia-node/libs/keystore"
+	nodemod "github.com/celestiaorg/celestia-node/nodebuilder/node"
+)
+
+func authCmd(fsets ...*flag.FlagSet) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "auth [permission-level (e.g. read || write || admin)]",
+		Short: "Signs and outputs a hex-encoded JWT token with the given permissions.",
+		Long: "Signs and outputs a hex-encoded JWT token with the given permissions. NOTE: only use this command when " +
+			"the node has already been initialized and started.",
+		RunE: newToken,
+	}
+
+	for _, set := range fsets {
+		cmd.Flags().AddFlagSet(set)
+	}
+	return cmd
+}
+
+func newToken(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("must specify permissions")
+	}
+
+	permissions, err := convertToPerms(args[0])
+	if err != nil {
+		return err
+	}
+
+	expanded, err := homedir.Expand(filepath.Clean(cmdnode.StorePath(cmd.Context())))
+	if err != nil {
+		return err
+	}
+	ks, err := keystore.NewFSKeystore(expanded + "/keys")
+	if err != nil {
+		return err
+	}
+
+	key, err := ks.Get(nodemod.SecretName)
+	if err != nil {
+		return err
+	}
+	signer, err := jwt.NewHS256(key.Body)
+	if err != nil {
+		return err
+	}
+
+	token, err := jwt.NewTokenBuilder(signer).Build(&perms.JWTPayload{
+		Allow: permissions,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s", token.InsecureString())
+	return nil
+}
+
+func convertToPerms(perm string) ([]auth.Permission, error) {
+	perms, ok := stringsToPerms[perm]
+	if !ok {
+		return nil, fmt.Errorf("invalid permission specified: %s", perm)
+	}
+	return perms, nil
+}
+
+var stringsToPerms = map[string][]auth.Permission{
+	"public": perms.DefaultPerms,
+	"read":   perms.ReadPerms,
+	"write":  perms.ReadWritePerms,
+	"admin":  perms.AllPerms,
+}

--- a/cmd/celestia/bridge.go
+++ b/cmd/celestia/bridge.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
@@ -16,34 +17,20 @@ import (
 // PersistentPreRun func on parent command.
 
 func init() {
+	flags := []*pflag.FlagSet{
+		cmdnode.NodeFlags(),
+		p2p.Flags(),
+		core.Flags(),
+		cmdnode.MiscFlags(),
+		rpc.Flags(),
+		gateway.Flags(),
+		state.Flags(),
+	}
+
 	bridgeCmd.AddCommand(
-		cmdnode.Init(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			core.Flags(),
-			cmdnode.MiscFlags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
-		cmdnode.Start(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			core.Flags(),
-			cmdnode.MiscFlags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
-		authCmd(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			core.Flags(),
-			cmdnode.MiscFlags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
+		cmdnode.Init(flags...),
+		cmdnode.Start(flags...),
+		cmdnode.AuthCmd(flags...),
 	)
 }
 

--- a/cmd/celestia/bridge.go
+++ b/cmd/celestia/bridge.go
@@ -35,6 +35,15 @@ func init() {
 			gateway.Flags(),
 			state.Flags(),
 		),
+		authCmd(
+			cmdnode.NodeFlags(),
+			p2p.Flags(),
+			core.Flags(),
+			cmdnode.MiscFlags(),
+			rpc.Flags(),
+			gateway.Flags(),
+			state.Flags(),
+		),
 	)
 }
 

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -42,6 +42,18 @@ func init() {
 			gateway.Flags(),
 			state.Flags(),
 		),
+		authCmd(
+			cmdnode.NodeFlags(),
+			p2p.Flags(),
+			header.Flags(),
+			cmdnode.MiscFlags(),
+			// NOTE: for now, state-related queries can only be accessed
+			// over an RPC connection with a celestia-core node.
+			core.Flags(),
+			rpc.Flags(),
+			gateway.Flags(),
+			state.Flags(),
+		),
 	)
 }
 

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
@@ -17,43 +18,23 @@ import (
 // PersistentPreRun func on parent command.
 
 func init() {
+	flags := []*pflag.FlagSet{
+		cmdnode.NodeFlags(),
+		p2p.Flags(),
+		header.Flags(),
+		cmdnode.MiscFlags(),
+		// NOTE: for now, state-related queries can only be accessed
+		// over an RPC connection with a celestia-core node.
+		core.Flags(),
+		rpc.Flags(),
+		gateway.Flags(),
+		state.Flags(),
+	}
+
 	fullCmd.AddCommand(
-		cmdnode.Init(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			header.Flags(),
-			cmdnode.MiscFlags(),
-			// NOTE: for now, state-related queries can only be accessed
-			// over an RPC connection with a celestia-core node.
-			core.Flags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
-		cmdnode.Start(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			header.Flags(),
-			cmdnode.MiscFlags(),
-			// NOTE: for now, state-related queries can only be accessed
-			// over an RPC connection with a celestia-core node.
-			core.Flags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
-		authCmd(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			header.Flags(),
-			cmdnode.MiscFlags(),
-			// NOTE: for now, state-related queries can only be accessed
-			// over an RPC connection with a celestia-core node.
-			core.Flags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
+		cmdnode.Init(flags...),
+		cmdnode.Start(flags...),
+		cmdnode.AuthCmd(flags...),
 	)
 }
 

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -42,6 +42,18 @@ func init() {
 			gateway.Flags(),
 			state.Flags(),
 		),
+		authCmd(
+			cmdnode.NodeFlags(),
+			p2p.Flags(),
+			header.Flags(),
+			cmdnode.MiscFlags(),
+			// NOTE: for now, state-related queries can only be accessed
+			// over an RPC connection with a celestia-core node.
+			core.Flags(),
+			rpc.Flags(),
+			gateway.Flags(),
+			state.Flags(),
+		),
 	)
 }
 

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
@@ -17,43 +18,23 @@ import (
 // PersistentPreRun func on parent command.
 
 func init() {
+	flags := []*pflag.FlagSet{
+		cmdnode.NodeFlags(),
+		p2p.Flags(),
+		header.Flags(),
+		cmdnode.MiscFlags(),
+		// NOTE: for now, state-related queries can only be accessed
+		// over an RPC connection with a celestia-core node.
+		core.Flags(),
+		rpc.Flags(),
+		gateway.Flags(),
+		state.Flags(),
+	}
+
 	lightCmd.AddCommand(
-		cmdnode.Init(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			header.Flags(),
-			cmdnode.MiscFlags(),
-			// NOTE: for now, state-related queries can only be accessed
-			// over an RPC connection with a celestia-core node.
-			core.Flags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
-		cmdnode.Start(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			header.Flags(),
-			cmdnode.MiscFlags(),
-			// NOTE: for now, state-related queries can only be accessed
-			// over an RPC connection with a celestia-core node.
-			core.Flags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
-		authCmd(
-			cmdnode.NodeFlags(),
-			p2p.Flags(),
-			header.Flags(),
-			cmdnode.MiscFlags(),
-			// NOTE: for now, state-related queries can only be accessed
-			// over an RPC connection with a celestia-core node.
-			core.Flags(),
-			rpc.Flags(),
-			gateway.Flags(),
-			state.Flags(),
-		),
+		cmdnode.Init(flags...),
+		cmdnode.Start(flags...),
+		cmdnode.AuthCmd(flags...),
 	)
 }
 

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -141,7 +141,7 @@ SyncHead(ctx context.Context) (*header.ExtendedHeader, error)
 ```go
   type P2PModule interface {
     // Info returns address information about the host.
-    Info(context.Context) peer.AddrInfo
+    Info(context.Context) (peer.AddrInfo, error)
     // Peers returns all peer IDs used across all inner stores.
     Peers(context.Context) []peer.ID
     // PeerInfo returns a small slice of information Peerstore has on the

--- a/nodebuilder/node/auth.go
+++ b/nodebuilder/node/auth.go
@@ -5,19 +5,37 @@ import (
 	"io"
 
 	"github.com/cristalhq/jwt"
+
+	"github.com/celestiaorg/celestia-node/libs/keystore"
 )
+
+var SecretName = keystore.KeyName("jwt-secret.jwt")
 
 // secret returns the node's JWT secret if it exists, or generates
 // and saves a new one if it does not.
-//
-// TODO @renaynay:
-//  1. implement checking for existing key
-//  2. implement saving the generated key to disk
-//     (if the secret needs to be generated)
-func secret() (jwt.Signer, error) {
+func secret(ks keystore.Keystore) (jwt.Signer, error) {
+	// if key already exists, use it
+	if pk, ok := existing(ks); ok {
+		return jwt.NewHS256(pk)
+	}
+	// otherwise, generate and save new priv key
 	sk, err := io.ReadAll(io.LimitReader(rand.Reader, 32))
 	if err != nil {
 		return nil, err
 	}
+	// save key
+	err = ks.Put(SecretName, keystore.PrivKey{Body: sk})
+	if err != nil {
+		return nil, err
+	}
+
 	return jwt.NewHS256(sk)
+}
+
+func existing(ks keystore.Keystore) ([]byte, bool) {
+	sk, err := ks.Get(SecretName)
+	if err != nil {
+		return nil, false
+	}
+	return sk.Body, true
 }

--- a/nodebuilder/p2p/p2p.go
+++ b/nodebuilder/p2p/p2p.go
@@ -24,7 +24,7 @@ var _ Module = (*API)(nil)
 //go:generate mockgen -destination=mocks/api.go -package=mocks . Module
 type Module interface {
 	// Info returns address information about the host.
-	Info(context.Context) peer.AddrInfo
+	Info(context.Context) (peer.AddrInfo, error)
 	// Peers returns all peer IDs used across all inner stores.
 	Peers(context.Context) []peer.ID
 	// PeerInfo returns a small slice of information Peerstore has on the
@@ -98,8 +98,8 @@ func newModule(
 	}
 }
 
-func (m *module) Info(context.Context) peer.AddrInfo {
-	return *libhost.InfoFromHost(m.host)
+func (m *module) Info(context.Context) (peer.AddrInfo, error) {
+	return *libhost.InfoFromHost(m.host), nil
 }
 
 func (m *module) Peers(context.Context) []peer.ID {
@@ -177,7 +177,7 @@ func (m *module) PubSubPeers(_ context.Context, topic string) []peer.ID {
 //nolint:dupl
 type API struct {
 	Internal struct {
-		Info                 func(context.Context) peer.AddrInfo                         `perm:"admin"`
+		Info                 func(context.Context) (peer.AddrInfo, error)                `perm:"admin"`
 		Peers                func(context.Context) []peer.ID                             `perm:"admin"`
 		PeerInfo             func(ctx context.Context, id peer.ID) peer.AddrInfo         `perm:"admin"`
 		Connect              func(ctx context.Context, pi peer.AddrInfo) error           `perm:"admin"`
@@ -197,7 +197,7 @@ type API struct {
 	}
 }
 
-func (api *API) Info(ctx context.Context) peer.AddrInfo {
+func (api *API) Info(ctx context.Context) (peer.AddrInfo, error) {
 	return api.Internal.Info(ctx)
 }
 

--- a/nodebuilder/p2p/p2p_test.go
+++ b/nodebuilder/p2p/p2p_test.go
@@ -117,7 +117,9 @@ func TestP2PModule_Bandwidth(t *testing.T) {
 	require.Equal(t, network.Connected, mgr.Connectedness(ctx, peer.ID()))
 
 	// open stream with host
-	stream, err := peer.NewStream(ctx, mgr.Info(ctx).ID, protoID)
+	info, err := mgr.Info(ctx)
+	require.NoError(t, err)
+	stream, err := peer.NewStream(ctx, info.ID, protoID)
 	require.NoError(t, err)
 
 	// write to stream to increase bandwidth usage get some substantive


### PR DESCRIPTION
Resolves #1187

This PR adds an `auth` subcommand to `bridge`, `full` and `light` nodes. 

Intended use: after a node is already initialized and started, a user can use the CLI to generate a signed token with some given perms via the `auth` cmd.

Example:

```
celestia bridge auth admin 
```

The above command outputs a signed JWT token with admin permissions that a user can use with `client.NewClient()` to access admin-level methods on the node.

Reference [this commit](https://github.com/celestiaorg/celestia-node/pull/1429/commits/2c833bca89790ff5503822875751f3330207b87f) for the actual diff.