### PR TITLE
feat(das): Don't sample recent jobs twice

### DIFF
--- a/das/checkpoint.go
+++ b/das/checkpoint.go
@@ -48,12 +48,3 @@ func (c checkpoint) String() string {
 
 	return str
 }
-
-// totalSampled returns the total amount of sampled headers
-func (c checkpoint) totalSampled() uint64 {
-	var totalInProgress uint64
-	for _, w := range c.Workers {
-		totalInProgress += (w.To - w.From) + 1
-	}
-	return c.SampleFrom - totalInProgress - uint64(len(c.Failed))
-}

--- a/das/coordinator.go
+++ b/das/coordinator.go
@@ -63,9 +63,6 @@ func newSamplingCoordinator(
 func (sc *samplingCoordinator) run(ctx context.Context, cp checkpoint) {
 	sc.state.resumeFromCheckpoint(cp)
 
-	// the amount of sampled headers from the last checkpoint
-	sc.metrics.recordTotalSampled(cp.totalSampled())
-
 	// resume workers
 	for _, wk := range cp.Workers {
 		sc.runWorker(ctx, sc.state.newJob(wk.From, wk.To))

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -204,11 +204,8 @@ func TestDASerSampleTimeout(t *testing.T) {
 	f := new(fraud.DummyService)
 
 	// create and start DASer
-	daser, err := NewDASer(avail, sub, getter, ds, f, newBroadcastMock(1))
+	daser, err := NewDASer(avail, sub, getter, ds, f, newBroadcastMock(1), WithSampleTimeout(1))
 	require.NoError(t, err)
-
-	// assign directly to avoid params validation
-	daser.params.SampleTimeout = 0
 
 	require.NoError(t, daser.Start(ctx))
 	require.NoError(t, daser.sampler.state.waitCatchUp(ctx))

--- a/das/state.go
+++ b/das/state.go
@@ -94,13 +94,18 @@ func (s *coordinatorState) updateHead(newHead int64) {
 }
 
 func (s *coordinatorState) newRecentJob(header *header.ExtendedHeader) job {
+	height := uint64(header.Height())
+	// move next, to prevent catchup job from processing same height
+	if s.next == height {
+		s.next++
+	}
 	s.nextJobID++
 	return job{
 		id:             s.nextJobID,
 		isRecentHeader: true,
 		header:         header,
-		From:           uint64(header.Height()),
-		To:             uint64(header.Height()),
+		From:           height,
+		To:             height,
 	}
 }
 

--- a/das/stats.go
+++ b/das/stats.go
@@ -1,21 +1,19 @@
 package das
 
-// SamplingStats collects information about the DASer process. Currently, there are
-// only two sampling routines: the main sampling routine which performs sampling
-// over current network headers, and the `catchUp` routine which performs sampling
-// over past headers from the last sampled checkpoint.
+// SamplingStats collects information about the DASer process.
 type SamplingStats struct {
 	// all headers before SampledChainHead were successfully sampled
 	SampledChainHead uint64 `json:"head_of_sampled_chain"`
-	// all headers before CatchupHead were submitted to sampling workers
+	// all headers before CatchupHead were submitted to sampling workers. They could be either already
+	// sampled, failed or still in progress. For in progress items check Workers stat.
 	CatchupHead uint64 `json:"head_of_catchup"`
 	// NetworkHead is the height of the most recent header in the network
 	NetworkHead uint64 `json:"network_head_height"`
-	// Failed contains all skipped header's heights with corresponding try count
+	// Failed contains all skipped headers heights with corresponding try count
 	Failed map[uint64]int `json:"failed,omitempty"`
 	// Workers has information about each currently running worker stats
 	Workers []WorkerStats `json:"workers,omitempty"`
-	// Concurrency currently running parallel workers
+	// Concurrency amount of currently running parallel workers
 	Concurrency int `json:"concurrency"`
 	// CatchUpDone indicates whether all known headers are sampled
 	CatchUpDone bool `json:"catch_up_done"`
@@ -29,4 +27,13 @@ type WorkerStats struct {
 	To   uint64 `json:"to"`
 
 	ErrMsg string `json:"error,omitempty"`
+}
+
+// totalSampled returns the total amount of sampled headers
+func (s SamplingStats) totalSampled() uint64 {
+	var inProgress uint64
+	for _, w := range s.Workers {
+		inProgress += w.To - w.Curr + 1
+	}
+	return s.CatchupHead - inProgress - uint64(len(s.Failed))
 }

--- a/das/worker.go
+++ b/das/worker.go
@@ -81,7 +81,7 @@ func (w *worker) run(ctx context.Context, timeout time.Duration, resultCh chan<-
 	}
 
 	log.Infow(
-		"finished sampling job",
+		"finished sampling headers",
 		"from", w.state.From,
 		"to", w.state.Curr,
 		"errors", len(w.state.failed),

--- a/das/worker.go
+++ b/das/worker.go
@@ -80,16 +80,13 @@ func (w *worker) run(ctx context.Context, timeout time.Duration, resultCh chan<-
 		}
 	}
 
-	if w.state.Curr > w.state.From {
-		jobTime := time.Since(jobStart)
-		log.Infow(
-			"sampled headers",
-			"from", w.state.From,
-			"to", w.state.Curr,
-			"finished (s)",
-			jobTime.Seconds(),
-		)
-	}
+	log.Infow(
+		"finished sampling job",
+		"from", w.state.From,
+		"to", w.state.Curr,
+		"errors", len(w.state.failed),
+		"finished (s)", time.Since(jobStart),
+	)
 
 	select {
 	case resultCh <- result{


### PR DESCRIPTION
## Overview

 - Prevent DASer from doing same job twice in case of recent sampling is run on synced node.
 - Log recent jobs with info level
