### PR TITLE
chore(log): Suppress pubsub logs to WARN and net/identify to ERROR

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -17,6 +17,7 @@ func SetAllLoggers(level logging.LogLevel) {
 	_ = logging.SetLogLevel("bitswap_network", "ERROR")
 	_ = logging.SetLogLevel("badger", "INFO")
 	_ = logging.SetLogLevel("basichost", "INFO")
+	_ = logging.SetLogLevel("pubsub", "WARN")
 }
 
 func SetDebugLogging() {

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -18,6 +18,7 @@ func SetAllLoggers(level logging.LogLevel) {
 	_ = logging.SetLogLevel("badger", "INFO")
 	_ = logging.SetLogLevel("basichost", "INFO")
 	_ = logging.SetLogLevel("pubsub", "WARN")
+	_ = logging.SetLogLevel("net/identify", "ERROR")
 }
 
 func SetDebugLogging() {


### PR DESCRIPTION
Partially fix #1992.

I'm not sure this is a final fix, but at least let's disable the spam message first, or we could not see any real problem.

I let it run on blockspacerace for about 2 hours after modify, don't see any problem besides having to resync bridge again.

My bridge established no more than 20 connections, seems very low.
