### PR TITLE
refactor(das): Don't increment totalSampled if header `isRecent`

### DIFF
--- a/das/metrics.go
+++ b/das/metrics.go
@@ -136,6 +136,7 @@ func (m *metrics) observeSample(
 	h *header.ExtendedHeader,
 	sampleTime time.Duration,
 	err error,
+	isRecentHeader bool,
 ) {
 	if m == nil {
 		return
@@ -152,7 +153,9 @@ func (m *metrics) observeSample(
 
 	atomic.StoreUint64(&m.lastSampledTS, uint64(time.Now().UTC().Unix()))
 
-	if err == nil {
+	// only increment the counter if it's not a recent header job
+	// as those happen twice.
+	if err == nil && !isRecentHeader {
 		atomic.AddUint64(&m.totalSampledInt, 1)
 	}
 }

--- a/das/worker.go
+++ b/das/worker.go
@@ -82,7 +82,8 @@ func (w *worker) run(
 			break
 		}
 		w.setResult(curr, err)
-		metrics.observeSample(ctx, h, time.Since(startSample), err)
+
+		metrics.observeSample(ctx, h, time.Since(startSample), err, w.state.isRecentHeader)
 
 		if err != nil {
 			log.Debugw(


### PR DESCRIPTION
This (not very elegantly) fixes an issue with tracking `totalSampled` inside the DASer which results in 2x the amount of sampled headers as were actually sampled. 

From @walldiss: 
```
It happens because DASer does not call Sampling directly, instead it calls SharesAvailable that ensures that block is sampled. Under the hood, SharesAvailable will check the internal cache and if it hits, it will return immediately. This logic was utilised in DASer design, to simplify independent tracking of recent headers sampling. So sampling recent headers could call SharesAvailable twice: first by recent sampling job and by catchup job later. It was done to simplify already complex DASer logic.
```

Eventually, `totalSampled` should probably be tracked inside `CacheAvailability` as that's the only place that will add an entry for a height one time only.