### PR TITLE
perf(share/full): avoid loading EDS for subsequent availability checks

### DIFF
--- a/nodebuilder/p2p/pubsub.go
+++ b/nodebuilder/p2p/pubsub.go
@@ -44,7 +44,8 @@ func pubSub(cfg Config, params pubSubParams) (*pubsub.PubSub, error) {
 	if isBootstrapper {
 		// Turn off the mesh in bootstrappers as per:
 		//
-		// https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#recommendations-for-network-operators
+		//
+		//https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#recommendations-for-network-operators
 		pubsub.GossipSubD = 0
 		pubsub.GossipSubDscore = 0
 		pubsub.GossipSubDlo = 0

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 
-	"github.com/celestiaorg/celestia-node/share/eds"
 	ipldFormat "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/celestiaorg/celestia-node/share/eds"
 
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/availability/discovery"
@@ -19,7 +20,7 @@ var log = logging.Logger("share/full")
 // recovery technique. It is considered "full" because it is required
 // to download enough shares to fully reconstruct the data square.
 type ShareAvailability struct {
-	store *eds.Store
+	store  *eds.Store
 	getter share.Getter
 	disc   *discovery.Discovery
 
@@ -29,7 +30,7 @@ type ShareAvailability struct {
 // NewShareAvailability creates a new full ShareAvailability.
 func NewShareAvailability(store *eds.Store, getter share.Getter, disc *discovery.Discovery) *ShareAvailability {
 	return &ShareAvailability{
-		store: store,
+		store:  store,
 		getter: getter,
 		disc:   disc,
 	}

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/celestiaorg/celestia-node/share/eds"
 	ipldFormat "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
 
@@ -18,6 +19,7 @@ var log = logging.Logger("share/full")
 // recovery technique. It is considered "full" because it is required
 // to download enough shares to fully reconstruct the data square.
 type ShareAvailability struct {
+	store *eds.Store
 	getter share.Getter
 	disc   *discovery.Discovery
 
@@ -25,8 +27,9 @@ type ShareAvailability struct {
 }
 
 // NewShareAvailability creates a new full ShareAvailability.
-func NewShareAvailability(getter share.Getter, disc *discovery.Discovery) *ShareAvailability {
+func NewShareAvailability(store *eds.Store, getter share.Getter, disc *discovery.Discovery) *ShareAvailability {
 	return &ShareAvailability{
+		store: store,
 		getter: getter,
 		disc:   disc,
 	}
@@ -54,6 +57,13 @@ func (fa *ShareAvailability) SharesAvailable(ctx context.Context, root *share.Ro
 		log.Errorw("Availability validation cannot be performed on a malformed DataAvailabilityHeader",
 			"err", err)
 		panic(err)
+	}
+
+	// a hack to avoid loading the whole EDS in mem if we store it already.
+	if fa.store != nil {
+		if ok, _ := fa.store.Has(ctx, root.Hash()); ok {
+			return nil
+		}
 	}
 
 	_, err := fa.getter.GetEDS(ctx, root)

--- a/share/availability/full/testing.go
+++ b/share/availability/full/testing.go
@@ -38,5 +38,5 @@ func Node(dn *availability_test.TestDagNet) *availability_test.TestNode {
 
 func TestAvailability(getter share.Getter) *ShareAvailability {
 	disc := discovery.NewDiscovery(nil, routing.NewRoutingDiscovery(routinghelpers.Null{}), 0, time.Second, time.Second)
-	return NewShareAvailability(getter, disc)
+	return NewShareAvailability(nil, getter, disc)
 }


### PR DESCRIPTION
Self-explanatory 