### PR TITLE
bypass backoff on dial

### DIFF
--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
@@ -100,7 +101,7 @@ func newInitStore(
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
 			for {
-				err := store.Init(ctx, s, ex, trustedHash)
+				err := store.Init(network.WithForceDirectDial(ctx, "bootstrapper connect"), s, ex, trustedHash)
 				if err == nil {
 					return nil
 				}

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/network"
 	"go.uber.org/fx"
 
 	libhead "github.com/celestiaorg/go-header"
@@ -81,7 +82,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 				return modfraud.Lifecycle(startCtx, ctx, byzantine.BadEncoding, fservice,
 					func(ctx context.Context) error {
 						for {
-							err := syncer.Start(ctx)
+							err := syncer.Start(network.WithForceDirectDial(ctx, "bootstrapper connect"))
 							if err == nil {
 								return nil
 							}


### PR DESCRIPTION
So far we know that connecting to bootstrappers in issues like #2006 fails with `dial backoff`. This context option always forces a dial. An experiment to know if it happens or not