### PR TITLE
fix(nodebuilder/share): Only provide necessary components to Bridge

### DIFF
--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"time"
 
-	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/filecoin-project/dagstore"
 	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/routing"
 	routingdisc "github.com/libp2p/go-libp2p/p2p/discovery/routing"
 	"go.uber.org/fx"
+
+	"github.com/celestiaorg/celestia-node/libs/fxutil"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
 

--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/filecoin-project/dagstore"
 	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -39,15 +40,11 @@ func discovery(cfg Config) func(routing.ContentRouting, host.Host) *disc.Discove
 // ensurePeersLifecycle controls the lifecycle for discovering full nodes.
 // This constructor is in place of the peer manager which generally controls the
 // EnsurePeers lifecycle.
-func ensurePeersLifecycle(lc fx.Lifecycle, discovery *disc.Discovery) error {
-	ctx, cancel := context.WithCancel(context.Background())
+func ensurePeersLifecycle(ctx context.Context, lc fx.Lifecycle, discovery *disc.Discovery) error {
+	ctx = fxutil.WithLifecycle(ctx, lc)
 	lc.Append(fx.Hook{
 		OnStart: func(context.Context) error {
 			go discovery.EnsurePeers(ctx)
-			return nil
-		},
-		OnStop: func(context.Context) error {
-			cancel()
 			return nil
 		},
 	})

--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -12,8 +12,6 @@ import (
 	routingdisc "github.com/libp2p/go-libp2p/p2p/discovery/routing"
 	"go.uber.org/fx"
 
-	"github.com/celestiaorg/celestia-node/libs/fxutil"
-
 	"github.com/celestiaorg/celestia-app/pkg/da"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -36,20 +34,6 @@ func discovery(cfg Config) func(routing.ContentRouting, host.Host) *disc.Discove
 			cfg.AdvertiseInterval,
 		)
 	}
-}
-
-// ensurePeersLifecycle controls the lifecycle for discovering full nodes.
-// This constructor is in place of the peer manager which generally controls the
-// EnsurePeers lifecycle.
-func ensurePeersLifecycle(ctx context.Context, lc fx.Lifecycle, discovery *disc.Discovery) error {
-	ctx = fxutil.WithLifecycle(ctx, lc)
-	lc.Append(fx.Hook{
-		OnStart: func(context.Context) error {
-			go discovery.EnsurePeers(ctx)
-			return nil
-		},
-	})
-	return nil
 }
 
 // cacheAvailability wraps either Full or Light availability with a cache for result sampling.

--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -17,6 +17,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/availability/cache"
 	disc "github.com/celestiaorg/celestia-node/share/availability/discovery"
+	"github.com/celestiaorg/celestia-node/share/availability/light"
 	"github.com/celestiaorg/celestia-node/share/eds"
 	"github.com/celestiaorg/celestia-node/share/getters"
 )
@@ -36,8 +37,8 @@ func discovery(cfg Config) func(routing.ContentRouting, host.Host) *disc.Discove
 	}
 }
 
-// cacheAvailability wraps either Full or Light availability with a cache for result sampling.
-func cacheAvailability[A share.Availability](lc fx.Lifecycle, ds datastore.Batching, avail A) share.Availability {
+// cacheAvailability wraps light availability with a cache for result sampling.
+func cacheAvailability(lc fx.Lifecycle, ds datastore.Batching, avail *light.ShareAvailability) share.Availability {
 	ca := cache.NewShareAvailability(avail, ds)
 	lc.Append(fx.Hook{
 		OnStop: ca.Close,

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -131,7 +131,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			// cacheAvailability's lifecycle continues to use a fx hook,
 			// since the LC requires a cacheAvailability but the constructor returns a share.Availability
 			fx.Provide(cacheAvailability[*light.ShareAvailability]),
-			fx.Invoke(ensurePeersLifecycle), // TODO doc why we need this in light
+			fx.Invoke(ensurePeersLifecycle),
 		)
 	case node.Bridge:
 		return fx.Module(
@@ -141,7 +141,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			fx.Provide(func(ipldGetter *getters.IPLDGetter) share.Getter {
 				return ipldGetter
 			}),
-			fx.Invoke(ensurePeersLifecycle), // TODO doc why we need this in bridge
+			fx.Invoke(ensurePeersLifecycle),
 		)
 	case node.Full:
 		return fx.Module(

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -96,9 +96,9 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 				return avail.Stop(ctx)
 			}),
 		)),
-		// cacheAvailability's lifecycle continues to use a fx hook,
-		// since the LC requires a cacheAvailability but the constructor returns a share.Availability
-		fx.Provide(cacheAvailability[*full.ShareAvailability]),
+		fx.Provide(func(avail *full.ShareAvailability) share.Availability {
+			return avail
+		}),
 		fx.Provide(func(shrexSub *shrexsub.PubSub) shrexsub.BroadcastFn {
 			return shrexSub.Broadcast
 		}),
@@ -129,7 +129,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			fx.Provide(fx.Annotate(light.NewShareAvailability)),
 			// cacheAvailability's lifecycle continues to use a fx hook,
 			// since the LC requires a cacheAvailability but the constructor returns a share.Availability
-			fx.Provide(cacheAvailability[*light.ShareAvailability]),
+			fx.Provide(cacheAvailability),
 		)
 	case node.Bridge:
 		return fx.Module(

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -43,7 +43,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 	)
 
 	bridgeAndFullComponents := fx.Options(
-		fx.Invoke(func(edsSrv *shrexeds.Server, ndSrc *shrexnd.Server) {}), // TODO: why do we need this ?
+		fx.Invoke(func(edsSrv *shrexeds.Server, ndSrc *shrexnd.Server) {}),
 		fx.Provide(fx.Annotate(
 			func(host host.Host, store *eds.Store, network modp2p.Network) (*shrexeds.Server, error) {
 				return shrexeds.NewServer(host, store, shrexeds.WithProtocolSuffix(network.String()))

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -131,6 +131,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			// cacheAvailability's lifecycle continues to use a fx hook,
 			// since the LC requires a cacheAvailability but the constructor returns a share.Availability
 			fx.Provide(cacheAvailability[*light.ShareAvailability]),
+			fx.Invoke(ensurePeersLifecycle), // TODO doc why we need this in light
 		)
 	case node.Bridge:
 		return fx.Module(
@@ -140,6 +141,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			fx.Provide(func(ipldGetter *getters.IPLDGetter) share.Getter {
 				return ipldGetter
 			}),
+			fx.Invoke(ensurePeersLifecycle), // TODO doc why we need this in bridge
 		)
 	case node.Full:
 		return fx.Module(

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -62,7 +62,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 				getter share.Getter,
 				network modp2p.Network,
 			) (*shrexnd.Server, error) {
-				return shrexnd.NewServer(host, store, getter, shrexnd.WithProtocolSuffix(string(network)))
+				return shrexnd.NewServer(host, store, getter, shrexnd.WithProtocolSuffix(network.String()))
 			},
 			fx.OnStart(func(ctx context.Context, server *shrexnd.Server) error {
 				return server.Start(ctx)
@@ -107,7 +107,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 				return shrexsub.NewPubSub(
 					ctx,
 					h,
-					string(network),
+					network.String(),
 				)
 			},
 		),

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -142,6 +142,13 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 				return ipldGetter
 			}),
 			fx.Invoke(ensurePeersLifecycle),
+			fx.Invoke(func(lc fx.Lifecycle, sub *shrexsub.PubSub) error {
+				lc.Append(fx.Hook{
+					OnStart: sub.Start,
+					OnStop:  sub.Stop,
+				})
+				return nil
+			}),
 		)
 	case node.Full:
 		return fx.Module(

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -59,7 +59,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			func(
 				host host.Host,
 				store *eds.Store,
-				getter *getters.IPLDGetter,
+				getter share.Getter,
 				network modp2p.Network,
 			) (*shrexnd.Server, error) {
 				return shrexnd.NewServer(host, store, getter, shrexnd.WithProtocolSuffix(string(network)))
@@ -111,7 +111,6 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 				)
 			},
 		),
-		fx.Provide(getters.NewIPLDGetter),
 	)
 
 	switch tp {
@@ -137,8 +136,8 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			"share",
 			baseComponents,
 			bridgeAndFullComponents,
-			fx.Provide(func(ipldGetter *getters.IPLDGetter) share.Getter {
-				return ipldGetter
+			fx.Provide(func(store *eds.Store) share.Getter {
+				return getters.NewStoreGetter(store)
 			}),
 			fx.Invoke(func(lc fx.Lifecycle, sub *shrexsub.PubSub) error {
 				lc.Append(fx.Hook{
@@ -174,6 +173,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 				}),
 			)),
 			fx.Provide(peers.NewManager),
+			fx.Provide(getters.NewIPLDGetter),
 		)
 	default:
 		panic("invalid node type")

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -131,7 +131,6 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			// cacheAvailability's lifecycle continues to use a fx hook,
 			// since the LC requires a cacheAvailability but the constructor returns a share.Availability
 			fx.Provide(cacheAvailability[*light.ShareAvailability]),
-			fx.Invoke(ensurePeersLifecycle),
 		)
 	case node.Bridge:
 		return fx.Module(
@@ -141,7 +140,6 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			fx.Provide(func(ipldGetter *getters.IPLDGetter) share.Getter {
 				return ipldGetter
 			}),
-			fx.Invoke(ensurePeersLifecycle),
 			fx.Invoke(func(lc fx.Lifecycle, sub *shrexsub.PubSub) error {
 				lc.Append(fx.Hook{
 					OnStart: sub.Start,


### PR DESCRIPTION
Bridge does not need: 
* shrexeds.Client
* shrexnd.Client
* *shrex.Getter
* peer.Manager

Bridge and Lights will also spawn EnsurePeers lifecycle from nodebuilder instead (as they don't use peer.Manager yet)