### PR TITLE
chore(markdownlint): disable 'Multiple headings with the same content' rule

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
 "default": true # Default state for all rules
 "MD013": false # Disable rule for line length
 "MD033": false # Disable rule banning inline HTML
+"MD024": false # Disable "Multiple headings with the same content" rule


### PR DESCRIPTION
Don't see why we would disallow having the same name shared between multiple headers. Got this from working on #1326 