### PR TITLE
feat(cmd): RPC over CLI

### DIFF
--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -43,6 +43,6 @@ var rootCmd = &cobra.Command{
 	`,
 	Args: cobra.NoArgs,
 	CompletionOptions: cobra.CompletionOptions{
-		DisableDefaultCmd: true,
+		DisableDefaultCmd: false,
 	},
 }

--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -99,12 +99,22 @@ func parseParams(method string, params []string) []interface{} {
 	}
 
 	for i, param := range params {
-		// try to parse arguments as numbers before adding them as strings
-		num, err := strconv.ParseInt(param, 10, 64)
-		if err != nil {
+		if param[0] == '{' || param[0] == '[' {
+			var raw json.RawMessage
+			if err := json.Unmarshal([]byte(param), &raw); err == nil {
+				parsedParams[i] = raw
+			} else {
+				parsedParams[i] = param
+			}
+		} else {
+			// try to parse arguments as numbers before adding them as strings
+			num, err := strconv.ParseInt(param, 10, 64)
+			if err == nil {
+				parsedParams[i] = num
+				continue
+			}
 			parsedParams[i] = param
 		}
-		parsedParams[i] = num
 	}
 
 	return parsedParams

--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -99,7 +99,12 @@ func parseParams(method string, params []string) []interface{} {
 	}
 
 	for i, param := range params {
-		parsedParams[i] = param
+		// try to parse arguments as numbers before adding them as strings
+		num, err := strconv.ParseInt(param, 10, 64)
+		if err != nil {
+			parsedParams[i] = param
+		}
+		parsedParams[i] = num
 	}
 
 	return parsedParams

--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -16,6 +16,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	authEnvKey = "CELESTIA_NODE_AUTH_TOKEN"
+)
+
 var requestURL string
 var authTokenFlag string
 
@@ -37,7 +41,7 @@ func init() {
 		&authTokenFlag,
 		"auth",
 		"",
-		"Authorization token (if not provided, the AUTH_TOKEN environment variable will be used)",
+		"Authorization token (if not provided, the "+authEnvKey+" environment variable will be used)",
 	)
 	rootCmd.AddCommand(rpcCmd)
 }
@@ -90,7 +94,7 @@ func parseParams(method string, params []string) []interface{} {
 		parsedParams[2] = params[2]
 		// 4. GasLimit (uint64)
 		num, err := strconv.ParseUint(params[3], 10, 64)
-		if err == nil {
+		if err != nil {
 			panic("Error parsing gas limit: uint64 could not be parsed.")
 		}
 		parsedParams[3] = num
@@ -143,7 +147,7 @@ func sendJSONRPCRequest(namespace, method string, params []interface{}) {
 
 	authToken := authTokenFlag
 	if authToken == "" {
-		authToken = os.Getenv("AUTH_TOKEN")
+		authToken = os.Getenv(authEnvKey)
 	}
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)

--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var requestURL string
+var authTokenFlag string
+
+type jsonRPCRequest struct {
+	ID      int64         `json:"id"`
+	JSONRPC string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+}
+
+func init() {
+	rpcCmd.PersistentFlags().StringVar(
+		&requestURL,
+		"url",
+		"http://localhost:26658",
+		"Request URL",
+	)
+	rpcCmd.PersistentFlags().StringVar(
+		&authTokenFlag,
+		"auth",
+		"",
+		"Authorization token (if not provided, the AUTH_TOKEN environment variable will be used)",
+	)
+	rootCmd.AddCommand(rpcCmd)
+}
+
+var rpcCmd = &cobra.Command{
+	Use:   "rpc [namespace] [method] [params...]",
+	Short: "Send JSON-RPC request",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		namespace := args[0]
+		method := args[1]
+		params := parseParams(method, args[2:])
+
+		sendJSONRPCRequest(namespace, method, params)
+	},
+}
+
+func parseParams(method string, params []string) []interface{} {
+	parsedParams := make([]interface{}, len(params))
+
+	switch method {
+	case "SubmitPayForBlob":
+		// 1. NamespaceID
+		if strings.HasPrefix(params[0], "0x") {
+			decoded, err := hex.DecodeString(params[0][2:])
+			if err != nil {
+				panic("Error decoding namespace ID: hex string could not be decoded.")
+			}
+			parsedParams[0] = decoded
+		} else {
+			// otherwise, it's just a base64 string
+			parsedParams[0] = params[0]
+		}
+		// 2. Blob
+		switch {
+		case strings.HasPrefix(params[1], "0x"):
+			decoded, err := hex.DecodeString(params[1][2:])
+			if err != nil {
+				panic("Error decoding blob: hex string could not be decoded.")
+			}
+			parsedParams[0] = decoded
+		case strings.HasPrefix(params[1], "\""):
+			// user input an utf string that needs to be encoded to base64
+			parsedParams[1] = base64.StdEncoding.EncodeToString([]byte(params[1]))
+		default:
+			// otherwise, we assume the user has already encoded their input to base64
+			parsedParams[1] = params[1]
+		}
+		// 3. Fee (state.Int is a string)
+		parsedParams[2] = params[2]
+		// 4. GasLimit (uint64)
+		num, err := strconv.ParseUint(params[3], 10, 64)
+		if err == nil {
+			panic("Error parsing gas limit: uint64 could not be parsed.")
+		}
+		parsedParams[3] = num
+		return parsedParams
+	default:
+	}
+
+	for i, param := range params {
+		parsedParams[i] = param
+	}
+
+	return parsedParams
+}
+
+func sendJSONRPCRequest(namespace, method string, params []interface{}) {
+	url := requestURL
+	request := jsonRPCRequest{
+		ID:      1,
+		JSONRPC: "2.0",
+		Method:  fmt.Sprintf("%s.%s", namespace, method),
+		Params:  params,
+	}
+
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		log.Fatalf("Error marshaling JSON-RPC request: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		log.Fatalf("Error creating JSON-RPC request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	authToken := authTokenFlag
+	if authToken == "" {
+		authToken = os.Getenv("AUTH_TOKEN")
+	}
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error sending JSON-RPC request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Error reading response body: %v", err) //nolint:gocritic
+	}
+
+	fmt.Println(string(responseBody))
+}

--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -130,18 +130,18 @@ func parseParams(method string, params []string) []interface{} {
 		var err error
 		parsedParams[0], err = parseAddressFromString(params[0])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("error parsing address: %w", err))
 		}
 		return parsedParams
 	case "QueryRedelegations":
 		var err error
 		parsedParams[0], err = parseAddressFromString(params[0])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("error parsing address: %w", err))
 		}
 		parsedParams[1], err = parseAddressFromString(params[1])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("error parsing address: %w", err))
 		}
 		return parsedParams
 	case "Transfer", "Delegate", "Undelegate":
@@ -149,7 +149,7 @@ func parseParams(method string, params []string) []interface{} {
 		var err error
 		parsedParams[0], err = parseAddressFromString(params[0])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("error parsing address: %w", err))
 		}
 		// 2. Amount + Fee
 		parsedParams[1] = params[1]
@@ -166,7 +166,7 @@ func parseParams(method string, params []string) []interface{} {
 		var err error
 		parsedParams[0], err = parseAddressFromString(params[0])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("error parsing address: %w", err))
 		}
 		// 2. Amount + Height + Fee
 		parsedParams[1] = params[1]
@@ -183,12 +183,12 @@ func parseParams(method string, params []string) []interface{} {
 		var err error
 		parsedParams[0], err = parseAddressFromString(params[0])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("error parsing address: %w", err))
 		}
 		// 2. Destination Validator Address
 		parsedParams[1], err = parseAddressFromString(params[1])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("error parsing address: %w", err))
 		}
 		// 2. Amount + Fee
 		parsedParams[2] = params[2]


### PR DESCRIPTION
Based on #3047. Beginning of the CLI.

Adds CLI over RPC. Format:
`celestia rpc [module] [method] [...args]`
`--auth TOKEN` flag sets the auth header (otherwise it reads it from the env, if not found, doesn't set auth)
`--url URL` sets request url, default localhost:26658

Most methods are easy to call. The args for `SubmitPayForBlob` are parsed specially, to improve UX. Other methods can be given special argument parsing rules for improved UX.

These special rules:
- The namespace ID can be encoded as either hex or base64
- The blob can be hex (`0x...`), base64 (`"..."`), or a normal string which will be encoded to base64 (`'"Hello There!"'`)
- `fee` doesn't need to be passed as a string as it normally would need to be, it is passed the same was as gasLim

examples of valid commands:
 ```
 celestia rpc state SubmitPayForBlob 0x1874e642f5dde589 '"Hello there!!"' 2000 100000

 celestia rpc node Info

celestia rpc share GetShare '{"row_roots":["//////////7//////////ql+/VFmJ8PWE9BcjrTDLrY/hzVeGdzFCpfEhiXDXZmt","/////////////////////zHeGnUtPJn8QyPpePSYl4qRVrcUvG2fwptyoA85Myik"],"column_roots":["//////////7//////////ql+/VFmJ8PWE9BcjrTDLrY/hzVeGdzFCpfEhiXDXZmt","/////////////////////zHeGnUtPJn8QyPpePSYl4qRVrcUvG2fwptyoA85Myik"]}' 1 1

celestia rpc header GetByHeight 5
```
