### PR TITLE
fix(gateway): deescalating log in gateway's writeErr

### DIFF
--- a/api/gateway/util.go
+++ b/api/gateway/util.go
@@ -6,7 +6,7 @@ import (
 )
 
 func writeError(w http.ResponseWriter, statusCode int, endpoint string, err error) {
-	log.Errorw("serving request", "endpoint", endpoint, "err", err)
+	log.Debugw("serving request", "endpoint", endpoint, "err", err)
 
 	w.WriteHeader(statusCode)
 	errBody, jerr := json.Marshal(err.Error())


### PR DESCRIPTION
Closes #2141 

writeError is called by almost all gateway endpoints. If a client makes a request for bad data, that is not an error for the server - but still useful as a debug log.