### PR TITLE
fix: adding traces to pyroscope dashboard

### DIFF
--- a/cmd/flags_misc.go
+++ b/cmd/flags_misc.go
@@ -235,7 +235,7 @@ func ParseMiscFlags(ctx context.Context, cmd *cobra.Command) (context.Context, e
 				tp,
 				otelpyroscope.WithAppName("celestia.da-node"),
 				otelpyroscope.WithPyroscopeURL(cmd.Flag(pyroscopeEndpoint).Value.String()),
-				otelpyroscope.WithRootSpanOnly(false),
+				otelpyroscope.WithRootSpanOnly(true),
 				otelpyroscope.WithAddSpanName(true),
 				otelpyroscope.WithProfileURL(true),
 				otelpyroscope.WithProfileBaselineURL(true),


### PR DESCRIPTION
This PR adds traces back to the pyroscope dashboard. I had them activated in the demo but for some reason it ended up deactivated in the original integration PR.