### PR TITLE
improvement(nodebuilder/p2p): Turn on PEX by default for bridges and fulls

### DIFF
--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -39,7 +39,7 @@ func DefaultConfig(tp node.Type) *Config {
 	commonConfig := &Config{
 		Core:    core.DefaultConfig(),
 		State:   state.DefaultConfig(),
-		P2P:     p2p.DefaultConfig(),
+		P2P:     p2p.DefaultConfig(tp),
 		RPC:     rpc.DefaultConfig(),
 		Gateway: gateway.DefaultConfig(),
 		Share:   share.DefaultConfig(),

--- a/nodebuilder/p2p/config.go
+++ b/nodebuilder/p2p/config.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
 const defaultRoutingRefreshPeriod = time.Minute
@@ -36,7 +38,7 @@ type Config struct {
 }
 
 // DefaultConfig returns default configuration for P2P subsystem.
-func DefaultConfig() Config {
+func DefaultConfig(tp node.Type) Config {
 	return Config{
 		ListenAddresses: []string{
 			"/ip4/0.0.0.0/udp/2121/quic-v1",
@@ -55,7 +57,7 @@ func DefaultConfig() Config {
 		},
 		MutualPeers:               []string{},
 		Bootstrapper:              false,
-		PeerExchange:              false,
+		PeerExchange:              tp == node.Bridge || tp == node.Full,
 		ConnManager:               defaultConnManagerConfig(),
 		RoutingTableRefreshPeriod: defaultRoutingRefreshPeriod,
 	}


### PR DESCRIPTION
Turns on peer exchange for bridges and fulls for better connectivity guarantees.