### PR TITLE
fix(header/p2p): preconnect trusted peers on header-ex start

### DIFF
--- a/header/p2p/exchange.go
+++ b/header/p2p/exchange.go
@@ -76,6 +76,12 @@ func (ex *Exchange) Start(context.Context) error {
 
 	go ex.peerTracker.gc()
 	go ex.peerTracker.track()
+	for _, p := range ex.trustedPeers {
+		// Try to pre-connect to trusted peers.
+		// We don't really care if we succeed at this point
+		// and just need any peers in the peerTracker asap
+		go ex.host.Connect(ex.ctx, peer.AddrInfo{ID: p}) //nolint:errcheck
+	}
 	return nil
 }
 

--- a/header/p2p/peer_tracker.go
+++ b/header/p2p/peer_tracker.go
@@ -71,8 +71,8 @@ func (p *peerTracker) track() {
 	}()
 
 	// store peers that have been already connected
-	for _, peer := range p.host.Peerstore().Peers() {
-		p.connected(peer)
+	for _, c := range p.host.Network().Conns() {
+		p.connected(c.RemotePeer())
 	}
 
 	subs, err := p.host.EventBus().Subscribe(&event.EvtPeerConnectednessChanged{})


### PR DESCRIPTION
We need to connect to trusted peers and kick off various protocols to start talking to them. In the past, a node was always connected to trusted peers to get headers from them. As from recent improvements to header-ex, we now only rely on trusted peers for initialization. Hence, if a node is already initialized, it won't contact go to connect to trusted peers and this commit fixes this.

This was found during fixing `no trusted peers` issue in swamp tests in https://github.com/celestiaorg/celestia-node/pull/1556