### PR TITLE
feat: pyroscope integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       - Wondertan
       - renaynay
     labels:
-      - kind:dependencies
+      - kind:deps
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/cmd/flags_misc.go
+++ b/cmd/flags_misc.go
@@ -3,12 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
-	otelpyroscope "github.com/pyroscope-io/otel-profiling-go"
 	"net/http"
 	"net/http/pprof"
 	"strings"
 
 	logging "github.com/ipfs/go-log/v2"
+	otelpyroscope "github.com/pyroscope-io/otel-profiling-go"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"go.opentelemetry.io/otel"

--- a/cmd/flags_misc.go
+++ b/cmd/flags_misc.go
@@ -189,7 +189,7 @@ func ParseMiscFlags(ctx context.Context, cmd *cobra.Command) (context.Context, e
 			)),
 		)
 		otel.SetTracerProvider(otelpyroscope.NewTracerProvider(tp,
-			otelpyroscope.WithAppName("celestia.fullnode"),
+			otelpyroscope.WithAppName("celestia.da-node"),
 			otelpyroscope.WithPyroscopeURL("http://localhost:4040"),
 			otelpyroscope.WithRootSpanOnly(true),
 			otelpyroscope.WithAddSpanName(true),

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,8 @@ require (
 	github.com/multiformats/go-multihash v0.2.2-0.20221030163302-608669da49b6
 	github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333
 	github.com/prometheus/client_golang v1.14.0
+	github.com/pyroscope-io/client v0.7.0
+	github.com/pyroscope-io/otel-profiling-go v0.4.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
@@ -260,9 +262,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/pyroscope-io/client v0.7.0 // indirect
 	github.com/pyroscope-io/godeltaprof v0.1.0 // indirect
-	github.com/pyroscope-io/otel-profiling-go v0.4.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.2.1 // indirect
 	github.com/quic-go/qtls-go1-20 v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -260,6 +260,9 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/pyroscope-io/client v0.7.0 // indirect
+	github.com/pyroscope-io/godeltaprof v0.1.0 // indirect
+	github.com/pyroscope-io/otel-profiling-go v0.4.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.2.1 // indirect
 	github.com/quic-go/qtls-go1-20 v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -599,6 +599,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -1592,6 +1593,12 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pyroscope-io/client v0.7.0 h1:LWuuqPQ1oa6x7BnmUOuo/aGwdX85QGhWZUBYWWW3zdk=
+github.com/pyroscope-io/client v0.7.0/go.mod h1:4h21iOU4pUOq0prKyDlvYRL+SCKsBc5wKiEtV+rJGqU=
+github.com/pyroscope-io/godeltaprof v0.1.0 h1:UBqtjt0yZi4jTxqZmLAs34XG6ycS3vUTlhEUSq4NHLE=
+github.com/pyroscope-io/godeltaprof v0.1.0/go.mod h1:psMITXp90+8pFenXkKIpNhrfmI9saQnPbba27VIaiQE=
+github.com/pyroscope-io/otel-profiling-go v0.4.0 h1:Hk/rbUqOWoByoWy1tt4r5BX5xoKAvs5drr0511Ki8ic=
+github.com/pyroscope-io/otel-profiling-go v0.4.0/go.mod h1:MXaofiWU7PgLP7eISUZJYVO4Z8WYMqpkYgeP4XrPLyg=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
 github.com/quic-go/qtls-go1-19 v0.2.1 h1:aJcKNMkH5ASEJB9FXNeZCyTEIHU1J7MmHyz1Q1TSG1A=
@@ -1859,6 +1866,7 @@ go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
+go.opentelemetry.io/otel v1.4.1/go.mod h1:StM6F/0fSwpd8dKWDCdRr7uRvEPYdW0hBSlbdTiUde4=
 go.opentelemetry.io/otel v1.13.0 h1:1ZAKnNQKwBBxFtww/GwxNUyTf0AxkZzrukO8MeXqe4Y=
 go.opentelemetry.io/otel v1.13.0/go.mod h1:FH3RtdZCzRkJYFTCsAKDy9l/XYjMdNv6QrkFFB8DvVg=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.11.2 h1:htgM8vZIF8oPSCxa341e3IZ4yr/sKxgu8KZYllByiVY=
@@ -1881,6 +1889,7 @@ go.opentelemetry.io/otel/sdk v1.11.2/go.mod h1:wZ1WxImwpq+lVRo4vsmSOxdd+xwoUJ6rq
 go.opentelemetry.io/otel/sdk/metric v0.34.0 h1:7ElxfQpXCFZlRTvVRTkcUvK8Gt5DC8QzmzsLsO2gdzo=
 go.opentelemetry.io/otel/sdk/metric v0.34.0/go.mod h1:l4r16BIqiqPy5rd14kkxllPy/fOI4tWo1jkpD9Z3ffQ=
 go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
+go.opentelemetry.io/otel/trace v1.4.1/go.mod h1:iYEVbroFCNut9QkwEczV9vMRPHNKSSwYZjulEtsmhFc=
 go.opentelemetry.io/otel/trace v1.13.0 h1:CBgRZ6ntv+Amuj1jDsMhZtlAPT6gbyIRdaIzFhfBSdY=
 go.opentelemetry.io/otel/trace v1.13.0/go.mod h1:muCvmmO9KKpvuXSf3KKAXXB2ygNYHQ+ZfI5X08d3tds=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=

--- a/nodebuilder/node/module.go
+++ b/nodebuilder/node/module.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"github.com/cristalhq/jwt"
-	"github.com/pyroscope-io/client/pyroscope"
 	"go.uber.org/fx"
 )
 
@@ -11,27 +10,6 @@ func ConstructModule(tp Type) fx.Option {
 		"node",
 		fx.Provide(func(secret jwt.Signer) Module {
 			return newModule(tp)
-		}),
-		fx.Invoke(func() {
-			pyroscope.Start(pyroscope.Config{
-				ApplicationName: "celestia.da-node",
-				// replace this with the address of pyroscope server
-				ServerAddress: "http://localhost:4040",
-				Tags: map[string]string{
-					"type": tp.String(),
-				},
-				// you can disable logging by setting this to nil
-				Logger: nil,
-				// by default all profilers are enabled,
-				// but you can select the ones you want to use:
-				ProfileTypes: []pyroscope.ProfileType{
-					pyroscope.ProfileCPU,
-					pyroscope.ProfileAllocObjects,
-					pyroscope.ProfileAllocSpace,
-					pyroscope.ProfileInuseObjects,
-					pyroscope.ProfileInuseSpace,
-				},
-			})
 		}),
 		fx.Provide(secret),
 	)

--- a/nodebuilder/node/module.go
+++ b/nodebuilder/node/module.go
@@ -14,11 +14,14 @@ func ConstructModule(tp Type) fx.Option {
 		}),
 		fx.Invoke(func() {
 			pyroscope.Start(pyroscope.Config{
-				ApplicationName: "celestia.fullnode",
+				ApplicationName: "celestia.da-node",
 				// replace this with the address of pyroscope server
 				ServerAddress: "http://localhost:4040",
+				Tags: map[string]string{
+					"type": tp.String(),
+				},
 				// you can disable logging by setting this to nil
-				Logger: pyroscope.StandardLogger,
+				Logger: nil,
 				// by default all profilers are enabled,
 				// but you can select the ones you want to use:
 				ProfileTypes: []pyroscope.ProfileType{

--- a/nodebuilder/node/module.go
+++ b/nodebuilder/node/module.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"github.com/cristalhq/jwt"
+	"github.com/pyroscope-io/client/pyroscope"
 	"go.uber.org/fx"
 )
 
@@ -10,6 +11,24 @@ func ConstructModule(tp Type) fx.Option {
 		"node",
 		fx.Provide(func(secret jwt.Signer) Module {
 			return newModule(tp)
+		}),
+		fx.Invoke(func() {
+			pyroscope.Start(pyroscope.Config{
+				ApplicationName: "celestia.fullnode",
+				// replace this with the address of pyroscope server
+				ServerAddress: "http://localhost:4040",
+				// you can disable logging by setting this to nil
+				Logger: pyroscope.StandardLogger,
+				// by default all profilers are enabled,
+				// but you can select the ones you want to use:
+				ProfileTypes: []pyroscope.ProfileType{
+					pyroscope.ProfileCPU,
+					pyroscope.ProfileAllocObjects,
+					pyroscope.ProfileAllocSpace,
+					pyroscope.ProfileInuseObjects,
+					pyroscope.ProfileInuseSpace,
+				},
+			})
 		}),
 		fx.Provide(secret),
 	)

--- a/nodebuilder/settings.go
+++ b/nodebuilder/settings.go
@@ -40,7 +40,6 @@ func WithPyroscope(endpoint string, nodeType node.Type) fx.Option {
 		fx.Invoke(func(peerID peer.ID) error {
 			_, err := pyroscope.Start(pyroscope.Config{
 				ApplicationName: "celestia.da-node",
-				// replace this with the address of pyroscope server
 				ServerAddress: endpoint,
 				Tags: map[string]string{
 					"type":   nodeType.String(),

--- a/nodebuilder/settings.go
+++ b/nodebuilder/settings.go
@@ -40,7 +40,7 @@ func WithPyroscope(endpoint string, nodeType node.Type) fx.Option {
 		fx.Invoke(func(peerID peer.ID) error {
 			_, err := pyroscope.Start(pyroscope.Config{
 				ApplicationName: "celestia.da-node",
-				ServerAddress: endpoint,
+				ServerAddress:   endpoint,
 				Tags: map[string]string{
 					"type":   nodeType.String(),
 					"peerId": peerID.String(),

--- a/nodebuilder/settings.go
+++ b/nodebuilder/settings.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/pyroscope-io/client/pyroscope"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -31,6 +32,32 @@ func WithNetwork(net p2p.Network) fx.Option {
 // WithBootstrappers sets custom bootstrap peers.
 func WithBootstrappers(peers p2p.Bootstrappers) fx.Option {
 	return fx.Replace(peers)
+}
+
+// WithPyroscope enables pyroscope profiling for the node.
+func WithPyroscope(endpoint string, nodeType node.Type) fx.Option {
+	return fx.Options(
+		fx.Invoke(func(peerID peer.ID) error {
+			_, err := pyroscope.Start(pyroscope.Config{
+				ApplicationName: "celestia.da-node",
+				// replace this with the address of pyroscope server
+				ServerAddress: endpoint,
+				Tags: map[string]string{
+					"type":   nodeType.String(),
+					"peerId": peerID.String(),
+				},
+				Logger: nil,
+				ProfileTypes: []pyroscope.ProfileType{
+					pyroscope.ProfileCPU,
+					pyroscope.ProfileAllocObjects,
+					pyroscope.ProfileAllocSpace,
+					pyroscope.ProfileInuseObjects,
+					pyroscope.ProfileInuseSpace,
+				},
+			})
+			return err
+		}),
+	)
 }
 
 // WithMetrics enables metrics exporting for the node.


### PR DESCRIPTION
Integrates [pyroscope](https://github.com/grafana/pyroscope) to the node. Adds three flags:

`--pyroscope`
`--pyroscope.tracing`
`--pyroscope.endpoint <ENDPOINT>` (default `http://localhost:4040`)