### PR TITLE
refactor(share/shrex): cleanup shrex logs

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -19,8 +19,8 @@ func SetAllLoggers(level logging.LogLevel) {
 	_ = logging.SetLogLevel("basichost", "INFO")
 	_ = logging.SetLogLevel("pubsub", "WARN")
 	_ = logging.SetLogLevel("net/identify", "ERROR")
-	_ = logging.SetLogLevel("shrex/nd", "ERROR")
-	_ = logging.SetLogLevel("shrex/eds", "ERROR")
+	_ = logging.SetLogLevel("shrex/nd", "WARN")
+	_ = logging.SetLogLevel("shrex/eds", "WARN")
 }
 
 func SetDebugLogging() {

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -19,6 +19,8 @@ func SetAllLoggers(level logging.LogLevel) {
 	_ = logging.SetLogLevel("basichost", "INFO")
 	_ = logging.SetLogLevel("pubsub", "WARN")
 	_ = logging.SetLogLevel("net/identify", "ERROR")
+	_ = logging.SetLogLevel("shrex/nd", "ERROR")
+	_ = logging.SetLogLevel("shrex/eds", "ERROR")
 }
 
 func SetDebugLogging() {

--- a/share/p2p/shrexeds/client.go
+++ b/share/p2p/shrexeds/client.go
@@ -61,7 +61,7 @@ func (c *Client) RequestEDS(
 		}
 	}
 	if err != p2p.ErrNotFound {
-		log.Debugw("client: eds request to peer failed", "peer", peer, "hash", dataHash.String())
+		log.Warnw("client: eds request to peer failed", "peer", peer, "hash", dataHash.String())
 	}
 
 	return nil, err
@@ -79,7 +79,7 @@ func (c *Client) doRequest(
 
 	if dl, ok := ctx.Deadline(); ok {
 		if err = stream.SetDeadline(dl); err != nil {
-			log.Debugf("error setting deadline: %s", err)
+			log.Debugw("error setting deadline: %s", "err", err)
 		}
 	}
 
@@ -94,8 +94,7 @@ func (c *Client) doRequest(
 	}
 	err = stream.CloseWrite()
 	if err != nil {
-		stream.Reset() //nolint:errcheck
-		return nil, fmt.Errorf("failed to close write on stream: %w", err)
+		log.Debugw("error closing write", "err", err)
 	}
 
 	// read and parse status from peer
@@ -119,12 +118,13 @@ func (c *Client) doRequest(
 		}
 		return eds, nil
 	case pb.Status_NOT_FOUND:
-		log.Debugf("client: peer %s couldn't serve eds %s with status %s", to.String(), dataHash.String(), resp.GetStatus())
 		return nil, p2p.ErrNotFound
-	case pb.Status_INVALID, pb.Status_INTERNAL:
+	case pb.Status_INVALID:
+		log.Debug("client: invalid request")
+		fallthrough
+	case pb.Status_INTERNAL:
 		fallthrough
 	default:
-		log.Errorf("request status %s returned for root %s", resp.Status.String(), dataHash.String())
 		return nil, p2p.ErrInvalidResponse
 	}
 }

--- a/share/p2p/shrexeds/params.go
+++ b/share/p2p/shrexeds/params.go
@@ -10,7 +10,7 @@ import (
 
 const protocolString = "/shrex/eds/v0.0.1"
 
-var log = logging.Logger("shrex-eds")
+var log = logging.Logger("shrex/eds")
 
 // Parameters is the set of parameters that must be configured for the shrex/eds protocol.
 type Parameters struct {

--- a/share/p2p/shrexeds/server.go
+++ b/share/p2p/shrexeds/server.go
@@ -64,7 +64,7 @@ func (s *Server) handleStream(stream network.Stream) {
 	// read request from stream to get the dataHash for store lookup
 	req, err := s.readRequest(stream)
 	if err != nil {
-		log.Errorw("server: reading request from stream", "err", err)
+		log.Warnw("server: reading request from stream", "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
@@ -73,6 +73,7 @@ func (s *Server) handleStream(stream network.Stream) {
 	hash := share.DataHash(req.Hash)
 	err = hash.Validate()
 	if err != nil {
+		log.Debugw("server: invalid request", "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
@@ -89,41 +90,44 @@ func (s *Server) handleStream(stream network.Stream) {
 	case errors.Is(err, eds.ErrNotFound):
 		status = p2p_pb.Status_NOT_FOUND
 	case err != nil:
-		log.Debugw("server: get car", "err", err)
+		log.Errorw("server: get car", "err", err)
 		status = p2p_pb.Status_INTERNAL
 	}
 
 	// inform the client of our status
 	err = s.writeStatus(status, stream)
 	if err != nil {
-		log.Errorw("server: writing status to stream", "err", err)
+		log.Warnw("server: writing status to stream", "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
 	// if we cannot serve the EDS, we are already done
 	if status != p2p_pb.Status_OK {
-		stream.Close()
+		err = stream.Close()
+		if err != nil {
+			log.Debugw("server: closing stream", "err", err)
+		}
 		return
 	}
 
 	// start streaming the ODS to the client
 	err = s.writeODS(edsReader, stream)
 	if err != nil {
-		log.Errorw("server: writing ods to stream", "hash", hash.String(), "err", err)
+		log.Warnw("server: writing ods to stream", "hash", hash.String(), "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
 
 	err = stream.Close()
 	if err != nil {
-		log.Errorw("server: closing stream", "err", err)
+		log.Debugw("server: closing stream", "err", err)
 	}
 }
 
 func (s *Server) readRequest(stream network.Stream) (*p2p_pb.EDSRequest, error) {
 	err := stream.SetReadDeadline(time.Now().Add(s.params.ServerReadTimeout))
 	if err != nil {
-		log.Debug(err)
+		log.Debugw("server: set read deadline", "err", err)
 	}
 
 	req := new(p2p_pb.EDSRequest)
@@ -133,7 +137,7 @@ func (s *Server) readRequest(stream network.Stream) (*p2p_pb.EDSRequest, error) 
 	}
 	err = stream.CloseRead()
 	if err != nil {
-		log.Error(err)
+		log.Debugw("server: closing read", "err", err)
 	}
 
 	return req, nil
@@ -142,7 +146,7 @@ func (s *Server) readRequest(stream network.Stream) (*p2p_pb.EDSRequest, error) 
 func (s *Server) writeStatus(status p2p_pb.Status, stream network.Stream) error {
 	err := stream.SetWriteDeadline(time.Now().Add(s.params.ServerWriteTimeout))
 	if err != nil {
-		log.Debug(err)
+		log.Debugw("server: set write deadline", "err", err)
 	}
 
 	resp := &p2p_pb.EDSResponse{Status: status}
@@ -153,7 +157,7 @@ func (s *Server) writeStatus(status p2p_pb.Status, stream network.Stream) error 
 func (s *Server) writeODS(edsReader io.Reader, stream network.Stream) error {
 	err := stream.SetWriteDeadline(time.Now().Add(s.params.ServerWriteTimeout))
 	if err != nil {
-		log.Debug(err)
+		log.Debugw("server: set read deadline", "err", err)
 	}
 
 	odsReader, err := eds.ODSReader(edsReader)

--- a/share/p2p/shrexnd/server.go
+++ b/share/p2p/shrexnd/server.go
@@ -70,15 +70,17 @@ func (srv *Server) Stop(context.Context) error {
 }
 
 func (srv *Server) handleNamespacedData(ctx context.Context, stream network.Stream) {
+	log.Debug("server: handling nd request")
+
 	err := stream.SetReadDeadline(time.Now().Add(srv.params.ServerReadTimeout))
 	if err != nil {
-		log.Debugf("server: setting read deadline: %s", err)
+		log.Debugw("server: setting read deadline", "err", err)
 	}
 
 	var req pb.GetSharesByNamespaceRequest
 	_, err = serde.Read(stream, &req)
 	if err != nil {
-		log.Errorw("server: reading request", "err", err)
+		log.Warnw("server: reading request", "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
@@ -86,12 +88,12 @@ func (srv *Server) handleNamespacedData(ctx context.Context, stream network.Stre
 
 	err = stream.CloseRead()
 	if err != nil {
-		log.Debugf("server: closing read side of the stream: %s", err)
+		log.Debugw("server: closing read side of the stream", "err", err)
 	}
 
 	err = validateRequest(req)
 	if err != nil {
-		log.Errorw("server: invalid request", "err", err)
+		log.Debugw("server: invalid request", "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
@@ -123,7 +125,6 @@ func (srv *Server) handleNamespacedData(ctx context.Context, stream network.Stre
 
 	resp := namespacedSharesToResponse(shares)
 	srv.respond(stream, resp)
-	log.Debugw("server: handled request", "namespaceId", string(req.NamespaceId), "roothash", string(req.RootHash))
 }
 
 // validateRequest checks correctness of the request
@@ -181,17 +182,17 @@ func namespacedSharesToResponse(shares share.NamespacedShares) *pb.GetSharesByNa
 func (srv *Server) respond(stream network.Stream, resp *pb.GetSharesByNamespaceResponse) {
 	err := stream.SetWriteDeadline(time.Now().Add(srv.params.ServerWriteTimeout))
 	if err != nil {
-		log.Debugf("server: seting write deadline: %s", err)
+		log.Debugw("server: seting write deadline", "err", err)
 	}
 
 	_, err = serde.Write(stream, resp)
 	if err != nil {
-		log.Errorf("server: writing response: %s", err.Error())
+		log.Warnw("server: writing response", "err", err)
 		stream.Reset() //nolint:errcheck
 		return
 	}
 
 	if err = stream.Close(); err != nil {
-		log.Errorf("server: closing stream: %s", err.Error())
+		log.Debugw("server: closing stream", "err", err)
 	}
 }


### PR DESCRIPTION
## Overview

Sort out logging level for shrex client / server logs.

DEBUG: unimportant errors, that doesn't affect logic
WARN: errors that could been induced by either party (client or server)
ERROR: node malfunction that needs operator attention

Since shrex client / server implementation propagates errors to the caller, default logging level should be set to ERROR, to reduce cognitive load on operator. Currently it is set in nodebuilder, but I would rather move default log level setting inside the package at some point.