### PR TITLE
refactor(share/getters): cleaning up error logs, wrapping cascadegetter with teegetter

### DIFF
--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -74,9 +74,12 @@ func fullGetter(
 		// if we are using share exchange, we split the timeout between the two getters
 		// once async cascadegetter is implemented, we can remove this
 		timeout /= 2
-		cascade = append(cascade, getters.NewTeeGetter(shrexGetter, store))
+		cascade = append(cascade, shrexGetter)
 	}
-	cascade = append(cascade, getters.NewTeeGetter(ipldGetter, store))
+	cascade = append(cascade, ipldGetter)
 
-	return getters.NewCascadeGetter(cascade, timeout)
+	return getters.NewTeeGetter(
+		getters.NewCascadeGetter(cascade, timeout),
+		store,
+	)
 }

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -59,7 +59,7 @@ func (fa *ShareAvailability) SharesAvailable(ctx context.Context, root *share.Ro
 
 	_, err := fa.getter.GetEDS(ctx, root)
 	if err != nil {
-		log.Errorw("availability validation failed", "root", root.Hash(), "err", err)
+		log.Errorw("availability validation failed", "root", root.Hash(), "err", err.Error())
 		if ipldFormat.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) {
 			return share.ErrNotAvailable
 		}

--- a/share/getters/shrex.go
+++ b/share/getters/shrex.go
@@ -3,6 +3,7 @@ package getters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -46,20 +47,20 @@ func (sg *ShrexGetter) Stop(ctx context.Context) error {
 }
 
 func (sg *ShrexGetter) GetShare(ctx context.Context, root *share.Root, row, col int) (share.Share, error) {
-	return nil, errors.New("shrex-getter: GetShare is not supported")
+	return nil, errors.New("getter/shrex: GetShare is not supported")
 }
 
 func (sg *ShrexGetter) GetEDS(ctx context.Context, root *share.Root) (*rsmt2d.ExtendedDataSquare, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("getter/shrex: %w", ctx.Err())
 		default:
 		}
 		peer, setStatus, err := sg.peerManager.Peer(ctx, root.Hash())
 		if err != nil {
 			log.Debugw("couldn't find peer", "datahash", root.String(), "err", err)
-			return nil, err
+			return nil, fmt.Errorf("getter/shrex: %w", err)
 		}
 
 		reqCtx, cancel := context.WithTimeout(ctx, sg.maxRequestDuration)
@@ -87,13 +88,13 @@ func (sg *ShrexGetter) GetSharesByNamespace(
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("getter/shrex: %w", ctx.Err())
 		default:
 		}
 		peer, setStatus, err := sg.peerManager.Peer(ctx, root.Hash())
 		if err != nil {
 			log.Debugw("couldn't find peer", "datahash", root.String(), "err", err)
-			return nil, err
+			return nil, fmt.Errorf("getter/shrex: %w", err)
 		}
 
 		reqCtx, cancel := context.WithTimeout(ctx, sg.maxRequestDuration)

--- a/share/getters/store.go
+++ b/share/getters/store.go
@@ -73,7 +73,7 @@ func (sg *StoreGetter) GetEDS(ctx context.Context, root *share.Root) (eds *rsmt2
 
 	eds, err = sg.store.Get(ctx, root.Hash())
 	if errors.Is(err, dagstore.ErrShardUnknown) {
-		return nil, fmt.Errorf("getter/store: eds does not yet exist")
+		return nil, fmt.Errorf("getter/store: eds not found")
 	}
 	if err != nil {
 		return nil, fmt.Errorf("getter/store: failed to retrieve eds: %w", err)

--- a/share/getters/store.go
+++ b/share/getters/store.go
@@ -2,8 +2,10 @@ package getters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/filecoin-project/dagstore"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -70,6 +72,9 @@ func (sg *StoreGetter) GetEDS(ctx context.Context, root *share.Root) (eds *rsmt2
 	}()
 
 	eds, err = sg.store.Get(ctx, root.Hash())
+	if errors.Is(err, dagstore.ErrShardUnknown) {
+		return nil, fmt.Errorf("getter/store: eds does not yet exist")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("getter/store: failed to retrieve eds: %w", err)
 	}

--- a/share/p2p/peers/manager.go
+++ b/share/p2p/peers/manager.go
@@ -224,7 +224,7 @@ func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID) DoneFunc {
 		log.Debugw("set peer status",
 			"peer", peerID,
 			"datahash", datahash.String(),
-			result, result)
+			"result", result)
 		switch result {
 		case ResultSuccess:
 		case ResultSynced:

--- a/share/p2p/shrexeds/options.go
+++ b/share/p2p/shrexeds/options.go
@@ -63,8 +63,8 @@ func (p *Parameters) Validate() error {
 	if p.BufferSize <= 0 {
 		return fmt.Errorf("invalid buffer size: %s", errSuffix)
 	}
-	if p.concurrencyLimit < 1 {
-		return fmt.Errorf("invalid concurrency limit: value should be greater than 0")
+	if p.concurrencyLimit <= 0 {
+		return fmt.Errorf("invalid concurrency limit: %s", errSuffix)
 	}
 	return nil
 }

--- a/share/p2p/shrexnd/options.go
+++ b/share/p2p/shrexnd/options.go
@@ -56,8 +56,8 @@ func (p *Parameters) Validate() error {
 	if p.serveTimeout <= 0 {
 		return fmt.Errorf("invalid serve timeout: %v, %s", p.serveTimeout, errSuffix)
 	}
-	if p.concurrencyLimit < 1 {
-		return fmt.Errorf("invalid concurrency limit: value should be greater than 0")
+	if p.concurrencyLimit <= 0 {
+		return fmt.Errorf("invalid concurrency limit: %v, %s", p.concurrencyLimit, errSuffix)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Closes #1755 
Also, cleans up error logs. Before:
```
2023-02-16T14:22:10.256+0100	ERROR	share/full	full/availability.go:62	availability validation failed	{“root”: “9bVWFLfSHJwY9Fotfkdb//8i9GcQWESAtX3cGIFNYnI=“, “err”: “getter/store: failed to retrieve eds: failed to get CAR file: failed to get accessor: failed to initialize shard acquisition: F5B55614B7D21C9C18F45A2D7E475BFFFF22F46710584480B57DDC18814D6272: shard not found; getter/tee: failed to store eds: failed to write EDS to file: share: creating eds writer: committing inner nodes to the dag: before batch commit: context deadline exceeded; getter/ipld: failed to retrieve eds: context deadline exceeded”, “errCauses”: [{“error”: “getter/store: failed to retrieve eds: failed to get CAR file: failed to get accessor: failed to initialize shard acquisition: F5B55614B7D21C9C18F45A2D7E475BFFFF22F46710584480B57DDC18814D6272: shard not found”}, {“error”: “getter/tee: failed to store eds: failed to write EDS to file: share: creating eds writer: committing inner nodes to the dag: before batch commit: context deadline exceeded”}, {“error”: “getter/ipld: failed to retrieve eds: context deadline exceeded”}]}
```

After:
```
2023-02-16T14:37:02.763+0100	ERROR	share/full	full/availability.go:62	availability validation failed	{“root”: “UEJtkWCDsi2MLAo2VdstjorpRRtq+1Dytd9Miy1AvvM=“, “err”: “getter/store: eds does not yet exist; getter/shrex: context deadline exceeded; getter/ipld: failed to retrieve eds: context deadline exceeded”}
```
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

