### PR TITLE
fix(cmd/cel-key): Ensure keyring-backend is actually `test` by default

### DIFF
--- a/cmd/cel-key/main.go
+++ b/cmd/cel-key/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/spf13/cobra"
 
@@ -48,7 +48,10 @@ func init() {
 		}
 
 		if !cmd.Flag(flags.FlagKeyringBackend).Changed {
-			cmd.Flag(flags.FlagKeyringBackend).Value.Set(keyring.BackendTest)
+			err = cmd.Flag(flags.FlagKeyringBackend).Value.Set(keyring.BackendTest)
+			if err != nil {
+				return err
+			}
 			cmd.Flag(flags.FlagKeyringBackend).Changed = true
 		}
 

--- a/cmd/cel-key/main.go
+++ b/cmd/cel-key/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -44,6 +45,11 @@ func init() {
 
 		if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
 			return err
+		}
+
+		if !cmd.Flag(flags.FlagKeyringBackend).Changed {
+			cmd.Flag(flags.FlagKeyringBackend).Value.Set(keyring.BackendTest)
+			cmd.Flag(flags.FlagKeyringBackend).Changed = true
 		}
 
 		return ParseDirectoryFlags(cmd)


### PR DESCRIPTION
`KeysCommand` from the sdk is quite wonky in that it really only sets a keyring backend if the flag was `changed`, so this hack ensures we can properly set a default and that the default is `test`.

Resolves #1876 