### PR TITLE
refactor(nodebuilder/das): update default DASer setting 

### DIFF
--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -50,7 +50,7 @@ func DefaultConfig(tp node.Type) *Config {
 	case node.Bridge:
 		return commonConfig
 	case node.Light, node.Full:
-		commonConfig.DASer = das.DefaultConfig()
+		commonConfig.DASer = das.DefaultConfig(tp)
 		return commonConfig
 	default:
 		panic("node: invalid node type")

--- a/nodebuilder/das/config.go
+++ b/nodebuilder/das/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/celestiaorg/celestia-node/das"
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
@@ -17,9 +18,19 @@ type Config das.Parameters
 // but this function will provide more once #1261 is addressed.
 //
 // TODO(@derrandz): Address #1261
-func DefaultConfig() Config {
+func DefaultConfig(tp node.Type) Config {
 	cfg := das.DefaultParameters()
-	cfg.SampleTimeout = modp2p.BlockTime * time.Duration(cfg.ConcurrencyLimit)
+	switch tp {
+	case node.Light:
+		cfg.SampleTimeout = modp2p.BlockTime * time.Duration(cfg.ConcurrencyLimit)
+	case node.Full:
+		// Default value for DASer concurrency limit is based on dasing using ipld getter.
+		// Full node will primarily use shrex protocol for sampling, that is much more efficient and can
+		// fully utilise nodes bandwidth with lower amount of parallel sampling workers
+		cfg.ConcurrencyLimit = 6
+		// Full node uses shrex with fallback to ipld to sample, so need 2x amount of time in worst case scenario
+		cfg.SampleTimeout = 2 * modp2p.BlockTime * time.Duration(cfg.ConcurrencyLimit)
+	}
 	return Config(cfg)
 }
 

--- a/nodebuilder/das/config.go
+++ b/nodebuilder/das/config.go
@@ -26,7 +26,7 @@ func DefaultConfig(tp node.Type) Config {
 	case node.Full:
 		// Default value for DASer concurrency limit is based on dasing using ipld getter.
 		// Full node will primarily use shrex protocol for sampling, that is much more efficient and can
-		// fully utilise nodes bandwidth with lower amount of parallel sampling workers
+		// fully utilize nodes bandwidth with lower amount of parallel sampling workers
 		cfg.ConcurrencyLimit = 6
 		// Full node uses shrex with fallback to ipld to sample, so need 2x amount of time in worst case scenario
 		cfg.SampleTimeout = 2 * modp2p.BlockTime * time.Duration(cfg.ConcurrencyLimit)

--- a/nodebuilder/das/module_test.go
+++ b/nodebuilder/das/module_test.go
@@ -19,7 +19,7 @@ func TestConstructModule_DASBridgeStub(t *testing.T) {
 
 	var mod Module
 
-	cfg := DefaultConfig()
+	cfg := DefaultConfig(node.Bridge)
 	app := fxtest.New(t,
 		ConstructModule(node.Bridge, &cfg),
 		fx.Populate(&mod)).


### PR DESCRIPTION
## Overview

DASer default settings are based on IPLD only getters measurements. With introduction of blocksync to full nodes as main sampling protocol, value should to be revised. Shrex has much less roundtrips to obtain data, thus it is much better at utilising network bandwidth with fewer workers. Default DASer setting are now updated with relation to node type. 
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

