### PR TITLE
fix(share/shrex/peer_manager): peer manager needs to do soft delete on synced pool instead of hard one

### DIFF
--- a/share/p2p/peers/manager.go
+++ b/share/p2p/peers/manager.go
@@ -67,8 +67,8 @@ type syncPool struct {
 
 	// isValidatedDataHash indicates if datahash was validated by receiving corresponding extended
 	// header from headerSub
-	isSynced            atomic.Bool
 	isValidatedDataHash atomic.Bool
+	isSynced            atomic.Bool
 	createdAt           time.Time
 }
 

--- a/share/p2p/peers/manager.go
+++ b/share/p2p/peers/manager.go
@@ -281,7 +281,9 @@ func (s *Manager) GC(ctx context.Context) {
 	var blacklist []peer.ID
 	for {
 		blacklist = s.cleanUp()
-		s.blacklistPeers(blacklist...)
+		if len(blacklist) > 0 {
+			s.blacklistPeers(blacklist...)
+		}
 
 		select {
 		case <-ticker.C:
@@ -320,10 +322,10 @@ func (s *Manager) cleanUp() []peer.ID {
 }
 
 func (p *syncPool) markSynced() {
+	p.isSynced.Store(true)
 	old := (*unsafe.Pointer)(unsafe.Pointer(&p.pool))
 	// release pointer to old pool to free up memory
 	atomic.StorePointer(old, unsafe.Pointer(newPool()))
-	p.isSynced.Store(true)
 }
 
 func (p *syncPool) markValidated() {

--- a/share/p2p/peers/manager.go
+++ b/share/p2p/peers/manager.go
@@ -321,7 +321,7 @@ func (s *Manager) cleanUp() []peer.ID {
 
 func (p *syncPool) markSynced() {
 	old := (*unsafe.Pointer)(unsafe.Pointer(&p.pool))
-	// release pointer to old pool to be garbage collected
+	// release pointer to old pool to free up memory
 	atomic.StorePointer(old, unsafe.Pointer(newPool()))
 	p.isSynced.Store(true)
 }

--- a/share/p2p/peers/manager_test.go
+++ b/share/p2p/peers/manager_test.go
@@ -69,11 +69,12 @@ func TestManager(t *testing.T) {
 		require.Equal(t, peerID, pID)
 
 		// check pool validation
-		require.True(t, manager.pools[h.DataHash.String()].isValidatedDataHash.Load())
+		require.True(t, manager.getOrCreatePool(h.DataHash.String()).isValidatedDataHash.Load())
 
 		done(ResultSuccess)
-		// pool should be removed after success
-		require.Len(t, manager.pools, 0)
+		// pool should not be removed after success
+		require.Len(t, manager.pools, 1)
+		require.Len(t, manager.getOrCreatePool(h.DataHash.String()).pool.peersList, 0)
 	})
 
 	t.Run("validator", func(t *testing.T) {
@@ -224,7 +225,8 @@ func TestManager(t *testing.T) {
 		require.True(t, pool.isSynced.Load())
 
 		// add peer on synced pool should be noop
-		pool.add("peer1", "peer2")
+		result = manager.validate(ctx, "peer2", h.DataHash.Bytes())
+		require.Equal(t, pubsub.ValidationIgnore, result)
 		require.Len(t, pool.peersList, 0)
 	})
 }


### PR DESCRIPTION
## Overview

This fix resolves an issue where peers who would broadcast hashes via shrex-sub that were already retrieved by the node would get blacklisted. This happened because after retrieval of a given hash, the `syncPool` corresponding to the given hash gets deleted, so when a delayed peer would broadcast the same hash after retrieval, the manager would create a new pool that goes unvalidated since the header was already received via header-sub, causing the delayed peers in the recreated pool to get blacklisted. 

The solution is to do a soft-delete of the pool such that delayed peers are GC'd rather than blacklisted.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
