### PR TITLE
refactor(core): `CoreListener` broadcasts EDS hash before it broadcasts `ExtendedHeader`

### DIFF
--- a/core/listener.go
+++ b/core/listener.go
@@ -117,13 +117,6 @@ func (cl *Listener) listen(ctx context.Context, sub <-chan *types.Block) {
 				}
 			}
 
-			// broadcast new ExtendedHeader, but if core is still syncing, notify only local subscribers
-			err = cl.headerBroadcaster.Broadcast(ctx, eh, pubsub.WithLocalPublication(syncing))
-			if err != nil {
-				log.Errorw("listener: broadcasting next header", "height", eh.Height(),
-					"err", err)
-			}
-
 			// notify network of new EDS hash only if core is already synced
 			if !syncing {
 				err = cl.hashBroadcaster(ctx, eh.DataHash.Bytes())
@@ -131,6 +124,13 @@ func (cl *Listener) listen(ctx context.Context, sub <-chan *types.Block) {
 					log.Errorw("listener: broadcasting data hash", "height", eh.Height(),
 						"hash", eh.Hash(), "err", err)
 				}
+			}
+
+			// broadcast new ExtendedHeader, but if core is still syncing, notify only local subscribers
+			err = cl.headerBroadcaster.Broadcast(ctx, eh, pubsub.WithLocalPublication(syncing))
+			if err != nil {
+				log.Errorw("listener: broadcasting next header", "height", eh.Height(),
+					"err", err)
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
Increases the chances that the EDS hash will arrive before the `ExtendedHeader` so that by the time `SharesAvailable` is called on the `ExtendedHeader` by recipient peer, it is more likely to have more peers available for the given eds hash.