### PR TITLE
fix: `namespaced_data` endpoint

### DIFF
--- a/api/gateway/share.go
+++ b/api/gateway/share.go
@@ -111,15 +111,22 @@ func (h *Handler) getShares(ctx context.Context, height uint64, nID namespace.ID
 	return shares, header.Height, err
 }
 
-func dataFromShares(shares []share.Share) ([][]byte, error) {
-	messages, err := appshares.ParseMsgs(shares)
+func dataFromShares(shares []share.Share) (data [][]byte, err error) {
+	sequences, err := appshares.ParseShares(shares)
 	if err != nil {
-		return nil, err
+		return data, err
 	}
-	data := make([][]byte, len(messages.MessagesList))
-	for i := range messages.MessagesList {
-		data[i] = messages.MessagesList[i].Data
+
+	for _, sequence := range sequences {
+		for _, share := range sequence.Shares {
+			rawData, err := share.RawData()
+			if err != nil {
+				return data, err
+			}
+			data = append(data, rawData)
+		}
 	}
+
 	return data, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cosmossdk.io/math v1.0.0-beta.3
 	github.com/BurntSushi/toml v1.2.1
 	github.com/alecthomas/jsonschema v0.0.0-20200530073317-71f438968921
-	github.com/celestiaorg/celestia-app v0.11.0
+	github.com/celestiaorg/celestia-app v0.11.1
 	github.com/celestiaorg/go-libp2p-messenger v0.1.0
 	github.com/celestiaorg/nmt v0.11.0
 	github.com/celestiaorg/rsmt2d v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-app v0.11.0 h1:F76mBdLJZ1LLjWEPVEjoFPJA4skaY7Wrg+5o1LVlHGY=
-github.com/celestiaorg/celestia-app v0.11.0/go.mod h1:6k/zcNDEgOyJRGnAgWw1VsrwTKcVjOyYG5LPTHcZR+w=
+github.com/celestiaorg/celestia-app v0.11.1 h1:rUvJ9zfSrBwJNSHuOKbix6v4gphddtU40rFgLyK3d5U=
+github.com/celestiaorg/celestia-app v0.11.1/go.mod h1:6k/zcNDEgOyJRGnAgWw1VsrwTKcVjOyYG5LPTHcZR+w=
 github.com/celestiaorg/celestia-core v1.5.0-tm-v0.34.20-verify-key-patch h1:b0swFbc0JqivwVz1UwnzFPlXYsVFkoHAmJ3LIfP4/2o=
 github.com/celestiaorg/celestia-core v1.5.0-tm-v0.34.20-verify-key-patch/go.mod h1:f4R8qNJrP1CDH0SNwj4jA3NymBLQM4lNdx6Ijmfllbw=
 github.com/celestiaorg/cosmos-sdk v1.4.0-sdk-v0.46.0 h1:65gnQ92mfz+9XNVTHeVwMp+SZuBqmToEnz8+WdDRmQ8=


### PR DESCRIPTION
## Description

Closes https://github.com/celestiaorg/celestia-node/issues/1448

Draft PR because I noticed that although this fixes #1448 by not truncating any part of the blob, it also includes the padding bytes in the `namespaced_data` response. This seems like a regression because per [these docs](https://docs.celestia.org/developers/node-api#get-namespaced_datanidheightheight):

> Returns original messages of the given namespace ID nID from the given block height.

so the `namespaced_data` response shouldn't include padding.

## Testing

Manual testing performed in [Go Playground](https://go.dev/play/p/9jBi49rOwa_y). This PR should be accompanied with integration tests for the RPC endpoints that are being modified but I haven't investigated how to do that yet. 