### PR TITLE
fix(header/p2p): add trivial retrying for trustedPeer requested

### DIFF
--- a/libs/header/p2p/exchange.go
+++ b/libs/header/p2p/exchange.go
@@ -82,7 +82,7 @@ func (ex *Exchange[H]) Start(context.Context) error {
 		// We don't really care if we succeed at this point
 		// and just need any peers in the peerTracker asap
 		go func(p peer.ID) {
-			err := ex.host.Connect(ex.ctx, peer.AddrInfo{ID: p}) //nolint:errcheck
+			err := ex.host.Connect(ex.ctx, peer.AddrInfo{ID: p})
 			if err != nil {
 				log.Debugw("err connecting to a bootstrap peer", "err", err, "peer", p)
 			}

--- a/libs/header/p2p/exchange.go
+++ b/libs/header/p2p/exchange.go
@@ -228,7 +228,7 @@ func (ex *Exchange[H]) performRequest(
 	for ctx.Err() == nil {
 		//nolint:gosec // G404: Use of weak random number generator
 		index := rand.Intn(len(ex.trustedPeers))
-		cctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		cctx, cancel := context.WithTimeout(ctx, time.Second)
 		h, err := ex.request(cctx, ex.trustedPeers[index], req)
 		cancel()
 		if err != nil {

--- a/libs/header/p2p/exchange.go
+++ b/libs/header/p2p/exchange.go
@@ -45,10 +45,6 @@ func NewExchange[H header.Header](
 	connGater *conngater.BasicConnectionGater,
 	opts ...Option[ClientParameters],
 ) (*Exchange[H], error) {
-	if len(trustedPeers) == 0 {
-		return nil, fmt.Errorf("no trusted peers")
-	}
-
 	params := DefaultClientParameters()
 	for _, opt := range opts {
 		opt(&params)

--- a/libs/header/p2p/exchange.go
+++ b/libs/header/p2p/exchange.go
@@ -225,6 +225,11 @@ func (ex *Exchange[H]) performRequest(
 		return make([]H, 0), nil
 	}
 
+	// TODO: Move this check to constructor()
+	if len(ex.trustedPeers) == 0 {
+		return nil, fmt.Errorf("no trusted peers")
+	}
+
 	for {
 		//nolint:gosec // G404: Use of weak random number generator
 		idx := rand.Intn(len(ex.trustedPeers))

--- a/libs/header/p2p/exchange.go
+++ b/libs/header/p2p/exchange.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -79,7 +80,7 @@ func (ex *Exchange[H]) Start(context.Context) error {
 		// and just need any peers in the peerTracker asap
 		go func(p peer.ID) {
 			err := ex.host.Connect(ex.ctx, peer.AddrInfo{ID: p})
-			if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				log.Debugw("err connecting to a bootstrap peer", "err", err, "peer", p)
 			}
 		}(p)

--- a/libs/header/p2p/exchange.go
+++ b/libs/header/p2p/exchange.go
@@ -79,7 +79,7 @@ func (ex *Exchange[H]) Start(context.Context) error {
 		// and just need any peers in the peerTracker asap
 		go func(p peer.ID) {
 			err := ex.host.Connect(ex.ctx, peer.AddrInfo{ID: p})
-			if err != nil {
+			if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 				log.Debugw("err connecting to a bootstrap peer", "err", err, "peer", p)
 			}
 		}(p)

--- a/libs/header/p2p/exchange.go
+++ b/libs/header/p2p/exchange.go
@@ -226,7 +226,7 @@ func (ex *Exchange[H]) performRequest(
 		return make([]H, 0), nil
 	}
 
-	// TODO: Move this check to constructor()
+	// TODO: Move this check to constructor(#1671)
 	if len(ex.trustedPeers) == 0 {
 		return nil, fmt.Errorf("no trusted peers")
 	}

--- a/libs/header/p2p/options.go
+++ b/libs/header/p2p/options.go
@@ -104,13 +104,14 @@ func WithRequestTimeout[T parameters](duration time.Duration) Option[T] {
 }
 
 // ClientParameters is the set of parameters that must be configured for the exchange.
+// TODO: #1667
 type ClientParameters struct {
 	// the target minimum amount of responses with the same chain head
 	MinResponses int
 	// MaxRequestSize defines the max amount of headers that can be handled at once.
-	MaxRequestSize uint64
+	MaxRequestSize uint64 // TODO: Rename to MaxRangeRequestSize
 	// MaxHeadersPerRequest defines the max amount of headers that can be requested per 1 request.
-	MaxHeadersPerRequest uint64
+	MaxHeadersPerRequest uint64 // TODO: Rename to MaxHeadersPerRangeRequest
 	// MaxAwaitingTime specifies the duration that gives to the disconnected peer to be back online,
 	// otherwise it will be removed on the next GC cycle.
 	MaxAwaitingTime time.Duration
@@ -118,7 +119,9 @@ type ClientParameters struct {
 	DefaultScore float32
 	// RequestTimeout defines a timeout after which the session will try to re-request headers
 	// from another peer.
-	RequestTimeout time.Duration
+	RequestTimeout time.Duration // TODO: Rename to RangeRequestTimeout
+	// TrustedPeersRequestTimeout a timeout for any request to a trusted peer.
+	TrustedPeersRequestTimeout time.Duration
 	// MaxTrackerSize specifies the max amount of peers that can be added to the peerTracker.
 	MaxPeerTrackerSize int
 }
@@ -132,6 +135,7 @@ func DefaultClientParameters() ClientParameters {
 		MaxAwaitingTime:      time.Hour,
 		DefaultScore:         1,
 		RequestTimeout:       time.Second * 3,
+		TrustedPeersRequestTimeout: time.Millisecond * 300,
 		MaxPeerTrackerSize:   100,
 	}
 }

--- a/libs/header/p2p/options.go
+++ b/libs/header/p2p/options.go
@@ -129,14 +129,14 @@ type ClientParameters struct {
 // DefaultClientParameters returns the default params to configure the store.
 func DefaultClientParameters() ClientParameters {
 	return ClientParameters{
-		MinResponses:         2,
-		MaxRequestSize:       512,
-		MaxHeadersPerRequest: 64,
-		MaxAwaitingTime:      time.Hour,
-		DefaultScore:         1,
-		RequestTimeout:       time.Second * 3,
+		MinResponses:               2,
+		MaxRequestSize:             512,
+		MaxHeadersPerRequest:       64,
+		MaxAwaitingTime:            time.Hour,
+		DefaultScore:               1,
+		RequestTimeout:             time.Second * 3,
 		TrustedPeersRequestTimeout: time.Millisecond * 300,
-		MaxPeerTrackerSize:   100,
+		MaxPeerTrackerSize:         100,
 	}
 }
 

--- a/libs/header/p2p/options.go
+++ b/libs/header/p2p/options.go
@@ -171,6 +171,10 @@ func (p *ClientParameters) Validate() error {
 		return fmt.Errorf("invalid request timeout for session: "+
 			"%s. %s: %v", greaterThenZero, providedSuffix, p.RequestTimeout)
 	}
+	if p.TrustedPeersRequestTimeout == 0 {
+		return fmt.Errorf("invalid TrustedPeersRequestTimeout: "+
+			"%s. %s: %v", greaterThenZero, providedSuffix, p.TrustedPeersRequestTimeout)
+	}
 	if p.MaxPeerTrackerSize <= 0 {
 		return fmt.Errorf("invalid MaxTrackerSize: %s. %s: %d", greaterThenZero, providedSuffix, p.MaxPeerTrackerSize)
 	}


### PR DESCRIPTION
Anyway, we should have a retry mechanism for requests here(but long term, it should be a better than this implementation), and also, this seems to be helping with #1623 during the first initialization of a node.