### PR TITLE
refactor(share): fixing subscriber too slow log in shrexsub and reducing lightavail log verbosity

### DIFF
--- a/share/availability/light/availability.go
+++ b/share/availability/light/availability.go
@@ -77,7 +77,7 @@ func (la *ShareAvailability) SharesAvailable(ctx context.Context, dah *share.Roo
 
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
-				log.Errorw("availability validation failed", "root", dah.Hash(), "err", err)
+				log.Errorw("availability validation failed", "root", dah.Hash(), "err", err.Error())
 			}
 			if ipldFormat.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) {
 				return share.ErrNotAvailable


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Fixes the following log:
```
2023-02-17T18:30:32.190+0100	INFO	pubsub	go-libp2p-pubsub@v0.8.3/pubsub.go:981	Can't deliver message to subscription for topic /eds-sub/v0.0.1/arabica-6; subscriber too slow
```

Also snuck in removing multierr's `errCauses` field from light availability logs (like we do in full availability), as it leads to duplicate information inside when cascadegetter fails.
