### PR TITLE
tests(swamp): fix test failing 'no trusted peers' and major cleanussy

### DIFF
--- a/libs/header/p2p/exchange.go
+++ b/libs/header/p2p/exchange.go
@@ -90,12 +90,11 @@ func (ex *Exchange[H]) Start(context.Context) error {
 	return nil
 }
 
-func (ex *Exchange[H]) Stop(context.Context) error {
+func (ex *Exchange[H]) Stop(ctx context.Context) error {
 	// cancel the session if it exists
 	ex.cancel()
 	// stop the peerTracker
-	ex.peerTracker.stop()
-	return nil
+	return ex.peerTracker.stop(ctx)
 }
 
 // Head requests the latest Header. Note that the Header must be verified thereafter.

--- a/libs/header/p2p/peer_tracker.go
+++ b/libs/header/p2p/peer_tracker.go
@@ -187,12 +187,18 @@ func (p *peerTracker) gc() {
 }
 
 // stop waits until all background routines will be finished.
-func (p *peerTracker) stop() {
+func (p *peerTracker) stop(ctx context.Context) error {
 	p.cancel()
 
 	for i := 0; i < cap(p.done); i++ {
-		<-p.done
+		select {
+		case <-p.done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
+
+	return nil
 }
 
 // blockPeer blocks a peer on the networking level and removes it from the local cache.

--- a/libs/header/p2p/peer_tracker_test.go
+++ b/libs/header/p2p/peer_tracker_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -33,7 +34,8 @@ func TestPeerTracker_GC(t *testing.T) {
 	go p.track()
 	go p.gc()
 	time.Sleep(time.Second * 1)
-	p.stop()
+	err = p.stop(context.Background())
+	require.NoError(t, err)
 	require.Nil(t, p.trackedPeers[pid1])
 	require.Nil(t, p.disconnectedPeers[pid3])
 }

--- a/nodebuilder/tests/fraud_test.go
+++ b/nodebuilder/tests/fraud_test.go
@@ -31,25 +31,18 @@ Steps:
 Note: 15 is not available because DASer will be stopped before reaching this height due to receiving a fraud proof.
 */
 func TestFraudProofBroadcasting(t *testing.T) {
-	// we increase the timeout for this test to decrease flakiness in CI
-	testTimeout := time.Millisecond * 200
-	sw := swamp.NewSwamp(t, swamp.WithBlockTime(testTimeout))
-
-	bridge := sw.NewBridgeNode(core.WithHeaderConstructFn(headertest.FraudMaker(t, 20)))
-
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
+	sw := swamp.NewSwamp(t, swamp.WithBlockTime(blockTime))
+
+	bridge := sw.NewBridgeNode(core.WithHeaderConstructFn(headertest.FraudMaker(t, 20)))
 	err := bridge.Start(ctx)
-	require.NoError(t, err)
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
 
 	cfg := nodebuilder.DefaultConfig(node.Full)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
 	store := nodebuilder.MockStore(t, cfg)
 	full := sw.NewNodeWithStore(node.Full, store)
-
 	err = full.Start(ctx)
 	require.NoError(t, err)
 
@@ -58,24 +51,30 @@ func TestFraudProofBroadcasting(t *testing.T) {
 	subscr, err := full.FraudServ.Subscribe(ctx, fraud.BadEncoding)
 	require.NoError(t, err)
 
-	p := <-subscr
-	require.Equal(t, 20, int(p.Height()))
+	select {
+	case p := <-subscr:
+		require.Equal(t, 20, int(p.Height()))
+	case <-ctx.Done():
+		t.Fatal("fraud proof was not received in time")
+	}
 
 	// This is an obscure way to check if the Syncer was stopped.
 	// If we cannot get a height header within a timeframe it means the syncer was stopped
 	// FIXME: Eventually, this should be a check on service registry managing and keeping
 	//  lifecycles of each Module.
-	syncCtx, syncCancel := context.WithTimeout(context.Background(), testTimeout)
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), time.Millisecond*200)
 	_, err = full.HeaderServ.GetByHeight(syncCtx, 100)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	syncCancel()
 
-	require.NoError(t, full.Stop(ctx))
-	require.NoError(t, sw.RemoveNode(full, node.Full))
+	err = full.Stop(ctx)
+	require.NoError(t, err)
+	sw.RemoveNode(full, node.Full)
 
 	full = sw.NewNodeWithStore(node.Full, store)
+	err = full.Start(ctx)
+	require.Error(t, err)
 
-	require.Error(t, full.Start(ctx))
 	proofs, err := full.FraudServ.Get(ctx, fraud.BadEncoding)
 	require.NoError(t, err)
 	require.NotNil(t, proofs)
@@ -95,9 +94,16 @@ Steps:
 7. Wait until LN will be connected to FN and fetch a fraud proof.
 */
 func TestFraudProofSyncing(t *testing.T) {
-	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Millisecond*300))
+	sw := swamp.NewSwamp(t, swamp.WithBlockTime(blockTime))
+
+	const defaultTimeInterval = time.Second * 5
 
 	cfg := nodebuilder.DefaultConfig(node.Bridge)
+	cfg.P2P.Bootstrapper = true
+	cfg.P2P.RoutingTableRefreshPeriod = defaultTimeInterval
+	cfg.Share.DiscoveryInterval = defaultTimeInterval
+	cfg.Share.AdvertiseInterval = defaultTimeInterval
+
 	store := nodebuilder.MockStore(t, cfg)
 	bridge := sw.NewNodeWithStore(node.Bridge, store, core.WithHeaderConstructFn(headertest.FraudMaker(t, 10)))
 
@@ -115,21 +121,14 @@ func TestFraudProofSyncing(t *testing.T) {
 	full := sw.NewNodeWithStore(node.Full, nodebuilder.MockStore(t, fullCfg))
 
 	lightCfg := nodebuilder.DefaultConfig(node.Light)
+	lightCfg.P2P.RoutingTableRefreshPeriod = defaultTimeInterval
+	lightCfg.Share.DiscoveryInterval = defaultTimeInterval
 	lightCfg.Header.TrustedPeers = append(lightCfg.Header.TrustedPeers, addrs[0].String())
 	ln := sw.NewNodeWithStore(node.Light, nodebuilder.MockStore(t, lightCfg))
+
 	require.NoError(t, full.Start(ctx))
-
+	require.NoError(t, ln.Start(ctx))
 	subsFN, err := full.FraudServ.Subscribe(ctx, fraud.BadEncoding)
-	require.NoError(t, err)
-
-	select {
-	case <-subsFN:
-	case <-ctx.Done():
-		t.Fatal("full node didn't get FP in time")
-	}
-
-	// start LN to enforce syncing logic, not the PubSub's broadcasting
-	err = ln.Start(ctx)
 	require.NoError(t, err)
 
 	// internal subscription for the fraud proof is done in order to ensure that light node
@@ -137,14 +136,17 @@ func TestFraudProofSyncing(t *testing.T) {
 	subsLN, err := ln.FraudServ.Subscribe(ctx, fraud.BadEncoding)
 	require.NoError(t, err)
 
-	// ensure that the full and light node are connected to speed up test
-	// alternatively, they would discover each other
+	// ensure that the full and light node are connected to preempt flakiness
 	err = ln.Host.Connect(ctx, *host.InfoFromHost(full.Host))
 	require.NoError(t, err)
 
-	select {
-	case <-subsLN:
-	case <-ctx.Done():
-		t.Fatal("light node didn't get FP in time")
+	// wait for BEFP to come through both subscriptions
+	for i := 0; i < 2; i++ {
+		select {
+		case <-subsFN:
+		case <-subsLN:
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
 	}
 }

--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -1,8 +1,3 @@
-// Test with light nodes spawns more goroutines than in the race detectors budget,
-// and thus we're disabling the race detector.
-// TODO(@Wondertan): Remove this once we move to go1.19 with unlimited race detector
-//go:build !race
-
 package tests
 
 import (
@@ -10,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
@@ -26,40 +20,30 @@ import (
 
 /*
 Test-Case: Full Node reconstructs blocks from a Bridge node
-Pre-Reqs:
-- First 20 blocks have a block size of 16
-- Blocktime is 100 ms
 Steps:
-1. Create a Bridge Node(BN)
-2. Start a BN
-3. Create a Full Node(FN) with BN as a trusted peer
-4. Start a FN
-5. Check that a FN can retrieve shares from 1 to 20 blocks
+1. Create and start a Bridge Node(BN)
+2. Create and start a Full Node(FN)
+3. Connect the FN to the BN
+4. Check that the FN can retrieve shares from 1 to 20 blocks
 */
 func TestFullReconstructFromBridge(t *testing.T) {
-	const (
-		blocks = 20
-		bsize  = 16
-		btime  = time.Millisecond * 300
-	)
-
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
-	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := sw.FillBlocks(ctx, bsize, blocks)
+
+	sw := swamp.NewSwamp(t, swamp.WithBlockTime(blockTime))
+	fillDn := sw.FillBlocks(ctx, blockSize, blocksAmount)
 
 	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
-	cfg := nodebuilder.DefaultConfig(node.Full)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, getMultiAddr(t, bridge.Host))
-	full := sw.NewNodeWithConfig(node.Full, cfg)
+	full := sw.NewFullNode()
 	err = full.Start(ctx)
 	require.NoError(t, err)
+	sw.Connect(bridge.Host.ID(), full.Host.ID())
 
 	errg, bctx := errgroup.WithContext(ctx)
-	for i := 1; i <= blocks+1; i++ {
+	for i := 1; i <= blocksAmount+1; i++ {
 		i := i
 		errg.Go(func() error {
 			h, err := full.HeaderServ.GetByHeight(bctx, uint64(i))
@@ -75,88 +59,60 @@ func TestFullReconstructFromBridge(t *testing.T) {
 }
 
 /*
-Test-Case: Full Node reconstructs blocks only from Light Nodes
-Pre-Reqs:
-- First 20 blocks have a block size of 16
-- Blocktime is 100 ms
+Test-Case: Full Node reconstructs blocks only from Light Nodes with discovery
 Steps:
-1. Create a Bridge Node(BN)
-2. Start a BN
-3. Create a Full Node(FN) that will act as a bootstrapper
-4. Create 69 Light Nodes(LNs) with BN as a trusted peer and a bootstrapper
-5. Start 69 LNs
-6. Create a Full Node(FN) with a bootstrapper
-7. Unlink FN connection to BN
-8. Start a FN
-9. Check that the FN can retrieve shares from 1 to 20 blocks
+1. Create and start a Light Node as a bootstrapper(so that LNs below are forced to discover BN for data)
+2. Create and start a Bridge Node(BN)
+3. Create and start a Full Node(FN)
+4. Unlink FN from BN(prevents any data syncing between them)
+5. Create and start 69 Light Nodes(LNs)
+6. Check that the FN can retrieve shares from 1 to 20 blocks
 */
-func TestFullReconstructFromLights(t *testing.T) {
+func TestFullReconstructFromLightsWithDiscovery(t *testing.T) {
 	eds.RetrieveQuadrantTimeout = time.Millisecond * 100
 	light.DefaultSampleAmount = 20
-	const (
-		blocks = 20
-		btime  = time.Millisecond * 300
-		bsize  = 16
-		lnodes = 69
-	)
+	const lnodes = 69
 
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
-
 	t.Cleanup(cancel)
-	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := sw.FillBlocks(ctx, bsize, blocks)
 
-	const defaultTimeInterval = time.Second * 5
-	cfg := nodebuilder.DefaultConfig(node.Full)
+	sw := swamp.NewSwamp(t, swamp.WithBlockTime(blockTime))
+	fillDn := sw.FillBlocks(ctx, blockSize, blocksAmount)
+
+	cfg := nodebuilder.DefaultConfig(node.Light)
 	cfg.P2P.Bootstrapper = true
-	setTimeInterval(cfg, defaultTimeInterval)
-
-	bridge := sw.NewBridgeNode()
-	addrsBridge, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+	setTimeInterval(cfg)
+	bootstrapper := sw.NewNodeWithConfig(node.Light, cfg)
+	err := bootstrapper.Start(ctx)
 	require.NoError(t, err)
-	bootstrapper := sw.NewNodeWithConfig(node.Full, cfg)
-	require.NoError(t, bootstrapper.Start(ctx))
-	require.NoError(t, bridge.Start(ctx))
-	bootstrapperAddr := host.InfoFromHost(bootstrapper.Host)
+	bootstrapperAddr := []peer.AddrInfo{*host.InfoFromHost(bootstrapper.Host)}
+
+	bridge := sw.NewBridgeNode(nodebuilder.WithBootstrappers(bootstrapperAddr))
+	err = bridge.Start(ctx)
+	require.NoError(t, err)
 
 	cfg = nodebuilder.DefaultConfig(node.Full)
-	setTimeInterval(cfg, defaultTimeInterval)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrsBridge[0].String())
-	nodesConfig := nodebuilder.WithBootstrappers([]peer.AddrInfo{*bootstrapperAddr})
-	full := sw.NewNodeWithConfig(node.Full, cfg, nodesConfig)
+	setTimeInterval(cfg)
+	full := sw.NewNodeWithConfig(node.Full, cfg, nodebuilder.WithBootstrappers(bootstrapperAddr))
+	sw.Disconnect(full.Host.ID(), bridge.Host.ID())
 
-	lights := make([]*nodebuilder.Node, lnodes)
-	subs := make([]event.Subscription, lnodes)
 	errg, errCtx := errgroup.WithContext(ctx)
 	for i := 0; i < lnodes; i++ {
-		i := i
 		errg.Go(func() error {
 			lnConfig := nodebuilder.DefaultConfig(node.Light)
-			setTimeInterval(lnConfig, defaultTimeInterval)
-			lnConfig.Header.TrustedPeers = append(lnConfig.Header.TrustedPeers, addrsBridge[0].String())
-			light := sw.NewNodeWithConfig(node.Light, lnConfig, nodesConfig)
-			sub, err := light.Host.EventBus().Subscribe(&event.EvtPeerIdentificationCompleted{})
-			if err != nil {
-				return err
-			}
-			subs[i] = sub
-			lights[i] = light
+			setTimeInterval(lnConfig)
+			light := sw.NewNodeWithConfig(node.Light, lnConfig, nodebuilder.WithBootstrappers(bootstrapperAddr))
 			return light.Start(errCtx)
 		})
 	}
-	require.NoError(t, errg.Wait())
-	require.NoError(t, full.Start(ctx))
-	for i := 0; i < lnodes; i++ {
-		select {
-		case <-ctx.Done():
-			t.Fatal("peer was not found")
-		case <-subs[i].Out():
-			require.NoError(t, subs[i].Close())
-			continue
-		}
-	}
+
+	err = errg.Wait()
+	require.NoError(t, err)
+	err = full.Start(ctx)
+	require.NoError(t, err)
+
 	errg, bctx := errgroup.WithContext(ctx)
-	for i := 1; i <= blocks+1; i++ {
+	for i := 1; i <= blocksAmount+1; i++ {
 		i := i
 		errg.Go(func() error {
 			h, err := full.HeaderServ.GetByHeight(bctx, uint64(i))
@@ -167,12 +123,9 @@ func TestFullReconstructFromLights(t *testing.T) {
 			return full.ShareServ.SharesAvailable(bctx, h.DAH)
 		})
 	}
-	require.NoError(t, <-fillDn)
-	require.NoError(t, errg.Wait())
-}
 
-func getMultiAddr(t *testing.T, h host.Host) string {
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(h))
+	err = <-fillDn
 	require.NoError(t, err)
-	return addrs[0].String()
+	err = errg.Wait()
+	require.NoError(t, err)
 }

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -118,15 +118,10 @@ func (s *Swamp) WaitTillHeight(ctx context.Context, height int64) libhead.Hash {
 		case <-ctx.Done():
 			require.NoError(s.t, ctx.Err())
 		case <-t.C:
-			status, err := s.ClientContext.Client.Status(ctx)
+			latest, err := s.ClientContext.LatestHeight()
 			require.NoError(s.t, err)
-
-			latest := status.SyncInfo.LatestBlockHeight
-			switch {
-			case latest == height:
-				return libhead.Hash(status.SyncInfo.LatestBlockHash)
-			case latest > height:
-				res, err := s.ClientContext.Client.Block(ctx, &height)
+			if latest >= height {
+				res, err := s.ClientContext.Client.Block(ctx, &latest)
 				require.NoError(s.t, err)
 				return libhead.Hash(res.BlockID.Hash)
 			}
@@ -161,7 +156,8 @@ func (s *Swamp) createPeer(ks keystore.Keystore) host.Host {
 // setupGenesis sets up genesis Header.
 // This is required to initialize and start correctly.
 func (s *Swamp) setupGenesis(ctx context.Context) {
-	s.WaitTillHeight(ctx, 1)
+	// ensure core has surpassed genesis block
+	s.WaitTillHeight(ctx, 2)
 
 	ex := core.NewExchange(
 		core.NewBlockFetcher(s.ClientContext.Client),

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -265,21 +265,19 @@ func (s *Swamp) newNode(t node.Type, store nodebuilder.Store, options ...fx.Opti
 // RemoveNode removes a node from the swamp's node slice
 // this allows reusage of the same var in the test scenario
 // if the user needs to stop and start the same node
-func (s *Swamp) RemoveNode(n *nodebuilder.Node, t node.Type) error {
+func (s *Swamp) RemoveNode(n *nodebuilder.Node, t node.Type) {
 	var err error
 	switch t {
 	case node.Light:
 		s.LightNodes, err = s.remove(n, s.LightNodes)
-		return err
 	case node.Bridge:
 		s.BridgeNodes, err = s.remove(n, s.BridgeNodes)
-		return err
 	case node.Full:
 		s.FullNodes, err = s.remove(n, s.FullNodes)
-		return err
 	default:
-		return fmt.Errorf("no such type or node")
+		panic("no such type or node")
 	}
+	require.NoError(s.t, err)
 }
 
 func (s *Swamp) remove(rn *nodebuilder.Node, sn []*nodebuilder.Node) ([]*nodebuilder.Node, error) {
@@ -302,18 +300,18 @@ func (s *Swamp) remove(rn *nodebuilder.Node, sn []*nodebuilder.Node) ([]*nodebui
 }
 
 // Connect allows to connect peers after hard disconnection.
-func (s *Swamp) Connect(t *testing.T, peerA, peerB peer.ID) {
+func (s *Swamp) Connect(peerA, peerB peer.ID) {
 	_, err := s.Network.LinkPeers(peerA, peerB)
-	require.NoError(t, err)
+	require.NoError(s.t, err)
 	_, err = s.Network.ConnectPeers(peerA, peerB)
-	require.NoError(t, err)
+	require.NoError(s.t, err)
 }
 
 // Disconnect allows to break a connection between two peers without any possibility to
 // re-establish it. Order is very important here. We have to unlink peers first, and only after
 // that call disconnect. This is hard disconnect and peers will not be able to reconnect.
 // In order to reconnect peers again, please use swamp.Connect
-func (s *Swamp) Disconnect(t *testing.T, peerA, peerB peer.ID) {
-	require.NoError(t, s.Network.UnlinkPeers(peerA, peerB))
-	require.NoError(t, s.Network.DisconnectPeers(peerA, peerB))
+func (s *Swamp) Disconnect(peerA, peerB peer.ID) {
+	require.NoError(s.t, s.Network.UnlinkPeers(peerA, peerB))
+	require.NoError(s.t, s.Network.DisconnectPeers(peerA, peerB))
 }

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -5,61 +5,49 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
 )
 
-// Common consts for tests producing filled blocks
+// Common consts for some of tests producing filled blocks
 const (
-	blocks = 20
-	bsize  = 16
-	btime  = time.Millisecond * 300
+	blocksAmount = 20                     // number of *filled* *blocks to generate
+	blockSize    = 16                     // block size to generate
+	blockTime    = time.Millisecond * 300 // how often to generate blocks
 )
 
 /*
 Test-Case: Sync a Light Node with a Bridge Node(includes DASing of non-empty blocks)
 Steps:
-1. Create a Bridge Node(BN)
-2. Start a BN
-3. Check BN is synced to height 20
-4. Create a Light Node(LN) with a trusted peer
-5. Start a LN with a defined connection to the BN
-6. Check LN is synced to height 30
+1. Create and start a Bridge Node(BN)
+2. Check BN is synced to height 20
+3. Create and start a Light Node(LN)
+4. Connect LN to BN
+5. Check LN is synced to height 30
 */
 func TestSyncLightWithBridge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
-	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := sw.FillBlocks(ctx, bsize, blocks)
-
-	bridge := sw.NewBridgeNode()
-
+	sw := swamp.NewSwamp(t)
+	fillDn := sw.FillBlocks(ctx, blockSize, blocksAmount)
 	sw.WaitTillHeight(ctx, 20)
 
+	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
 	h, err := bridge.HeaderServ.GetByHeight(ctx, 20)
 	require.NoError(t, err)
-
 	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
 
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
-	require.NoError(t, err)
-
-	cfg := nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	light := sw.NewNodeWithConfig(node.Light, cfg)
-
+	light := sw.NewLightNode()
 	err = light.Start(ctx)
 	require.NoError(t, err)
+	sw.Connect(light.Host.ID(), bridge.Host.ID())
 
 	h, err = light.HeaderServ.GetByHeight(ctx, 30)
 	require.NoError(t, err)
@@ -69,112 +57,92 @@ func TestSyncLightWithBridge(t *testing.T) {
 
 	err = light.DASer.WaitCatchUp(ctx)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
 	require.NoError(t, <-fillDn)
 }
 
 /*
 Test-Case: Light Node continues sync after abrupt stop/start
-Pre-Requisites:
-- CoreClient is started by swamp
-- CoreClient has generated 50 blocks
 Steps:
-1. Create a Bridge Node(BN)
-2. Start a BN
-3. Check BN is synced to height 20
-4. Create a Light Node(LN) with a trusted peer
-5. Start a LN with a defined connection to the BN
-6. Check LN is synced to height 30
-7. Stop LN
-8. Start LN
-9. Check LN is synced to height 40
+1. Create and start a Bridge Node(BN)
+2. Check BN is synced to height 20
+3. Create and start a Light Node(LN)
+4. Connect LN to BN
+5. Check LN is synced to height 30
+6. Restart LN
+7. Check LN is synced to height 40
 */
 func TestSyncStartStopLightWithBridge(t *testing.T) {
-	sw := swamp.NewSwamp(t)
-
-	bridge := sw.NewBridgeNode()
-
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
+	sw := swamp.NewSwamp(t)
 	sw.WaitTillHeight(ctx, 50)
 
+	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
 	h, err := bridge.HeaderServ.GetByHeight(ctx, 20)
 	require.NoError(t, err)
-
 	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
 
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+	light := sw.NewLightNode()
+	err = light.Start(ctx)
 	require.NoError(t, err)
-
-	cfg := nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	light := sw.NewNodeWithConfig(node.Light, cfg)
-	require.NoError(t, light.Start(ctx))
+	sw.Connect(light.Host.ID(), bridge.Host.ID())
 
 	h, err = light.HeaderServ.GetByHeight(ctx, 30)
 	require.NoError(t, err)
-
 	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
 
-	require.NoError(t, light.Stop(ctx))
-	require.NoError(t, sw.RemoveNode(light, node.Light))
+	err = light.Stop(ctx)
+	require.NoError(t, err)
+	sw.RemoveNode(light, node.Light)
 
-	cfg = nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	light = sw.NewNodeWithConfig(node.Light, cfg)
-	require.NoError(t, light.Start(ctx))
+	light = sw.NewLightNode()
+	err = light.Start(ctx)
+	require.NoError(t, err)
+	sw.Connect(light.Host.ID(), bridge.Host.ID())
 
 	h, err = light.HeaderServ.GetByHeight(ctx, 40)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 40))
 }
 
 /*
 Test-Case: Sync a Full Node with a Bridge Node(includes DASing of non-empty blocks)
 Steps:
-1. Create a Bridge Node(BN)
-2. Start a BN
-3. Check BN is synced to height 20
-4. Create a Full Node(FN) with a connection to BN as a trusted peer
-5. Start a FN
-6. Check FN is synced to height 30
+1. Create and start a Bridge Node(BN)
+2. Check BN is synced to height 20
+3. Create and start a Full Node(FN)
+4. Connect FN to BN
+5. Check FN is synced to height 30
 */
+
 func TestSyncFullWithBridge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
-	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := sw.FillBlocks(ctx, bsize, blocks)
-
-	bridge := sw.NewBridgeNode()
-
+	sw := swamp.NewSwamp(t, swamp.WithBlockTime(blockTime))
+	fillDn := sw.FillBlocks(ctx, blockSize, blocksAmount)
 	sw.WaitTillHeight(ctx, 20)
 
+	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
 	h, err := bridge.HeaderServ.GetByHeight(ctx, 20)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
 
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+	full := sw.NewFullNode()
+	err = full.Start(ctx)
 	require.NoError(t, err)
-
-	cfg := nodebuilder.DefaultConfig(node.Full)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	full := sw.NewNodeWithConfig(node.Full, cfg)
-	require.NoError(t, full.Start(ctx))
+	sw.Connect(full.Host.ID(), bridge.Host.ID())
 
 	h, err = full.HeaderServ.GetByHeight(ctx, 30)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
 
 	err = full.ShareServ.SharesAvailable(ctx, h.DAH)
@@ -182,136 +150,101 @@ func TestSyncFullWithBridge(t *testing.T) {
 
 	err = full.DASer.WaitCatchUp(ctx)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
 	require.NoError(t, <-fillDn)
 }
 
 /*
 Test-Case: Sync a Light Node from a Full Node
-Pre-Requisites:
-- CoreClient is started by swamp
-- CoreClient has generated 20 blocks
 Steps:
-1. Create a Bridge Node(BN)
-2. Start a BN
-3. Check BN is synced to height 20
-4. Create a Full Node(FN) with a connection to BN as a trusted peer
-5. Start a FN
-6. Check FN is synced to height 30
-7. Create a Light Node(LN) with a connection to FN as a trusted peer
-8. Start LN
-9. Check LN is synced to height 50
+1. Create and start a Bridge Node(BN)
+2. Check BN is synced to height 20
+3. Create and start a Full Node(FN)
+4. Connect FN to BN
+5. Check FN is synced to height 30
+6. Create and start a Light Node(LN)
+7. Connect LN to FN
+8. Check LN is synced to height 50
 */
 func TestSyncLightWithFull(t *testing.T) {
-	sw := swamp.NewSwamp(t)
-
-	bridge := sw.NewBridgeNode()
-
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
+	sw := swamp.NewSwamp(t)
 	sw.WaitTillHeight(ctx, 20)
 
+	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
 	h, err := bridge.HeaderServ.GetByHeight(ctx, 20)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
 
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+	full := sw.NewFullNode()
+	err = full.Start(ctx)
 	require.NoError(t, err)
-
-	cfg := nodebuilder.DefaultConfig(node.Full)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	full := sw.NewNodeWithConfig(node.Full, cfg)
-	require.NoError(t, full.Start(ctx))
+	sw.Connect(full.Host.ID(), bridge.Host.ID())
 
 	h, err = full.HeaderServ.GetByHeight(ctx, 30)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
 
-	addrs, err = peer.AddrInfoToP2pAddrs(host.InfoFromHost(full.Host))
-	require.NoError(t, err)
-
-	cfg = nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	light := sw.NewNodeWithConfig(node.Light, cfg)
-
-	err = sw.Network.UnlinkPeers(bridge.Host.ID(), light.Host.ID())
-	require.NoError(t, err)
-
+	light := sw.NewLightNode()
 	err = light.Start(ctx)
 	require.NoError(t, err)
 
+	sw.Disconnect(light.Host.ID(), bridge.Host.ID())
+	sw.Connect(light.Host.ID(), full.Host.ID())
+
 	h, err = light.HeaderServ.GetByHeight(ctx, 50)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 50))
 }
 
 /*
 Test-Case: Sync a Light Node with multiple trusted peers
-Pre-Requisites:
-- CoreClient is started by swamp
-- CoreClient has generated 20 blocks
 Steps:
-1. Create a Bridge Node(BN)
-2. Start a BN
-3. Check BN is synced to height 20
-4. Create a Full Node(FN) with a connection to BN as a trusted peer
-5. Start a FN
-6. Check FN is synced to height 30
-7. Create a Light Node(LN) with a connection to BN, FN as trusted peers
-8. Start LN
-9. Check LN is synced to height 50
+1. Create and start a Bridge Node(BN)
+2. Check BN is synced to height 20
+3. Create and start a Full Node(FN)
+4. Connect FN to BN
+5. Check FN is synced to height 30
+6. Create and start a Light Node(LN)
+7. Connect LN to FN and BN
+8. Check LN is synced to height 50
 */
-func TestSyncLightWithTrustedPeers(t *testing.T) {
-	sw := swamp.NewSwamp(t)
-
-	bridge := sw.NewBridgeNode()
-
+func TestSyncLightFromMultiplePeers(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
+	sw := swamp.NewSwamp(t)
 	sw.WaitTillHeight(ctx, 20)
 
+	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
 	h, err := bridge.HeaderServ.GetByHeight(ctx, 20)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
 
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+	full := sw.NewFullNode()
+	err = full.Start(ctx)
 	require.NoError(t, err)
-
-	cfg := nodebuilder.DefaultConfig(node.Full)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	full := sw.NewNodeWithConfig(node.Full, cfg)
-	require.NoError(t, full.Start(ctx))
+	sw.Connect(full.Host.ID(), bridge.Host.ID())
 
 	h, err = full.HeaderServ.GetByHeight(ctx, 30)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
 
-	addrs, err = peer.AddrInfoToP2pAddrs(host.InfoFromHost(full.Host))
-	require.NoError(t, err)
-
-	cfg = nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	light := sw.NewNodeWithConfig(node.Light, cfg)
-
+	light := sw.NewLightNode()
+	sw.Connect(light.Host.ID(), bridge.Host.ID())
+	sw.Connect(light.Host.ID(), full.Host.ID())
 	err = light.Start(ctx)
 	require.NoError(t, err)
 
 	h, err = light.HeaderServ.GetByHeight(ctx, 50)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 50))
 }


### PR DESCRIPTION
Fixes test by pre-initializing all the swamp nodes with the correct genesis header.
Additionally effectively rewrites all the existing swamp tests and adds a fix to HeaderEx peerTracker

Should be merged and reviewed after https://github.com/celestiaorg/celestia-node/pull/1556 has landed.

Also closes #825  

### TODO
- [x] Extract peerTracker change in a personal PR
- [ ] Finish cleaning for `fraud` and `p2p` swamp tests
- [ ] Prettify logic around bootstrap settings
- [ ] Prettify setting of discovery interval, potentially set them for every node in the bridge
- [ ] Dive deeper into the RemoveNode method of the swamp, which seems useless
- [ ] Stop listening to redundant addresses in swamp

### Other thoughts
* Bunch of tests we have in the swamp is useless, but I am not removing them
* I hope that future someone who will start fixing flakiness will say me a huge 'thank you' for this cleanup
* Our tests were appalling, and I was insulting everyone in my head who wrote that code, including myself, but mostly others
* To truly appreciate a cleanup, you would need to check out and see how code blocks are grouped and see how much redundancy was removed in diffs
