### PR TITLE
perf(header): make HeaderSub msgid to be header hash

### DIFF
--- a/header/serde.go
+++ b/header/serde.go
@@ -96,37 +96,21 @@ func ProtoToExtendedHeader(pb *header_pb.ExtendedHeader) (*ExtendedHeader, error
 }
 
 // msgID computes an id for a pubsub message
-// TODO(@Wondertan): This cause additional allocations per each recvd message in the topic. Find a
-// way to avoid those.
+// TODO(@Wondertan): This cause additional allocations per each recvd message in the topic
+//
+//	Find a way to avoid those.
 func MsgID(pmsg *pb.Message) string {
 	mID := func(data []byte) string {
 		hash := blake2b.Sum256(data)
 		return string(hash[:])
 	}
 
-	h, err := UnmarshalExtendedHeader(pmsg.Data)
-	if err != nil {
+	h, _ := UnmarshalExtendedHeader(pmsg.Data)
+	if h == nil || h.RawHeader.ValidateBasic() != nil {
 		// There is nothing we can do about the error, and it will be anyway caught during validation.
 		// We also *have* to return some ID for the msg, so give the hash of even faulty msg
 		return mID(pmsg.Data)
 	}
 
-	// IMPORTANT NOTE:
-	// Due to the nature of the Tendermint consensus, validators don't necessarily collect commit
-	// signatures from the entire validator set, but only the minimum required amount of them (>2/3 of
-	// voting power). In addition, signatures are collected asynchronously. Therefore, each validator
-	// may have a different set of signatures that pass the minimum required voting power threshold,
-	// causing nondeterminism in the header message gossiped over the network. Subsequently, this
-	// causes message duplicates as each Bridge Node, connected to a personal validator, sends the
-	// validator's own view of commits of effectively the same header.
-	// To solve the problem above, we exclude nondeterministic value from message id calculation
-	h.Commit.Signatures = nil
-
-	data, err := MarshalExtendedHeader(h)
-	if err != nil {
-		// See the note under unmarshalling step
-		return mID(pmsg.Data)
-	}
-
-	return mID(data)
+	return h.Commit.BlockID.String()
 }


### PR DESCRIPTION
This patch attempts to solve the header duplication issue on the ITN network by making the msg-id always equal to the header hash. As a byproduct, this also simplifies the logic for msg-id and avoids additional serialization rounds.

The only way to really check if this fixes #1958 is by updating the whole network