### PR TITLE
fix: return a struct instead of a pointer in params creation

### DIFF
--- a/header/p2p/exchange.go
+++ b/header/p2p/exchange.go
@@ -35,7 +35,7 @@ type Exchange struct {
 	trustedPeers peer.IDSlice
 	peerTracker  *peerTracker
 
-	Params *ClientParameters
+	Params ClientParameters
 }
 
 func NewExchange(
@@ -46,7 +46,7 @@ func NewExchange(
 ) (*Exchange, error) {
 	params := DefaultClientParameters()
 	for _, opt := range opts {
-		opt(params)
+		opt(&params)
 	}
 
 	err := params.Validate()

--- a/header/p2p/options.go
+++ b/header/p2p/options.go
@@ -26,8 +26,8 @@ type ServerParameters struct {
 }
 
 // DefaultServerParameters returns the default params to configure the store.
-func DefaultServerParameters() *ServerParameters {
-	return &ServerParameters{
+func DefaultServerParameters() ServerParameters {
+	return ServerParameters{
 		WriteDeadline:  time.Second * 5,
 		ReadDeadline:   time.Minute,
 		MaxRequestSize: 512,
@@ -101,8 +101,8 @@ type ClientParameters struct {
 }
 
 // DefaultClientParameters returns the default params to configure the store.
-func DefaultClientParameters() *ClientParameters {
-	return &ClientParameters{
+func DefaultClientParameters() ClientParameters {
+	return ClientParameters{
 		MinResponses:         2,
 		MaxRequestSize:       512,
 		MaxHeadersPerRequest: 64,
@@ -110,6 +110,13 @@ func DefaultClientParameters() *ClientParameters {
 		DefaultScore:         1,
 		MaxPeerTrackerSize:   100,
 	}
+}
+
+// Empty checks if config was initialized.
+func (p *ClientParameters) Empty() bool {
+	return p.MinResponses == 0 && p.MaxRequestSize == 0 &&
+		p.MaxHeadersPerRequest == 0 && p.MaxAwaitingTime == 0 &&
+		p.DefaultScore == 0 && p.MaxPeerTrackerSize == 0
 }
 
 const (

--- a/header/p2p/options.go
+++ b/header/p2p/options.go
@@ -112,13 +112,6 @@ func DefaultClientParameters() ClientParameters {
 	}
 }
 
-// Empty checks if config was initialized.
-func (p *ClientParameters) Empty() bool {
-	return p.MinResponses == 0 && p.MaxRequestSize == 0 &&
-		p.MaxHeadersPerRequest == 0 && p.MaxAwaitingTime == 0 &&
-		p.DefaultScore == 0 && p.MaxPeerTrackerSize == 0
-}
-
 const (
 	greaterThenZero = "should be greater than 0"
 	providedSuffix  = "Provided value"

--- a/header/p2p/server.go
+++ b/header/p2p/server.go
@@ -26,7 +26,7 @@ type ExchangeServer struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	Params *ServerParameters
+	Params ServerParameters
 }
 
 // NewExchangeServer returns a new P2P server that handles inbound
@@ -39,7 +39,7 @@ func NewExchangeServer(
 ) (*ExchangeServer, error) {
 	params := DefaultServerParameters()
 	for _, opt := range opts {
-		opt(params)
+		opt(&params)
 	}
 	if err := params.Validate(); err != nil {
 		return nil, err

--- a/header/store/options.go
+++ b/header/store/options.go
@@ -22,8 +22,8 @@ type Parameters struct {
 }
 
 // DefaultParameters returns the default params to configure the store.
-func DefaultParameters() *Parameters {
-	return &Parameters{
+func DefaultParameters() Parameters {
+	return Parameters{
 		StoreCacheSize: 4096,
 		IndexCacheSize: 16384,
 		WriteBatchSize: 2048,

--- a/header/store/store.go
+++ b/header/store/store.go
@@ -51,7 +51,7 @@ type Store struct {
 	// pending keeps headers pending to be written in one batch
 	pending *batch
 
-	Params *Parameters
+	Params Parameters
 }
 
 // NewStore constructs a Store over datastore.
@@ -79,7 +79,7 @@ func NewStoreWithHead(
 func newStore(ds datastore.Batching, opts ...Option) (*Store, error) {
 	params := DefaultParameters()
 	for _, opt := range opts {
-		opt(params)
+		opt(&params)
 	}
 
 	if err := params.Validate(); err != nil {

--- a/nodebuilder/header/config.go
+++ b/nodebuilder/header/config.go
@@ -24,10 +24,10 @@ type Config struct {
 	// headers at any moment.
 	TrustedPeers []string
 
-	Store *store.Parameters
+	Store store.Parameters
 
-	Server *p2p_exchange.ServerParameters
-	Client *p2p_exchange.ClientParameters `toml:",omitempty"`
+	Server p2p_exchange.ServerParameters
+	Client p2p_exchange.ClientParameters `toml:",omitempty"`
 }
 
 func DefaultConfig(tp node.Type) Config {
@@ -93,7 +93,7 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("module/header: misconfiguration of p2p exchange server: %w", err)
 	}
 
-	if cfg.Client != nil {
+	if !cfg.Client.Empty() {
 		err = cfg.Client.Validate()
 		if err != nil {
 			return fmt.Errorf("module/header: misconfiguration of p2p exchange client: %w", err)

--- a/nodebuilder/header/config.go
+++ b/nodebuilder/header/config.go
@@ -82,7 +82,7 @@ func (cfg *Config) trustedHash(net p2p.Network) (tmbytes.HexBytes, error) {
 }
 
 // Validate performs basic validation of the config.
-func (cfg *Config) Validate() error {
+func (cfg *Config) Validate(tp node.Type) error {
 	err := cfg.Store.Validate()
 	if err != nil {
 		return fmt.Errorf("module/header: misconfiguration of store: %w", err)
@@ -93,11 +93,15 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("module/header: misconfiguration of p2p exchange server: %w", err)
 	}
 
-	if !cfg.Client.Empty() {
-		err = cfg.Client.Validate()
-		if err != nil {
-			return fmt.Errorf("module/header: misconfiguration of p2p exchange client: %w", err)
-		}
+	// we do not create a client for bridge nodes
+	if tp == node.Bridge {
+		return nil
 	}
+
+	err = cfg.Client.Validate()
+	if err != nil {
+		return fmt.Errorf("module/header: misconfiguration of p2p exchange client: %w", err)
+	}
+
 	return nil
 }

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -21,7 +21,7 @@ var log = logging.Logger("module/header")
 
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	// sanitize config values before constructing module
-	cfgErr := cfg.Validate()
+	cfgErr := cfg.Validate(tp)
 
 	baseComponents := fx.Options(
 		fx.Supply(*cfg),


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Return a struct instead of a pointer to a struct in params creation 
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
