### PR TITLE
github/CI: Fix over kill of '.gitignore'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+/build/
 *.bak
 *.iml
 *.log
@@ -10,14 +10,13 @@ build/
 *.coverprofile
 *.test
 *.orig
-*/vendor
 vendor
 .DS_Store
 .bak
 .idea/
 .vscode/
-celestia
-cel-shed
-cel-key
+/celestia
+/cel-shed
+/cel-key
 coverage.txt
 go.work


### PR DESCRIPTION
Closes #1442 

Limit some pattern to root folder.
Remove duplicated pattern.
