### PR TITLE
fix(cel-key): `keyring-dir` flag should override `node.type` if provided.

### DIFF
--- a/cmd/cel-key/node_types.go
+++ b/cmd/cel-key/node_types.go
@@ -36,6 +36,11 @@ func DirectoryFlags() *flag.FlagSet {
 }
 
 func ParseDirectoryFlags(cmd *cobra.Command) error {
+	// if keyring-dir is explicitly set, use it
+	if cmd.Flags().Changed(sdkflags.FlagKeyringDir) {
+		return nil
+	}
+
 	nodeType := cmd.Flag(nodeDirKey).Value.String()
 	if nodeType == "" {
 		return errors.New("no node type provided")


### PR DESCRIPTION
This PR fixes `cel-key` such that if the `--keyring-dir` flag is provided, it will override the `node.type` store determination. 

So if a user passes `--keyring-dir`, the utility will look to the given path instead of the default paths calculated via `node.type` flag.