### PR TITLE
feat: if NODE_STORE is set use it in custom init command

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,11 +4,16 @@ set -e
 
 if [ "$1" = 'celestia' ]; then
     echo "Initializing Celestia Node with command:"
-    echo "celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}""
+
+    if [[ -n "$NODE_STORE" ]]; then
+        echo "celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}" --node.store "${NODE_STORE}""
+        celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}" --node.store "${NODE_STORE}"
+    else
+        echo "celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}""
+        celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}"
+    fi
+
     echo ""
-
-    celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}"
-
     echo ""
 fi
 


### PR DESCRIPTION
This change in the `entrypoint.sh` is for supporting docker compose setup in [rollkit/gm](https://github.com/rollkit/gm). See [here](https://github.com/rollkit/gm/pull/2).

When the `NODE_STORE` env variable is set, the init command specifies the `node.store` parameter to this environment variable.

This is non-breaking; if the variable is not set, nothing changes.