### PR TITLE
WIP -> fix: Go ldflags inside Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,14 @@ COPY . .
 ARG TARGETOS TARGETARCH
 ENV GOOS=$TARGETOS
 ENV GOARCH=$TARGETARCH
-RUN make build && make cel-key
+
+RUN echo "--> Building celestia" &&\
+	go build -o build/ \
+	-ldflags="-X 'main.buildTime=$(date)' -X 'main.lastCommit=$(git rev-parse HEAD)' -X 'main.semanticVersion=$(git describe --tags)'" \
+	./cmd/celestia
+
+RUN echo "--> Building cel-key" &&\
+	go build -o build/ ./cmd/cel-key
 
 FROM ubuntu:20.04
 # Default node type can be overwritten in deployment manifest
@@ -18,7 +25,7 @@ COPY docker/entrypoint.sh /
 
 # Copy in the binary
 COPY --from=builder /src/build/celestia /
-COPY --from=builder /src/./cel-key /
+COPY --from=builder /src/build/cel-key /
 
 EXPOSE 2121
 


### PR DESCRIPTION
## Overview

Hello team!

Small change to the `Dockerfiles` and the way that we build the images.

Until now, we are building the `go` service using the `Makefile`, but seems like for any reason, the `ldflags` are not being generated properly and we are not able to identify what version are we running once we deploy the container...

![Screenshot 2023-03-13 at 18 05 24](https://user-images.githubusercontent.com/32740567/224773991-c32350b7-28b9-4a1a-a64c-ffbd89918146.png)

I've check some version (until 0.6.0), and they have the same issue, so it's not new.

I have made these changes and test them, after build the container in this way, everything seems to be ok:

The build pipeline works ok:

You can check the logs: [here](https://github.com/jrmanes/celestia-node/actions/runs/4407452652)


## Checklist

- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates