### PR TITLE
fix(core/exchange): handle nil height pointer in log

### DIFF
--- a/core/exchange.go
+++ b/core/exchange.go
@@ -134,6 +134,9 @@ func (ce *Exchange) Head(ctx context.Context) (*header.ExtendedHeader, error) {
 func (ce *Exchange) getExtendedHeaderByHeight(ctx context.Context, height *int64) (*header.ExtendedHeader, error) {
 	b, err := ce.fetcher.GetSignedBlock(ctx, height)
 	if err != nil {
+		if height == nil {
+			return nil, fmt.Errorf("fetching signed block for head from core: %w", err)
+		}
 		return nil, fmt.Errorf("fetching signed block at height %d from core: %w", *height, err)
 	}
 	log.Debugw("fetched signed block from core", "height", b.Header.Height)


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x101a611fc]

goroutine 525 [running]:
github.com/celestiaorg/celestia-node/core.(*Exchange).getExtendedHeaderByHeight(0x140007b02a0, {0x103229658, 0x14008e568a0}, 0x0)
        /Users/vladkrintisn/Celestia/celestia-node-original/core/exchange.go:141 +0x13c
github.com/celestiaorg/celestia-node/core.(*Exchange).Head(0x1049da160?, {0x103229658, 0x14008e568a0})
        /Users/vladkrintisn/Celestia/celestia-node-original/core/exchange.go:131 +0x8c
github.com/celestiaorg/go-header/sync.(*syncGetter[...]).Head(0x14000021500, {0x103229658?, 0x14008e568a0})
        /Users/vladkrintisn/go/pkg/mod/github.com/celestiaorg/go-header@v0.2.3/sync/sync_getter.go:29 +0x150
github.com/celestiaorg/go-header/sync.(*Syncer[...]).Head(0x1032549a0, {0x103229658, 0x14008e568a0})
        /Users/vladkrintisn/go/pkg/mod/github.com/celestiaorg/go-header@v0.2.3/sync/sync_head.go:34 +0x7c
github.com/celestiaorg/go-header/sync.(*Syncer[...]).Start(0x1032549a0, {0x103229658, 0x14008e568a0})
        /Users/vladkrintisn/go/pkg/mod/github.com/celestiaorg/go-header@v0.2.3/sync/sync.go:89 +0x11c
github.com/celestiaorg/celestia-node/nodebuilder/fraud.Lifecycle({0x103229658, 0x14008e568a0}, {0x1032295e8?, 0x14008a69f40}, {0x101ef5c68, 0xb}, {0x103212cc0, 0x14008c7c140}, 0x14008e774f8, 0x1400134b920)
        /Users/vladkrintisn/Celestia/celestia-node-original/nodebuilder/fraud/lifecycle.go:29 +0xcc
github.com/celestiaorg/celestia-node/nodebuilder/header.ConstructModule.func8({0x103229658, 0x14008e568a0}, {0x1032295e8, 0x14008a69f40}, {0x103212cc0, 0x14008c7c140}, 0x140006d1800)
        /Users/vladkrintisn/Celestia/celestia-node-original/nodebuilder/header/module.go:80 +0xb4
reflect.Value.call({0x102e00660?, 0x1031f1f08?, 0x14008e77c38?}, {0x101ec50d4, 0x4}, {0x14008b732c0, 0x4, 0x14008e77c88?})
        /usr/local/go/src/reflect/value.go:586 +0x838
reflect.Value.Call({0x102e00660?, 0x1031f1f08?, 0x1fd9277d3580d?}, {0x14008b732c0?, 0x25d21d1808e77ce8?, 0x64243c76?})
        /usr/local/go/src/reflect/value.go:370 +0x90
go.uber.org/fx.(*lifecycleHookAnnotation).Build.func1.1({0x103229658?, 0x14008e568a0?})
        /Users/vladkrintisn/go/pkg/mod/go.uber.org/fx@v1.18.2/annotated.go:439 +0x140
go.uber.org/fx/internal/lifecycle.(*Lifecycle).runStartHook(0x140004b1340, {0x103229658, 0x14008e568a0}, {0x14008b55140, 0x0, {{0x14000621800, 0x35}, {0x1038c6b85, 0x42}, 0x1bf}})
        /Users/vladkrintisn/go/pkg/mod/go.uber.org/fx@v1.18.2/internal/lifecycle/lifecycle.go:130 +0x1a4
go.uber.org/fx/internal/lifecycle.(*Lifecycle).Start(0x140004b1340, {0x103229658, 0x14008e568a0})
        /Users/vladkrintisn/go/pkg/mod/go.uber.org/fx@v1.18.2/internal/lifecycle/lifecycle.go:95 +0x370
go.uber.org/fx.(*App).start(0x14001bcbad0, {0x103229658, 0x14008e568a0})
        /Users/vladkrintisn/go/pkg/mod/go.uber.org/fx@v1.18.2/app.go:679 +0x34
go.uber.org/fx.withTimeout.func1()
        /Users/vladkrintisn/go/pkg/mod/go.uber.org/fx@v1.18.2/app.go:784 +0x74
created by go.uber.org/fx.withTimeout
        /Users/vladkrintisn/go/pkg/mod/go.uber.org/fx@v1.18.2/app.go:772 +0xcc
        ```