### PR TITLE
feat(modp2p): tune GossipSub

### DIFF
--- a/fraud/gossip_score.go
+++ b/fraud/gossip_score.go
@@ -1,6 +1,7 @@
 package fraud
 
 import (
+	"math"
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -9,7 +10,9 @@ import (
 // GossibSubScore provides a set of recommended parameters for header GossipSub topic, a.k.a
 // FraudSub. TODO(@Wondertan): We should disable mesh on publish for this topic to minimize
 // chances of censoring FPs by eclipsing nodes producing them.
-var GossibSubScore = &pubsub.TopicScoreParams{
+var GossibSubScore = pubsub.TopicScoreParams{
+	SkipAtomicValidation: true,
+
 	// expected > 1 tx/second
 	TopicWeight: 0.1, // max cap is 5, single invalid message is -100
 
@@ -25,7 +28,7 @@ var GossibSubScore = &pubsub.TopicScoreParams{
 	// no cap, if the peer is giving us *valid* FPs, just keep increasing peer's score with no limit
 	// again, this is such a rare case to happen, but if it happens, we should prefer the peer who
 	// gave it to us
-	FirstMessageDeliveriesCap: 0,
+	FirstMessageDeliveriesCap: math.MaxFloat64,
 
 	// we don't really need this, as we block list peers who give us a bad message,
 	// so disabled

--- a/libs/header/p2p/gossip_score.go
+++ b/libs/header/p2p/gossip_score.go
@@ -8,7 +8,7 @@ import (
 
 // GossibSubScore provides a set of recommended parameters for header GossipSub topic, a.k.a
 // HeaderSub.
-var GossibSubScore = &pubsub.TopicScoreParams{
+var GossibSubScore = pubsub.TopicScoreParams{
 	// expected > 1 tx/second
 	TopicWeight: 0.1, // max cap is 5, single invalid message is -100
 

--- a/nodebuilder/header/mocks/api.go
+++ b/nodebuilder/header/mocks/api.go
@@ -8,10 +8,11 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	header "github.com/celestiaorg/celestia-node/header"
 	header0 "github.com/celestiaorg/celestia-node/libs/header"
 	sync "github.com/celestiaorg/celestia-node/libs/header/sync"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockModule is a mock of Module interface.

--- a/nodebuilder/p2p/pubsub.go
+++ b/nodebuilder/p2p/pubsub.go
@@ -14,6 +14,23 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+func init() {
+	// TODO(@Wondertan): Requires deeper analysis
+	// configure larger overlay parameters
+	// the default ones are pretty conservative
+	pubsub.GossipSubD = 8
+	pubsub.GossipSubDscore = 6
+	pubsub.GossipSubDout = 3
+	pubsub.GossipSubDlo = 6
+	pubsub.GossipSubDhi = 12
+	pubsub.GossipSubDlazy = 12
+
+	pubsub.GossipSubIWantFollowupTime = 5 * time.Second
+	pubsub.GossipSubHistoryLength = 10 // cache msgs longer
+	// MutualPeers will wait for 30secs before connecting
+	pubsub.GossipSubDirectConnectInitialDelay = 30 * time.Second
+}
+
 // pubSub provides a constructor for PubSub protocol with GossipSub routing.
 func pubSub(cfg Config, params pubSubParams) (*pubsub.PubSub, error) {
 	fpeers, err := cfg.mutualPeers()

--- a/nodebuilder/p2p/pubsub.go
+++ b/nodebuilder/p2p/pubsub.go
@@ -96,11 +96,11 @@ type pubSubParams struct {
 
 func topicScoreParams(network Network) map[string]*pubsub.TopicScoreParams {
 	mp := map[string]*pubsub.TopicScoreParams{
-		headp2p.PubsubTopicID(network.String()): headp2p.GossibSubScore,
+		headp2p.PubsubTopicID(network.String()): &headp2p.GossibSubScore,
 	}
 
 	for _, pt := range fraud.Registered() {
-		mp[fraud.PubsubTopicID(string(pt), network.String())] = fraud.GossibSubScore
+		mp[fraud.PubsubTopicID(pt.String(), network.String())] = &fraud.GossibSubScore
 	}
 
 	return mp

--- a/nodebuilder/p2p/pubsub.go
+++ b/nodebuilder/p2p/pubsub.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/celestiaorg/celestia-node/fraud"
-	headp2p "github.com/celestiaorg/celestia-node/libs/header/p2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	hst "github.com/libp2p/go-libp2p/core/host"
@@ -13,6 +11,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"go.uber.org/fx"
 	"golang.org/x/crypto/blake2b"
+
+	"github.com/celestiaorg/celestia-node/fraud"
+	headp2p "github.com/celestiaorg/celestia-node/libs/header/p2p"
 )
 
 func init() {
@@ -42,6 +43,7 @@ func pubSub(cfg Config, params pubSubParams) (*pubsub.PubSub, error) {
 	isBootstrapper := cfg.Bootstrapper
 	if isBootstrapper {
 		// Turn off the mesh in bootstrappers as per:
+		//
 		// https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#recommendations-for-network-operators
 		pubsub.GossipSubD = 0
 		pubsub.GossipSubDscore = 0
@@ -88,10 +90,10 @@ func hashMsgID(m *pubsub_pb.Message) string {
 type pubSubParams struct {
 	fx.In
 
-	Ctx  context.Context
-	Host hst.Host
+	Ctx           context.Context
+	Host          hst.Host
 	Bootstrappers Bootstrappers
-	Network Network
+	Network       Network
 }
 
 func topicScoreParams(network Network) map[string]*pubsub.TopicScoreParams {
@@ -112,7 +114,8 @@ func peerScoreParams(isBootstrapper bool, bootstrappers Bootstrappers) *pubsub.P
 		bootstrapperSet[b.ID] = struct{}{}
 	}
 
-	// See https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#the-score-function
+	// See
+	// https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#the-score-function
 	return &pubsub.PeerScoreParams{
 		AppSpecificScore: func(p peer.ID) float64 {
 			// return a heavy positive score for bootstrappers so that we don't unilaterally prune
@@ -124,7 +127,7 @@ func peerScoreParams(isBootstrapper bool, bootstrappers Bootstrappers) *pubsub.P
 
 			// TODO(@Wondertan):
 			//  Plug the application specific score to the node itself in order
-			//  to provide feedback to the pubsub system based on observed behaviour
+			//  to provide feedback to the pubsub system based on observed behavior
 			return 0
 		},
 		AppSpecificWeight: 1,
@@ -150,7 +153,8 @@ func peerScoreParams(isBootstrapper bool, bootstrappers Bootstrappers) *pubsub.P
 }
 
 func peerScoreThresholds() *pubsub.PeerScoreThresholds {
-	// https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#overview-of-new-parameters
+	//
+	//https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#overview-of-new-parameters
 	return &pubsub.PeerScoreThresholds{
 		GossipThreshold:             -1000,
 		PublishThreshold:            -2000,

--- a/nodebuilder/p2p/pubsub.go
+++ b/nodebuilder/p2p/pubsub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/celestiaorg/celestia-node/fraud"
 	headp2p "github.com/celestiaorg/celestia-node/libs/header/p2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
@@ -94,9 +95,15 @@ type pubSubParams struct {
 }
 
 func topicScoreParams(network Network) map[string]*pubsub.TopicScoreParams {
-	return map[string]*pubsub.TopicScoreParams{
+	mp := map[string]*pubsub.TopicScoreParams{
 		headp2p.PubsubTopicID(network.String()): headp2p.GossibSubScore,
 	}
+
+	for _, pt := range fraud.Registered() {
+		mp[fraud.PubsubTopicID(string(pt), network.String())] = fraud.GossibSubScore
+	}
+
+	return mp
 }
 
 func peerScoreParams(isBootstrapper bool, bootstrappers Bootstrappers) *pubsub.PeerScoreParams {

--- a/share/p2p/shrexsub/pubsub.go
+++ b/share/p2p/shrexsub/pubsub.go
@@ -40,7 +40,8 @@ type PubSub struct {
 
 // NewPubSub creates a libp2p.PubSub wrapper.
 func NewPubSub(ctx context.Context, h host.Host, networkID string) (*PubSub, error) {
-	// WithSeenMessagesTTL without duration allows to process all incoming messages(even with the same msgId)
+	// WithSeenMessagesTTL without duration allows to process all incoming messages(even with the same
+	// msgId)
 	pubsub, err := pubsub.NewFloodSub(ctx, h, pubsub.WithSeenMessagesTTL(0))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #1330 

Ideally, we should test how our network performance under these new parameters before merging. However, the parameters here do not substantially diverge from parameters from Prysm and Filecoin, so it is safe to go without it.

Some refs:
* https://gist.github.com/blacktemplar/5c1862cb3f0e32a1a7fb0b25e79e6e2c
* https://github.com/ethereum-optimism/optimism/blob/develop/op-node/p2p/gossip.go
* https://github.com/prysmaticlabs/prysm/blob/develop/beacon-chain/p2p/gossip_scoring_params.go
* https://github.com/filecoin-project/lotus/blob/master/node/modules/lp2p/pubsub.go

TODO:
* Add topic params for FraudSub
	* FraudSub should have better resiliency to eclipse attacks and do flood publish. However, it's not possible to configure this for a specific topic in PubSub at this point.
* Extract topic params into separate per pkg PRs