### PR TITLE
chore(deps): Upgrading to go 1.20

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: '1.20'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.19.7-alpine3.17 as builder
+FROM docker.io/golang:1.20-alpine3.17 as builder
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Continue reading [here](https://blog.celestia.org/celestia-mvp-release-data-avai
 ## Minimum requirements
 
 | Requirement | Notes          |
-| ----------- | -------------- |
-| Go version  | 1.19 or higher |
+| ----------- |----------------|
+| Go version  | 1.20 or higher |
 
 ## System Requirements
 

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -27,8 +25,6 @@ func main() {
 }
 
 func run() error {
-	rand.Seed(time.Now().Unix())
-
 	return rootCmd.ExecuteContext(context.Background())
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -9,7 +10,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
-	"go.uber.org/multierr"
 
 	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/app/encoding"
@@ -48,8 +48,9 @@ Options passed on start override configuration options only on start and are not
 			if err != nil {
 				return err
 			}
-			// TODO(@Wondertan): Use join errors instead in go1.21
-			defer multierr.AppendInvoke(&err, multierr.Invoke(store.Close))
+			defer func() {
+				err = errors.Join(err, store.Close())
+			}()
 
 			nd, err := nodebuilder.NewWithConfig(NodeType(ctx), Network(ctx), store, &cfg, NodeOptions(ctx)...)
 			if err != nil {

--- a/das/state_test.go
+++ b/das/state_test.go
@@ -62,7 +62,7 @@ func Test_coordinatorStats(t *testing.T) {
 						Curr:   15,
 						From:   11,
 						To:     20,
-						ErrMsg: "12: failed; 13: failed",
+						ErrMsg: "12: failed\n13: failed",
 					},
 				},
 				Concurrency: 2,

--- a/das/state_test.go
+++ b/das/state_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/multierr"
 )
 
 func Test_coordinatorStats(t *testing.T) {
@@ -38,7 +37,7 @@ func Test_coordinatorStats(t *testing.T) {
 							},
 							Curr:   15,
 							failed: []uint64{12, 13},
-							Err:    multierr.Append(errors.New("12: failed"), errors.New("13: failed")),
+							Err:    errors.Join(errors.New("12: failed"), errors.New("13: failed")),
 						}
 					},
 				},

--- a/das/worker.go
+++ b/das/worker.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/multierr"
-
 	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/header"
@@ -179,7 +177,7 @@ func (w *worker) setResult(curr uint64, err error) {
 	defer w.lock.Unlock()
 	if err != nil {
 		w.state.failed = append(w.state.failed, curr)
-		w.state.Err = multierr.Append(w.state.Err, fmt.Errorf("height: %v, err: %w", curr, err))
+		w.state.Err = errors.Join(w.state.Err, fmt.Errorf("height: %v, err: %w", curr, err))
 	}
 	w.state.Curr = curr
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/celestia-node
 
-go 1.19
+go 1.20
 
 replace github.com/ipfs/go-verifcid => github.com/celestiaorg/go-verifcid v0.0.1-lazypatch
 
@@ -69,9 +69,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.13.0
 	go.opentelemetry.io/proto/otlp v0.19.0
 	go.uber.org/fx v1.18.2
-	go.uber.org/multierr v1.9.0
 	golang.org/x/crypto v0.7.0
-	golang.org/x/exp v0.0.0-20230129154200-a960b3787bd2
 	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.8.0
 	google.golang.org/grpc v1.53.0
@@ -305,7 +303,9 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.11.2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/dig v1.15.0 // indirect
+	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/exp v0.0.0-20230129154200-a960b3787bd2 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.4.0 // indirect

--- a/header/headertest/testing.go
+++ b/header/headertest/testing.go
@@ -2,6 +2,7 @@ package headertest
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	mrand "math/rand"
 	"sort"
@@ -19,7 +20,6 @@ import (
 	"github.com/tendermint/tendermint/proto/tendermint/version"
 	"github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
-	"golang.org/x/exp/rand"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	libhead "github.com/celestiaorg/go-header"
@@ -248,7 +248,7 @@ func RandValidator(randPower bool, minPower int64) (*types.Validator, types.Priv
 	privVal := types.NewMockPV()
 	votePower := minPower
 	if randPower {
-		votePower += int64(rand.Uint32())
+		votePower += int64(mrand.Uint32()) //nolint:gosec
 	}
 	pubKey, err := privVal.GetPubKey()
 	if err != nil {
@@ -287,8 +287,8 @@ func RandBlockID(*testing.T) types.BlockID {
 			Hash:  make([]byte, 32),
 		},
 	}
-	mrand.Read(bid.Hash)               //nolint:gosec
-	mrand.Read(bid.PartSetHeader.Hash) //nolint:gosec
+	_, _ = rand.Read(bid.Hash)
+	_, _ = rand.Read(bid.PartSetHeader.Hash)
 	return bid
 }
 

--- a/nodebuilder/p2p/p2p_test.go
+++ b/nodebuilder/p2p/p2p_test.go
@@ -2,7 +2,7 @@ package p2p
 
 import (
 	"context"
-	"math/rand"
+	"crypto/rand"
 	"testing"
 	"time"
 

--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ipfs/go-datastore"
 	dsbadger "github.com/ipfs/go-ds-badger2"
 	"github.com/mitchellh/go-homedir"
-	"go.uber.org/multierr"
 
 	"github.com/celestiaorg/celestia-node/libs/fslock"
 	"github.com/celestiaorg/celestia-node/libs/keystore"
@@ -154,9 +153,9 @@ func (f *fsStore) Datastore() (_ datastore.Batching, err error) {
 }
 
 func (f *fsStore) Close() (err error) {
-	err = multierr.Append(err, f.dirLock.Unlock())
+	err = errors.Join(err, f.dirLock.Unlock())
 	if f.data != nil {
-		err = multierr.Append(err, f.data.Close())
+		err = errors.Join(err, f.data.Close())
 	}
 	return
 }

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -2,8 +2,8 @@ package swamp
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"net"
 	"testing"
 	"time"
@@ -139,7 +139,7 @@ func (s *Swamp) createPeer(ks keystore.Keystore) host.Host {
 
 	// IPv6 will be starting with 100:0
 	token := make([]byte, 12)
-	rand.Read(token) //nolint:gosec
+	_, _ = rand.Read(token)
 	ip := append(net.IP{}, blackholeIP6...)
 	copy(ip[net.IPv6len-len(token):], token)
 

--- a/share/availability/full/availability_test.go
+++ b/share/availability/full/availability_test.go
@@ -2,19 +2,12 @@ package full
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	availability_test "github.com/celestiaorg/celestia-node/share/availability/test"
 )
-
-func init() {
-	// randomize quadrant fetching, otherwise quadrant sampling is deterministic
-	rand.Seed(time.Now().UnixNano())
-}
 
 func TestShareAvailableOverMocknet_Full(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -3,19 +3,17 @@ package light
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	_ "embed"
 	"encoding/hex"
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	core "github.com/tendermint/tendermint/types"
 	mrand "math/rand"
 	"strconv"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/libs/rand"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	core "github.com/tendermint/tendermint/types"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	appshares "github.com/celestiaorg/celestia-app/pkg/shares"
@@ -24,11 +22,6 @@ import (
 	"github.com/celestiaorg/celestia-node/share"
 	availability_test "github.com/celestiaorg/celestia-node/share/availability/test"
 )
-
-func init() {
-	// randomize quadrant fetching, otherwise quadrant sampling is deterministic
-	rand.Seed(time.Now().UnixNano())
-}
 
 func TestSharesAvailable(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -230,7 +223,7 @@ func TestSharesRoundTrip(t *testing.T) {
 	}
 	randBytes := func(n int) []byte {
 		bs := make([]byte, n)
-		mrand.Read(bs)
+		_, _ = rand.Read(bs)
 		return bs
 	}
 	for i := 128; i < 4192; i += mrand.Intn(256) {

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -7,13 +7,14 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"encoding/json"
+	mrand "math/rand"
+	"strconv"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	core "github.com/tendermint/tendermint/types"
-	mrand "math/rand"
-	"strconv"
-	"testing"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	appshares "github.com/celestiaorg/celestia-app/pkg/shares"

--- a/share/availability/test/corrupt_data.go
+++ b/share/availability/test/corrupt_data.go
@@ -2,6 +2,7 @@ package availability_test
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	mrand "math/rand"
 	"testing"
@@ -90,7 +91,7 @@ func (fb FraudulentBlockstore) Put(ctx context.Context, block blocks.Block) erro
 	// create data that doesn't match the CID with arbitrary lengths between 1 and
 	// len(block.RawData())*2
 	corrupted := make([]byte, 1+mrand.Int()%(len(block.RawData())*2-1)) //nolint:gosec
-	mrand.Read(corrupted)                                               //nolint:gosec
+	_, _ = rand.Read(corrupted)
 	return fb.Datastore.Put(ctx, ds.NewKey("corrupt"+block.Cid().String()), corrupted)
 }
 

--- a/share/eds/adapters_test.go
+++ b/share/eds/adapters_test.go
@@ -2,8 +2,9 @@ package eds
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
-	"math/rand"
+	mrand "math/rand"
 	"sort"
 	"testing"
 	"time"
@@ -47,7 +48,7 @@ func TestBlockGetter_GetBlocks(t *testing.T) {
 		cids := randCIDs(32)
 
 		// split cids into failed and succeeded
-		failedLen := rand.Intn(len(cids)-1) + 1
+		failedLen := mrand.Intn(len(cids)-1) + 1
 		failed := make(map[cid.Cid]struct{}, failedLen)
 		succeeded := make([]cid.Cid, 0, len(cids)-failedLen)
 		for i, cid := range cids {
@@ -141,7 +142,7 @@ func (r rbsMock) HashOnRead(bool) {
 
 func randCID() cid.Cid {
 	hash := make([]byte, ipld.NmtHashSize)
-	rand.Read(hash)
+	_, _ = rand.Read(hash)
 	return ipld.MustCidFromNamespacedSha256(hash)
 }
 

--- a/share/eds/retriever_test.go
+++ b/share/eds/retriever_test.go
@@ -3,7 +3,6 @@ package eds
 import (
 	"context"
 	"errors"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -24,11 +23,6 @@ import (
 	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
 	"github.com/celestiaorg/celestia-node/share/ipld"
 )
-
-func init() {
-	// randomize quadrant fetching, otherwise quadrant sampling is deterministic
-	rand.Seed(time.Now().UnixNano())
-}
 
 func TestRetriever_Retrieve(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/share/get_test.go
+++ b/share/get_test.go
@@ -2,7 +2,7 @@ package share
 
 import (
 	"context"
-	"math/rand"
+	mrand "math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -130,7 +130,7 @@ func removeRandShares(data [][]byte, d int) [][]byte {
 	count := len(data)
 	// remove shares randomly
 	for i := 0; i < d; {
-		ind := rand.Intn(count)
+		ind := mrand.Intn(count)
 		if len(data[ind]) == 0 {
 			continue
 		}
@@ -331,7 +331,7 @@ func TestGetSharesWithProofsByNamespace(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			rand.Seed(time.Now().UnixNano())
+			rand := mrand.New(mrand.NewSource(time.Now().UnixNano()))
 			// choose random range in shares slice
 			from := rand.Intn(len(tt.rawData))
 			to := rand.Intn(len(tt.rawData))

--- a/share/getters/cascade.go
+++ b/share/getters/cascade.go
@@ -6,7 +6,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/celestiaorg/rsmt2d"
@@ -127,8 +126,7 @@ func cascadeGetters[V any](
 		}
 
 		if !errors.Is(getErr, errOperationNotSupported) {
-			// TODO(@Wondertan): migrate to errors.Join once Go1.20 is out!
-			err = multierr.Append(err, getErr)
+			err = errors.Join(err, getErr)
 			span.RecordError(getErr, trace.WithAttributes(attribute.Int("getter_idx", i)))
 		}
 	}

--- a/share/getters/cascade_test.go
+++ b/share/getters/cascade_test.go
@@ -3,11 +3,11 @@ package getters
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/multierr"
 
 	"github.com/celestiaorg/rsmt2d"
 
@@ -93,7 +93,7 @@ func TestCascade(t *testing.T) {
 		getters := []share.Getter{immediateFailGetter, timeoutGetter, immediateFailGetter}
 		_, err := cascadeGetters(ctx, getters, get)
 		assert.Error(t, err)
-		assert.Len(t, multierr.Errors(err), 3)
+		assert.Equal(t, strings.Count(err.Error(), "\n"), 2)
 	})
 
 	t.Run("Single", func(t *testing.T) {

--- a/share/getters/shrex.go
+++ b/share/getters/shrex.go
@@ -2,10 +2,9 @@ package getters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
-
-	"go.uber.org/multierr"
 
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/celestiaorg/rsmt2d"
@@ -72,7 +71,7 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, root *share.Root) (*rsmt2d.Ex
 		start := time.Now()
 		peer, setStatus, getErr := sg.peerManager.Peer(ctx, root.Hash())
 		if getErr != nil {
-			err = multierr.Append(err, getErr)
+			err = errors.Join(err, getErr)
 			log.Debugw("couldn't find peer",
 				"datahash", root.String(),
 				"err", getErr,
@@ -96,7 +95,7 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, root *share.Root) (*rsmt2d.Ex
 		}
 
 		if !ErrorContains(err, getErr) {
-			err = multierr.Append(err, getErr)
+			err = errors.Join(err, getErr)
 		}
 		log.Debugw("request failed",
 			"datahash", root.String(),
@@ -121,7 +120,7 @@ func (sg *ShrexGetter) GetSharesByNamespace(
 		start := time.Now()
 		peer, setStatus, getErr := sg.peerManager.Peer(ctx, root.Hash())
 		if getErr != nil {
-			err = multierr.Append(err, getErr)
+			err = errors.Join(err, getErr)
 			log.Debugw("couldn't find peer",
 				"datahash", root.String(),
 				"err", getErr,
@@ -145,7 +144,7 @@ func (sg *ShrexGetter) GetSharesByNamespace(
 		}
 
 		if !ErrorContains(err, getErr) {
-			err = multierr.Append(err, getErr)
+			err = errors.Join(err, getErr)
 		}
 		log.Debugw("request failed",
 			"datahash", root.String(),

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -2,7 +2,7 @@ package getters
 
 import (
 	"context"
-	"math/rand"
+	mrand "math/rand"
 	"testing"
 	"time"
 
@@ -80,8 +80,8 @@ func newStore(t *testing.T) (*eds.Store, error) {
 func generateTestEDS(t *testing.T, bServ bsrv.BlockService) (*rsmt2d.ExtendedDataSquare, namespace.ID) {
 	shares := share.RandShares(t, 16)
 
-	from := rand.Intn(len(shares))
-	to := rand.Intn(len(shares))
+	from := mrand.Intn(len(shares))
+	to := mrand.Intn(len(shares))
 
 	if to < from {
 		from, to = to, from

--- a/share/getters/utils_test.go
+++ b/share/getters/utils_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/multierr"
 )
 
 func Test_ErrorContains(t *testing.T) {
@@ -80,14 +79,14 @@ func Test_ErrorContains(t *testing.T) {
 		},
 		{"multierr first in slice",
 			args{
-				err:    multierr.Append(w1(err1), w2(err2)),
+				err:    errors.Join(w1(err1), w2(err2)),
 				target: w2(err1),
 			},
 			true,
 		},
 		{"multierr second in slice",
 			args{
-				err:    multierr.Append(w1(err1), w2(err2)),
+				err:    errors.Join(w1(err1), w2(err2)),
 				target: w1(err2),
 			},
 			true,

--- a/share/ipld/nmt_test.go
+++ b/share/ipld/nmt_test.go
@@ -2,7 +2,7 @@ package ipld
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"sort"
 	"strconv"
 	"testing"
@@ -51,14 +51,14 @@ func generateRandNamespacedRawData(total, nidSize, leafSize uint32) [][]byte {
 	for i := uint32(0); i < total; i++ {
 		nid := make([]byte, nidSize)
 
-		rand.Read(nid)
+		_, _ = rand.Read(nid)
 		data[i] = nid
 	}
 	sortByteArrays(data)
 	for i := uint32(0); i < total; i++ {
 		d := make([]byte, leafSize)
 
-		rand.Read(d)
+		_, _ = rand.Read(d)
 		data[i] = append(data[i], d...)
 	}
 

--- a/share/ipld/test_helpers.go
+++ b/share/ipld/test_helpers.go
@@ -1,7 +1,7 @@
 package ipld
 
 import (
-	mrand "math/rand"
+	"crypto/rand"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -10,7 +10,7 @@ import (
 
 func RandNamespacedCID(t *testing.T) cid.Cid {
 	raw := make([]byte, NmtHashSize)
-	_, err := mrand.Read(raw) //nolint:gosec
+	_, err := rand.Read(raw)
 	require.NoError(t, err)
 	id, err := CidFromNamespacedSha256(raw)
 	require.NoError(t, err)

--- a/share/p2p/peers/options.go
+++ b/share/p2p/peers/options.go
@@ -54,7 +54,8 @@ func DefaultParameters() Parameters {
 		// the new block before we ask them again.
 		PeerCooldown: 3 * time.Second,
 		GcInterval:   time.Second * 30,
-		// blacklisting is off by default //TODO(@walldiss): enable blacklisting once all related issues are resolved
+		// blacklisting is off by default //TODO(@walldiss): enable blacklisting once all related issues
+		// are resolved
 		EnableBlackListing: false,
 	}
 }

--- a/share/test_helpers.go
+++ b/share/test_helpers.go
@@ -2,7 +2,7 @@ package share
 
 import (
 	"bytes"
-	mrand "math/rand"
+	"crypto/rand"
 	"sort"
 
 	"github.com/stretchr/testify/require"
@@ -53,14 +53,14 @@ func RandShares(t require.TestingT, total int) []Share {
 	shares := make([]Share, total)
 	for i := range shares {
 		nid := make([]byte, Size)
-		_, err := mrand.Read(nid[:NamespaceSize]) //nolint:gosec
+		_, err := rand.Read(nid[:NamespaceSize])
 		require.NoError(t, err)
 		shares[i] = nid
 	}
 	sort.Slice(shares, func(i, j int) bool { return bytes.Compare(shares[i], shares[j]) < 0 })
 
 	for i := range shares {
-		_, err := mrand.Read(shares[i][NamespaceSize:]) //nolint:gosec
+		_, err := rand.Read(shares[i][NamespaceSize:])
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

- upgrade golang to 1.20
 - replace multierr with new errors.Join
 - replace deprecated math/rand Read with crypto/rand Read
 
