### PR TITLE
fix(header/store): cleanup subscription early if was cancelled

### DIFF
--- a/header/store/heightsub.go
+++ b/header/store/heightsub.go
@@ -62,6 +62,10 @@ func (hs *heightSub) Sub(ctx context.Context, height uint64) (*header.ExtendedHe
 	case resp := <-resp:
 		return resp, nil
 	case <-ctx.Done():
+		// no need to keep the request, if the op is canceled
+		hs.heightReqsLk.Lock()
+		delete(hs.heightReqs, height)
+		hs.heightReqsLk.Unlock()
 		return nil, ctx.Err()
 	}
 }


### PR DESCRIPTION
Not an actual bug because we clean up things anyway. This just cleans them as soon as we don't need them and prevents the publisher from processing the sub. Was randomly found during the weekend