### PR TITLE
fix(nodebuilder/tests): Add dummy trusted peers to satisfy fx

### DIFF
--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -117,6 +117,9 @@ func TestFullReconstructFromLights(t *testing.T) {
 	require.NoError(t, err)
 
 	os.Setenv(p2p.EnvKeyCelestiaBootstrapper, "true")
+	cfg.Header.TrustedPeers = []string{
+		"/ip4/1.2.3.4/tcp/12345/p2p/12D3KooWNaJ1y1Yio3fFJEXCZyd1Cat3jmrPdgkYCrHfKD3Ce21p",
+	}
 	bootstrapper := sw.NewNodeWithConfig(node.Full, cfg)
 	require.NoError(t, bootstrapper.Start(ctx))
 	require.NoError(t, bridge.Start(ctx))

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -188,6 +188,9 @@ func (s *Swamp) NewBridgeNode(options ...fx.Option) *nodebuilder.Node {
 // and a mockstore to the NewNodeWithStore method
 func (s *Swamp) NewFullNode(options ...fx.Option) *nodebuilder.Node {
 	cfg := nodebuilder.DefaultConfig(node.Full)
+	cfg.Header.TrustedPeers = []string{
+		"/ip4/1.2.3.4/tcp/12345/p2p/12D3KooWNaJ1y1Yio3fFJEXCZyd1Cat3jmrPdgkYCrHfKD3Ce21p",
+	}
 	store := nodebuilder.MockStore(s.t, cfg)
 
 	return s.NewNodeWithStore(node.Full, store, options...)
@@ -197,6 +200,10 @@ func (s *Swamp) NewFullNode(options ...fx.Option) *nodebuilder.Node {
 // and a mockstore to the NewNodeWithStore method
 func (s *Swamp) NewLightNode(options ...fx.Option) *nodebuilder.Node {
 	cfg := nodebuilder.DefaultConfig(node.Light)
+	cfg.Header.TrustedPeers = []string{
+		"/ip4/1.2.3.4/tcp/12345/p2p/12D3KooWNaJ1y1Yio3fFJEXCZyd1Cat3jmrPdgkYCrHfKD3Ce21p",
+	}
+
 	store := nodebuilder.MockStore(s.t, cfg)
 
 	return s.NewNodeWithStore(node.Light, store, options...)


### PR DESCRIPTION
Fx requires trusted peers now so this fix is needed in the meantime to satisfy that.

Don't worry, these tests will be THOROUGHLY cleanussied in follow up PRs.