### PR TITLE
refactor(share/p2p): Discovery controls `ensurePeers` lifecycle

### DIFF
--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -11,6 +11,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/share"
+	disc "github.com/celestiaorg/celestia-node/share/availability/discovery"
 	"github.com/celestiaorg/celestia-node/share/availability/full"
 	"github.com/celestiaorg/celestia-node/share/availability/light"
 	"github.com/celestiaorg/celestia-node/share/eds"
@@ -29,7 +30,15 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 		fx.Supply(*cfg),
 		fx.Error(cfgErr),
 		fx.Options(options...),
-		fx.Provide(discovery(*cfg)),
+		fx.Provide(fx.Annotate(
+			discovery(*cfg),
+			fx.OnStart(func(ctx context.Context, d *disc.Discovery) error {
+				return d.Start(ctx)
+			}),
+			fx.OnStop(func(ctx context.Context, d *disc.Discovery) error {
+				return d.Stop(ctx)
+			}),
+		)),
 		fx.Provide(newModule),
 	)
 

--- a/share/availability/discovery/discovery.go
+++ b/share/availability/discovery/discovery.go
@@ -76,7 +76,7 @@ func (d *Discovery) Start(context.Context) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	d.cancel = cancel
 
-	go d.EnsurePeers(ctx)
+	go d.ensurePeers(ctx)
 	return nil
 }
 
@@ -119,10 +119,10 @@ func (d *Discovery) handlePeerFound(ctx context.Context, topic string, peer peer
 	d.host.ConnManager().TagPeer(peer.ID, topic, peerWeight)
 }
 
-// EnsurePeers ensures we always have 'peerLimit' connected peers.
+// ensurePeers ensures we always have 'peerLimit' connected peers.
 // It starts peer discovery every 30 seconds until peer cache reaches peersLimit.
 // Discovery is restarted if any previously connected peers disconnect.
-func (d *Discovery) EnsurePeers(ctx context.Context) {
+func (d *Discovery) ensurePeers(ctx context.Context) {
 	if d.peersLimit == 0 {
 		log.Warn("peers limit is set to 0. Skipping discovery...")
 		return

--- a/share/p2p/peers/manager.go
+++ b/share/p2p/peers/manager.go
@@ -45,7 +45,6 @@ type Manager struct {
 	// header subscription is necessary in order to validate the inbound eds hash
 	headerSub libhead.Subscriber[*header.ExtendedHeader]
 	shrexSub  *shrexsub.PubSub
-	disc      *discovery.Discovery
 	host      host.Host
 	connGater *conngater.BasicConnectionGater
 
@@ -93,7 +92,6 @@ func NewManager(
 	s := &Manager{
 		headerSub:             headerSub,
 		shrexSub:              shrexSub,
-		disc:                  discovery,
 		connGater:             connGater,
 		host:                  host,
 		pools:                 make(map[string]*syncPool),
@@ -148,7 +146,6 @@ func (m *Manager) Start(startCtx context.Context) error {
 		return fmt.Errorf("subscribing to headersub: %w", err)
 	}
 
-	go m.disc.EnsurePeers(ctx)
 	go m.subscribeHeader(ctx, headerSub)
 	go m.GC(ctx)
 

--- a/share/p2p/peers/manager_test.go
+++ b/share/p2p/peers/manager_test.go
@@ -315,7 +315,14 @@ func TestIntegration(t *testing.T) {
 			routingdisc.NewRoutingDiscovery(router2),
 			10,
 			time.Second,
-			time.Second)
+			time.Second,
+		)
+		err = fnDisc.Start(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err = fnDisc.Stop(ctx)
+			require.NoError(t, err)
+		})
 
 		// hook peer manager to discovery
 		connGater, err := conngater.NewBasicConnectionGater(sync.MutexWrap(datastore.NewMapDatastore()))
@@ -340,7 +347,6 @@ func TestIntegration(t *testing.T) {
 		require.NoError(t, router1.Bootstrap(ctx))
 		require.NoError(t, router2.Bootstrap(ctx))
 
-		go fnDisc.EnsurePeers(ctx)
 		go bnDisc.Advertise(ctx)
 
 		select {


### PR DESCRIPTION
Extracts `ensurePeers` lifecycle management from `peer.Manager`, and privatizes `ensurePeers`.

As All the node types call it, so we can do it by default.