### PR TITLE
fix(rpc): allow methods with same names in different namespaces

### DIFF
--- a/api/docgen/openrpc.go
+++ b/api/docgen/openrpc.go
@@ -67,14 +67,12 @@ func ParseCommentsFromNodebuilderModules(moduleNames ...string) Comments {
 		v := &Visitor{make(map[string]ast.Node)}
 		ast.Walk(v, f)
 
-		// TODO(@distractedm1nd): An issue with this could be two methods with the same name in different
-		// modules
 		for mn, node := range v.Methods {
 			filteredComments := cmap.Filter(node).Comments()
 			if len(filteredComments) == 0 {
-				nodeComments[mn] = "No comment exists yet for this method."
+				nodeComments[moduleName+mn] = "No comment exists yet for this method."
 			} else {
-				nodeComments[mn] = filteredComments[0].Text()
+				nodeComments[moduleName+mn] = filteredComments[0].Text()
 			}
 		}
 	}
@@ -140,7 +138,7 @@ func NewOpenRPCDocument(comments Comments) *go_openrpc_reflect.Document {
 
 	appReflector.FnIsMethodEligible = func(m reflect.Method) bool {
 		// methods are only eligible if they were found in the Module interface
-		_, ok := comments[m.Name]
+		_, ok := comments[extractPackageNameFromAPIMethod(m)+m.Name]
 		if !ok {
 			return false
 		}
@@ -170,7 +168,7 @@ func NewOpenRPCDocument(comments Comments) *go_openrpc_reflect.Document {
 	}
 
 	appReflector.FnGetMethodSummary = func(r reflect.Value, m reflect.Method, funcDecl *ast.FuncDecl) (string, error) {
-		if v, ok := comments[m.Name]; ok {
+		if v, ok := comments[extractPackageNameFromAPIMethod(m)+m.Name]; ok {
 			return v, nil
 		}
 		return "", nil // noComment
@@ -231,4 +229,8 @@ func OpenRPCSchemaTypeMapper(ty reflect.Type) *jsonschema.Type {
 	}
 
 	return nil
+}
+
+func extractPackageNameFromAPIMethod(m reflect.Method) string {
+	return strings.TrimSuffix(m.Type.In(0).String()[1:], ".API")
 }

--- a/api/rpc_test.go
+++ b/api/rpc_test.go
@@ -72,21 +72,19 @@ func TestRPCCallsUnderlyingNode(t *testing.T) {
 }
 
 // api contains all modules that are made available as the node's
-// public API surface (except for the `node` module as the node
-// module contains a method `Info` that is also contained in the
-// p2p module).
-type api interface {
-	fraud.Module
-	header.Module
-	statemod.Module
-	share.Module
-	das.Module
-	p2p.Module
+// public API surface
+type api struct {
+	Fraud fraud.Module
+	Header header.Module
+	State statemod.Module
+	Share share.Module
+	DAS das.Module
+	Node node.Module
+	P2P p2p.Module
 }
 
 func TestModulesImplementFullAPI(t *testing.T) {
 	api := reflect.TypeOf(new(api)).Elem()
-	nodeapi := reflect.TypeOf(new(node.Module)).Elem() // TODO @renaynay: explain
 	client := reflect.TypeOf(new(client.Client)).Elem()
 	for i := 0; i < client.NumField(); i++ {
 		module := client.Field(i)
@@ -94,22 +92,13 @@ func TestModulesImplementFullAPI(t *testing.T) {
 		case "closer":
 			// the "closers" field is not an actual module
 			continue
-		case "Node":
-			// node module contains a duplicate method to the p2p module
-			// and must be tested separately.
-			internal, ok := module.Type.FieldByName("Internal")
-			require.True(t, ok, "module %s's API does not have an Internal field", module.Name)
-			for j := 0; j < internal.Type.NumField(); j++ {
-				impl := internal.Type.Field(j)
-				method, _ := nodeapi.MethodByName(impl.Name)
-				require.Equal(t, method.Type, impl.Type, "method %s does not match", impl.Name)
-			}
 		default:
 			internal, ok := module.Type.FieldByName("Internal")
 			require.True(t, ok, "module %s's API does not have an Internal field", module.Name)
 			for j := 0; j < internal.Type.NumField(); j++ {
 				impl := internal.Type.Field(j)
-				method, _ := api.MethodByName(impl.Name)
+				field, _ := api.FieldByName(module.Name)
+				method, _ := field.Type.MethodByName(impl.Name)
 				require.Equal(t, method.Type, impl.Type, "method %s does not match", impl.Name)
 			}
 		}


### PR DESCRIPTION
Previously, the RPC did not allow two methods with the same name, even if they were found in separate modules. This PR gets rid of this requirement