### PR TITLE
fix(share/ipld): use parent context for ipld session instead of request context

### DIFF
--- a/share/availability/full/reconstruction_test.go
+++ b/share/availability/full/reconstruction_test.go
@@ -4,7 +4,6 @@ package full
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -214,12 +213,9 @@ func TestShareAvailable_DisconnectedFullNodes(t *testing.T) {
 	lights1, lights2 := make(
 		[]*availability_test.TestNode, lightNodes/2),
 		make([]*availability_test.TestNode, lightNodes/2)
-	var wg sync.WaitGroup
-	wg.Add(lightNodes)
 	for i := 0; i < len(lights1); i++ {
 		lights1[i] = light.Node(net)
 		go func(i int) {
-			defer wg.Done()
 			err := lights1[i].SharesAvailable(ctx, root)
 			if err != nil {
 				t.Log("light1 errors:", err)
@@ -228,7 +224,6 @@ func TestShareAvailable_DisconnectedFullNodes(t *testing.T) {
 
 		lights2[i] = light.Node(net)
 		go func(i int) {
-			defer wg.Done()
 			err := lights2[i].SharesAvailable(ctx, root)
 			if err != nil {
 				t.Log("light2 errors:", err)
@@ -265,5 +260,4 @@ func TestShareAvailable_DisconnectedFullNodes(t *testing.T) {
 	require.NoError(t, err, share.ErrNotAvailable)
 	err = full2.SharesAvailable(ctx, root)
 	require.NoError(t, err, share.ErrNotAvailable)
-	wg.Wait()
 }

--- a/share/availability/full/reconstruction_test.go
+++ b/share/availability/full/reconstruction_test.go
@@ -4,6 +4,7 @@ package full
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -213,9 +214,12 @@ func TestShareAvailable_DisconnectedFullNodes(t *testing.T) {
 	lights1, lights2 := make(
 		[]*availability_test.TestNode, lightNodes/2),
 		make([]*availability_test.TestNode, lightNodes/2)
+	var wg sync.WaitGroup
+	wg.Add(lightNodes)
 	for i := 0; i < len(lights1); i++ {
 		lights1[i] = light.Node(net)
 		go func(i int) {
+			defer wg.Done()
 			err := lights1[i].SharesAvailable(ctx, root)
 			if err != nil {
 				t.Log("light1 errors:", err)
@@ -224,6 +228,7 @@ func TestShareAvailable_DisconnectedFullNodes(t *testing.T) {
 
 		lights2[i] = light.Node(net)
 		go func(i int) {
+			defer wg.Done()
 			err := lights2[i].SharesAvailable(ctx, root)
 			if err != nil {
 				t.Log("light2 errors:", err)
@@ -260,4 +265,5 @@ func TestShareAvailable_DisconnectedFullNodes(t *testing.T) {
 	require.NoError(t, err, share.ErrNotAvailable)
 	err = full2.SharesAvailable(ctx, root)
 	require.NoError(t, err, share.ErrNotAvailable)
+	wg.Wait()
 }

--- a/share/getters/ipld.go
+++ b/share/getters/ipld.go
@@ -109,6 +109,7 @@ var sessionKey = &session{}
 // session is a struct that can optionally be passed by context to the share.Getter methods using
 // WithSession to indicate that a blockservice session should be created.
 type session struct {
+	ctx context.Context
 	sync.Mutex
 	atomic.Pointer[blockservice.Session]
 }
@@ -116,7 +117,7 @@ type session struct {
 // WithSession stores an empty session in the context, indicating that a blockservice session should
 // be created.
 func WithSession(ctx context.Context) context.Context {
-	return context.WithValue(ctx, sessionKey, &session{})
+	return context.WithValue(ctx, sessionKey, &session{ctx: ctx})
 }
 
 func getGetter(ctx context.Context, service blockservice.BlockService) blockservice.BlockGetter {
@@ -134,7 +135,7 @@ func getGetter(ctx context.Context, service blockservice.BlockService) blockserv
 	defer s.Unlock()
 	val = s.Load()
 	if val == nil {
-		val = blockservice.NewSession(ctx, service)
+		val = blockservice.NewSession(s.ctx, service)
 		s.Store(val)
 	}
 	return val

--- a/share/getters/ipld.go
+++ b/share/getters/ipld.go
@@ -109,9 +109,9 @@ var sessionKey = &session{}
 // session is a struct that can optionally be passed by context to the share.Getter methods using
 // WithSession to indicate that a blockservice session should be created.
 type session struct {
-	ctx context.Context
 	sync.Mutex
 	atomic.Pointer[blockservice.Session]
+	ctx context.Context
 }
 
 // WithSession stores an empty session in the context, indicating that a blockservice session should


### PR DESCRIPTION
## Overview
Introduction of cascade getter created a case where ctx is created just before call to `ipld.GetShare` and this local context is canceled right after the call. 

It turns out ipld.Session is created with ctx from first call that created it, instead of parent context from Availability. Session context should common parent context from ShareAvailable call, instead of local single request call.
