### PR TITLE
feat(logs): Suppress pubsub to WARN level and supress net/identify to ERROR

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -17,6 +17,8 @@ func SetAllLoggers(level logging.LogLevel) {
 	_ = logging.SetLogLevel("bitswap_network", "ERROR")
 	_ = logging.SetLogLevel("badger", "INFO")
 	_ = logging.SetLogLevel("basichost", "INFO")
+	_ = logging.SetLogLevel("pubsub", "WARN")
+	_ = logging.SetLogLevel("net/identify", "ERROR")
 }
 
 func SetDebugLogging() {


### PR DESCRIPTION
After some discussions with @wpank and @distractedm1nd , I think it's better if we, by default, suppress pubsub + net/identify logs as they cloud log output without much value to the node runners.