### PR TITLE
feat(nodebuilder/gateway): Add warn log if gateway is enabled so users know to use with caution

### DIFF
--- a/nodebuilder/gateway/module.go
+++ b/nodebuilder/gateway/module.go
@@ -21,6 +21,8 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	if !cfg.Enabled {
 		return fx.Options()
 	}
+	// NOTE @distractedm1nd @renaynay: Remove whenever/if we decide to add auth to gateway
+	log.Warn("Gateway is enabled, however gateway endpoints are not authenticated. Use with caution!")
 
 	baseComponents := fx.Options(
 		fx.Supply(cfg),


### PR DESCRIPTION
Since the gateway's endpoints are not authenticated and it is disabled by default, we should warn users to use the gateway with caution if gateway is enabled.

Closes #1752 