### PR TITLE
chore(modp2p): temporary remove routed host

### DIFF
--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -14,7 +14,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/routing"
-	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"go.uber.org/fx"
 
@@ -23,8 +22,9 @@ import (
 
 // routedHost constructs a wrapped Host that may fallback to address discovery,
 // if any top-level operation on the Host is provided with PeerID(Hash(PbK)) only.
-func routedHost(base HostBase, r routing.PeerRouting) hst.Host {
-	return routedhost.Wrap(base, r)
+func routedHost(base HostBase, _ routing.PeerRouting) hst.Host {
+	// FIXME: Return back routed host
+	return base
 }
 
 // host returns constructor for Host.


### PR DESCRIPTION
To facilitate the investigation of issues like #2006, I propose temporarily removing the RoutedHost as instead of returning a real dial error, it returns the `failed to find any peer in table`. We need to see what folks error with. So far, we know they fail with `dial backoff`(related https://github.com/libp2p/go-libp2p/issues/2220), but there could be other errors as well. To be included in the next release

Note that https://github.com/libp2p/go-libp2p/pull/2169 was merged more than a month ago but was not released yet, thus this temporal workaround. 

Originally, I wanted to merge it in the main, but then decide to put it into the testing #1985 branch.