### PR TITLE
chore(nodebuilder): timeouts, errors and logs

### DIFF
--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -27,7 +27,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
 
-const Timeout = time.Second * 15
+const Timeout = time.Minute
 
 var log = logging.Logger("node")
 


### PR DESCRIPTION
Was originally for debugging purposes but actually solved the issue. The bootstrapper with a corrupted DAGstore state was not able to start quickly enough. 

Ideally, we should make this value configurable(https://github.com/celestiaorg/celestia-node/issues/2126)