### PR TITLE
share/eds: replace OS use with fs

### DIFF
--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -2,8 +2,8 @@ package nodebuilder
 
 import (
 	"context"
-
 	"go.uber.org/fx"
+	"os"
 
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
@@ -31,6 +31,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		fx.Provide(store.Datastore),
 		fx.Provide(store.Keystore),
 		fx.Supply(node.StorePath(store.Path())),
+		fx.Supply(os.DirFS(store.Path())),
 		// modules provided by the node
 		p2p.ConstructModule(tp, &cfg.P2P),
 		state.ConstructModule(tp, &cfg.State),

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -2,10 +2,10 @@ package share
 
 import (
 	"context"
-
 	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p/core/host"
 	"go.uber.org/fx"
+	"io/fs"
 
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -73,8 +73,8 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 				},
 			),
 			fx.Provide(fx.Annotate(
-				func(path node.StorePath, ds datastore.Batching) (*eds.Store, error) {
-					return eds.NewStore(string(path), ds)
+				func(path node.StorePath, ds datastore.Batching, FS fs.FS) (*eds.Store, error) {
+					return eds.NewStore(string(path), ds, FS)
 				},
 				fx.OnStart(func(ctx context.Context, store *eds.Store) error {
 					err := store.Start(ctx)

--- a/nodebuilder/share/share_test.go
+++ b/nodebuilder/share/share_test.go
@@ -2,16 +2,16 @@ package share
 
 import (
 	"context"
-	"testing"
-
+	"github.com/celestiaorg/celestia-node/share/eds"
 	"github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/share/eds"
 )
 
 func Test_EmptyCARExists(t *testing.T) {
@@ -20,7 +20,7 @@ func Test_EmptyCARExists(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
-	edsStore, err := eds.NewStore(tmpDir, ds)
+	edsStore, err := eds.NewStore(tmpDir, ds, os.DirFS(tmpDir))
 	require.NoError(t, err)
 	err = edsStore.Start(ctx)
 	require.NoError(t, err)

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -254,6 +255,8 @@ func (s *Swamp) newNode(t node.Type, store nodebuilder.Store, options ...fx.Opti
 	options = append(options,
 		p2p.WithHost(s.createPeer(ks)),
 		fx.Replace(node.StorePath(tempDir)),
+		fx.Replace(os.DirFS(tempDir)),
+		
 		fx.Invoke(func(ctx context.Context, store libhead.Store[*header.ExtendedHeader]) error {
 			return store.Init(ctx, s.genesis)
 		}),

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -109,7 +109,7 @@ func TestEDSStore(t *testing.T) {
 
 		// file no longer exists
 		_, err = os.Stat(edsStore.basepath + blocksPath + dah.String())
-		assert.ErrorContains(t, err, "no such file or directory")
+		assert.ErrorContains(t, err, "such file or directory")
 	})
 
 	t.Run("Has", func(t *testing.T) {
@@ -211,7 +211,7 @@ func newStore(t *testing.T) (*Store, error) {
 
 	tmpDir := t.TempDir()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
-	return NewStore(tmpDir, ds)
+	return NewStore(tmpDir, ds, os.DirFS(tmpDir))
 }
 
 func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, share.Root) {

--- a/share/getters/getter_test.go
+++ b/share/getters/getter_test.go
@@ -2,20 +2,18 @@ package getters
 
 import (
 	"context"
-	"testing"
-
+	"github.com/celestiaorg/celestia-app/pkg/da"
+	"github.com/celestiaorg/celestia-app/pkg/wrapper"
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/rsmt2d"
 	"github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
 	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/celestiaorg/celestia-app/pkg/da"
-	"github.com/celestiaorg/celestia-app/pkg/wrapper"
-	"github.com/celestiaorg/rsmt2d"
-
-	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/share/eds"
+	"os"
+	"testing"
 )
 
 func TestTeeGetter(t *testing.T) {
@@ -24,7 +22,7 @@ func TestTeeGetter(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
-	edsStore, err := eds.NewStore(tmpDir, ds)
+	edsStore, err := eds.NewStore(tmpDir, ds, os.DirFS(tmpDir))
 	require.NoError(t, err)
 
 	err = edsStore.Start(ctx)
@@ -79,7 +77,7 @@ func TestStoreGetter(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
-	edsStore, err := eds.NewStore(tmpDir, ds)
+	edsStore, err := eds.NewStore(tmpDir, ds, os.DirFS(tmpDir))
 	require.NoError(t, err)
 
 	err = edsStore.Start(ctx)

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -3,6 +3,7 @@ package getters
 import (
 	"context"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func newStore(t *testing.T) (*eds.Store, error) {
 
 	tmpDir := t.TempDir()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
-	return eds.NewStore(tmpDir, ds)
+	return eds.NewStore(tmpDir, ds, os.DirFS(tmpDir))
 }
 
 func generateTestEDS(t *testing.T, bServ bsrv.BlockService) (*rsmt2d.ExtendedDataSquare, namespace.ID) {

--- a/share/p2p/shrexeds/exchange_test.go
+++ b/share/p2p/shrexeds/exchange_test.go
@@ -2,6 +2,7 @@ package shrexeds
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -90,7 +91,7 @@ func newStore(t *testing.T) *eds.Store {
 
 	tmpDir := t.TempDir()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
-	store, err := eds.NewStore(tmpDir, ds)
+	store, err := eds.NewStore(tmpDir, ds, os.DirFS(tmpDir))
 	require.NoError(t, err)
 	return store
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This pr relates to #1438.
I've replaced the use of OS from eds/store to use fs. I've also changed the tests to use fs impl.

@distractedm1nd is this what you were thinking? I wasn't able to remove the use of tmpDir completely because the dagstore use os call, let me know if there is anything that I can do better 

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
