### PR TITLE
fix(ipld): Make namespaceHasher fully implement hash.Hash and update go-multihash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-base32 v0.1.0
 	github.com/multiformats/go-multiaddr v0.7.0
-	github.com/multiformats/go-multihash v0.2.0
+	github.com/multiformats/go-multihash v0.2.2-0.20221030163302-608669da49b6
 	github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1435,8 +1435,6 @@ github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUj
 github.com/multiformats/go-multihash v0.0.14/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-multihash v0.0.15/go.mod h1:D6aZrWNLFTV/ynMpKsNtB40mJzmCl4jb1alC0OvHiHg=
 github.com/multiformats/go-multihash v0.1.0/go.mod h1:RJlXsxt6vHGaia+S8We0ErjhojtKzPP2AH4+kYM7k84=
-github.com/multiformats/go-multihash v0.2.0 h1:oytJb9ZA1OUW0r0f9ea18GiaPOo4SXyc7p2movyUuo4=
-github.com/multiformats/go-multihash v0.2.0/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
 github.com/multiformats/go-multihash v0.2.2-0.20221030163302-608669da49b6 h1:qLF997Rz0X1WvdcZ2r5CUkLZ2rvdiXwG1JRSrJZEAuE=
 github.com/multiformats/go-multihash v0.2.2-0.20221030163302-608669da49b6/go.mod h1:kaHxr8TfO1cxIR/tYxgZ7e59HraJq8arEQQR8E/YNvI=
 github.com/multiformats/go-multistream v0.1.0/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=

--- a/go.sum
+++ b/go.sum
@@ -1437,6 +1437,8 @@ github.com/multiformats/go-multihash v0.0.15/go.mod h1:D6aZrWNLFTV/ynMpKsNtB40mJ
 github.com/multiformats/go-multihash v0.1.0/go.mod h1:RJlXsxt6vHGaia+S8We0ErjhojtKzPP2AH4+kYM7k84=
 github.com/multiformats/go-multihash v0.2.0 h1:oytJb9ZA1OUW0r0f9ea18GiaPOo4SXyc7p2movyUuo4=
 github.com/multiformats/go-multihash v0.2.0/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
+github.com/multiformats/go-multihash v0.2.2-0.20221030163302-608669da49b6 h1:qLF997Rz0X1WvdcZ2r5CUkLZ2rvdiXwG1JRSrJZEAuE=
+github.com/multiformats/go-multihash v0.2.2-0.20221030163302-608669da49b6/go.mod h1:kaHxr8TfO1cxIR/tYxgZ7e59HraJq8arEQQR8E/YNvI=
 github.com/multiformats/go-multistream v0.1.0/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-multistream v0.1.1/go.mod h1:KmHZ40hzVxiaiwlj3MEbYgK9JFk2/9UktWZAF54Du38=
 github.com/multiformats/go-multistream v0.2.1/go.mod h1:5GZPQZbkWOLOn3J2y4Y99vVW7vOfsAflxARk3x14o6k=

--- a/nodebuilder/node/mocks/api.go
+++ b/nodebuilder/node/mocks/api.go
@@ -8,9 +8,10 @@ import (
 	context "context"
 	reflect "reflect"
 
-	node "github.com/celestiaorg/celestia-node/nodebuilder/node"
 	auth "github.com/filecoin-project/go-jsonrpc/auth"
 	gomock "github.com/golang/mock/gomock"
+
+	node "github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
 // MockModule is a mock of Module interface.

--- a/share/ipld/namespace_hasher.go
+++ b/share/ipld/namespace_hasher.go
@@ -19,16 +19,27 @@ func init() {
 }
 
 // namespaceHasher implements hash.Hash over NMT Hasher.
-// TODO: Move to NMT repo?
+// TODO: Move to NMT repo!
+//  As NMT already defines Hasher that implements hash.Hash by embedding,
+//  it should define full and *correct* implementation of hash.Hash,
+//  which is the namespaceHasher. This hash.Hash, is not IPLD specific and
+//  can be used elsewhere.
 type namespaceHasher struct {
-	*nmt.Hasher
+	hasher *nmt.Hasher
 	tp   byte
 	data []byte
 }
 
 // defaultHasher constructs the namespaceHasher with default configuration
 func defaultHasher() *namespaceHasher {
-	return &namespaceHasher{Hasher: nmt.NewNmtHasher(sha256.New(), NamespaceSize, true)}
+	 nh := &namespaceHasher{hasher: nmt.NewNmtHasher(sha256.New(), NamespaceSize, true)}
+	 nh.Reset()
+	 return nh
+}
+
+// Size returns the number of bytes Sum will return.
+func (n *namespaceHasher) Size() int {
+	return n.hasher.Size() + int(n.hasher.NamespaceLen) * 2
 }
 
 // Write writes the namespaced data to be hashed.
@@ -58,18 +69,24 @@ func (n *namespaceHasher) Write(data []byte) (int, error) {
 // Sum computes the hash.
 // Does not append the given suffix and violating the interface.
 func (n *namespaceHasher) Sum([]byte) []byte {
-	// if n.data is empty, it hit the default case in Write.
-	// this will be seen by multihash.encodeHash, where it will be caught and an error will be returned.
-	if len(n.data) == 0 {
-		return nil
+	switch n.tp {
+	case nmt.LeafPrefix:
+		return n.hasher.HashLeaf(n.data)
+	case nmt.NodePrefix:
+		flagLen := int(n.hasher.NamespaceLen * 2)
+		sha256Len := n.hasher.Size()
+		return n.hasher.HashNode(n.data[:flagLen+sha256Len], n.data[flagLen+sha256Len:])
+	default:
+		panic("namespaceHasher: node type wasn't set")
 	}
+}
 
-	isLeafData := n.tp == nmt.LeafPrefix
-	if isLeafData {
-		return n.Hasher.HashLeaf(n.data)
-	}
+// Reset resets the Hash to its initial state.
+func (n *namespaceHasher) Reset() {
+	n.tp, n.data = 255, nil  // reset with an invalid node type, as zero value is a valid Leaf
+}
 
-	flagLen := int(n.NamespaceLen * 2)
-	sha256Len := n.Hasher.Size()
-	return n.Hasher.HashNode(n.data[:flagLen+sha256Len], n.data[flagLen+sha256Len:])
+// BlockSize returns the hash's underlying block size.
+func (n *namespaceHasher) BlockSize() int {
+	return n.hasher.BlockSize()
 }

--- a/share/ipld/namespace_hasher_test.go
+++ b/share/ipld/namespace_hasher_test.go
@@ -75,16 +75,6 @@ func TestNamespaceHasherSum(t *testing.T) {
 			NmtHashSize,
 			innerSize,
 		},
-		{
-			"ShortGarbage",
-			0,
-			13,
-		},
-		{
-			"LongGarbage",
-			0,
-			500,
-		},
 	}
 
 	for _, ts := range tt {

--- a/share/ipld/namespace_hasher_test.go
+++ b/share/ipld/namespace_hasher_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 )
@@ -44,9 +45,9 @@ func TestNamespaceHasherWrite(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, leafSize, n)
 
-		n, err = h.Write(make([]byte, leafSize))
-		assert.Error(t, err)
-		assert.Equal(t, 0, n)
+		require.Panics(t, func() {
+			h.Write(make([]byte, leafSize))
+		})
 	})
 
 	t.Run("ErrorIncorrectSize", func(t *testing.T) {

--- a/share/ipld/namespace_hasher_test.go
+++ b/share/ipld/namespace_hasher_test.go
@@ -46,7 +46,7 @@ func TestNamespaceHasherWrite(t *testing.T) {
 		assert.Equal(t, leafSize, n)
 
 		require.Panics(t, func() {
-			h.Write(make([]byte, leafSize))
+			_, _ = h.Write(make([]byte, leafSize))
 		})
 	})
 


### PR DESCRIPTION
In preparation for the full libp2p update

* New version of go-multihash has a stricter rules on passed hash.Hash implementation and check size
	* Previously, we returned 32 as what underlying sha256 returns, but in fact Sum results in 48, thus the change
* Removes old ugly 'if' and supporting tests that came as solution for go-multihash omitting error check after Write
* Makes namespaceHasher fully compliant with hash.Hash and it can now be reused anywhere and ideally moved to NMT lib
LI or documentation updates

