### PR TITLE
fix(header): don't stop Subscriber in Syncer and remove Stop from interface

### DIFF
--- a/header/interface.go
+++ b/header/interface.go
@@ -35,8 +35,6 @@ type Subscriber interface {
 	// before they are sent through Subscriptions.
 	// Multiple validators can be registered.
 	AddValidator(Validator) error
-	// Stop removes header-sub validator and closes the topic.
-	Stop(context.Context) error
 }
 
 // Subscription can retrieve the next ExtendedHeader from the

--- a/header/sync/sync.go
+++ b/header/sync/sync.go
@@ -87,9 +87,9 @@ func (s *Syncer) Start(ctx context.Context) error {
 }
 
 // Stop stops Syncer.
-func (s *Syncer) Stop(ctx context.Context) error {
+func (s *Syncer) Stop(context.Context) error {
 	s.cancel()
-	return s.sub.Stop(ctx)
+	return nil
 }
 
 // WaitSync blocks until ongoing sync is done.


### PR DESCRIPTION
We need to fix this earlier to fix fraud tests in #1555

Closes https://github.com/celestiaorg/celestia-node/issues/1386