### PR TITLE
refactor(nodebuilder/p2p): Switch default network from `arabica` to `mocha`

### DIFF
--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -10,7 +10,7 @@ import (
 // NOTE: Every time we add a new long-running network, it has to be added here.
 const (
 	// DefaultNetwork is the default network of the current build.
-	DefaultNetwork = Arabica
+	DefaultNetwork = Mocha
 	// Arabica testnet. See: celestiaorg/networks.
 	Arabica Network = "arabica-2"
 	// Mocha testnet. See: celestiaorg/networks.


### PR DESCRIPTION
Based on #1434 

Switches default network from arabica to mocha