### PR TITLE
fix(libs/header/syncer): fix bounds during syncing

### DIFF
--- a/libs/header/sync/sync.go
+++ b/libs/header/sync/sync.go
@@ -282,7 +282,7 @@ func (s *Syncer[H]) findHeaders(ctx context.Context, from, to uint64) ([]H, erro
 		// if we have some range cached - use it
 		r, ok := s.pending.FirstRangeWithin(from, to)
 		if !ok {
-			hs, err := s.exchange.GetRangeByHeight(ctx, from, to-from+1)
+			hs, err := s.exchange.GetRangeByHeight(ctx, from, to-from)
 			return append(out, hs...), err
 		}
 

--- a/libs/header/sync/sync.go
+++ b/libs/header/sync/sync.go
@@ -274,7 +274,8 @@ func (s *Syncer[H]) processHeaders(ctx context.Context, from, to uint64) (int, e
 func (s *Syncer[H]) findHeaders(ctx context.Context, from, to uint64) ([]H, error) {
 	amount := to - from + 1 // + 1 to include 'to' height as well
 	if amount > s.Params.MaxRequestSize {
-		to, amount = from+s.Params.MaxRequestSize, s.Params.MaxRequestSize
+		to = from + s.Params.MaxRequestSize - 1 // `from` is already included in range
+		amount = s.Params.MaxRequestSize
 	}
 
 	out := make([]H, 0, amount)
@@ -282,7 +283,7 @@ func (s *Syncer[H]) findHeaders(ctx context.Context, from, to uint64) ([]H, erro
 		// if we have some range cached - use it
 		r, ok := s.pending.FirstRangeWithin(from, to)
 		if !ok {
-			hs, err := s.exchange.GetRangeByHeight(ctx, from, to-from)
+			hs, err := s.exchange.GetRangeByHeight(ctx, from, to-from+1)
 			return append(out, hs...), err
 		}
 

--- a/libs/header/sync/sync_test.go
+++ b/libs/header/sync/sync_test.go
@@ -61,6 +61,40 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	assert.True(t, state.Finished(), state)
 }
 
+func TestDoSyncFullRangeFromExternalPeer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := test.NewTestSuite(t)
+	head := suite.Head()
+
+	remoteStore := store.NewTestStore(ctx, t, head)
+	localStore := store.NewTestStore(ctx, t, head)
+	syncer, err := NewSyncer[*test.DummyHeader](
+		local.NewExchange(remoteStore),
+		localStore,
+		&test.DummySubscriber{},
+		WithMaxRequestSize(10),
+	)
+	require.NoError(t, err)
+	require.NoError(t, syncer.Start(ctx))
+	_, err = remoteStore.Append(ctx, suite.GenDummyHeaders(10)...)
+	require.NoError(t, err)
+	// give store time to update heightSub index
+	time.Sleep(time.Millisecond * 100)
+	localHead, err := localStore.Head(ctx)
+	require.NoError(t, err)
+	remoteHead, err := remoteStore.Head(ctx)
+	require.NoError(t, err)
+	err = syncer.doSync(ctx, localHead, remoteHead)
+	require.NoError(t, err)
+	// give store time to update heightSub index
+	time.Sleep(time.Millisecond * 100)
+	newHead, err := localStore.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, newHead.Height(), remoteHead.Height())
+}
+
 func TestSyncCatchUp(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)

--- a/libs/header/sync/sync_test.go
+++ b/libs/header/sync/sync_test.go
@@ -78,18 +78,23 @@ func TestDoSyncFullRangeFromExternalPeer(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, syncer.Start(ctx))
+
 	_, err = remoteStore.Append(ctx, suite.GenDummyHeaders(10)...)
 	require.NoError(t, err)
 	// give store time to update heightSub index
 	time.Sleep(time.Millisecond * 100)
+
 	localHead, err := localStore.Head(ctx)
 	require.NoError(t, err)
+
 	remoteHead, err := remoteStore.Head(ctx)
 	require.NoError(t, err)
+
 	err = syncer.doSync(ctx, localHead, remoteHead)
 	require.NoError(t, err)
 	// give store time to update heightSub index
 	time.Sleep(time.Millisecond * 100)
+
 	newHead, err := localStore.Head(ctx)
 	require.NoError(t, err)
 	require.Equal(t, newHead.Height(), remoteHead.Height())


### PR DESCRIPTION
## Overview
Made a mistake and calculated `to.Height` incorrectly
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
