### PR TITLE
fix(das): always set result when worker sampled

### DIFF
--- a/das/worker.go
+++ b/das/worker.go
@@ -69,13 +69,10 @@ func (w *worker) run(ctx context.Context, timeout time.Duration, resultCh chan<-
 
 	for curr := w.state.From; curr <= w.state.To; curr++ {
 		err := w.sample(ctx, timeout, curr)
-		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				// sampling worker will resume upon restart
-				break
-			}
-			w.setResult(curr, err)
-			continue
+		w.setResult(curr, err)
+		if errors.Is(err, context.Canceled) {
+			// sampling worker will resume upon restart
+			break
 		}
 	}
 


### PR DESCRIPTION
Not a critical bug, but fixes logging issues, where showed range was always one header.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
