### PR TITLE
fix(nodebuilder/tests): Fix flakeyness in tests with non-empty blocks by waiting til block height 1

### DIFF
--- a/core/testing_grpc.go
+++ b/core/testing_grpc.go
@@ -3,7 +3,6 @@ package core
 import (
 	"net"
 	"strings"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -104,19 +103,11 @@ func startGRPCServer(
 		return nil, err
 	}
 
-	errCh := make(chan error)
 	go func() {
 		err = grpcSrv.Serve(listener)
-		errCh <- err
-	}()
-
-	select {
-	case err := <-errCh:
 		if err != nil {
-			return nil, err
+			log.Error("serving GRPC: ", err)
 		}
-	case <-time.After(time.Second * 2):
-		// assume server started successfully
-	}
+	}()
 	return grpcSrv, nil
 }

--- a/core/testing_grpc.go
+++ b/core/testing_grpc.go
@@ -109,5 +109,6 @@ func startGRPCServer(
 			log.Error("serving GRPC: ", err)
 		}
 	}()
+
 	return grpcSrv, nil
 }

--- a/nodebuilder/tests/swamp/swamp_tx.go
+++ b/nodebuilder/tests/swamp/swamp_tx.go
@@ -9,6 +9,8 @@ import (
 // FillBlocks produces the given amount of contiguous blocks with customizable size.
 // The returned channel reports when the process is finished.
 func (s *Swamp) FillBlocks(ctx context.Context, bsize, blocks int) chan error {
+	// wait for first block to begin filling blocks
+	s.WaitTillHeight(ctx, 1)
 	errCh := make(chan error)
 	go func() {
 		// TODO: FillBlock must respect the context

--- a/nodebuilder/tests/swamp/swamp_tx.go
+++ b/nodebuilder/tests/swamp/swamp_tx.go
@@ -2,6 +2,7 @@ package swamp
 
 import (
 	"context"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 )
@@ -9,8 +10,8 @@ import (
 // FillBlocks produces the given amount of contiguous blocks with customizable size.
 // The returned channel reports when the process is finished.
 func (s *Swamp) FillBlocks(ctx context.Context, bsize, blocks int) chan error {
-	// wait for first block to begin filling blocks
-	s.WaitTillHeight(ctx, 1)
+	// TODO @renaynay: figure out why sleep is necessary to prevent flakeyness for macOS
+	time.Sleep(time.Millisecond * 50)
 	errCh := make(chan error)
 	go func() {
 		// TODO: FillBlock must respect the context

--- a/nodebuilder/tests/swamp/swamp_tx.go
+++ b/nodebuilder/tests/swamp/swamp_tx.go
@@ -11,7 +11,7 @@ import (
 // The returned channel reports when the process is finished.
 func (s *Swamp) FillBlocks(ctx context.Context, bsize, blocks int) chan error {
 	// TODO @renaynay: figure out why sleep is necessary to prevent flakeyness for macOS
-	time.Sleep(time.Millisecond * 50)
+	time.Sleep(time.Millisecond * 100)
 	errCh := make(chan error)
 	go func() {
 		// TODO: FillBlock must respect the context


### PR DESCRIPTION
This PR fixes flakeyness observed mainly on macOS when running integration tests (swamp tests) that had to use non-empty blocks.


Resolves #1669 

