### PR TITLE
feat(state)!: Adding fee parameter to `CoreAccessor` operations

### DIFF
--- a/api/gateway/state.go
+++ b/api/gateway/state.go
@@ -43,12 +43,14 @@ type submitTxRequest struct {
 type submitPFDRequest struct {
 	NamespaceID string `json:"namespace_id"`
 	Data        string `json:"data"`
+	Fee         int64  `json:"fee"`
 	GasLimit    uint64 `json:"gas_limit"`
 }
 
 type transferRequest struct {
 	To       string `json:"to"`
 	Amount   int64  `json:"amount"`
+	Fee      int64  `json:"fee"`
 	GasLimit uint64 `json:"gas_limit"`
 }
 
@@ -57,6 +59,7 @@ type transferRequest struct {
 type delegationRequest struct {
 	To       string `json:"to"`
 	Amount   int64  `json:"amount"`
+	Fee      int64  `json:"fee"`
 	GasLimit uint64 `json:"gas_limit"`
 }
 
@@ -65,6 +68,7 @@ type redelegationRequest struct {
 	From     string `json:"from"`
 	To       string `json:"to"`
 	Amount   int64  `json:"amount"`
+	Fee      int64  `json:"fee"`
 	GasLimit uint64 `json:"gas_limit"`
 }
 
@@ -72,6 +76,7 @@ type redelegationRequest struct {
 type unbondRequest struct {
 	From     string `json:"from"`
 	Amount   int64  `json:"amount"`
+	Fee      int64  `json:"fee"`
 	GasLimit uint64 `json:"gas_limit"`
 }
 
@@ -80,6 +85,7 @@ type cancelUnbondRequest struct {
 	From     string `json:"from"`
 	Amount   int64  `json:"amount"`
 	Height   int64  `json:"height"`
+	Fee      int64  `json:"fee"`
 	GasLimit uint64 `json:"gas_limit"`
 }
 
@@ -177,8 +183,9 @@ func (h *Handler) handleSubmitPFD(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, submitPFDEndpoint, err)
 		return
 	}
+	fee := types.NewInt(req.Fee)
 	// perform request
-	txResp, err := h.state.SubmitPayForData(r.Context(), nID, data, req.GasLimit)
+	txResp, err := h.state.SubmitPayForData(r.Context(), nID, data, fee, req.GasLimit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, submitPFDEndpoint, err)
 		return
@@ -212,8 +219,9 @@ func (h *Handler) handleTransfer(w http.ResponseWriter, r *http.Request) {
 		addr = valAddr.Bytes()
 	}
 	amount := types.NewInt(req.Amount)
+	fee := types.NewInt(req.Fee)
 
-	txResp, err := h.state.Transfer(r.Context(), addr, amount, req.GasLimit)
+	txResp, err := h.state.Transfer(r.Context(), addr, amount, fee, req.GasLimit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, transferEndpoint, err)
 		return
@@ -242,8 +250,9 @@ func (h *Handler) handleDelegation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	amount := types.NewInt(req.Amount)
+	fee := types.NewInt(req.Fee)
 
-	txResp, err := h.state.Delegate(r.Context(), addr, amount, req.GasLimit)
+	txResp, err := h.state.Delegate(r.Context(), addr, amount, fee, req.GasLimit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, delegationEndpoint, err)
 		return
@@ -272,8 +281,9 @@ func (h *Handler) handleUndelegation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	amount := types.NewInt(req.Amount)
+	fee := types.NewInt(req.Fee)
 
-	txResp, err := h.state.Undelegate(r.Context(), addr, amount, req.GasLimit)
+	txResp, err := h.state.Undelegate(r.Context(), addr, amount, fee, req.GasLimit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, undelegationEndpoint, err)
 		return
@@ -303,7 +313,8 @@ func (h *Handler) handleCancelUnbonding(w http.ResponseWriter, r *http.Request) 
 	}
 	amount := types.NewInt(req.Amount)
 	height := types.NewInt(req.Height)
-	txResp, err := h.state.CancelUnbondingDelegation(r.Context(), addr, amount, height, req.GasLimit)
+	fee := types.NewInt(req.Fee)
+	txResp, err := h.state.CancelUnbondingDelegation(r.Context(), addr, amount, height, fee, req.GasLimit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, cancelUnbondingEndpoint, err)
 		return
@@ -337,8 +348,9 @@ func (h *Handler) handleRedelegation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	amount := types.NewInt(req.Amount)
+	fee := types.NewInt(req.Fee)
 
-	txResp, err := h.state.BeginRedelegate(r.Context(), srcAddr, dstAddr, amount, req.GasLimit)
+	txResp, err := h.state.BeginRedelegate(r.Context(), srcAddr, dstAddr, amount, fee, req.GasLimit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, beginRedelegationEndpoint, err)
 		return

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -246,15 +246,17 @@ SyncHead(ctx context.Context) (*header.ExtendedHeader, error)
     SubmitPayForData(
       ctx context.Context, 
       nID namespace.ID, 
-      data []byte, 
+      data []byte,
+      fee types.Int,
       gasLimit uint64,
     ) (*state.TxResponse, error)
     // Transfer sends the given amount of coins from default wallet of the node 
     // to the given account address.
     Transfer(
       ctx context.Context, 
-      to types.Address, 
-      amount types.Int, 
+      to types.Address,
+      amount types.Int,
+      fee types.Int,
       gasLimit uint64,
     ) (*state.TxResponse, error)
 
@@ -275,7 +277,8 @@ yet.
     Delegate(
         ctx context.Context, 
         delAddr state.ValAddress, 
-        amount state.Int, 
+        amount state.Int,
+        fee types.Int,
         gasLim uint64,
     ) (*state.TxResponse, error)
     // BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
@@ -284,6 +287,7 @@ yet.
         srcValAddr,
         dstValAddr state.ValAddress,
         amount state.Int,
+        fee types.Int,
         gasLim uint64, 
     ) (*state.TxResponse, error)
     // Undelegate undelegates a user's delegated tokens, unbonding them from the
@@ -292,6 +296,7 @@ yet.
         ctx context.Context, 
         delAddr state.ValAddress,
         amount state.Int,
+        fee types.Int,
         gasLim uint64,
     ) (*state.TxResponse, error)
 
@@ -300,8 +305,9 @@ yet.
     CancelUnbondingDelegation(
         ctx context.Context,
         valAddr state.ValAddress,
-        amount,
-        height state.Int,
+        amount types.Int,
+        height types.Int,
+        fee types.Int,
         gasLim uint64,
     ) (*state.TxResponse, error)
 

--- a/nodebuilder/state/mocks/api.go
+++ b/nodebuilder/state/mocks/api.go
@@ -9,12 +9,11 @@ import (
 	reflect "reflect"
 
 	math "cosmossdk.io/math"
+	namespace "github.com/celestiaorg/nmt/namespace"
 	types "github.com/cosmos/cosmos-sdk/types"
 	types0 "github.com/cosmos/cosmos-sdk/x/staking/types"
 	gomock "github.com/golang/mock/gomock"
 	types1 "github.com/tendermint/tendermint/types"
-
-	namespace "github.com/celestiaorg/nmt/namespace"
 )
 
 // MockModule is a mock of Module interface.
@@ -86,62 +85,62 @@ func (mr *MockModuleMockRecorder) BalanceForAddress(arg0, arg1 interface{}) *gom
 }
 
 // BeginRedelegate mocks base method.
-func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
+func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3, arg4 math.Int, arg5 uint64) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BeginRedelegate", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "BeginRedelegate", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BeginRedelegate indicates an expected call of BeginRedelegate.
-func (mr *MockModuleMockRecorder) BeginRedelegate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) BeginRedelegate(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginRedelegate", reflect.TypeOf((*MockModule)(nil).BeginRedelegate), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginRedelegate", reflect.TypeOf((*MockModule)(nil).BeginRedelegate), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // CancelUnbondingDelegation mocks base method.
-func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
+func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3, arg4 math.Int, arg5 uint64) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelUnbondingDelegation", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "CancelUnbondingDelegation", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CancelUnbondingDelegation indicates an expected call of CancelUnbondingDelegation.
-func (mr *MockModuleMockRecorder) CancelUnbondingDelegation(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) CancelUnbondingDelegation(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUnbondingDelegation", reflect.TypeOf((*MockModule)(nil).CancelUnbondingDelegation), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUnbondingDelegation", reflect.TypeOf((*MockModule)(nil).CancelUnbondingDelegation), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Delegate mocks base method.
-func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 uint64) (*types.TxResponse, error) {
+func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delegate", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Delegate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Delegate indicates an expected call of Delegate.
-func (mr *MockModuleMockRecorder) Delegate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) Delegate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delegate", reflect.TypeOf((*MockModule)(nil).Delegate), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delegate", reflect.TypeOf((*MockModule)(nil).Delegate), arg0, arg1, arg2, arg3, arg4)
 }
 
 // IsStopped mocks base method.
-func (m *MockModule) IsStopped() bool {
+func (m *MockModule) IsStopped(arg0 context.Context) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsStopped")
+	ret := m.ctrl.Call(m, "IsStopped", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsStopped indicates an expected call of IsStopped.
-func (mr *MockModuleMockRecorder) IsStopped() *gomock.Call {
+func (mr *MockModuleMockRecorder) IsStopped(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStopped", reflect.TypeOf((*MockModule)(nil).IsStopped))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStopped", reflect.TypeOf((*MockModule)(nil).IsStopped), arg0)
 }
 
 // QueryDelegation mocks base method.
@@ -190,18 +189,18 @@ func (mr *MockModuleMockRecorder) QueryUnbonding(arg0, arg1 interface{}) *gomock
 }
 
 // SubmitPayForData mocks base method.
-func (m *MockModule) SubmitPayForData(arg0 context.Context, arg1 namespace.ID, arg2 []byte, arg3 uint64) (*types.TxResponse, error) {
+func (m *MockModule) SubmitPayForData(arg0 context.Context, arg1 namespace.ID, arg2 []byte, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitPayForData", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SubmitPayForData", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SubmitPayForData indicates an expected call of SubmitPayForData.
-func (mr *MockModuleMockRecorder) SubmitPayForData(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) SubmitPayForData(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitPayForData", reflect.TypeOf((*MockModule)(nil).SubmitPayForData), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitPayForData", reflect.TypeOf((*MockModule)(nil).SubmitPayForData), arg0, arg1, arg2, arg3, arg4)
 }
 
 // SubmitTx mocks base method.
@@ -220,31 +219,31 @@ func (mr *MockModuleMockRecorder) SubmitTx(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // Transfer mocks base method.
-func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 uint64) (*types.TxResponse, error) {
+func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Transfer", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Transfer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Transfer indicates an expected call of Transfer.
-func (mr *MockModuleMockRecorder) Transfer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) Transfer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transfer", reflect.TypeOf((*MockModule)(nil).Transfer), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transfer", reflect.TypeOf((*MockModule)(nil).Transfer), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Undelegate mocks base method.
-func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 uint64) (*types.TxResponse, error) {
+func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Undelegate", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Undelegate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Undelegate indicates an expected call of Undelegate.
-func (mr *MockModuleMockRecorder) Undelegate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) Undelegate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Undelegate", reflect.TypeOf((*MockModule)(nil).Undelegate), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Undelegate", reflect.TypeOf((*MockModule)(nil).Undelegate), arg0, arg1, arg2, arg3, arg4)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Adding fee parameter to `CoreAccessor` operations.

All transaction endpoints now have a "fee" key needed in the JSON request. An example value for this can be 2000. This includes the following endpoints:

- SubmitPayForData
- Transfer
- Delegate
- BeginRedelegate
- Undelegate
- CancelUnbondingDelegation

After this change, a new field is added to the json requests in the gateway:
`{oldRequest..., "fee": 2000}`