### PR TITLE
fix(fraud): fix race by using correct peer id in log statement

### DIFF
--- a/fraud/sync.go
+++ b/fraud/sync.go
@@ -79,7 +79,7 @@ func (f *ProofService) syncFraudProofs(ctx context.Context) {
 				span.SetStatus(codes.Ok, "")
 				return
 			}
-			log.Debugw("got fraud proofs from peer", "pid", connStatus.Peer)
+			log.Debugw("got fraud proofs from peer", "pid", pid)
 			for _, data := range respProofs {
 				f.topicsLk.RLock()
 				topic, ok := f.topics[ProofType(data.Type)]


### PR DESCRIPTION
Fixes a rare data race found in https://github.com/celestiaorg/celestia-node/pull/1596

```
WARNING: DATA RACE
Write at 0x00c0066ef4a0 by goroutine 6416:
  github.com/celestiaorg/celestia-node/fraud.(*ProofService).syncFraudProofs()
      /home/runner/work/celestia-node/celestia-node/fraud/sync.go:50 +0x784
  github.com/celestiaorg/celestia-node/fraud.(*ProofService).Start.func1()
      /home/runner/work/celestia-node/celestia-node/fraud/service.go:90 +0x58

Previous read at 0x00c0066ef4a0 by goroutine 6467:
  github.com/celestiaorg/celestia-node/fraud.(*ProofService).syncFraudProofs.func1()
      /home/runner/work/celestia-node/celestia-node/fraud/sync.go:82 +0x638
  github.com/celestiaorg/celestia-node/fraud.(*ProofService).syncFraudProofs.func3()
      /home/runner/work/celestia-node/celestia-node/fraud/sync.go:107 +0x58
```
