### PR TITLE
ci(.github): Fix kind label for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       - Wondertan
       - renaynay
     labels:
-      - kind:dependencies
+      - kind:deps
   - package-ecosystem: docker
     directory: "/"
     schedule:


### PR DESCRIPTION
The only issue I can see with this is if the dep upgrade leads to a breaking change for some reason. But in that case, we can manually change the label.