### PR TITLE
fix(swamp): fixing p2p_test and reconstruct_test

### DIFF
--- a/nodebuilder/p2p/bootstrap.go
+++ b/nodebuilder/p2p/bootstrap.go
@@ -8,10 +8,10 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-const envKeyCelestiaBootstrapper = "CELESTIA_BOOTSTRAPPER"
+const EnvKeyCelestiaBootstrapper = "CELESTIA_BOOTSTRAPPER"
 
 func isBootstrapper() bool {
-	return os.Getenv(envKeyCelestiaBootstrapper) == strconv.FormatBool(true)
+	return os.Getenv(EnvKeyCelestiaBootstrapper) == strconv.FormatBool(true)
 }
 
 // BootstrappersFor returns address information of bootstrap peers for a given network.

--- a/nodebuilder/p2p/pubsub.go
+++ b/nodebuilder/p2p/pubsub.go
@@ -67,7 +67,7 @@ func pubSub(cfg Config, params pubSubParams) (*pubsub.PubSub, error) {
 	//  * lotus
 	//  * prysm
 	topicScores := topicScoreParams(params.Network)
-	peerScores, err := peerScoreParams(isBootstrapper, params.Bootstrappers, cfg)
+	peerScores, err := peerScoreParams(params.Bootstrappers, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func topicScoreParams(network Network) map[string]*pubsub.TopicScoreParams {
 	return mp
 }
 
-func peerScoreParams(isBootstrapper bool, bootstrappers Bootstrappers, cfg Config) (*pubsub.PeerScoreParams, error) {
+func peerScoreParams(bootstrappers Bootstrappers, cfg Config) (*pubsub.PeerScoreParams, error) {
 	bootstrapperSet := map[peer.ID]struct{}{}
 	for _, b := range bootstrappers {
 		bootstrapperSet[b.ID] = struct{}{}
@@ -141,7 +141,7 @@ func peerScoreParams(isBootstrapper bool, bootstrappers Bootstrappers, cfg Confi
 			// return a heavy positive score for bootstrappers so that we don't unilaterally prune
 			// them and accept PX from them
 			_, ok := bootstrapperSet[p]
-			if ok && !isBootstrapper {
+			if ok {
 				return 2500
 			}
 

--- a/nodebuilder/tests/p2p_test.go
+++ b/nodebuilder/tests/p2p_test.go
@@ -133,7 +133,7 @@ func TestBootstrapNodesFromBridgeNode(t *testing.T) {
 	go func() {
 		for e := range sub.Out() {
 			connStatus := e.(event.EvtPeerConnectednessChanged)
-			if connStatus.Peer == full.Host.ID() {
+			if connStatus.Peer == full.Host.ID() && connStatus.Connectedness == network.NotConnected {
 				ch <- struct{}{}
 			}
 		}

--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -52,6 +52,7 @@ func TestFullReconstructFromBridge(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := nodebuilder.DefaultConfig(node.Full)
+	cfg.Share.UseShareExchange = false
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, getMultiAddr(t, bridge.Host))
 	full := sw.NewNodeWithConfig(node.Full, cfg)
 	err = full.Start(ctx)
@@ -119,6 +120,7 @@ func TestFullReconstructFromLights(t *testing.T) {
 
 	cfg = nodebuilder.DefaultConfig(node.Full)
 	setTimeInterval(cfg, defaultTimeInterval)
+	cfg.Share.UseShareExchange = false
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrsBridge[0].String())
 	nodesConfig := nodebuilder.WithBootstrappers([]peer.AddrInfo{*bootstrapperAddr})
 	full := sw.NewNodeWithConfig(node.Full, cfg, nodesConfig)

--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -7,6 +7,7 @@ package tests
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
 	"github.com/celestiaorg/celestia-node/share/availability/light"
 	"github.com/celestiaorg/celestia-node/share/eds"
@@ -113,6 +115,8 @@ func TestFullReconstructFromLights(t *testing.T) {
 	bridge := sw.NewBridgeNode()
 	addrsBridge, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
+
+	os.Setenv(p2p.EnvKeyCelestiaBootstrapper, "true")
 	bootstrapper := sw.NewNodeWithConfig(node.Full, cfg)
 	require.NoError(t, bootstrapper.Start(ctx))
 	require.NoError(t, bridge.Start(ctx))
@@ -124,6 +128,7 @@ func TestFullReconstructFromLights(t *testing.T) {
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrsBridge[0].String())
 	nodesConfig := nodebuilder.WithBootstrappers([]peer.AddrInfo{*bootstrapperAddr})
 	full := sw.NewNodeWithConfig(node.Full, cfg, nodesConfig)
+	os.Setenv(p2p.EnvKeyCelestiaBootstrapper, "false")
 
 	lights := make([]*nodebuilder.Node, lnodes)
 	subs := make([]event.Subscription, lnodes)

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -169,6 +169,7 @@ func TestSyncFullWithBridge(t *testing.T) {
 
 	cfg := nodebuilder.DefaultConfig(node.Full)
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+	cfg.Share.UseShareExchange = false
 	full := sw.NewNodeWithConfig(node.Full, cfg)
 	require.NoError(t, full.Start(ctx))
 


### PR DESCRIPTION
Some hotfixes that fix swamp tests. Would like to understand why these fixes work before taking out of draft 