### PR TITLE
fix: use udp/quic instead of tcp/quic in NoAnnounceAddress

### DIFF
--- a/nodebuilder/p2p/config.go
+++ b/nodebuilder/p2p/config.go
@@ -47,7 +47,7 @@ func DefaultConfig() Config {
 		AnnounceAddresses: []string{},
 		NoAnnounceAddresses: []string{
 			"/ip4/0.0.0.0/udp/2121/quic",
-			"/ip4/127.0.0.1/tcp/2121/quic",
+			"/ip4/127.0.0.1/udp/2121/quic",
 			"/ip6/::/udp/2121/quic",
 			"/ip4/0.0.0.0/tcp/2121",
 			"/ip4/127.0.0.1/tcp/2121",


### PR DESCRIPTION


<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Resolves #1457.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
