### PR TITLE
refactor(share/shrex): improve shrex logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.13.0
 	go.opentelemetry.io/proto/otlp v0.19.0
 	go.uber.org/fx v1.19.2
+	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.7.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.8.0
@@ -306,7 +307,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/dig v1.16.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp v0.0.0-20230129154200-a960b3787bd2 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect

--- a/share/getters/shrex.go
+++ b/share/getters/shrex.go
@@ -72,8 +72,8 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, root *share.Root) (*rsmt2d.Ex
 		peer, setStatus, getErr := sg.peerManager.Peer(ctx, root.Hash())
 		if getErr != nil {
 			err = errors.Join(err, getErr)
-			log.Debugw("couldn't find peer",
-				"datahash", root.String(),
+			log.Debugw("eds: couldn't find peer",
+				"hash", root.String(),
 				"err", getErr,
 				"finished (s)", time.Since(start))
 			return nil, fmt.Errorf("getter/shrex: %w", err)
@@ -101,8 +101,8 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, root *share.Root) (*rsmt2d.Ex
 		if !ErrorContains(err, getErr) {
 			err = errors.Join(err, getErr)
 		}
-		log.Debugw("request failed",
-			"datahash", root.String(),
+		log.Debugw("eds: request failed",
+			"hash", root.String(),
 			"peer", peer.String(),
 			"attempt", attempt,
 			"err", getErr,
@@ -125,8 +125,8 @@ func (sg *ShrexGetter) GetSharesByNamespace(
 		peer, setStatus, getErr := sg.peerManager.Peer(ctx, root.Hash())
 		if getErr != nil {
 			err = errors.Join(err, getErr)
-			log.Debugw("couldn't find peer",
-				"datahash", root.String(),
+			log.Debugw("nd: couldn't find peer",
+				"hash", root.String(),
 				"err", getErr,
 				"finished (s)", time.Since(start))
 			return nil, fmt.Errorf("getter/shrex: %w", err)
@@ -154,8 +154,8 @@ func (sg *ShrexGetter) GetSharesByNamespace(
 		if !ErrorContains(err, getErr) {
 			err = errors.Join(err, getErr)
 		}
-		log.Debugw("request failed",
-			"datahash", root.String(),
+		log.Debugw("nd: request failed",
+			"hash", root.String(),
 			"peer", peer.String(),
 			"attempt", attempt,
 			"err", getErr,

--- a/share/p2p/middleware.go
+++ b/share/p2p/middleware.go
@@ -20,7 +20,7 @@ func RateLimitMiddleware(inner network.StreamHandler, concurrencyLimit int) netw
 			log.Debug("concurrency limit reached")
 			err := stream.Close()
 			if err != nil {
-				log.Errorw("server: closing stream", "err", err)
+				log.Debugw("server: closing stream", "err", err)
 			}
 			return
 		}

--- a/share/p2p/peers/pool.go
+++ b/share/p2p/peers/pool.go
@@ -12,7 +12,7 @@ const defaultCleanupThreshold = 2
 
 // pool stores peers and provides methods for simple round-robin access.
 type pool struct {
-	m           sync.Mutex
+	m           sync.RWMutex
 	peersList   []peer.ID
 	statuses    map[peer.ID]status
 	cooldown    *timedQueue
@@ -196,7 +196,7 @@ func (p *pool) checkHasPeers() {
 }
 
 func (p *pool) size() int {
-	p.m.Lock()
-	defer p.m.Unlock()
+	p.m.RLock()
+	defer p.m.RUnlock()
 	return p.activeCount
 }

--- a/share/p2p/peers/pool.go
+++ b/share/p2p/peers/pool.go
@@ -194,3 +194,9 @@ func (p *pool) checkHasPeers() {
 		p.hasPeer = false
 	}
 }
+
+func (p *pool) size() int {
+	p.m.Lock()
+	defer p.m.Unlock()
+	return p.activeCount
+}

--- a/share/p2p/shrexeds/client.go
+++ b/share/p2p/shrexeds/client.go
@@ -61,7 +61,10 @@ func (c *Client) RequestEDS(
 		}
 	}
 	if err != p2p.ErrNotFound {
-		log.Warnw("client: eds request to peer failed", "peer", peer, "hash", dataHash.String())
+		log.Warnw("client: eds request to peer failed",
+			"peer", peer,
+			"hash", dataHash.String(),
+			"err", err)
 	}
 
 	return nil, err
@@ -79,7 +82,7 @@ func (c *Client) doRequest(
 
 	if dl, ok := ctx.Deadline(); ok {
 		if err = stream.SetDeadline(dl); err != nil {
-			log.Debugw("error setting deadline: %s", "err", err)
+			log.Debugw("client: error setting deadline: %s", "err", err)
 		}
 	}
 
@@ -94,7 +97,7 @@ func (c *Client) doRequest(
 	}
 	err = stream.CloseWrite()
 	if err != nil {
-		log.Debugw("error closing write", "err", err)
+		log.Debugw("client: error closing write", "err", err)
 	}
 
 	// read and parse status from peer

--- a/share/p2p/shrexnd/client.go
+++ b/share/p2p/shrexnd/client.go
@@ -58,7 +58,7 @@ func (c *Client) RequestND(
 		return shares, err
 	}
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-		return nil, ctx.Err()
+		return nil, err
 	}
 	// some net.Errors also mean the context deadline was exceeded, but yamux/mocknet do not
 	// unwrap to a ctx err
@@ -69,7 +69,7 @@ func (c *Client) RequestND(
 		}
 	}
 	if err != p2p.ErrNotFound {
-		log.Warnw("client-nd: peer returned err", "peer", peer, "err", err)
+		log.Warnw("client: peer returned err", "err", err)
 	}
 	return nil, err
 }

--- a/share/p2p/shrexnd/client.go
+++ b/share/p2p/shrexnd/client.go
@@ -69,7 +69,7 @@ func (c *Client) RequestND(
 		}
 	}
 	if err != p2p.ErrNotFound {
-		log.Warnw("client: peer returned err", "err", err)
+		log.Warnw("client-nd: peer returned err", "err", err)
 	}
 	return nil, err
 }


### PR DESCRIPTION
## Overview
 - Previously shrex-nd and shrex-eds error logs were indistinguishable, that lead to confusion of errors source. 
 - add peerID to server logs
 - Improve some other shrex logging.
 

Resolves https://github.com/celestiaorg/celestia-node/issues/2035