### PR TITLE
fix(das | share): handle `ErrByzantine` from `multierr`s when found with `context.Canceled`

### DIFF
--- a/das/daser.go
+++ b/das/daser.go
@@ -152,9 +152,6 @@ func (d *DASer) sample(ctx context.Context, h *header.ExtendedHeader) error {
 
 	err := d.da.SharesAvailable(ctx, h.DAH)
 	if err != nil {
-		if err == context.Canceled {
-			return err
-		}
 		var byzantineErr *byzantine.ErrByzantine
 		if errors.As(err, &byzantineErr) {
 			log.Warn("Propagating proof...")
@@ -162,6 +159,8 @@ func (d *DASer) sample(ctx context.Context, h *header.ExtendedHeader) error {
 			if sendErr != nil {
 				log.Errorw("fraud proof propagating failed", "err", sendErr)
 			}
+		} else if err == context.Canceled {
+			return err
 		}
 
 		log.Errorw("sampling failed", "height", h.Height(), "hash", h.Hash(),

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/availability/discovery"
+	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
 )
 
 var log = logging.Logger("share/full")
@@ -60,7 +61,8 @@ func (fa *ShareAvailability) SharesAvailable(ctx context.Context, root *share.Ro
 	_, err := fa.getter.GetEDS(ctx, root)
 	if err != nil {
 		log.Errorw("availability validation failed", "root", root.Hash(), "err", err.Error())
-		if ipldFormat.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) {
+		var byzantineErr *byzantine.ErrByzantine
+		if ipldFormat.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) && !errors.As(err, &byzantineErr) {
 			return share.ErrNotAvailable
 		}
 


### PR DESCRIPTION
Getters returning context errors to the `CascadeGetter` instance were appended to a multierr. This meant that `ErrByzantine` errors were short-circuited in the daser, returning the context error instead of the `ErrByzantine`.