### PR TITLE
improvement(header/p2p): Implement context deadline on requests to store inside server

### DIFF
--- a/header/p2p/options.go
+++ b/header/p2p/options.go
@@ -23,6 +23,8 @@ type ServerParameters struct {
 	ReadDeadline time.Duration
 	// MaxRequestSize defines the max amount of headers that can be handled at once.
 	MaxRequestSize uint64
+	// ServeTimeout defines the deadline for serving requests.
+	ServeTimeout time.Duration
 }
 
 // DefaultServerParameters returns the default params to configure the store.
@@ -31,6 +33,7 @@ func DefaultServerParameters() ServerParameters {
 		WriteDeadline:  time.Second * 5,
 		ReadDeadline:   time.Minute,
 		MaxRequestSize: 512,
+		ServeTimeout:   time.Second * 5,
 	}
 }
 
@@ -43,6 +46,9 @@ func (p *ServerParameters) Validate() error {
 	}
 	if p.MaxRequestSize == 0 {
 		return fmt.Errorf("invalid max request size: %d", p.MaxRequestSize)
+	}
+	if p.ServeTimeout == time.Duration(0) {
+		return fmt.Errorf("invalid request timeout: %d", p.ServeTimeout)
 	}
 	return nil
 }
@@ -78,6 +84,17 @@ func WithMaxRequestSize[T parameters](size uint64) Option[T] {
 			t.MaxRequestSize = size
 		case *ServerParameters:
 			t.MaxRequestSize = size
+		}
+	}
+}
+
+// WithRequestTimeout is a functional option that configures the
+// `ServeTimeout` parameter.
+func WithRequestTimeout[T parameters](timeout time.Duration) Option[T] {
+	return func(p *T) {
+		switch t := any(p).(type) { //nolint:gocritic
+		case *ServerParameters:
+			t.ServeTimeout = timeout
 		}
 	}
 }

--- a/header/p2p/options.go
+++ b/header/p2p/options.go
@@ -88,9 +88,9 @@ func WithMaxRequestSize[T parameters](size uint64) Option[T] {
 	}
 }
 
-// WithRequestTimeout is a functional option that configures the
+// WithServeTimeout is a functional option that configures the
 // `ServeTimeout` parameter.
-func WithRequestTimeout[T parameters](timeout time.Duration) Option[T] {
+func WithServeTimeout[T parameters](timeout time.Duration) Option[T] {
 	return func(p *T) {
 		switch t := any(p).(type) { //nolint:gocritic
 		case *ServerParameters:

--- a/header/store/store.go
+++ b/header/store/store.go
@@ -23,7 +23,7 @@ var (
 	errStoppedStore = errors.New("stopped store")
 )
 
-// store implements the Store interface for ExtendedHeaders over Datastore.
+// Store implements the Store interface for ExtendedHeaders over Datastore.
 type Store struct {
 	// header storing
 	//

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -42,6 +42,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 					p2p.WithWriteDeadline(cfg.Server.WriteDeadline),
 					p2p.WithReadDeadline(cfg.Server.ReadDeadline),
 					p2p.WithMaxRequestSize[p2p.ServerParameters](cfg.Server.MaxRequestSize),
+					p2p.WithRequestTimeout[p2p.ServerParameters](cfg.Server.ServeTimeout),
 				}
 			}),
 		fx.Provide(NewHeaderService),

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -42,7 +42,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 					p2p.WithWriteDeadline(cfg.Server.WriteDeadline),
 					p2p.WithReadDeadline(cfg.Server.ReadDeadline),
 					p2p.WithMaxRequestSize[p2p.ServerParameters](cfg.Server.MaxRequestSize),
-					p2p.WithRequestTimeout[p2p.ServerParameters](cfg.Server.ServeTimeout),
+					p2p.WithServeTimeout[p2p.ServerParameters](cfg.Server.ServeTimeout),
 				}
 			}),
 		fx.Provide(NewHeaderService),

--- a/nodebuilder/header/module_test.go
+++ b/nodebuilder/header/module_test.go
@@ -121,4 +121,5 @@ func TestConstructModule_ExchangeParams(t *testing.T) {
 	require.Equal(t, exchangeServer.Params.WriteDeadline, cfg.Server.WriteDeadline)
 	require.Equal(t, exchangeServer.Params.ReadDeadline, cfg.Server.ReadDeadline)
 	require.Equal(t, exchangeServer.Params.MaxRequestSize, cfg.Server.MaxRequestSize)
+	require.Equal(t, exchangeServer.Params.ServeTimeout, cfg.Server.ServeTimeout)
 }


### PR DESCRIPTION
This PR introduces server-side context deadlines for **all** requests down to store with a config parameter for the server `RequestTimeout`