### PR TITLE
fix(header/sync): add drift to recency detection

### DIFF
--- a/libs/header/sync/sync_head.go
+++ b/libs/header/sync/sync_head.go
@@ -170,5 +170,5 @@ func isExpired(header header.Header, period time.Duration) bool {
 
 // isRecent checks if header is recent against the given blockTime.
 func isRecent(header header.Header, blockTime time.Duration) bool {
-	return time.Since(header.Time()) <= blockTime // TODO @renaynay: should we allow for a 5-10 block drift here?
+	return time.Since(header.Time()) <= blockTime+blockTime/2 // add half block time drift
 }


### PR DESCRIPTION
Pretty often, when you start a node for the first time, there is a warning complaining about an unsynced trusted peer, while we know that the peer is 100% synced. This warning also means we make an additional Head request for a bad reason. The fix is introducing a half-block time drift. I've tested it like 20 times and wasn't able to reproduce the warning. We also don't need to be super precise about head to worry about this additional half. The main goal here is to get the head quick enough after being a day or more out of sync.