### PR TITLE
fix: flake in TestNamespaceHasher_CorruptedData

### DIFF
--- a/share/availability/test/corrupt_data.go
+++ b/share/availability/test/corrupt_data.go
@@ -87,9 +87,9 @@ func (fb FraudulentBlockstore) Put(ctx context.Context, block blocks.Block) erro
 		return err
 	}
 
-	// create data that doesn't match the CID with arbitrary lengths between 0 and
+	// create data that doesn't match the CID with arbitrary lengths between 1 and
 	// len(block.RawData())*2
-	corrupted := make([]byte, mrand.Int()%(len(block.RawData())*2))
+	corrupted := make([]byte, 1+mrand.Int()%(len(block.RawData())*2-1))
 	mrand.Read(corrupted)
 	return fb.Datastore.Put(ctx, ds.NewKey("corrupt"+block.Cid().String()), corrupted)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Fixes a flake in TestNamespaceHasher_CorruptedData that occurs when we try to hash an empty byte array.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

