### PR TITLE
fix(nodebuilder/share): Revert providing `shrex.Getter` and its associated components to light node

### DIFF
--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
+
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/availability/cache"
 	disc "github.com/celestiaorg/celestia-node/share/availability/discovery"
@@ -58,21 +59,6 @@ func ensureEmptyCARExists(ctx context.Context, store *eds.Store) error {
 		return nil
 	}
 	return err
-}
-
-func lightGetter(
-	shrexGetter *getters.ShrexGetter,
-	ipldGetter *getters.IPLDGetter,
-) share.Getter {
-	return getters.NewCascadeGetter(
-		[]share.Getter{
-			shrexGetter,
-			ipldGetter,
-		},
-		// based on the default value of das.SampleTimeout.
-		// will no longer be needed when async cascadegetter is merged
-		time.Minute,
-	)
 }
 
 func fullGetter(


### PR DESCRIPTION
This PR reverts providing shrex-getter and its associated components to light nodes as they are both unnecessary for now and are buggy, causing the following error to occur: 

light node tries to sample a recent header and fails on the first try with 
```
"PT2agmOhBwBuDZu++Vq+LGcATmrI9UZbJKEsvlHKlls=", "err": "getter/shrex: GetShare is not supported; getter/ipld: failed to retrieve share: promise channel was closed", "errCauses": [{"error": "getter/shrex: GetShare is not supported"}, {"error": "getter/ipld: failed to retrieve share: **promise channel was closed**"}]} 
```
but succeeds on a second try when the `catchUp` routine inside the DASer samples once again over that height.

For now, we will remove this feature (which will only impact the "speed" of the RPC call for requesting data by namespace) and debug it at a later date.