### PR TITLE
test(share/getters): Fix cascade test

### DIFF
--- a/share/getters/cascade.go
+++ b/share/getters/cascade.go
@@ -8,10 +8,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 
-	"github.com/celestiaorg/celestia-node/libs/utils"
-	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/libs/utils"
+	"github.com/celestiaorg/celestia-node/share"
 )
 
 var _ share.Getter = (*CascadeGetter)(nil)

--- a/share/getters/cascade_test.go
+++ b/share/getters/cascade_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
 
+	"github.com/celestiaorg/rsmt2d"
+
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/mocks"
-	"github.com/celestiaorg/rsmt2d"
 )
 
 func TestCascadeGetter(t *testing.T) {
@@ -53,8 +54,7 @@ func TestCascade(t *testing.T) {
 	successGetter := mocks.NewMockGetter(ctrl)
 	timeoutGetter.EXPECT().GetEDS(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, _ *share.Root) (*rsmt2d.ExtendedDataSquare, error) {
-			<-ctx.Done()
-			return nil, ctx.Err()
+			return nil, context.DeadlineExceeded
 		}).AnyTimes()
 	immediateFailGetter.EXPECT().GetEDS(gomock.Any(), gomock.Any()).
 		Return(nil, errors.New("second getter fails immediately")).AnyTimes()


### PR DESCRIPTION
Test was hanging before on waiting for context to time out, now `timedoutGetter` returns immediately with context.DeadlineExceeded