### PR TITLE
feat(header/core): Put eds in `eds.Store` in listener

### DIFF
--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -5,12 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/celestiaorg/rsmt2d"
-
-	availability_test "github.com/celestiaorg/celestia-node/share/availability/test"
-
-	"github.com/tendermint/tendermint/types"
-
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
@@ -20,12 +14,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/types"
+
+	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/fraud"
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/availability/full"
 	"github.com/celestiaorg/celestia-node/share/availability/light"
+	availability_test "github.com/celestiaorg/celestia-node/share/availability/test"
 )
 
 var timeout = time.Second * 15

--- a/header/core/exchange.go
+++ b/header/core/exchange.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ipfs/go-blockservice"
 	logging "github.com/ipfs/go-log/v2"
-
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 
 	"github.com/celestiaorg/celestia-node/core"
@@ -17,16 +15,17 @@ import (
 var log = logging.Logger("header/core")
 
 type Exchange struct {
-	fetcher    *core.BlockFetcher
-	shareStore blockservice.BlockService
-	construct  header.ConstructFn
+	fetcher *core.BlockFetcher
+
+	construct header.ConstructFn
+	storeFn   header.StoreFn
 }
 
-func NewExchange(fetcher *core.BlockFetcher, bServ blockservice.BlockService, construct header.ConstructFn) *Exchange {
+func NewExchange(fetcher *core.BlockFetcher, construct header.ConstructFn, storeFn header.StoreFn) *Exchange {
 	return &Exchange{
-		fetcher:    fetcher,
-		shareStore: bServ,
-		construct:  construct,
+		fetcher:   fetcher,
+		construct: construct,
+		storeFn:   storeFn,
 	}
 }
 
@@ -84,7 +83,7 @@ func (ce *Exchange) Get(ctx context.Context, hash tmbytes.HexBytes) (*header.Ext
 		return nil, err
 	}
 
-	eh, err := ce.construct(ctx, block, comm, vals, ce.shareStore)
+	eh, err := ce.construct(ctx, block, comm, vals, ce.storeFn)
 	if err != nil {
 		return nil, err
 	}
@@ -113,5 +112,5 @@ func (ce *Exchange) getExtendedHeaderByHeight(ctx context.Context, height *int64
 		return nil, err
 	}
 
-	return ce.construct(ctx, b, comm, vals, ce.shareStore)
+	return ce.construct(ctx, b, comm, vals, ce.storeFn)
 }

--- a/header/core/exchange_test.go
+++ b/header/core/exchange_test.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"testing"
 
-	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/header"
@@ -15,12 +16,11 @@ import (
 
 func TestCoreExchange_RequestHeaders(t *testing.T) {
 	fetcher := createCoreFetcher(t)
-	store := mdutils.Bserv()
 
 	// generate 10 blocks
 	generateBlocks(t, fetcher)
 
-	ce := NewExchange(fetcher, store, header.MakeExtendedHeader)
+	ce := NewExchange(fetcher, header.MakeExtendedHeader, noopStore)
 	headers, err := ce.GetRangeByHeight(context.Background(), 1, 10)
 	require.NoError(t, err)
 
@@ -46,4 +46,8 @@ func generateBlocks(t *testing.T, fetcher *core.BlockFetcher) {
 	for i := 0; i < 10; i++ {
 		<-sub
 	}
+}
+
+func noopStore(context.Context, []byte, *rsmt2d.ExtendedDataSquare) error {
+	return nil
 }

--- a/header/core/exchange_test.go
+++ b/header/core/exchange_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/rsmt2d"
-
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/header"
 )
@@ -20,7 +18,7 @@ func TestCoreExchange_RequestHeaders(t *testing.T) {
 	// generate 10 blocks
 	generateBlocks(t, fetcher)
 
-	ce := NewExchange(fetcher, header.MakeExtendedHeader, noopStore)
+	ce := NewExchange(fetcher, header.MakeExtendedHeader, header.NoopTestStore)
 	headers, err := ce.GetRangeByHeight(context.Background(), 1, 10)
 	require.NoError(t, err)
 
@@ -46,8 +44,4 @@ func generateBlocks(t *testing.T, fetcher *core.BlockFetcher) {
 	for i := 0; i < 10; i++ {
 		<-sub
 	}
-}
-
-func noopStore(context.Context, []byte, *rsmt2d.ExtendedDataSquare) error {
-	return nil
 }

--- a/header/core/listener.go
+++ b/header/core/listener.go
@@ -22,8 +22,8 @@ type Listener struct {
 	bcast   header.Broadcaster
 	fetcher *core.BlockFetcher
 
-	construct header.ConstructFn
-	storeFn   header.StoreFn
+	construct header.ConstructFn // construct is a callback function to construct an ExtendedHeader
+	store     header.StoreFn     // store is a callback function to store an extended square
 
 	cancel context.CancelFunc
 }
@@ -38,7 +38,7 @@ func NewListener(
 		bcast:     bcast,
 		fetcher:   fetcher,
 		construct: construct,
-		storeFn:   storeFn,
+		store:     storeFn,
 	}
 }
 
@@ -90,7 +90,7 @@ func (cl *Listener) listen(ctx context.Context, sub <-chan *types.Block) {
 				return
 			}
 
-			eh, err := cl.construct(ctx, b, comm, vals, cl.storeFn)
+			eh, err := cl.construct(ctx, b, comm, vals, cl.store)
 			if err != nil {
 				log.Errorw("listener: making extended header", "err", err)
 				return

--- a/header/core/listener_test.go
+++ b/header/core/listener_test.go
@@ -101,5 +101,5 @@ func createListener(
 		require.NoError(t, err)
 	})
 
-	return NewListener(p2pSub, fetcher, header.MakeExtendedHeader, noopStore)
+	return NewListener(p2pSub, fetcher, header.MakeExtendedHeader, header.NoopTestStore)
 }

--- a/header/core/listener_test.go
+++ b/header/core/listener_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/libp2p/go-libp2p-core/event"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
@@ -102,5 +101,5 @@ func createListener(
 		require.NoError(t, err)
 	})
 
-	return NewListener(p2pSub, fetcher, mdutils.Bserv(), header.MakeExtendedHeader)
+	return NewListener(p2pSub, fetcher, header.MakeExtendedHeader, noopStore)
 }

--- a/header/header_test.go
+++ b/header/header_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/rand"
+
+	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/core"
 )
@@ -18,8 +19,6 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 
 	_, client := core.StartTestCoreWithApp(t)
 	fetcher := core.NewBlockFetcher(client)
-
-	store := mdutils.Bserv()
 
 	sub, err := fetcher.SubscribeNewBlockEvent(ctx)
 	require.NoError(t, err)
@@ -32,7 +31,8 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 	comm, val, err := fetcher.GetBlockInfo(ctx, &height)
 	require.NoError(t, err)
 
-	headerExt, err := MakeExtendedHeader(ctx, b, comm, val, store)
+	noop := func(ctx context.Context, root []byte, square *rsmt2d.ExtendedDataSquare) error { return nil }
+	headerExt, err := MakeExtendedHeader(ctx, b, comm, val, noop)
 	require.NoError(t, err)
 
 	assert.Equal(t, EmptyDAH(), *headerExt.DAH)

--- a/header/header_test.go
+++ b/header/header_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/rand"
 
-	"github.com/celestiaorg/rsmt2d"
-
 	"github.com/celestiaorg/celestia-node/core"
 )
 
@@ -31,8 +29,7 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 	comm, val, err := fetcher.GetBlockInfo(ctx, &height)
 	require.NoError(t, err)
 
-	noop := func(ctx context.Context, root []byte, square *rsmt2d.ExtendedDataSquare) error { return nil }
-	headerExt, err := MakeExtendedHeader(ctx, b, comm, val, noop)
+	headerExt, err := MakeExtendedHeader(ctx, b, comm, val, NoopTestStore)
 	require.NoError(t, err)
 
 	assert.Equal(t, EmptyDAH(), *headerExt.DAH)

--- a/header/interface.go
+++ b/header/interface.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ipfs/go-blockservice"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	core "github.com/tendermint/tendermint/types"
@@ -17,7 +16,7 @@ type ConstructFn = func(
 	*core.Block,
 	*core.Commit,
 	*core.ValidatorSet,
-	blockservice.BlockService,
+	StoreFn,
 ) (*ExtendedHeader, error)
 
 // Validator aliases a func that validates ExtendedHeader.

--- a/header/testing.go
+++ b/header/testing.go
@@ -20,6 +20,7 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
+	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/share"
@@ -279,3 +280,7 @@ func (mhs *DummySubscriber) NextHeader(ctx context.Context) (*ExtendedHeader, er
 
 func (mhs *DummySubscriber) Stop(context.Context) error { return nil }
 func (mhs *DummySubscriber) Cancel()                    {}
+
+var NoopTestStore = func(ctx context.Context, root []byte, square *rsmt2d.ExtendedDataSquare) error {
+	return nil
+}

--- a/libs/utils/square.go
+++ b/libs/utils/square.go
@@ -1,0 +1,8 @@
+package utils
+
+import "math"
+
+// SquareSize returns the size of the square based on the given amount of shares.
+func SquareSize(lenShares int) uint64 {
+	return uint64(math.Sqrt(float64(lenShares)))
+}

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -7,6 +7,8 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"
 
+	"github.com/celestiaorg/rsmt2d"
+
 	"github.com/celestiaorg/celestia-node/fraud"
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/p2p"
@@ -15,6 +17,7 @@ import (
 	fraudServ "github.com/celestiaorg/celestia-node/nodebuilder/fraud"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	"github.com/celestiaorg/celestia-node/share/eds"
 )
 
 var log = logging.Logger("module/header")
@@ -126,6 +129,11 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 			baseComponents,
 			fx.Provide(func(subscriber *p2p.Subscriber) header.Broadcaster {
 				return subscriber
+			}),
+			fx.Provide(func(store *eds.Store) header.StoreFn {
+				return func(ctx context.Context, root []byte, eds *rsmt2d.ExtendedDataSquare) error {
+					return store.Put(ctx, root, eds)
+				}
 			}),
 			fx.Supply(header.MakeExtendedHeader),
 		)

--- a/share/add.go
+++ b/share/add.go
@@ -3,14 +3,15 @@ package share
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/ipfs/go-blockservice"
 
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
-	"github.com/celestiaorg/celestia-node/share/ipld"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/libs/utils"
+	"github.com/celestiaorg/celestia-node/share/ipld"
 )
 
 // AddShares erasures and extends shares to blockservice.BlockService using the provided
@@ -23,7 +24,7 @@ func AddShares(
 	if len(shares) == 0 {
 		return nil, fmt.Errorf("empty data") // empty block is not an empty Data
 	}
-	squareSize := int(math.Sqrt(float64(len(shares))))
+	squareSize := int(utils.SquareSize(len(shares)))
 	// create nmt adder wrapping batch adder with calculated size
 	batchAdder := ipld.NewNmtNodeAdder(ctx, adder, ipld.MaxSizeBatchOption(squareSize*2))
 	// create the nmt wrapper to generate row and col commitments
@@ -52,7 +53,7 @@ func ImportShares(
 	if len(shares) == 0 {
 		return nil, fmt.Errorf("ipld: importing empty data")
 	}
-	squareSize := int(math.Sqrt(float64(len(shares))))
+	squareSize := int(utils.SquareSize(len(shares)))
 	// create nmt adder wrapping batch adder with calculated size
 	batchAdder := ipld.NewNmtNodeAdder(ctx, adder, ipld.MaxSizeBatchOption(squareSize*2))
 	// recompute the eds

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"encoding/json"
-	"math"
 	mrand "math/rand"
 	"strconv"
 	"testing"
@@ -19,7 +18,9 @@ import (
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	appshares "github.com/celestiaorg/celestia-app/pkg/shares"
+
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/libs/utils"
 	"github.com/celestiaorg/celestia-node/share"
 	availability_test "github.com/celestiaorg/celestia-node/share/availability/test"
 )
@@ -141,7 +142,7 @@ func TestGetShares(t *testing.T) {
 	}
 	// generate DAH from shares returned by `share.GetShares` to compare
 	// calculated DAH to expected DAH
-	squareSize := uint64(math.Sqrt(float64(len(flattened))))
+	squareSize := utils.SquareSize(len(flattened))
 	eds, err := da.ExtendShares(squareSize, flattened)
 	require.NoError(t, err)
 	gotDAH := da.NewDataAvailabilityHeader(eds)

--- a/share/get_test.go
+++ b/share/get_test.go
@@ -2,7 +2,6 @@ package share
 
 import (
 	"context"
-	"math"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -20,10 +19,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
-	"github.com/celestiaorg/celestia-node/share/ipld"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/libs/utils"
+	"github.com/celestiaorg/celestia-node/share/ipld"
 )
 
 func TestGetShare(t *testing.T) {
@@ -73,7 +74,7 @@ func TestBlockRecovery(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			squareSize := uint64(math.Sqrt(float64(len(tc.shares))))
+			squareSize := utils.SquareSize(len(tc.shares))
 
 			eds, err := rsmt2d.ComputeExtendedDataSquare(tc.shares, rsmt2d.NewRSGF8Codec(), wrapper.NewConstructor(squareSize))
 			require.NoError(t, err)

--- a/share/ipld/nmt_test.go
+++ b/share/ipld/nmt_test.go
@@ -2,7 +2,6 @@ package ipld
 
 import (
 	"bytes"
-	"math"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -13,6 +12,8 @@ import (
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/da"
+
+	"github.com/celestiaorg/celestia-node/libs/utils"
 )
 
 // TestNamespaceFromCID checks that deriving the Namespaced hash from
@@ -28,7 +29,7 @@ func TestNamespaceFromCID(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			// create DAH from rand data
-			squareSize := uint64(math.Sqrt(float64(len(tt.randData))))
+			squareSize := utils.SquareSize(len(tt.randData))
 			eds, err := da.ExtendShares(squareSize, tt.randData)
 			require.NoError(t, err)
 			dah := da.NewDataAvailabilityHeader(eds)


### PR DESCRIPTION
Something to note about this PR - the level of abstraction introduced by `header.StoreFn` is unfortunately necessary due to cyclical dependencies between `share/eds` and `share/eds/byzantine` where both import the header pkg.

Resolves #1423 