### PR TITLE
improvement(cel-key): Network alias check for `--p2p.network` flag

### DIFF
--- a/cmd/cel-key/node_types.go
+++ b/cmd/cel-key/node_types.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
-
-	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
@@ -43,9 +42,18 @@ func ParseDirectoryFlags(cmd *cobra.Command) error {
 	}
 
 	network := cmd.Flag(networkKey).Value.String()
+	err := p2p.Network(network).Validate()
+	if err != nil {
+		if net, ok := p2p.NetworkAliases[network]; ok {
+			network = string(net)
+		} else {
+			fmt.Println("WARNING: unknown network specified: ", network)
+		}
+	}
 	switch nodeType {
 	case "bridge", "full", "light":
 		keyPath := fmt.Sprintf("~/.celestia-%s-%s/keys", nodeType, strings.ToLower(network))
+		fmt.Println("using directory: ", keyPath)
 		if err := cmd.Flags().Set(sdkflags.FlagKeyringDir, keyPath); err != nil {
 			return err
 		}

--- a/cmd/cel-key/node_types.go
+++ b/cmd/cel-key/node_types.go
@@ -42,13 +42,10 @@ func ParseDirectoryFlags(cmd *cobra.Command) error {
 	}
 
 	network := cmd.Flag(networkKey).Value.String()
-	err := p2p.Network(network).Validate()
-	if err != nil {
-		if net, ok := p2p.NetworkAliases[network]; ok {
-			network = string(net)
-		} else {
-			fmt.Println("WARNING: unknown network specified: ", network)
-		}
+	if net, err := p2p.Network(network).Validate(); err == nil {
+		network = string(net)
+	} else {
+		fmt.Println("WARNING: unknown network specified: ", network)
 	}
 	switch nodeType {
 	case "bridge", "full", "light":

--- a/nodebuilder/p2p/bootstrap.go
+++ b/nodebuilder/p2p/bootstrap.go
@@ -17,7 +17,9 @@ func BootstrappersFor(net Network) (Bootstrappers, error) {
 
 // bootstrappersFor reports multiaddresses of bootstrap peers for a given network.
 func bootstrappersFor(net Network) ([]string, error) {
-	if err := net.Validate(); err != nil {
+	var err error
+	net, err = net.Validate()
+	if err != nil {
 		return nil, err
 	}
 

--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -78,7 +78,7 @@ func ParseNetwork(cmd *cobra.Command) (Network, error) {
 		return envNetwork, err
 	}
 	// check if user provided an alias
-	parsedNetwork, ok := networkAliases[parsed]
+	parsedNetwork, ok := NetworkAliases[parsed]
 	if ok {
 		return parsedNetwork, nil
 	}

--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -77,14 +77,10 @@ func ParseNetwork(cmd *cobra.Command) (Network, error) {
 		}
 		return envNetwork, err
 	}
-	// check if user provided an alias
-	parsedNetwork, ok := NetworkAliases[parsed]
-	if ok {
-		return parsedNetwork, nil
-	}
 	// check if user provided the actual network value
-	if err := Network(parsed).Validate(); err == nil {
-		return Network(parsed), nil
+	// or an alias
+	if net, err := Network(parsed).Validate(); err == nil {
+		return net, nil
 	}
 	return "", fmt.Errorf("invalid network specified: %s", parsed)
 }

--- a/nodebuilder/p2p/genesis.go
+++ b/nodebuilder/p2p/genesis.go
@@ -7,7 +7,9 @@ import (
 // GenesisFor reports a hash of a genesis block for a given network.
 // Genesis is strictly defined and can't be modified.
 func GenesisFor(net Network) (string, error) {
-	if err := net.Validate(); err != nil {
+	var err error
+	net, err = net.Validate()
+	if err != nil {
 		return "", err
 	}
 

--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -46,10 +46,10 @@ var networksList = map[Network]struct{}{
 	Private: {},
 }
 
-// networkAliases is a strict list of all known long-standing networks
+// NetworkAliases is a strict list of all known long-standing networks
 // mapped from the string representation of their *alias* (rather than
 // their actual value) to the Network.
-var networkAliases = map[string]Network{
+var NetworkAliases = map[string]Network{
 	"arabica": Arabica,
 	"mocha":   Mocha,
 	"private": Private,

--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -32,11 +32,15 @@ type Bootstrappers []peer.AddrInfo
 var ErrInvalidNetwork = errors.New("params: invalid network")
 
 // Validate the network.
-func (n Network) Validate() error {
-	if _, ok := networksList[n]; !ok {
-		return ErrInvalidNetwork
+func (n Network) Validate() (Network, error) {
+	// return actual network if alias was provided
+	if net, ok := networkAliases[string(n)]; ok {
+		return net, nil
 	}
-	return nil
+	if _, ok := networksList[n]; !ok {
+		return "", ErrInvalidNetwork
+	}
+	return n, nil
 }
 
 // networksList is a strict list of all known long-standing networks.
@@ -46,10 +50,10 @@ var networksList = map[Network]struct{}{
 	Private: {},
 }
 
-// NetworkAliases is a strict list of all known long-standing networks
+// networkAliases is a strict list of all known long-standing networks
 // mapped from the string representation of their *alias* (rather than
 // their actual value) to the Network.
-var NetworkAliases = map[string]Network{
+var networkAliases = map[string]Network{
 	"arabica": Arabica,
 	"mocha":   Mocha,
 	"private": Private,


### PR DESCRIPTION
Allows users to pass the network alias instead of the full network name to the `cel-key` utility as is done with the celestia binary. 

We allow networks other than the "valid" networks to be specified with the cel-key utility since it can be used for testing, but it will print a warning.