### PR TITLE
refactor(WIP): only storing ODS on disk

### DIFF
--- a/share/eds/rs_mount.go
+++ b/share/eds/rs_mount.go
@@ -1,0 +1,96 @@
+package eds
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/filecoin-project/dagstore/mount"
+
+	"github.com/celestiaorg/celestia-node/share"
+)
+
+type RSMount struct {
+	Path     string
+	Datahash share.DataHash
+}
+
+func (r *RSMount) Fetch(ctx context.Context) (mount.Reader, error) {
+	fReader, err := os.Open(r.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", r.Path, err)
+	}
+	odsReader, err := ODSReader(fReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ODS reader: %w", err)
+	}
+	eds, _ := ReadEDS(ctx, odsReader, r.Datahash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read EDS: %w", err)
+	}
+	pipeReader, pipeWriter := io.Pipe()
+
+	go func() {
+		defer pipeWriter.Close()
+
+		err := WriteEDS(ctx, eds, pipeWriter)
+		if err != nil {
+			log.Errorw("failed to write EDS: ", err)
+		}
+	}()
+
+	carBytes, err := io.ReadAll(pipeReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read EDS from pipe: %w", err)
+	}
+	return bytesReader{bytes.NewReader(carBytes)}, nil
+}
+
+type bytesReader struct {
+	*bytes.Reader
+}
+
+func (f *RSMount) Stat(_ context.Context) (mount.Stat, error) {
+	stat, err := os.Stat(f.Path)
+	if err != nil && os.IsNotExist(err) {
+		return mount.Stat{}, err
+	}
+	return mount.Stat{
+		Exists: !os.IsNotExist(err),
+		Size:   stat.Size(),
+	}, err
+}
+
+func (b bytesReader) Close() error {
+	return nil
+}
+
+func (f *RSMount) Info() mount.Info {
+	return mount.Info{
+		Kind:             mount.KindLocal,
+		AccessRandom:     true,
+		AccessSeek:       true,
+		AccessSequential: true,
+	}
+}
+
+func (f *RSMount) Serialize() *url.URL {
+	return &url.URL{
+		Host: f.Path,
+	}
+}
+
+func (f *RSMount) Deserialize(u *url.URL) error {
+	if u.Host == "" {
+		return fmt.Errorf("invalid host")
+	}
+	f.Path = u.Host
+	return nil
+}
+
+func (f *RSMount) Close() error {
+	return nil
+}


### PR DESCRIPTION
This PR is a very rough, badly coded POC of only storing the ODS on disk. Seems functional on blockspace-race.

The way this works is that 
1. We store only the CAR Header and first quadrant on disk. "ODS CAR"
2. The file gets registered on the dagstore using the`RSMount`. The `RSMount` mount reads the ODS CAR from disk and generates the EDS on the fly, creating the "extended CAR" which is cached in memory
3. On shard registration, the dagstore populates both the top level index of all IPLD blocks (multihash -> shard) as well as the individual CAR index (shard key x CID -> byte offset in extended CAR)
4. On shard acquire, the `RSMount` is fetched so that the ODS CAR is read from disk but the shard accessor returns a mount Reader over the extended CAR.
    - This means that the Blockstore returned will be over the extended CAR, used as usual, and
    - The accessor also works over shrex in the same way, so ODSes can be served as usual


Because recent shard accessors stay in the `eds.Store`'s LRU cache, the extended data square is only calculated once and left in the cache until it is no longer being requested. This can be further optimized by already caching on `Put`, since we know the shard will be accessed almost immediately after (unless the node is doing its initial sync, but this is fine).

There are other efficiency problems with this and a lot of things to be optimized but I think its at the very least a promising PoC