### PR TITLE
fix: always calculate the data root even for blocks with no txs

### DIFF
--- a/header/header.go
+++ b/header/header.go
@@ -82,22 +82,15 @@ func MakeExtendedHeader(
 	vals *core.ValidatorSet,
 	bServ blockservice.BlockService,
 ) (*ExtendedHeader, error) {
-	var dah DataAvailabilityHeader
-	if len(b.Txs) > 0 {
-		shares, err := appshares.Split(b.Data, true)
-		if err != nil {
-			return nil, err
-		}
-		extended, err := share.AddShares(ctx, appshares.ToBytes(shares), bServ)
-		if err != nil {
-			return nil, err
-		}
-		dah = da.NewDataAvailabilityHeader(extended)
-	} else {
-		// use MinDataAvailabilityHeader for empty block
-		dah = EmptyDAH()
-		log.Debugw("empty block received", "height", "blockID", "time", b.Height, b.Time.String(), comm.BlockID)
+	shares, err := appshares.Split(b.Data, true)
+	if err != nil {
+		return nil, err
 	}
+	extended, err := share.AddShares(ctx, appshares.ToBytes(shares), bServ)
+	if err != nil {
+		return nil, err
+	}
+	dah := da.NewDataAvailabilityHeader(extended)
 
 	eh := &ExtendedHeader{
 		RawHeader:    b.Header,


### PR DESCRIPTION
## Overview

closes #1677 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
