### PR TITLE
perf(modshare): increase the PeersLimit default

### DIFF
--- a/nodebuilder/share/config.go
+++ b/nodebuilder/share/config.go
@@ -32,7 +32,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		PeersLimit:        3,
+		PeersLimit:        5,
 		DiscoveryInterval: time.Second * 30,
 		AdvertiseInterval: time.Second * 30,
 		UseShareExchange:  true,


### PR DESCRIPTION
We expect 750 LN for 200 FN(including BN) and 750/200 ~= 4
And we add plus one because the balancing is randomized and not even