### PR TITLE
Extend label automation to add external label

### DIFF
--- a/.github/workflows/issue-label-automation.yml
+++ b/.github/workflows/issue-label-automation.yml
@@ -8,9 +8,24 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Check for External Contributor
+        uses: tspascoal/get-user-teams-membership@v2
+        id: teamCheck
+        with:
+          username: ${{ github.actor }}
+          team: "celestia-node"
+          GITHUB_TOKEN: ${{ secrets.PAT_TEAM_CHECK }}
+
       - name: Triage labeling
         uses: andymckay/labeler@master
         with:
           add-labels: "needs:triage"
           ignore-if-labeled: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: External labeling
+        if: ${{ steps.teamCheck.outputs.isTeamMember == 'false' }}
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "external"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Overview

Rene was interested in external issue labels, was easier to just do it then explain it in slack :-) 

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
