### PR TITLE
refactor(api/gateway) return error from gateway if header is not synced yet

### DIFF
--- a/api/gateway/availability.go
+++ b/api/gateway/availability.go
@@ -28,6 +28,7 @@ func (h *Handler) handleHeightAvailabilityRequest(w http.ResponseWriter, r *http
 		return
 	}
 
+	//TODO: change this to NetworkHead once the adjacency in the store is fixed.
 	head, err := h.header.LocalHead(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, heightAvailabilityEndpoint, err)
@@ -35,7 +36,8 @@ func (h *Handler) handleHeightAvailabilityRequest(w http.ResponseWriter, r *http
 	}
 	if headHeight := int(head.Height()); headHeight < height {
 		err = fmt.Errorf(
-			"current header store head height: %v is lower then requested height: %v", headHeight, height)
+			"current head store head height: %v is lower then requested height: %v"+
+				" give header sync some time and retry later", headHeight, height)
 		writeError(w, http.StatusServiceUnavailable, heightAvailabilityEndpoint, err)
 		return
 	}

--- a/api/gateway/availability.go
+++ b/api/gateway/availability.go
@@ -36,7 +36,7 @@ func (h *Handler) handleHeightAvailabilityRequest(w http.ResponseWriter, r *http
 	}
 	if headHeight := int(head.Height()); headHeight < height {
 		err = fmt.Errorf(
-			"current head store head height: %v is lower then requested height: %v"+
+			"current head local chain head: %d is lower than requested height: %d"+
 				" give header sync some time and retry later", headHeight, height)
 		writeError(w, http.StatusServiceUnavailable, heightAvailabilityEndpoint, err)
 		return

--- a/api/gateway/header.go
+++ b/api/gateway/header.go
@@ -70,6 +70,7 @@ func (h *Handler) performGetHeaderRequest(
 		writeError(w, http.StatusBadRequest, endpoint, err)
 		return nil, err
 	}
+	//TODO: change this to NetworkHead once the adjacency in the store is fixed.
 	head, err := h.header.LocalHead(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, heightAvailabilityEndpoint, err)
@@ -77,7 +78,8 @@ func (h *Handler) performGetHeaderRequest(
 	}
 	if headHeight := int(head.Height()); headHeight < height {
 		err = fmt.Errorf(
-			"current head store head height: %v is lower then requested height: %v", headHeight, height)
+			"current head store head height: %v is lower then requested height: %v"+
+				" give header sync some time and retry later", headHeight, height)
 		writeError(w, http.StatusServiceUnavailable, endpoint, err)
 		return nil, err
 	}

--- a/api/gateway/header.go
+++ b/api/gateway/header.go
@@ -78,7 +78,7 @@ func (h *Handler) performGetHeaderRequest(
 	}
 	if headHeight := int(head.Height()); headHeight < height {
 		err = fmt.Errorf(
-			"current head store head height: %v is lower then requested height: %v"+
+			"current head local chain head: %d is lower than requested height: %d"+
 				" give header sync some time and retry later", headHeight, height)
 		writeError(w, http.StatusServiceUnavailable, endpoint, err)
 		return nil, err

--- a/api/gateway/share.go
+++ b/api/gateway/share.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -98,10 +99,19 @@ func (h *Handler) getShares(ctx context.Context, height uint64, nID namespace.ID
 		err    error
 		header *header.ExtendedHeader
 	)
-	switch height {
-	case 0:
-		header, err = h.header.LocalHead(ctx)
-	default:
+
+	header, err = h.header.LocalHead(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if height > 0 {
+		if storeHeight := uint64(header.Height()); storeHeight < height {
+			return nil, 0, fmt.Errorf(
+				"current header store head height: %v is lower then requested height: %v",
+				storeHeight, height,
+			)
+		}
 		header, err = h.header.GetByHeight(ctx, height)
 	}
 	if err != nil {

--- a/api/gateway/share.go
+++ b/api/gateway/share.go
@@ -109,7 +109,7 @@ func (h *Handler) getShares(ctx context.Context, height uint64, nID namespace.ID
 	if height > 0 {
 		if storeHeight := uint64(header.Height()); storeHeight < height {
 			return nil, 0, fmt.Errorf(
-				"current head store head height: %v is lower then requested height: %v"+
+				"current head local chain head: %d is lower than requested height: %d"+
 					" give header sync some time and retry later", storeHeight, height)
 		}
 		header, err = h.header.GetByHeight(ctx, height)

--- a/api/gateway/share.go
+++ b/api/gateway/share.go
@@ -100,6 +100,7 @@ func (h *Handler) getShares(ctx context.Context, height uint64, nID namespace.ID
 		header *header.ExtendedHeader
 	)
 
+	//TODO: change this to NetworkHead once the adjacency in the store is fixed.
 	header, err = h.header.LocalHead(ctx)
 	if err != nil {
 		return nil, 0, err
@@ -108,9 +109,8 @@ func (h *Handler) getShares(ctx context.Context, height uint64, nID namespace.ID
 	if height > 0 {
 		if storeHeight := uint64(header.Height()); storeHeight < height {
 			return nil, 0, fmt.Errorf(
-				"current header store head height: %v is lower then requested height: %v",
-				storeHeight, height,
-			)
+				"current head store head height: %v is lower then requested height: %v"+
+					" give header sync some time and retry later", storeHeight, height)
 		}
 		header, err = h.header.GetByHeight(ctx, height)
 	}


### PR DESCRIPTION
## Overview

If header was not in header store, gateway would hang until client context was canceled. PR allows gateway to return an error immediately in this case.

