### PR TITLE
feat: include function signatures in rpc cli autocompletions

### DIFF
--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -71,7 +71,7 @@ var rpcCmd = &cobra.Command{
 			methods := reflect.VisibleFields(reflect.TypeOf(module).Elem())
 			var methodNames []string
 			for _, m := range methods {
-				methodNames = append(methodNames, m.Name)
+				methodNames = append(methodNames, m.Name+"\t"+parseSignatureForHelpstring(m))
 			}
 			return methodNames, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -296,4 +296,24 @@ func parseAddressFromString(addrStr string) (state.Address, error) {
 	}
 
 	return addr, nil
+}
+
+func parseSignatureForHelpstring(methodSig reflect.StructField) string {
+	simplifiedSignature := "("
+	in, out := methodSig.Type.NumIn(), methodSig.Type.NumOut()
+	for i := 1; i < in; i++ {
+		simplifiedSignature += methodSig.Type.In(i).String()
+		if i != in-1 {
+			simplifiedSignature += ", "
+		}
+	}
+	simplifiedSignature += ") -> ("
+	for i := 0; i < out-1; i++ {
+		simplifiedSignature += methodSig.Type.Out(i).String()
+		if i != out-2 {
+			simplifiedSignature += ", "
+		}
+	}
+	simplifiedSignature += ")"
+	return simplifiedSignature
 }


### PR DESCRIPTION
Adds function signatures (excluding input context field, and output error field) to the RPC CLI autocompletions. Now the autocompletions for the methods looks like this: 

![image](https://user-images.githubusercontent.com/16523232/230006576-a7263d3f-5360-4277-adaa-e500eed3fed6.png)