### PR TITLE
Ugly fix with retries for ITN peering issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/celestiaorg/celestia-app v0.12.2
 	github.com/celestiaorg/go-fraud v0.1.0
-	github.com/celestiaorg/go-header v0.2.5
+	github.com/celestiaorg/go-header v0.2.6-0.20230414143843-ecb1e50a8a73
 	github.com/celestiaorg/go-libp2p-messenger v0.2.0
 	github.com/celestiaorg/nmt v0.15.0
 	github.com/celestiaorg/rsmt2d v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/celestiaorg/go-fraud v0.1.0 h1:v6mZvlmf2J5ELZfPnrtmmOvKbaYIUs/erDWPO8
 github.com/celestiaorg/go-fraud v0.1.0/go.mod h1:yoNM35cKMAkt5Mi/Qx3Wi9bnPilLi8n6RpHZVglTUDs=
 github.com/celestiaorg/go-header v0.2.5 h1:TV1EybWjRRJfYc8Wf5UFVytGxEQJdPdNbVEfenUVXzo=
 github.com/celestiaorg/go-header v0.2.5/go.mod h1:i9OpY70+PJ1xPw1IgMfF0Pk6vBD6VWPmjY3bgubJBcU=
+github.com/celestiaorg/go-header v0.2.6-0.20230414143843-ecb1e50a8a73 h1:gTgWUe4/LWXJe9MwaVAVfVTmSHfUUUxC6Ki+N5U6U3s=
+github.com/celestiaorg/go-header v0.2.6-0.20230414143843-ecb1e50a8a73/go.mod h1:i9OpY70+PJ1xPw1IgMfF0Pk6vBD6VWPmjY3bgubJBcU=
 github.com/celestiaorg/go-libp2p-messenger v0.2.0 h1:/0MuPDcFamQMbw9xTZ73yImqgTO3jHV7wKHvWD/Irao=
 github.com/celestiaorg/go-libp2p-messenger v0.2.0/go.mod h1:s9PIhMi7ApOauIsfBcQwbr7m+HBzmVfDIS+QLdgzDSo=
 github.com/celestiaorg/go-verifcid v0.0.1-lazypatch h1:9TSe3w1cmJmbWlweCwCTIZkan7jV8M+KwglXpdD+UG8=

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
@@ -100,7 +101,7 @@ func newInitStore(
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
 			for {
-				err := store.Init(ctx, s, ex, trustedHash)
+				err := store.Init(network.WithForceDirectDial(ctx, "bootstrapper connect"), s, ex, trustedHash)
 				if err == nil {
 					return nil
 				}

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -106,6 +106,7 @@ func newInitStore(
 					return nil
 				}
 
+				log.Errorf("initing store: %s", err)
 				time.Sleep(time.Millisecond * 50)
 				if ctx.Err() != nil {
 					return ctx.Err()

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -2,6 +2,7 @@ package header
 
 import (
 	"context"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -98,7 +99,17 @@ func newInitStore(
 
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			return store.Init(ctx, s, ex, trustedHash)
+			for {
+				err := store.Init(ctx, s, ex, trustedHash)
+				if err == nil {
+					return nil
+				}
+
+				time.Sleep(time.Millisecond * 50)
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+			}
 		},
 	})
 

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -87,6 +87,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 								return nil
 							}
 
+							log.Errorf("starting syncer: %s", err)
 							time.Sleep(time.Millisecond * 50)
 							if ctx.Err() != nil {
 								return ctx.Err()

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/network"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/go-fraud"
@@ -81,7 +82,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 				return modfraud.Lifecycle(startCtx, ctx, byzantine.BadEncoding, fservice,
 					func(ctx context.Context) error {
 						for {
-							err := syncer.Start(ctx)
+							err := syncer.Start(network.WithForceDirectDial(ctx, "bootstrapper connect"))
 							if err == nil {
 								return nil
 							}

--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -27,7 +27,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
 
-const Timeout = time.Second * 15
+const Timeout = time.Hour
 
 var log = logging.Logger("node")
 

--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -14,7 +14,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/routing"
-	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
@@ -24,8 +23,9 @@ import (
 
 // routedHost constructs a wrapped Host that may fallback to address discovery,
 // if any top-level operation on the Host is provided with PeerID(Hash(PbK)) only.
-func routedHost(base HostBase, r routing.PeerRouting) hst.Host {
-	return routedhost.Wrap(base, r)
+func routedHost(base HostBase, _ routing.PeerRouting) hst.Host {
+	// FIXME: Return back routed host
+	return base
 }
 
 // host returns constructor for Host.


### PR DESCRIPTION
Should not be merged. The ugly fix for peering issues we observe on the ITN blockspace-race network. 
If a sufficient number of people report that they cannot reproduce it - we should release a patch basing on this branch.

Might be related: https://github.com/libp2p/go-libp2p/issues/2220