### PR TITLE
fix(node/p2p)!: remove resource manager and it's API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/libp2p/go-libp2p-peerstore v0.7.1
 	github.com/libp2p/go-libp2p-pubsub v0.7.0
 	github.com/libp2p/go-libp2p-record v0.1.3
-	github.com/libp2p/go-libp2p-resource-manager v0.5.1
 	github.com/libp2p/go-libp2p-routing-helpers v0.2.3
 	github.com/minio/sha256-simd v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -211,6 +210,7 @@ require (
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.4.7 // indirect
 	github.com/libp2p/go-libp2p-loggables v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-resource-manager v0.5.1 // indirect
 	github.com/libp2p/go-msgio v0.2.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect
 	github.com/libp2p/go-netroute v0.2.0 // indirect

--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -75,7 +75,7 @@ type hostParams struct {
 	PStore    peerstore.Peerstore
 	ConnMngr  connmgr.ConnManager
 	ConnGater *conngater.BasicConnectionGater
-	Bandwidth  *metrics.BandwidthCounter
+	Bandwidth *metrics.BandwidthCounter
 
 	Tp node.Type
 }

--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -9,7 +9,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/metrics"
-	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/libp2p/go-libp2p-core/routing"
@@ -28,7 +27,7 @@ func RoutedHost(base HostBase, r routing.PeerRouting) host.Host {
 }
 
 // Host returns constructor for Host.
-func Host(cfg Config, params hostParams, bw *metrics.BandwidthCounter, rm network.ResourceManager) (HostBase, error) {
+func Host(cfg Config, params hostParams) (HostBase, error) {
 	opts := []libp2p.Option{
 		libp2p.NoListenAddrs, // do not listen automatically
 		libp2p.AddrsFactory(params.AddrF),
@@ -39,8 +38,7 @@ func Host(cfg Config, params hostParams, bw *metrics.BandwidthCounter, rm networ
 		libp2p.UserAgent(fmt.Sprintf("celestia-%s", params.Net)),
 		libp2p.NATPortMap(), // enables upnp
 		libp2p.DisableRelay(),
-		libp2p.BandwidthReporter(bw),
-		libp2p.ResourceManager(rm),
+		libp2p.BandwidthReporter(params.Bandwith),
 		// to clearly define what defaults we rely upon
 		libp2p.DefaultSecurity,
 		libp2p.DefaultTransports,
@@ -77,6 +75,7 @@ type hostParams struct {
 	PStore    peerstore.Peerstore
 	ConnMngr  connmgr.ConnManager
 	ConnGater *conngater.BasicConnectionGater
+	Bandwith *metrics.BandwidthCounter
 
 	Tp node.Type
 }

--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -38,7 +38,7 @@ func Host(cfg Config, params hostParams) (HostBase, error) {
 		libp2p.UserAgent(fmt.Sprintf("celestia-%s", params.Net)),
 		libp2p.NATPortMap(), // enables upnp
 		libp2p.DisableRelay(),
-		libp2p.BandwidthReporter(params.Bandwith),
+		libp2p.BandwidthReporter(params.Bandwidth),
 		// to clearly define what defaults we rely upon
 		libp2p.DefaultSecurity,
 		libp2p.DefaultTransports,
@@ -75,7 +75,7 @@ type hostParams struct {
 	PStore    peerstore.Peerstore
 	ConnMngr  connmgr.ConnManager
 	ConnGater *conngater.BasicConnectionGater
-	Bandwith  *metrics.BandwidthCounter
+	Bandwidth  *metrics.BandwidthCounter
 
 	Tp node.Type
 }

--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -75,7 +75,7 @@ type hostParams struct {
 	PStore    peerstore.Peerstore
 	ConnMngr  connmgr.ConnManager
 	ConnGater *conngater.BasicConnectionGater
-	Bandwith *metrics.BandwidthCounter
+	Bandwith  *metrics.BandwidthCounter
 
 	Tp node.Type
 }

--- a/nodebuilder/p2p/mocks/api.go
+++ b/nodebuilder/p2p/mocks/api.go
@@ -13,7 +13,6 @@ import (
 	network "github.com/libp2p/go-libp2p-core/network"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	protocol "github.com/libp2p/go-libp2p-core/protocol"
-	rcmgr "github.com/libp2p/go-libp2p-resource-manager"
 )
 
 // MockModule is a mock of Module interface.
@@ -246,21 +245,6 @@ func (m *MockModule) PubSubPeers(arg0 context.Context, arg1 string) []peer.ID {
 func (mr *MockModuleMockRecorder) PubSubPeers(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PubSubPeers", reflect.TypeOf((*MockModule)(nil).PubSubPeers), arg0, arg1)
-}
-
-// ResourceState mocks base method.
-func (m *MockModule) ResourceState(arg0 context.Context) (rcmgr.ResourceManagerStat, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResourceState", arg0)
-	ret0, _ := ret[0].(rcmgr.ResourceManagerStat)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResourceState indicates an expected call of ResourceState.
-func (mr *MockModuleMockRecorder) ResourceState(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceState", reflect.TypeOf((*MockModule)(nil).ResourceState), arg0)
 }
 
 // UnblockPeer mocks base method.

--- a/nodebuilder/p2p/module.go
+++ b/nodebuilder/p2p/module.go
@@ -3,8 +3,6 @@ package p2p
 import (
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/metrics"
-	"github.com/libp2p/go-libp2p-core/network"
-	rcmgr "github.com/libp2p/go-libp2p-resource-manager"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -34,12 +32,6 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 		fx.Provide(ContentRouting),
 		fx.Provide(AddrsFactory(cfg.AnnounceAddresses, cfg.NoAnnounceAddresses)),
 		fx.Provide(metrics.NewBandwidthCounter),
-		fx.Provide(func(cfg Config) (network.ResourceManager, error) {
-			if cfg.Bootstrapper {
-				return rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.InfiniteLimits))
-			}
-			return rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.DefaultLimits.AutoScale()))
-		}),
 		fx.Provide(newModule),
 		fx.Invoke(Listen(cfg.ListenAddresses)),
 	)

--- a/nodebuilder/p2p/p2p.go
+++ b/nodebuilder/p2p/p2p.go
@@ -66,7 +66,8 @@ type Module interface {
 	// BandwidthForPeer returns a Stats struct with bandwidth metrics associated with the given peer.ID.
 	// The metrics returned include all traffic sent / received for the peer, regardless of protocol.
 	BandwidthForPeer(ctx context.Context, id peer.ID) metrics.Stats
-	// BandwidthForProtocol returns a Stats struct with bandwidth metrics associated with the given protocol.ID.
+	// BandwidthForProtocol returns a Stats struct with bandwidth metrics associated with the given
+	// protocol.ID.
 	BandwidthForProtocol(ctx context.Context, proto protocol.ID) metrics.Stats
 
 	// PubSubPeers returns the peer IDs of the peers joined on

--- a/nodebuilder/p2p/p2p_test.go
+++ b/nodebuilder/p2p/p2p_test.go
@@ -14,7 +14,6 @@ import (
 	libpeer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	rcmgr "github.com/libp2p/go-libp2p-resource-manager"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,7 @@ func TestP2PModule_Host(t *testing.T) {
 	require.NoError(t, err)
 	host, peer := net.Hosts()[0], net.Hosts()[1]
 
-	mgr := newModule(host, nil, nil, nil, nil)
+	mgr := newModule(host, nil, nil, nil)
 
 	ctx := context.Background()
 
@@ -53,7 +52,7 @@ func TestP2PModule_ConnManager(t *testing.T) {
 	peer, err := libp2p.New()
 	require.NoError(t, err)
 
-	mgr := newModule(host, nil, nil, nil, nil)
+	mgr := newModule(host, nil, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -73,7 +72,7 @@ func TestP2PModule_Autonat(t *testing.T) {
 	host, err := libp2p.New(libp2p.EnableNATService())
 	require.NoError(t, err)
 
-	mgr := newModule(host, nil, nil, nil, nil)
+	mgr := newModule(host, nil, nil, nil)
 
 	status, err := mgr.NATStatus(context.Background())
 	assert.NoError(t, err)
@@ -105,7 +104,7 @@ func TestP2PModule_Bandwidth(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	mgr := newModule(host, nil, nil, bw, nil)
+	mgr := newModule(host, nil, nil, bw)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -160,7 +159,7 @@ func TestP2PModule_Pubsub(t *testing.T) {
 	gs, err := pubsub.NewGossipSub(ctx, host)
 	require.NoError(t, err)
 
-	mgr := newModule(host, gs, nil, nil, nil)
+	mgr := newModule(host, gs, nil, nil)
 
 	topicStr := "test-topic"
 
@@ -194,7 +193,7 @@ func TestP2PModule_ConnGater(t *testing.T) {
 	gater, err := ConnectionGater(datastore.NewMapDatastore())
 	require.NoError(t, err)
 
-	mgr := newModule(nil, nil, gater, nil, nil)
+	mgr := newModule(nil, nil, gater, nil)
 
 	ctx := context.Background()
 
@@ -202,18 +201,4 @@ func TestP2PModule_ConnGater(t *testing.T) {
 	assert.Len(t, mgr.ListBlockedPeers(ctx), 1)
 	assert.NoError(t, mgr.UnblockPeer(ctx, "badpeer"))
 	assert.Len(t, mgr.ListBlockedPeers(ctx), 0)
-}
-
-// TestP2PModule_ResourceManager tests P2P Module methods on
-// the ResourceManager.
-func TestP2PModule_ResourceManager(t *testing.T) {
-	rm, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.DefaultLimits.AutoScale()))
-	require.NoError(t, err)
-
-	mgr := newModule(nil, nil, nil, nil, rm)
-
-	state, err := mgr.ResourceState(context.Background())
-	require.NoError(t, err)
-
-	assert.NotNil(t, state)
 }


### PR DESCRIPTION
This is a temporary fix for bootstrappers. Infinite Limits seem to be buggy. The proper fix is to update to the latest version of libp2p                                                
