### PR TITLE
bugfix(header|sync): clear range after syncing

### DIFF
--- a/header/sync/ranges.go
+++ b/header/sync/ranges.go
@@ -25,6 +25,9 @@ func (rs *ranges) Head() *header.ExtendedHeader {
 	}
 
 	head := rs.ranges[ln-1]
+	if head == nil {
+		return nil
+	}
 	return head.Head()
 }
 
@@ -89,11 +92,20 @@ func (rs *ranges) First() (*headerRange, bool) {
 		}
 
 		out := rs.ranges[0]
-		if !out.Empty() {
+		if out != nil && !out.Empty() {
 			return out, true
 		}
 
 		rs.ranges = rs.ranges[1:]
+	}
+}
+
+// Clear removes the first range of headers.
+func (rs *ranges) Clear() {
+	rs.lk.Lock()
+	defer rs.lk.Unlock()
+	if len(rs.ranges) > 0 {
+		rs.ranges[0] = nil
 	}
 }
 

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -276,6 +276,8 @@ func (s *Syncer) findHeaders(ctx context.Context, from, to uint64) ([]*header.Ex
 		cached, ln := r.Before(to)
 		out = append(out, cached...)
 		from += ln
+		// we do not need this range anymore
+		s.pending.Clear()
 	}
 
 	return out, nil

--- a/header/sync/sync_test.go
+++ b/header/sync/sync_test.go
@@ -143,11 +143,13 @@ func TestSyncPendingRangesWithMisses(t *testing.T) {
 
 	// and fire up a sync
 	syncer.sync(ctx)
-
+	// give some time to finish writing
+	time.Sleep(time.Millisecond * 200)
 	_, err = remoteStore.GetByHeight(ctx, 43)
 	require.NoError(t, err)
-	_, err = localStore.GetByHeight(ctx, 43)
+	h, err := localStore.GetByHeight(ctx, 43)
 	require.NoError(t, err)
+	require.Equal(t, h.Height, int64(43))
 
 	exp, err := remoteStore.Head(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION

## Overview
Resolves https://github.com/celestiaorg/celestia-node/issues/1399
I think the root cause of this issue is in keeping synced ranges in pending cache. Unfortunately, the log is not full, so this is just an assumption. 
Storing the new head failed after receiving "new" network head with Height ... 
// incomingNetHead processes new gossiped network headers.
func (s *Syncer) incomingNetHead(ctx context.Context, netHead *header.ExtendedHeader) pubsub.ValidationResult {
```
	// Try to short-circuit netHead with append. If not adjacent/from future - try it as new network
	// header
	_, err := s.store.Append(ctx, netHead)
	if err == nil {
		// a happy case where we appended maybe head directly, so accept
		return pubsub.ValidationAccept
	}
```
So, we fall into this condition(log level is debug so we don't see any logs in the output):
```
if errors.As(err, &nonAdj) {
		// not adjacent, maybe we've missed a few headers or its from the past
		log.Debugw("attempted to append non-adjacent header", "store head",
			nonAdj.Head, "attempted", nonAdj.Attempted)
}
```
We are calling `subjectiveHead` inside the `validate` function, which returns `head`:
// validate checks validity of the given header against the subjective head.
```
func (s *Syncer) validate(ctx context.Context, new *header.ExtendedHeader) pubsub.ValidationResult {
	sbjHead, err := s.subjectiveHead(ctx)
	if err != nil {
		log.Errorw("getting subjective head during validation", "err", err)
		return pubsub.ValidationIgnore // local error, so ignore
	}
```
As we haven't cleared any ranges before, it seems that we received `s.pending.Head` As this header is from the past - all other conditions might be finished successfully.
```
	// pending head is the latest known subjective head Syncer syncs to, so try to get it
	// NOTES:
	// * Empty when no sync is in progress
	// * Pending cannot be expired, guaranteed
	pendHead := s.pending.Head()
	if pendHead != nil {
		return pendHead, nil
	}
```
so we add our old-new head to pending and started explicit syncing:

```
// and if valid, set it as new subjective head
	s.pending.Add(netHead)
	s.wantSync()
	log.Infow("new network head", "height", netHead.Height, "hash", netHead.Hash())
	return pubsub.ValidationAccept

```
My suggestion is to remove pending range once we have synced it.
## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
