### PR TITLE
chore(all): lint all the comment with cfmt and add cfmt to lint rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ lint:
 	@echo "--> Running linter"
 	@golangci-lint run
 	@markdownlint --config .markdownlint.yaml '**/*.md'
+	@cfmt -m=100 ./...
 .PHONY: lint
 
 ## test-unit: Running unit tests

--- a/header/p2p/exchange.go
+++ b/header/p2p/exchange.go
@@ -161,8 +161,8 @@ func (ex *Exchange) GetRangeByHeight(ctx context.Context, from, amount uint64) (
 	return session.getRangeByHeight(ctx, from, amount, ex.Params.MaxHeadersPerRequest)
 }
 
-// GetVerifiedRange performs a request for the given range of ExtendedHeaders to the network and ensures
-// that returned headers are correct against the passed one.
+// GetVerifiedRange performs a request for the given range of ExtendedHeaders to the network and
+// ensures that returned headers are correct against the passed one.
 func (ex *Exchange) GetVerifiedRange(
 	ctx context.Context,
 	from *header.ExtendedHeader,

--- a/header/p2p/helpers.go
+++ b/header/p2p/helpers.go
@@ -20,9 +20,9 @@ func protocolID(protocolSuffix string) protocol.ID {
 	return protocol.ID(fmt.Sprintf("/header-ex/v0.0.3/%s", protocolSuffix))
 }
 
-// sendMessage opens the stream to the given peers and sends ExtendedHeaderRequest to fetch ExtendedHeaders.
-// As a result sendMessage returns ExtendedHeaderResponse, the size of fetched data,
-// the duration of the request and an error.
+// sendMessage opens the stream to the given peers and sends ExtendedHeaderRequest to fetch
+// ExtendedHeaders. As a result sendMessage returns ExtendedHeaderResponse, the size of fetched
+// data, the duration of the request and an error.
 func sendMessage(
 	ctx context.Context,
 	host host.Host,

--- a/header/p2p/session.go
+++ b/header/p2p/session.go
@@ -101,7 +101,8 @@ func (s *session) handleOutgoingRequests(ctx context.Context, result chan []*hea
 	}
 }
 
-// doRequest chooses the best peer to fetch headers and sends a request in range of available maxRetryAttempts.
+// doRequest chooses the best peer to fetch headers and sends a request in range of available
+// maxRetryAttempts.
 func (s *session) doRequest(
 	ctx context.Context,
 	stat *peerStat,
@@ -129,8 +130,8 @@ func (s *session) doRequest(
 		return
 	}
 	log.Debugw("request headers from peer succeed ", "from", s.host.ID(), "pID", stat.peerID, "amount", req.Amount)
-	// send headers to the channel, update peer stats and return peer to the queue, so it can be re-used in case
-	// if there are other requests awaiting
+	// send headers to the channel, update peer stats and return peer to the queue, so it can be
+	// re-used in case if there are other requests awaiting
 	headers <- h
 	stat.updateStats(size, duration)
 	s.queue.push(stat)

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -93,8 +93,8 @@ func newInitStore(
 			err = store.Init(ctx, s, ex, trustedHash)
 			if err != nil {
 				// TODO(@Wondertan): Error is ignored, as otherwise unit tests for Node construction fail.
-				// 	This is due to requesting step of initialization, which fetches initial Header by trusted hash from
-				//  the network. The step can't be done during unit tests and fixing it would require either
+				// 	This is due to requesting step of initialization, which fetches initial Header by trusted hash
+				// from  the network. The step can't be done during unit tests and fixing it would require either
 				//   * Having some test/dev/offline mode for Node that mocks out all the networking
 				//   * Hardcoding full extended header in params pkg, instead of hashes, so we avoid requesting step
 				//   * Or removing explicit initialization in favor of automated initialization by Syncer

--- a/nodebuilder/node/admin.go
+++ b/nodebuilder/node/admin.go
@@ -28,7 +28,8 @@ type Info struct {
 func (m *module) Info(context.Context) (Info, error) {
 	return Info{
 		Type: m.tp,
-		// TODO @renaynay @distractedm1nd: Implement versioning in API and way to extract that into this struct
+		// TODO @renaynay @distractedm1nd: Implement versioning in API and way to extract that into this
+		// struct
 	}, nil
 }
 

--- a/nodebuilder/node/mocks/api.go
+++ b/nodebuilder/node/mocks/api.go
@@ -8,9 +8,10 @@ import (
 	context "context"
 	reflect "reflect"
 
-	node "github.com/celestiaorg/celestia-node/nodebuilder/node"
 	auth "github.com/filecoin-project/go-jsonrpc/auth"
 	gomock "github.com/golang/mock/gomock"
+
+	node "github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
 // MockModule is a mock of Module interface.

--- a/nodebuilder/node/type.go
+++ b/nodebuilder/node/type.go
@@ -4,7 +4,8 @@ package node
 // The zero value for Type is invalid.
 type Type uint8
 
-// StorePath is an alias used in order to pass the base path of the node store to nodebuilder modules.
+// StorePath is an alias used in order to pass the base path of the node store to nodebuilder
+// modules.
 type StorePath string
 
 const (

--- a/nodebuilder/p2p/p2p.go
+++ b/nodebuilder/p2p/p2p.go
@@ -67,7 +67,8 @@ type Module interface {
 	// BandwidthForPeer returns a Stats struct with bandwidth metrics associated with the given peer.ID.
 	// The metrics returned include all traffic sent / received for the peer, regardless of protocol.
 	BandwidthForPeer(ctx context.Context, id peer.ID) metrics.Stats
-	// BandwidthForProtocol returns a Stats struct with bandwidth metrics associated with the given protocol.ID.
+	// BandwidthForProtocol returns a Stats struct with bandwidth metrics associated with the given
+	// protocol.ID.
 	BandwidthForProtocol(ctx context.Context, proto protocol.ID) metrics.Stats
 
 	// ResourceState returns the state of the resource manager.

--- a/nodebuilder/share/mocks/api.go
+++ b/nodebuilder/share/mocks/api.go
@@ -8,9 +8,10 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	da "github.com/celestiaorg/celestia-app/pkg/da"
 	namespace "github.com/celestiaorg/nmt/namespace"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockModule is a mock of Module interface.

--- a/nodebuilder/share/share.go
+++ b/nodebuilder/share/share.go
@@ -28,7 +28,8 @@ var _ Module = (*API)(nil)
 //
 //go:generate mockgen -destination=mocks/api.go -package=mocks . Module
 type Module interface {
-	// SharesAvailable subjectively validates if Shares committed to the given Root are available on the Network.
+	// SharesAvailable subjectively validates if Shares committed to the given Root are available on
+	// the Network.
 	SharesAvailable(context.Context, *share.Root) error
 	// ProbabilityOfAvailability calculates the probability of the data square
 	// being available based on the number of samples collected.

--- a/nodebuilder/state/mocks/api.go
+++ b/nodebuilder/state/mocks/api.go
@@ -9,11 +9,12 @@ import (
 	reflect "reflect"
 
 	math "cosmossdk.io/math"
-	namespace "github.com/celestiaorg/nmt/namespace"
 	types "github.com/cosmos/cosmos-sdk/types"
 	types0 "github.com/cosmos/cosmos-sdk/x/staking/types"
 	gomock "github.com/golang/mock/gomock"
 	types1 "github.com/tendermint/tendermint/types"
+
+	namespace "github.com/celestiaorg/nmt/namespace"
 )
 
 // MockModule is a mock of Module interface.

--- a/share/ipld/proof.go
+++ b/share/ipld/proof.go
@@ -12,7 +12,8 @@ type Proof struct {
 	Start, End int
 }
 
-// proofCollector collects proof nodes' CIDs for the construction of a shares inclusion validation nmt.Proof.
+// proofCollector collects proof nodes' CIDs for the construction of a shares inclusion validation
+// nmt.Proof.
 type proofCollector struct {
 	left, right []cid.Cid
 }


### PR DESCRIPTION
Now, we will have comments always right, as cfmt is add to the lint rules