### PR TITLE
refactoring(share/p2p): remove TTL in pubsub

### DIFF
--- a/share/p2p/shrexsub/pubsub.go
+++ b/share/p2p/shrexsub/pubsub.go
@@ -46,9 +46,7 @@ type PubSub struct {
 
 // NewPubSub creates a libp2p.PubSub wrapper.
 func NewPubSub(ctx context.Context, h host.Host, networkID string) (*PubSub, error) {
-	// WithSeenMessagesTTL without duration allows to process all incoming messages(even with the same
-	// msgId)
-	pubsub, err := pubsub.NewFloodSub(ctx, h, pubsub.WithSeenMessagesTTL(0))
+	pubsub, err := pubsub.NewFloodSub(ctx, h)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Overview
Return TTL back to the default value to avoid message duplication with the same msgID.

## Checklist
- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
