### PR TITLE
fix(daser) replace catchUpDoneCh channel gracefuly 

### DIFF
--- a/das/state.go
+++ b/das/state.go
@@ -2,6 +2,7 @@ package das
 
 import (
 	"context"
+	"sync/atomic"
 )
 
 // coordinatorState represents the current state of sampling
@@ -18,7 +19,7 @@ type coordinatorState struct {
 	next        uint64 // all headers before next were sent to workers
 	networkHead uint64
 
-	catchUpDone   bool          // indicates if all headers are sampled
+	catchUpDone   *atomic.Bool  // indicates if all headers are sampled
 	catchUpDoneCh chan struct{} // blocks until all headers are sampled
 }
 
@@ -34,7 +35,7 @@ func newCoordinatorState(params Parameters) coordinatorState {
 		nextJobID:         0,
 		next:              params.SampleFrom,
 		networkHead:       params.SampleFrom,
-		catchUpDone:       false,
+		catchUpDone:       new(atomic.Bool),
 		catchUpDoneCh:     make(chan struct{}),
 	}
 }
@@ -201,28 +202,31 @@ func (s *coordinatorState) unsafeStats() SamplingStats {
 		Failed:           failed,
 		Workers:          workers,
 		Concurrency:      len(workers),
-		CatchUpDone:      s.catchUpDone,
-		IsRunning:        len(workers) > 0 || s.catchUpDone,
+		CatchUpDone:      s.catchUpDone.Load(),
+		IsRunning:        len(workers) > 0 || s.catchUpDone.Load(),
 	}
 }
 
 func (s *coordinatorState) checkDone() {
 	if len(s.inProgress) == 0 && len(s.priority) == 0 && s.next > s.networkHead {
-		if !s.catchUpDone {
+		if s.catchUpDone.CompareAndSwap(false, true) {
 			close(s.catchUpDoneCh)
-			s.catchUpDone = true
 		}
 		return
 	}
 
-	if s.catchUpDone {
+	if s.catchUpDone.Load() {
+		// overwrite channel before storing done flag
 		s.catchUpDoneCh = make(chan struct{})
-		s.catchUpDone = false
+		s.catchUpDone.Store(false)
 	}
 }
 
 // waitCatchUp waits for sampling process to indicate catchup is done
 func (s *coordinatorState) waitCatchUp(ctx context.Context) error {
+	if s.catchUpDone.Load() {
+		return nil
+	}
 	select {
 	case <-s.catchUpDoneCh:
 	case <-ctx.Done():

--- a/das/state.go
+++ b/das/state.go
@@ -19,7 +19,7 @@ type coordinatorState struct {
 	next        uint64 // all headers before next were sent to workers
 	networkHead uint64
 
-	catchUpDone   *atomic.Bool  // indicates if all headers are sampled
+	catchUpDone   atomic.Bool   // indicates if all headers are sampled
 	catchUpDoneCh chan struct{} // blocks until all headers are sampled
 }
 
@@ -35,7 +35,6 @@ func newCoordinatorState(params Parameters) coordinatorState {
 		nextJobID:         0,
 		next:              params.SampleFrom,
 		networkHead:       params.SampleFrom,
-		catchUpDone:       new(atomic.Bool),
 		catchUpDoneCh:     make(chan struct{}),
 	}
 }

--- a/das/state_test.go
+++ b/das/state_test.go
@@ -3,7 +3,6 @@ package das
 import (
 	"errors"
 	"sort"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +47,6 @@ func Test_coordinatorStats(t *testing.T) {
 				nextJobID:   0,
 				next:        31,
 				networkHead: 100,
-				catchUpDone: new(atomic.Bool),
 			},
 			SamplingStats{
 				SampledChainHead: 11,

--- a/das/state_test.go
+++ b/das/state_test.go
@@ -3,6 +3,7 @@ package das
 import (
 	"errors"
 	"sort"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,7 @@ func Test_coordinatorStats(t *testing.T) {
 				nextJobID:   0,
 				next:        31,
 				networkHead: 100,
+				catchUpDone: new(atomic.Bool),
 			},
 			SamplingStats{
 				SampledChainHead: 11,


### PR DESCRIPTION
DASer `waitCatchUp` method has a data race for catchUpDoneCh pointer. Pointer needs to be swapped gracefully. 
Would occur only if user was fortunate enough to call `waitCatchUp` in the span of time the pointer was being swapped. 
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
