### PR TITLE
fix: changing entrypoint path to /opt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apk update && apk add --no-cache \
     # Creates a user with $UID and $GID=$UID
     && adduser ${USER_NAME} \
         -D \
-        -g "celestia" \
+        -g ${USER_NAME} \
         -h ${CELESTIA_HOME} \
         -s /sbin/nologin \
         -u ${UID}
@@ -42,11 +42,11 @@ RUN apk update && apk add --no-cache \
 COPY --from=builder /src/build/celestia /bin/celestia
 COPY --from=builder /src/./cel-key /bin/cel-key
 
-COPY docker/entrypoint.sh /home/celestia/entrypoint.sh
+COPY --chown=${USER_NAME}:${USER_NAME} docker/entrypoint.sh /opt/entrypoint.sh
 
 USER ${USER_NAME}
 
 EXPOSE 2121
 
-ENTRYPOINT [ "/bin/bash", "/home/celestia/entrypoint.sh" ]
+ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]
 CMD [ "celestia" ]


### PR DESCRIPTION
When using a container and mounting a host folder to the default home (`/home/celestia`) in the container the `entrypoint.sh` gets overwritten.
This PR uses another path so this can't happen.