### PR TITLE
fix(eds): WriteEDS thread safety for concurrent writingSessions

### DIFF
--- a/share/eds/eds.go
+++ b/share/eds/eds.go
@@ -3,7 +3,6 @@ package eds
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +16,7 @@ import (
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/ipld/go-car"
 	"github.com/ipld/go-car/util"
+	"github.com/minio/sha256-simd"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/da"

--- a/share/ipld/namespace_hasher_test.go
+++ b/share/ipld/namespace_hasher_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNamespaceHasherWrite(t *testing.T) {
 	leafSize := appconsts.ShareSize + appconsts.NamespaceSize
-	innerSize := nmtHashSize * 2
+	innerSize := NmtHashSize * 2
 	tt := []struct {
 		name         string
 		expectedSize int
@@ -59,7 +59,7 @@ func TestNamespaceHasherWrite(t *testing.T) {
 
 func TestNamespaceHasherSum(t *testing.T) {
 	leafSize := appconsts.ShareSize + appconsts.NamespaceSize
-	innerSize := nmtHashSize * 2
+	innerSize := NmtHashSize * 2
 	tt := []struct {
 		name         string
 		expectedSize int
@@ -67,12 +67,12 @@ func TestNamespaceHasherSum(t *testing.T) {
 	}{
 		{
 			"Leaf",
-			nmtHashSize,
+			NmtHashSize,
 			leafSize,
 		},
 		{
 			"Inner",
-			nmtHashSize,
+			NmtHashSize,
 			innerSize,
 		},
 		{

--- a/share/ipld/nmt.go
+++ b/share/ipld/nmt.go
@@ -42,11 +42,11 @@ const (
 	// NamespaceSize is a system-wide size for NMT namespaces.
 	NamespaceSize = appconsts.NamespaceSize
 
-	// nmtHashSize is the size of a digest created by an NMT in bytes.
-	nmtHashSize = 2*NamespaceSize + sha256.Size
+	// NmtHashSize is the size of a digest created by an NMT in bytes.
+	NmtHashSize = 2*NamespaceSize + sha256.Size
 
 	// innerNodeSize is the size of data in inner nodes.
-	innerNodeSize = nmtHashSize * 2
+	innerNodeSize = NmtHashSize * 2
 
 	// leafNodeSize is the size of data in leaf nodes.
 	leafNodeSize = NamespaceSize + appconsts.ShareSize
@@ -98,8 +98,8 @@ func (n nmtNode) Links() []*ipld.Link {
 	default:
 		panic(fmt.Sprintf("unexpected size %v", len(n.RawData())))
 	case innerNodeSize:
-		leftCid := MustCidFromNamespacedSha256(n.RawData()[:nmtHashSize])
-		rightCid := MustCidFromNamespacedSha256(n.RawData()[nmtHashSize:])
+		leftCid := MustCidFromNamespacedSha256(n.RawData()[:NmtHashSize])
+		rightCid := MustCidFromNamespacedSha256(n.RawData()[NmtHashSize:])
 
 		return []*ipld.Link{{Cid: leftCid}, {Cid: rightCid}}
 	case leafNodeSize:
@@ -129,7 +129,7 @@ func (n nmtNode) Size() (uint64, error) {
 
 // CidFromNamespacedSha256 uses a hash from an nmt tree to create a CID
 func CidFromNamespacedSha256(namespacedHash []byte) (cid.Cid, error) {
-	if got, want := len(namespacedHash), nmtHashSize; got != want {
+	if got, want := len(namespacedHash), NmtHashSize; got != want {
 		return cid.Cid{}, fmt.Errorf("invalid namespaced hash length, got: %v, want: %v", got, want)
 	}
 	buf, err := mh.Encode(namespacedHash, sha256Namespace8Flagged)

--- a/share/ipld/test_helpers.go
+++ b/share/ipld/test_helpers.go
@@ -9,7 +9,7 @@ import (
 )
 
 func RandNamespacedCID(t *testing.T) cid.Cid {
-	raw := make([]byte, nmtHashSize)
+	raw := make([]byte, NmtHashSize)
 	_, err := mrand.Read(raw)
 	require.NoError(t, err)
 	id, err := CidFromNamespacedSha256(raw)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
This PR removes usage of nmt's defaultHasher to allow for concurrent writingSessions.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [X] New and updated code has appropriate documentation
- ~~New and updated code has new and/or updated testing~~
- [x] Required CI checks are passing
- ~~Visual proof for any user facing features like CLI or documentation updates~~
- ~~Linked issues closed with keywords~~
