### PR TITLE
fix(share): order proof nodes by depth before returning

### DIFF
--- a/share/ipld/get.go
+++ b/share/ipld/get.go
@@ -292,8 +292,7 @@ func GetLeavesByNamespace(
 					id: lnk.Cid,
 					// sharePos represents potential share position in share slice
 					sharePos: j.sharePos*2 + i,
-					// position represents the index in a flattened binary tree,
-					// so we can return a slice of leaves in order
+					// depth represents the number of edges present in path from the root node of a tree to that node
 					depth: j.depth + 1,
 					// we pass the context to job so that spans are tracked in a tree
 					// structure
@@ -306,7 +305,7 @@ func GetLeavesByNamespace(
 				// proof is on the right side, if the nID is less than min namespace of jobNid
 				if nID.Less(nmt.MinNamespace(jobNid, nID.Size())) {
 					if collectProofs {
-						proofs.addRight(lnk.Cid)
+						proofs.addRight(lnk.Cid, newJob.depth)
 					}
 					continue
 				}
@@ -314,7 +313,7 @@ func GetLeavesByNamespace(
 				// proof is on the left side, if the nID is bigger than max namespace of jobNid
 				if !nID.LessOrEqual(nmt.MaxNamespace(jobNid, nID.Size())) {
 					if collectProofs {
-						proofs.addLeft(lnk.Cid)
+						proofs.addLeft(lnk.Cid, newJob.depth)
 					}
 					continue
 				}

--- a/share/ipld/proof.go
+++ b/share/ipld/proof.go
@@ -15,35 +15,24 @@ type Proof struct {
 // proofCollector collects proof nodes' CIDs for the construction of a shares inclusion validation
 // nmt.Proof.
 type proofCollector struct {
-	left, right []node
-}
-
-type node struct {
-	cid   cid.Cid
-	depth int
+	left, right []cid.Cid
 }
 
 func newProofCollector(maxShares int) *proofCollector {
 	// maximum possible amount of required proofs from each side is equal to tree height.
 	height := int(math.Log2(float64(maxShares))) + 1
 	return &proofCollector{
-		left:  make([]node, height),
-		right: make([]node, height),
+		left:  make([]cid.Cid, height),
+		right: make([]cid.Cid, height),
 	}
 }
 
 func (c *proofCollector) addLeft(cid cid.Cid, depth int) {
-	c.left[depth] = node{
-		cid:   cid,
-		depth: depth,
-	}
+	c.left[depth] = cid
 }
 
 func (c *proofCollector) addRight(cid cid.Cid, depth int) {
-	c.right[depth] = node{
-		cid:   cid,
-		depth: depth,
-	}
+	c.right[depth] = cid
 }
 
 // Nodes returns nodes collected by proofCollector in the order that nmt.Proof validator will use
@@ -51,16 +40,16 @@ func (c *proofCollector) addRight(cid cid.Cid, depth int) {
 func (c *proofCollector) Nodes() []cid.Cid {
 	cids := make([]cid.Cid, 0, len(c.left)+len(c.right))
 	// left side will be traversed in bottom-up order
-	for _, node := range c.left {
-		if node.cid.ByteLen() != 0 {
-			cids = append(cids, node.cid)
+	for _, cid := range c.left {
+		if cid.ByteLen() != 0 {
+			cids = append(cids, cid)
 		}
 	}
 
 	// right side of the tree will be traversed from top to bottom,
 	// so sort in reversed order
 	for i := len(c.right) - 1; i >= 0; i-- {
-		cid := c.right[i].cid
+		cid := c.right[i]
 		if cid.ByteLen() != 0 {
 			cids = append(cids, cid)
 		}

--- a/share/ipld/proof.go
+++ b/share/ipld/proof.go
@@ -1,9 +1,9 @@
 package ipld
 
 import (
-	"github.com/ipfs/go-cid"
 	"math"
-	"sort"
+
+	"github.com/ipfs/go-cid"
 )
 
 // Proof contains information required for Leaves inclusion validation.
@@ -51,9 +51,6 @@ func (c *proofCollector) addRight(cid cid.Cid, depth int) {
 func (c *proofCollector) Nodes() []cid.Cid {
 	cids := make([]cid.Cid, 0, len(c.left)+len(c.right))
 	// left side will be traversed in bottom-up order
-	sort.Slice(c.left, func(i, j int) bool {
-		return c.left[i].depth < c.left[j].depth
-	})
 	for _, node := range c.left {
 		if node.cid.ByteLen() != 0 {
 			cids = append(cids, node.cid)
@@ -62,12 +59,10 @@ func (c *proofCollector) Nodes() []cid.Cid {
 
 	// right side of the tree will be traversed from top to bottom,
 	// so sort in reversed order
-	sort.Slice(c.right, func(i, j int) bool {
-		return c.right[i].depth > c.right[j].depth
-	})
-	for _, node := range c.right {
-		if node.cid.ByteLen() != 0 {
-			cids = append(cids, node.cid)
+	for i := len(c.right) - 1; i >= 0; i-- {
+		cid := c.right[i].cid
+		if cid.ByteLen() != 0 {
+			cids = append(cids, cid)
 		}
 	}
 	return cids

--- a/share/ipld/proof.go
+++ b/share/ipld/proof.go
@@ -41,7 +41,7 @@ func (c *proofCollector) Nodes() []cid.Cid {
 	cids := make([]cid.Cid, 0, len(c.left)+len(c.right))
 	// left side will be traversed in bottom-up order
 	for _, cid := range c.left {
-		if cid.ByteLen() != 0 {
+		if cid.Defined() {
 			cids = append(cids, cid)
 		}
 	}
@@ -50,7 +50,7 @@ func (c *proofCollector) Nodes() []cid.Cid {
 	// so sort in reversed order
 	for i := len(c.right) - 1; i >= 0; i-- {
 		cid := c.right[i]
-		if cid.ByteLen() != 0 {
+		if cid.Defined() {
 			cids = append(cids, cid)
 		}
 	}


### PR DESCRIPTION
## Overview

Fix the order of inclusion proof nodes returned by `GetSharesByNamespace` to be possible incorrect.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
