### PR TITLE
fix(modp2p): fix libp2p metrics

### DIFF
--- a/cmd/flags_misc.go
+++ b/cmd/flags_misc.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/logs"
 	"github.com/celestiaorg/celestia-node/nodebuilder"
+	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 var (
@@ -273,7 +274,7 @@ func ParseMiscFlags(ctx context.Context, cmd *cobra.Command) (context.Context, e
 		if metricsEnabled, _ := cmd.Flags().GetBool(metricsFlag); !metricsEnabled {
 			log.Error("--p2p.metrics used without --metrics being enabled")
 		} else {
-			ctx = WithNodeOptions(ctx, nodebuilder.WithP2PMetrics())
+			ctx = WithNodeOptions(ctx, modp2p.WithMetrics())
 		}
 	}
 

--- a/nodebuilder/init.go
+++ b/nodebuilder/init.go
@@ -71,7 +71,8 @@ func Init(cfg Config, path string, tp node.Type) error {
 	return nil
 }
 
-// Reset removes all data from the datastore and dagstore directories. It leaves the keystore and config intact.
+// Reset removes all data from the datastore and dagstore directories. It leaves the keystore and
+// config intact.
 func Reset(path string, tp node.Type) error {
 	path, err := storePath(path)
 	if err != nil {

--- a/nodebuilder/p2p/config.go
+++ b/nodebuilder/p2p/config.go
@@ -32,8 +32,6 @@ type Config struct {
 	ConnManager               connManagerConfig
 	RoutingTableRefreshPeriod time.Duration
 
-	// Libp2p Metrics Configuration
-	Metrics MetricsConfig
 	// Allowlist for IPColocation PubSub parameter, a list of string CIDRs
 	IPColocationWhitelist []string
 }
@@ -60,7 +58,6 @@ func DefaultConfig(tp node.Type) Config {
 		PeerExchange:              tp == node.Bridge || tp == node.Full,
 		ConnManager:               defaultConnManagerConfig(),
 		RoutingTableRefreshPeriod: defaultRoutingRefreshPeriod,
-		Metrics:                   DefaultMetricsConfig(),
 	}
 }
 
@@ -82,5 +79,5 @@ func (cfg *Config) Validate() error {
 		cfg.RoutingTableRefreshPeriod = defaultRoutingRefreshPeriod
 		log.Warnf("routingTableRefreshPeriod is not valid. restoring to default value: %d", cfg.RoutingTableRefreshPeriod)
 	}
-	return cfg.Metrics.Validate()
+	return nil
 }

--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -16,6 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/routing"
 	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -45,6 +46,10 @@ func host(params hostParams) (HostBase, error) {
 		libp2p.DefaultSecurity,
 		libp2p.DefaultTransports,
 		libp2p.DefaultMuxers,
+	}
+
+	if params.Registry != nil {
+		opts = append(opts, libp2p.PrometheusRegisterer(params.Registry))
 	}
 
 	// All node types except light (bridge, full) will enable NATService
@@ -79,6 +84,7 @@ type hostParams struct {
 	ConnGater       *conngater.BasicConnectionGater
 	Bandwidth       *metrics.BandwidthCounter
 	ResourceManager network.ResourceManager
+	Registry        prometheus.Registerer `optional:"true"`
 
 	Tp node.Type
 }

--- a/nodebuilder/p2p/metrics.go
+++ b/nodebuilder/p2p/metrics.go
@@ -4,60 +4,41 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
-	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core/network"
-	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
-	ma "github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/fx"
-
-	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
-const promAgentEndpoint = "/metrics"
-
-type MetricsConfig struct {
-	// Prometheus Agent http configuration
-	PrometheusAgentPort string
+// WithMetrics option sets up native libp2p metrics up.
+func WithMetrics() fx.Option {
+	return fx.Options(
+		fx.Provide(resourceManagerOpt(traceReporter)),
+		fx.Provide(prometheusRegisterer),
+		fx.Invoke(prometheusMetrics),
+	)
 }
 
-// DefaultMetricsConfig returns default configuration for P2P subsystem.
-func DefaultMetricsConfig() MetricsConfig {
-	return MetricsConfig{
-		PrometheusAgentPort: "8890",
-	}
-}
+const (
+	promAgentEndpoint = "/metrics"
+	promAgentPort     = "8890"
+)
 
-func (cfg *MetricsConfig) Validate() error {
-	if cfg.PrometheusAgentPort == "" {
-		return fmt.Errorf("p2p metrics: prometheus agent port cannot be empty")
-	}
+// prometheusMetrics option sets up native libp2p metrics up
+func prometheusMetrics(lifecycle fx.Lifecycle, registerer prometheus.Registerer) error {
+	rcmgrObs.MustRegisterWith(registerer)
 
-	if _, err := strconv.Atoi(cfg.PrometheusAgentPort); err != nil {
-		return fmt.Errorf("p2p metrics: prometheus agent port must be a number")
-	}
-
-	return nil
-}
-
-// WithMetrics option sets up native libp2p metrics up
-func WithMetrics(lifecycle fx.Lifecycle, cfg Config) error {
-	rcmgrObs.MustRegisterWith(prometheus.DefaultRegisterer)
-
-	reg := prometheus.DefaultRegisterer
-	registry := reg.(*prometheus.Registry)
+	registry := registerer.(*prometheus.Registry)
 
 	mux := http.NewServeMux()
-	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{Registry: reg})
+	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{Registry: registerer})
 	mux.Handle(promAgentEndpoint, handler)
 
+	// TODO(@Wondertan): Unify all the servers into one (See #2007)
 	promHTTPServer := &http.Server{
-		Addr:              fmt.Sprintf(":%s", cfg.Metrics.PrometheusAgentPort),
+		Addr:              fmt.Sprintf(":%s", promAgentPort),
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
@@ -66,12 +47,11 @@ func WithMetrics(lifecycle fx.Lifecycle, cfg Config) error {
 		OnStart: func(ctx context.Context) error {
 			go func() {
 				if err := promHTTPServer.ListenAndServe(); err != nil {
-					log.Error("Error starting Prometheus metrics exporter http server")
-					panic(err)
+					log.Errorf("Error starting Prometheus metrics exporter http server: %s", err)
 				}
 			}()
 
-			log.Info("Prometheus agent started on :%s/%s", cfg.Metrics.PrometheusAgentPort, promAgentEndpoint)
+			log.Info("Prometheus agent started on :%s/%s", promAgentPort, promAgentEndpoint)
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
@@ -81,36 +61,6 @@ func WithMetrics(lifecycle fx.Lifecycle, cfg Config) error {
 	return nil
 }
 
-func WithMonitoredResourceManager(nodeType node.Type, allowlist []ma.Multiaddr) (network.ResourceManager, error) {
-	str, err := rcmgrObs.NewStatsTraceReporter()
-	if err != nil {
-		return nil, err
-	}
-
-	var monitoredRcmgr network.ResourceManager
-
-	switch nodeType {
-	case node.Full, node.Bridge:
-		monitoredRcmgr, err = rcmgr.NewResourceManager(
-			rcmgr.NewFixedLimiter(rcmgr.InfiniteLimits),
-			rcmgr.WithTraceReporter(str),
-		)
-
-	case node.Light:
-		limits := rcmgr.DefaultLimits
-		libp2p.SetDefaultServiceLimits(&limits)
-
-		monitoredRcmgr, err = rcmgr.NewResourceManager(
-			rcmgr.NewFixedLimiter(limits.AutoScale()),
-			rcmgr.WithAllowlistedMultiaddrs(allowlist),
-			rcmgr.WithTraceReporter(str),
-		)
-	default:
-		panic("invalid node type")
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return monitoredRcmgr, err
+func prometheusRegisterer() prometheus.Registerer {
+	return prometheus.NewRegistry()
 }

--- a/nodebuilder/p2p/module.go
+++ b/nodebuilder/p2p/module.go
@@ -1,15 +1,8 @@
 package p2p
 
 import (
-	"context"
-
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/metrics"
-	"github.com/libp2p/go-libp2p/core/network"
-	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
-	ma "github.com/multiformats/go-multiaddr"
-	madns "github.com/multiformats/go-multiaddr-dns"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -41,6 +34,8 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 		fx.Provide(metrics.NewBandwidthCounter),
 		fx.Provide(newModule),
 		fx.Invoke(Listen(cfg.ListenAddresses)),
+		fx.Provide(resourceManager),
+		fx.Provide(resourceManagerOpt(allowList)),
 	)
 
 	switch tp {
@@ -49,56 +44,14 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 			"p2p",
 			baseComponents,
 			fx.Provide(blockstoreFromEDSStore),
-			fx.Provide(func() (network.ResourceManager, error) {
-				return rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.InfiniteLimits))
-			}),
+			fx.Provide(infiniteResources),
 		)
 	case node.Light:
 		return fx.Module(
 			"p2p",
 			baseComponents,
 			fx.Provide(blockstoreFromDatastore),
-			fx.Provide(func(ctx context.Context, bootstrappers Bootstrappers) (allowlist []ma.Multiaddr, err error) {
-				mutual, err := cfg.mutualPeers()
-				if err != nil {
-					return nil, err
-				}
-
-				// TODO(@Wondertan): We should resolve their addresses only once, but currently
-				//  we resolve it here and libp2p stuck does that as well internally
-				allowlist = make([]ma.Multiaddr, 0, len(bootstrappers)+len(mutual))
-				for _, b := range bootstrappers {
-					for _, baddr := range b.Addrs {
-						resolved, err := madns.DefaultResolver.Resolve(ctx, baddr)
-						if err != nil {
-							log.Warnw("error resolving bootstrapper DNS", "addr", baddr.String(), "err", err)
-							continue
-						}
-						allowlist = append(allowlist, resolved...)
-					}
-				}
-				for _, m := range mutual {
-					for _, maddr := range m.Addrs {
-						resolved, err := madns.DefaultResolver.Resolve(ctx, maddr)
-						if err != nil {
-							log.Warnw("error resolving mutual peer DNS", "addr", maddr.String(), "err", err)
-							continue
-						}
-						allowlist = append(allowlist, resolved...)
-					}
-				}
-
-				return allowlist, nil
-			}),
-			fx.Provide(func(ctx context.Context, allowlist []ma.Multiaddr) (network.ResourceManager, error) {
-				limits := rcmgr.DefaultLimits
-				libp2p.SetDefaultServiceLimits(&limits)
-
-				return rcmgr.NewResourceManager(
-					rcmgr.NewFixedLimiter(limits.AutoScale()),
-					rcmgr.WithAllowlistedMultiaddrs(allowlist),
-				)
-			}),
+			fx.Provide(autoscaleResources),
 		)
 	default:
 		panic("invalid node type")

--- a/nodebuilder/p2p/module_test.go
+++ b/nodebuilder/p2p/module_test.go
@@ -1,0 +1,67 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"github.com/celestiaorg/celestia-node/libs/keystore"
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+)
+
+func testModule(tp node.Type) fx.Option {
+	cfg := DefaultConfig(tp)
+	// TODO(@Wondertan): Most of these can be deduplicated
+	//  by moving Store into the modnode and introducing there a TestModNode module
+	//  that testers would import
+	return fx.Options(
+		fx.NopLogger,
+		ConstructModule(tp, &cfg),
+		fx.Provide(context.Background),
+		fx.Supply(Private),
+		fx.Supply(Bootstrappers{}),
+		fx.Supply(tp),
+		fx.Provide(keystore.NewMapKeystore),
+		fx.Supply(fx.Annotate(ds_sync.MutexWrap(datastore.NewMapDatastore()), fx.As(new(datastore.Batching)))),
+	)
+}
+
+func TestModuleBuild(t *testing.T) {
+	var test = []struct {
+		tp node.Type
+	}{
+		{tp: node.Bridge},
+		{tp: node.Full},
+		{tp: node.Light},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.tp.String(), func(t *testing.T) {
+			app := fxtest.New(t, testModule(tt.tp))
+			app.RequireStart()
+			app.RequireStop()
+		})
+	}
+}
+
+func TestModuleBuild_WithMetrics(t *testing.T) {
+	var test = []struct {
+		tp node.Type
+	}{
+		{tp: node.Full},
+		{tp: node.Bridge},
+		{tp: node.Light},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.tp.String(), func(t *testing.T) {
+			app := fxtest.New(t, testModule(tt.tp), WithMetrics())
+			app.RequireStart()
+			app.RequireStop()
+		})
+	}
+}

--- a/nodebuilder/p2p/resources.go
+++ b/nodebuilder/p2p/resources.go
@@ -1,0 +1,83 @@
+package p2p
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
+	ma "github.com/multiformats/go-multiaddr"
+	madns "github.com/multiformats/go-multiaddr-dns"
+	"go.uber.org/fx"
+)
+
+func resourceManager(params resourceManagerParams) (network.ResourceManager, error) {
+	return rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(params.Limits))
+}
+
+func infiniteResources() rcmgr.ConcreteLimitConfig {
+	return rcmgr.InfiniteLimits
+}
+
+func autoscaleResources() rcmgr.ConcreteLimitConfig {
+	limits := rcmgr.DefaultLimits
+	libp2p.SetDefaultServiceLimits(&limits)
+	return limits.AutoScale()
+}
+
+func allowList(ctx context.Context, cfg Config, bootstrappers Bootstrappers) (rcmgr.Option, error) {
+	mutual, err := cfg.mutualPeers()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(@Wondertan): We should resolve their addresses only once, but currently
+	//  we resolve it here and libp2p stuck does that as well internally
+	allowlist := make([]ma.Multiaddr, 0, len(bootstrappers)+len(mutual))
+	for _, b := range bootstrappers {
+		for _, baddr := range b.Addrs {
+			resolved, err := madns.DefaultResolver.Resolve(ctx, baddr)
+			if err != nil {
+				log.Warnw("error resolving bootstrapper DNS", "addr", baddr.String(), "err", err)
+				continue
+			}
+			allowlist = append(allowlist, resolved...)
+		}
+	}
+	for _, m := range mutual {
+		for _, maddr := range m.Addrs {
+			resolved, err := madns.DefaultResolver.Resolve(ctx, maddr)
+			if err != nil {
+				log.Warnw("error resolving mutual peer DNS", "addr", maddr.String(), "err", err)
+				continue
+			}
+			allowlist = append(allowlist, resolved...)
+		}
+	}
+
+	return rcmgr.WithAllowlistedMultiaddrs(allowlist), nil
+}
+
+func traceReporter() rcmgr.Option {
+	str, err := rcmgrObs.NewStatsTraceReporter()
+	if err != nil {
+		panic(err) // err is always nil as per sources
+	}
+
+	return rcmgr.WithTraceReporter(str)
+}
+
+type resourceManagerParams struct {
+	fx.In
+
+	Limits rcmgr.ConcreteLimitConfig
+	Opts   []rcmgr.Option `group:"rcmgr-opts"`
+}
+
+func resourceManagerOpt(opt any) fx.Annotated {
+	return fx.Annotated{
+		Group:  "rcmgr-opts",
+		Target: opt,
+	}
+}

--- a/nodebuilder/settings.go
+++ b/nodebuilder/settings.go
@@ -90,14 +90,6 @@ func WithMetrics(metricOpts []otlpmetrichttp.Option, nodeType node.Type) fx.Opti
 	return opts
 }
 
-// WithP2PMetrics option enables native libp2p metrisc for node
-func WithP2PMetrics() fx.Option {
-	return fx.Options(
-		fx.Decorate(p2p.WithMonitoredResourceManager),
-		fx.Invoke(p2p.WithMetrics),
-	)
-}
-
 // initializeMetrics initializes the global meter provider.
 func initializeMetrics(
 	ctx context.Context,

--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -191,7 +191,8 @@ func blocksPath(base string) string {
 }
 
 func transientsPath(base string) string {
-	// we don't actually use the transients directory anymore, but it could be populated from previous versions.
+	// we don't actually use the transients directory anymore, but it could be populated from previous
+	// versions.
 	return filepath.Join(base, "transients")
 }
 


### PR DESCRIPTION
* Introduces unit tests for p2p module builds to avoid such issues in future
* Reworks and cleans up resource manager registering with an actual fix
* Removes libp2p metrics config
	* There is no need for users to configure Prometheus port because of future #2007 
* Moves `WithP2PMetrics` `nodebuilder` -> `modp2p`, because it needs access to private funcs