### PR TITLE
fix(eds/share): replacing fsmount with filemount registration

### DIFF
--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -66,7 +66,7 @@ func NewStore(basepath string, ds datastore.Batching) (*Store, error) {
 	}
 
 	r := mount.NewRegistry()
-	err = r.Register("fs", &mount.FSMount{FS: os.DirFS(basepath + blocksPath)})
+	err = r.Register("fs", &mount.FileMount{Path: basepath + blocksPath})
 	if err != nil {
 		return nil, fmt.Errorf("failed to register FS mount on the registry: %w", err)
 	}
@@ -181,9 +181,8 @@ func (s *Store) Put(ctx context.Context, root share.DataHash, square *rsmt2d.Ext
 	}
 
 	ch := make(chan dagstore.ShardResult, 1)
-	err = s.dgstr.RegisterShard(ctx, shard.KeyFromString(key), &mount.FSMount{
-		FS:   os.DirFS(s.basepath + blocksPath),
-		Path: key,
+	err = s.dgstr.RegisterShard(ctx, shard.KeyFromString(key), &mount.FileMount{
+		Path: s.basepath + blocksPath + key,
 	}, ch, dagstore.RegisterOpts{})
 	if err != nil {
 		return fmt.Errorf("failed to initiate shard registration: %w", err)


### PR DESCRIPTION
This PR replaces FSMount with FileMount, getting rid of the need for transients and avoiding unnecessary copying. 