### PR TITLE
fix(core/listener): Only broadcast datahash if core node is not syncing

### DIFF
--- a/core/listener.go
+++ b/core/listener.go
@@ -109,11 +109,13 @@ func (cl *Listener) listen(ctx context.Context, sub <-chan *types.Block) {
 					"err", err)
 			}
 
-			// notify network of new EDS hash
-			err = cl.hashBroadcaster(ctx, eh.DataHash.Bytes())
-			if err != nil {
-				log.Errorw("listener: broadcasting data hash", "height", eh.Height(),
-					"hash", eh.Hash(), "err", err)
+			// notify network of new EDS hash only if core is already synced
+			if !syncing {
+				err = cl.hashBroadcaster(ctx, eh.DataHash.Bytes())
+				if err != nil {
+					log.Errorw("listener: broadcasting data hash", "height", eh.Height(),
+						"hash", eh.Hash(), "err", err)
+				}
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
Fixes a bug found in implementation of datahash broadcasting in bridge nodes -- now bridge nodes will only broadcast a hash if its connected core node is synced up.