### PR TITLE
fix(share): enabling discovery on light nodes

### DIFF
--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -30,6 +30,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 		fx.Supply(*cfg),
 		fx.Error(cfgErr),
 		fx.Options(options...),
+		fx.Invoke(func(disc *disc.Discovery) {}),
 		fx.Provide(fx.Annotate(
 			discovery(*cfg),
 			fx.OnStart(func(ctx context.Context, d *disc.Discovery) error {


### PR DESCRIPTION
Since light nodes no longer call a constructor that takes discovery, fx was never starting it.
This bug was caught by `TestBootstrapNodesFromBridgeNode`
