### PR TITLE
bugfix(libs/header/p2p): fix range validation in session

### DIFF
--- a/libs/header/p2p/session_test.go
+++ b/libs/header/p2p/session_test.go
@@ -1,9 +1,15 @@
 package p2p
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/libs/header/test"
 )
 
 func Test_PrepareRequests(t *testing.T) {
@@ -13,4 +19,40 @@ func Test_PrepareRequests(t *testing.T) {
 	require.Len(t, requests, 2)
 	require.Equal(t, requests[0].GetOrigin(), uint64(1))
 	require.Equal(t, requests[1].GetOrigin(), uint64(6))
+}
+
+// Test_Validate ensures that headers range is adjacent and valid.
+func Test_Validate(t *testing.T) {
+	suite := test.NewTestSuite(t)
+	head := suite.Head()
+	ses := newSession(
+		context.Background(),
+		nil,
+		&peerTracker{trackedPeers: make(map[peer.ID]*peerStat)},
+		"", time.Second,
+		withValidation(head),
+	)
+
+	headers := suite.GenDummyHeaders(5)
+	err := ses.validate(headers)
+	assert.NoError(t, err)
+}
+
+// Test_ValidateFails ensures that non-adjacent range will return an error.
+func Test_ValidateFails(t *testing.T) {
+	suite := test.NewTestSuite(t)
+	head := suite.Head()
+	ses := newSession(
+		context.Background(),
+		nil,
+		&peerTracker{trackedPeers: make(map[peer.ID]*peerStat)},
+		"", time.Second,
+		withValidation(head),
+	)
+
+	headers := suite.GenDummyHeaders(5)
+	// break adjacency
+	headers[2] = headers[4]
+	err := ses.validate(headers)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Overview
Added extra condition to verify the adjacency-only in headers from the received range. 
## Checklist
- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
