### PR TITLE
chore(nodebuilder/tests): Clean up sync_test tests

### DIFF
--- a/nodebuilder/tests/fraud_test.go
+++ b/nodebuilder/tests/fraud_test.go
@@ -34,17 +34,18 @@ Another note: this test disables share exchange to speed up test results.
 */
 func TestFraudProofBroadcasting(t *testing.T) {
 	t.Skip("requires BEFP generation on app side to work")
-
-	const (
-		blocks = 15
-		bsize  = 2
-		btime  = time.Millisecond * 300
-	)
-	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, bsize, blocks)
+	const (
+		blocks    = 15
+		blockSize = 2
+		blockTime = time.Millisecond * 300
+	)
+
+	sw := swamp.NewSwamp(t, swamp.WithBlockTime(blockTime))
+	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, blockSize, blocks)
+
 	cfg := nodebuilder.DefaultConfig(node.Bridge)
 	cfg.Share.UseShareExchange = false
 	bridge := sw.NewNodeWithConfig(
@@ -55,12 +56,13 @@ func TestFraudProofBroadcasting(t *testing.T) {
 
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
-	require.NoError(t, err)
 
 	cfg = nodebuilder.DefaultConfig(node.Full)
 	cfg.Share.UseShareExchange = false
+	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+	require.NoError(t, err)
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+
 	store := nodebuilder.MockStore(t, cfg)
 	full := sw.NewNodeWithStore(node.Full, store)
 
@@ -72,9 +74,12 @@ func TestFraudProofBroadcasting(t *testing.T) {
 	subscr, err := full.FraudServ.Subscribe(ctx, byzantine.BadEncoding)
 	require.NoError(t, err)
 
-	p := <-subscr
-	require.Equal(t, 10, int(p.Height()))
-
+	select {
+	case p := <-subscr:
+		require.Equal(t, 10, int(p.Height()))
+	case <-ctx.Done():
+		t.Fatal("fraud proof was not received in time")
+	}
 	// This is an obscure way to check if the Syncer was stopped.
 	// If we cannot get a height header within a timeframe it means the syncer was stopped
 	// FIXME: Eventually, this should be a check on service registry managing and keeping

--- a/nodebuilder/tests/p2p_test.go
+++ b/nodebuilder/tests/p2p_test.go
@@ -142,7 +142,7 @@ func TestBootstrapNodesFromBridgeNode(t *testing.T) {
 	// ensure that the light node is connected to the full node
 	assert.True(t, light.Host.Network().Connectedness(addrFull.ID) == network.Connected)
 
-	sw.Disconnect(t, light.Host.ID(), full.Host.ID())
+	sw.Disconnect(t, light, full)
 	require.NoError(t, full.Stop(ctx))
 	select {
 	case <-ctx.Done():
@@ -206,7 +206,7 @@ func TestRestartNodeDiscovery(t *testing.T) {
 	connectSub, err := nodes[0].Host.EventBus().Subscribe(&event.EvtPeerConnectednessChanged{})
 	require.NoError(t, err)
 	defer connectSub.Close()
-	sw.Disconnect(t, nodes[0].Host.ID(), nodes[1].Host.ID())
+	sw.Disconnect(t, nodes[0], nodes[1])
 	require.NoError(t, node.Start(ctx))
 
 	// ensure that the last node is connected to one of the nodes

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -293,10 +293,10 @@ func (s *Swamp) StopNode(ctx context.Context, nd *nodebuilder.Node) {
 }
 
 // Connect allows to connect peers after hard disconnection.
-func (s *Swamp) Connect(t *testing.T, peerA, peerB peer.ID) {
-	_, err := s.Network.LinkPeers(peerA, peerB)
+func (s *Swamp) Connect(t *testing.T, peerA, peerB *nodebuilder.Node) {
+	_, err := s.Network.LinkPeers(peerA.Host.ID(), peerB.Host.ID())
 	require.NoError(t, err)
-	_, err = s.Network.ConnectPeers(peerA, peerB)
+	_, err = s.Network.ConnectPeers(peerA.Host.ID(), peerB.Host.ID())
 	require.NoError(t, err)
 }
 
@@ -304,7 +304,15 @@ func (s *Swamp) Connect(t *testing.T, peerA, peerB peer.ID) {
 // re-establish it. Order is very important here. We have to unlink peers first, and only after
 // that call disconnect. This is hard disconnect and peers will not be able to reconnect.
 // In order to reconnect peers again, please use swamp.Connect
-func (s *Swamp) Disconnect(t *testing.T, peerA, peerB peer.ID) {
-	require.NoError(t, s.Network.UnlinkPeers(peerA, peerB))
-	require.NoError(t, s.Network.DisconnectPeers(peerA, peerB))
+func (s *Swamp) Disconnect(t *testing.T, peerA, peerB *nodebuilder.Node) {
+	require.NoError(t, s.Network.UnlinkPeers(peerA.Host.ID(), peerB.Host.ID()))
+	require.NoError(t, s.Network.DisconnectPeers(peerA.Host.ID(), peerB.Host.ID()))
+}
+
+func WithTrustedPeers(t *testing.T, cfg *nodebuilder.Config, trustedPeers ...*nodebuilder.Node) {
+	for _, trusted := range trustedPeers {
+		addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(trusted.Host))
+		require.NoError(t, err)
+		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+	}
 }

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -51,6 +51,12 @@ type Swamp struct {
 	cfg *Config
 
 	Network       mocknet.Mocknet
+	Bootstrappers []ma.Multiaddr
+
+	BridgeNodes []*nodebuilder.Node
+	FullNodes   []*nodebuilder.Node
+	LightNodes  []*nodebuilder.Node
+
 	ClientContext testnode.Context
 	Accounts      []string
 
@@ -210,6 +216,10 @@ func (s *Swamp) NewFullNode(options ...fx.Option) *nodebuilder.Node {
 	cfg.Header.TrustedPeers = []string{
 		"/ip4/1.2.3.4/tcp/12345/p2p/12D3KooWNaJ1y1Yio3fFJEXCZyd1Cat3jmrPdgkYCrHfKD3Ce21p",
 	}
+	// add all bootstrappers in suite as trusted peers
+	for _, bootstrapper := range s.Bootstrappers {
+		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bootstrapper.String())
+	}
 	store := nodebuilder.MockStore(s.t, cfg)
 
 	return s.NewNodeWithStore(node.Full, store, options...)
@@ -222,6 +232,10 @@ func (s *Swamp) NewLightNode(options ...fx.Option) *nodebuilder.Node {
 	cfg.Header.TrustedPeers = []string{
 		"/ip4/1.2.3.4/tcp/12345/p2p/12D3KooWNaJ1y1Yio3fFJEXCZyd1Cat3jmrPdgkYCrHfKD3Ce21p",
 	}
+	// add all bootstrappers in suite as trusted peers
+	for _, bootstrapper := range s.Bootstrappers {
+		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bootstrapper.String())
+	}
 
 	store := nodebuilder.MockStore(s.t, cfg)
 
@@ -230,6 +244,10 @@ func (s *Swamp) NewLightNode(options ...fx.Option) *nodebuilder.Node {
 
 func (s *Swamp) NewNodeWithConfig(nodeType node.Type, cfg *nodebuilder.Config, options ...fx.Option) *nodebuilder.Node {
 	store := nodebuilder.MockStore(s.t, cfg)
+	// add all bootstrappers in suite as trusted peers
+	for _, bootstrapper := range s.Bootstrappers {
+		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bootstrapper.String())
+	}
 	return s.NewNodeWithStore(nodeType, store, options...)
 }
 
@@ -309,10 +327,15 @@ func (s *Swamp) Disconnect(t *testing.T, peerA, peerB *nodebuilder.Node) {
 	require.NoError(t, s.Network.DisconnectPeers(peerA.Host.ID(), peerB.Host.ID()))
 }
 
-func WithTrustedPeers(t *testing.T, cfg *nodebuilder.Config, trustedPeers ...*nodebuilder.Node) {
-	for _, trusted := range trustedPeers {
+// SetBootstrapper sets the given bootstrappers as the "bootstrappers" for the
+// Swamp test suite. Every new full or light node created on the suite afterwards
+// will automatically add the suite's bootstrappers as trusted peers to their config.
+// NOTE: Bridge nodes do not automaatically add the bootstrappers as trusted peers.
+// NOTE: Use `NewNodeWithStore` to avoid this automatic configuration.
+func (s *Swamp) SetBootstrapper(t *testing.T, bootstrappers ...*nodebuilder.Node) {
+	for _, trusted := range bootstrappers {
 		addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(trusted.Host))
 		require.NoError(t, err)
-		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+		s.Bootstrappers = append(s.Bootstrappers, addrs[0])
 	}
 }

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -53,10 +53,6 @@ type Swamp struct {
 	Network       mocknet.Mocknet
 	Bootstrappers []ma.Multiaddr
 
-	BridgeNodes []*nodebuilder.Node
-	FullNodes   []*nodebuilder.Node
-	LightNodes  []*nodebuilder.Node
-
 	ClientContext testnode.Context
 	Accounts      []string
 

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -234,9 +234,7 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 
 	sw.StopNode(ctx, light)
 
-	cfg = nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	light = sw.NewNodeWithConfig(node.Light, cfg)
+	light = sw.NewLightNode()
 	require.NoError(t, light.Start(ctx))
 
 	// ensure when light node comes back up, it can sync the remainder of the chain it

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-node/nodebuilder"
-	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
 )
 
@@ -66,8 +64,7 @@ func TestSyncAgainstBridge_NonEmptyChain(t *testing.T) {
 	t.Run("light sync against bridge", func(t *testing.T) {
 		// create a light node that is connected to the bridge node as
 		// a bootstrapper
-		cfg := nodebuilder.DefaultConfig(node.Light)
-		light := sw.NewNodeWithConfig(node.Light, cfg)
+		light := sw.NewLightNode()
 		// start light node and wait for it to sync 20 blocks
 		err = light.Start(ctx)
 		require.NoError(t, err)
@@ -86,9 +83,7 @@ func TestSyncAgainstBridge_NonEmptyChain(t *testing.T) {
 
 	t.Run("full sync against bridge", func(t *testing.T) {
 		// create a full node with bridge node as its bootstrapper
-		cfg := nodebuilder.DefaultConfig(node.Full)
-		full := sw.NewNodeWithConfig(node.Full, cfg)
-
+		full := sw.NewFullNode()
 		// let full node sync 20 blocks
 		err = full.Start(ctx)
 		require.NoError(t, err)
@@ -156,8 +151,7 @@ func TestSyncAgainstBridge_EmptyChain(t *testing.T) {
 	t.Run("light sync against bridge", func(t *testing.T) {
 		// create a light node that is connected to the bridge node as
 		// a bootstrapper
-		cfg := nodebuilder.DefaultConfig(node.Light)
-		light := sw.NewNodeWithConfig(node.Light, cfg)
+		light := sw.NewLightNode()
 		// start light node and wait for it to sync 20 blocks
 		err = light.Start(ctx)
 		require.NoError(t, err)
@@ -176,9 +170,7 @@ func TestSyncAgainstBridge_EmptyChain(t *testing.T) {
 
 	t.Run("full sync against bridge", func(t *testing.T) {
 		// create a full node with bridge node as its bootstrapper
-		cfg := nodebuilder.DefaultConfig(node.Full)
-		full := sw.NewNodeWithConfig(node.Full, cfg)
-
+		full := sw.NewFullNode()
 		// let full node sync 20 blocks
 		err = full.Start(ctx)
 		require.NoError(t, err)
@@ -232,9 +224,7 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
 	// create a light node and connect it to the bridge node as a bootstrapper
-	cfg := nodebuilder.DefaultConfig(node.Light)
-	light := sw.NewNodeWithConfig(node.Light, cfg)
-
+	light := sw.NewLightNode()
 	// start light node and let it sync to 20
 	err = light.Start(ctx)
 	require.NoError(t, err)
@@ -301,9 +291,7 @@ func TestSyncLightAgainstFull(t *testing.T) {
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
 	// create a FN with BN as a trusted peer
-	cfg := nodebuilder.DefaultConfig(node.Full)
-	full := sw.NewNodeWithConfig(node.Full, cfg)
-
+	full := sw.NewFullNode()
 	// start FN and wait for it to sync up to head of BN
 	err = full.Start(ctx)
 	require.NoError(t, err)
@@ -318,8 +306,7 @@ func TestSyncLightAgainstFull(t *testing.T) {
 	sw.SetBootstrapper(t, full)
 
 	// create an LN with FN as a trusted peer
-	cfg = nodebuilder.DefaultConfig(node.Light)
-	light := sw.NewNodeWithConfig(node.Light, cfg)
+	light := sw.NewLightNode()
 
 	// ensure there is no direct connection between LN and BN so that
 	// LN relies only on FN for syncing
@@ -377,8 +364,7 @@ func TestSyncLightWithTrustedPeers(t *testing.T) {
 	require.NoError(t, err)
 
 	// create a FN with BN as trusted peer
-	cfg := nodebuilder.DefaultConfig(node.Full)
-	full := sw.NewNodeWithConfig(node.Full, cfg)
+	full := sw.NewFullNode()
 
 	// let FN sync to network head
 	err = full.Start(ctx)
@@ -390,8 +376,7 @@ func TestSyncLightWithTrustedPeers(t *testing.T) {
 	sw.SetBootstrapper(t, full)
 
 	// create a LN with both FN and BN as trusted peers
-	cfg = nodebuilder.DefaultConfig(node.Light)
-	light := sw.NewNodeWithConfig(node.Light, cfg)
+	light := sw.NewLightNode()
 
 	// let LN sync to network head
 	err = light.Start(ctx)

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -17,60 +17,100 @@ import (
 
 // Common consts for tests producing filled blocks
 const (
-	blocks = 20
-	bsize  = 16
-	btime  = time.Millisecond * 300
+	numBlocks = 20
+	bsize     = 16
+	btime     = time.Millisecond * 300
 )
 
 /*
-Test-Case: Sync a Light Node with a Bridge Node(includes DASing of non-empty blocks)
+Test-Case: Header and block/sample sync against a Bridge Node of non-empty blocks.
+
 Steps:
 1. Create a Bridge Node(BN)
 2. Start a BN
 3. Check BN is synced to height 20
-4. Create a Light Node(LN) with a trusted peer
+
+Light node:
+4. Create a Light Node (LN) with bridge as a trusted peer
 5. Start a LN with a defined connection to the BN
-6. Check LN is synced to height 30
+6. Check LN is header-synced to height 20
+7. Wait until LN has sampled height 20
+8. Wait for LN DASer to catch up to network head
+
+Full node:
+4. Create a Full Node (FN) with bridge as a trusted peer
+5. Start a FN with a defined connection to the BN
+6. Check FN is header-synced to height 20
+7. Wait until FN has synced block at height 20
+8. Wait for FN DASer to catch up to network head
 */
-func TestSyncLightWithBridge(t *testing.T) {
+func TestSyncAgainstBridge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, bsize, blocks)
+	// wait for core network to fill 20 blocks
+	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, bsize, numBlocks)
+	sw.WaitTillHeight(ctx, numBlocks)
 
+	// start a bridge and wait for it to sync to 20
 	bridge := sw.NewBridgeNode()
-
-	sw.WaitTillHeight(ctx, 20)
-
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
-	h, err := bridge.HeaderServ.WaitForHeight(ctx, 20)
+	h, err := bridge.HeaderServ.WaitForHeight(ctx, numBlocks)
 	require.NoError(t, err)
+	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
-	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
+	t.Run("light sync against bridge", func(t *testing.T) {
+		// create a light node that is connected to the bridge node as
+		// a bootstrapper
+		cfg := nodebuilder.DefaultConfig(node.Light)
+		addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+		require.NoError(t, err)
+		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+		light := sw.NewNodeWithConfig(node.Light, cfg)
+		// start light node and wait for it to sync 20 blocks
+		err = light.Start(ctx)
+		require.NoError(t, err)
+		h, err = light.HeaderServ.WaitForHeight(ctx, numBlocks)
+		require.NoError(t, err)
+		assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
-	require.NoError(t, err)
+		// check that the light node has also sampled over the block at height 20
+		err = light.ShareServ.SharesAvailable(ctx, h.DAH)
+		assert.NoError(t, err)
 
-	cfg := nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	light := sw.NewNodeWithConfig(node.Light, cfg)
+		// wait until the entire chain (up to network head) has been sampled
+		err = light.DASer.WaitCatchUp(ctx)
+		require.NoError(t, err)
+	})
 
-	err = light.Start(ctx)
-	require.NoError(t, err)
+	t.Run("full sync against bridge", func(t *testing.T) {
+		// create a full node with bridge node as its bootstrapper
+		cfg := nodebuilder.DefaultConfig(node.Full)
+		addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+		require.NoError(t, err)
+		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+		full := sw.NewNodeWithConfig(node.Full, cfg)
 
-	h, err = light.HeaderServ.WaitForHeight(ctx, 30)
-	require.NoError(t, err)
+		// let full node sync 20 blocks
+		err = full.Start(ctx)
+		require.NoError(t, err)
+		h, err = full.HeaderServ.WaitForHeight(ctx, numBlocks)
+		require.NoError(t, err)
+		assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
-	err = light.ShareServ.SharesAvailable(ctx, h.DAH)
-	assert.NoError(t, err)
+		// check to ensure the full node can sync the 20th block's data
+		err = full.ShareServ.SharesAvailable(ctx, h.DAH)
+		assert.NoError(t, err)
 
-	err = light.DASer.WaitCatchUp(ctx)
-	require.NoError(t, err)
+		// wait for full node to sync up the blocks from genesis -> network head.
+		err = full.DASer.WaitCatchUp(ctx)
+		require.NoError(t, err)
+	})
 
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
+	// wait for the core block filling process to exit
 	require.NoError(t, <-fillDn)
 }
 
@@ -85,41 +125,43 @@ Steps:
 3. Check BN is synced to height 20
 4. Create a Light Node(LN) with a trusted peer
 5. Start a LN with a defined connection to the BN
-6. Check LN is synced to height 30
-7. Stop LN
-8. Start LN
+6. Check LN is synced to height 20
+7. Disconnect LN from BN for 3 seconds while BN continues broadcasting new blocks from core
+8. Re-connect LN and let it sync up again
 9. Check LN is synced to height 40
 */
 func TestSyncStartStopLightWithBridge(t *testing.T) {
-	sw := swamp.NewSwamp(t)
-
-	bridge := sw.NewBridgeNode()
-
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
-	t.Cleanup(cancel)
+	defer cancel()
 
-	sw.WaitTillHeight(ctx, 50)
+	sw := swamp.NewSwamp(t)
+	// wait for core network to fill 20 blocks
+	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, bsize, numBlocks)
+	sw.WaitTillHeight(ctx, numBlocks)
 
+	// create bridge
+	bridge := sw.NewBridgeNode()
+	// and let bridge node sync up with core network
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
-	h, err := bridge.HeaderServ.WaitForHeight(ctx, 20)
+	h, err := bridge.HeaderServ.WaitForHeight(ctx, numBlocks)
 	require.NoError(t, err)
+	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
-	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
-
+	// create a light node and connect it to the bridge node as a bootstrapper
+	cfg := nodebuilder.DefaultConfig(node.Light)
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
-
-	cfg := nodebuilder.DefaultConfig(node.Light)
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
 	light := sw.NewNodeWithConfig(node.Light, cfg)
-	require.NoError(t, light.Start(ctx))
 
-	h, err = light.HeaderServ.WaitForHeight(ctx, 30)
+	// start light node and let it sync to 20
+	err = light.Start(ctx)
 	require.NoError(t, err)
-
-	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
+	h, err = light.HeaderServ.WaitForHeight(ctx, numBlocks)
+	require.NoError(t, err)
+	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
 	sw.StopNode(ctx, light)
 
@@ -128,62 +170,12 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 	light = sw.NewNodeWithConfig(node.Light, cfg)
 	require.NoError(t, light.Start(ctx))
 
+	// ensure when light node comes back up, it can sync the remainder of the chain it
+	// missed while sleeping
 	h, err = light.HeaderServ.WaitForHeight(ctx, 40)
 	require.NoError(t, err)
-
 	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 40))
-}
 
-/*
-Test-Case: Sync a Full Node with a Bridge Node(includes DASing of non-empty blocks)
-Steps:
-1. Create a Bridge Node(BN)
-2. Start a BN
-3. Check BN is synced to height 20
-4. Create a Full Node(FN) with a connection to BN as a trusted peer
-5. Start a FN
-6. Check FN is synced to height 30
-*/
-func TestSyncFullWithBridge(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
-	t.Cleanup(cancel)
-
-	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, bsize, blocks)
-
-	bridge := sw.NewBridgeNode()
-
-	sw.WaitTillHeight(ctx, 20)
-
-	err := bridge.Start(ctx)
-	require.NoError(t, err)
-
-	h, err := bridge.HeaderServ.WaitForHeight(ctx, 20)
-	require.NoError(t, err)
-
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
-
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
-	require.NoError(t, err)
-
-	cfg := nodebuilder.DefaultConfig(node.Full)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	cfg.Share.UseShareExchange = false
-	full := sw.NewNodeWithConfig(node.Full, cfg)
-	require.NoError(t, full.Start(ctx))
-
-	h, err = full.HeaderServ.WaitForHeight(ctx, 30)
-	require.NoError(t, err)
-
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
-
-	err = full.ShareServ.SharesAvailable(ctx, h.DAH)
-	assert.NoError(t, err)
-
-	err = full.DASer.WaitCatchUp(ctx)
-	require.NoError(t, err)
-
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
 	require.NoError(t, <-fillDn)
 }
 
@@ -198,59 +190,63 @@ Steps:
 3. Check BN is synced to height 20
 4. Create a Full Node(FN) with a connection to BN as a trusted peer
 5. Start a FN
-6. Check FN is synced to height 30
+6. Check FN is synced to network head
 7. Create a Light Node(LN) with a connection to FN as a trusted peer
-8. Start LN
-9. Check LN is synced to height 50
+8. Ensure LN is NOT connected to BN and only connected to FN
+9. Start LN
+10. Check LN is synced to network head
 */
-func TestSyncLightWithFull(t *testing.T) {
-	sw := swamp.NewSwamp(t)
-
-	bridge := sw.NewBridgeNode()
-
+func TestSyncLightAgainstFull(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
-	sw.WaitTillHeight(ctx, 20)
+	sw := swamp.NewSwamp(t)
+	// wait for the core network to fill up 20 blocks
+	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, bsize, numBlocks)
+	sw.WaitTillHeight(ctx, numBlocks)
 
+	// start a bridge node and wait for it to sync up 20 blocks
+	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
 
-	h, err := bridge.HeaderServ.WaitForHeight(ctx, 20)
+	h, err := bridge.HeaderServ.WaitForHeight(ctx, numBlocks)
 	require.NoError(t, err)
+	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
-
+	// create a FN with BN as a trusted peer
+	cfg := nodebuilder.DefaultConfig(node.Full)
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
-
-	cfg := nodebuilder.DefaultConfig(node.Full)
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
 	full := sw.NewNodeWithConfig(node.Full, cfg)
-	require.NoError(t, full.Start(ctx))
 
-	h, err = full.HeaderServ.WaitForHeight(ctx, 30)
+	// start FN and wait for it to sync up to BN
+	err = full.Start(ctx)
+	require.NoError(t, err)
+	err = full.HeaderServ.SyncWait(ctx)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
-
+	// create an LN with FN as a trusted peer
+	cfg = nodebuilder.DefaultConfig(node.Light)
 	addrs, err = peer.AddrInfoToP2pAddrs(host.InfoFromHost(full.Host))
 	require.NoError(t, err)
-
-	cfg = nodebuilder.DefaultConfig(node.Light)
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
 	light := sw.NewNodeWithConfig(node.Light, cfg)
 
+	// ensure there is no direct connection between LN and BN so that
+	// LN relies only on FN for syncing
 	err = sw.Network.UnlinkPeers(bridge.Host.ID(), light.Host.ID())
 	require.NoError(t, err)
 
+	// start LN and wait for it to sync up to network head against the FN
 	err = light.Start(ctx)
 	require.NoError(t, err)
-
-	h, err = light.HeaderServ.WaitForHeight(ctx, 50)
+	err = light.HeaderServ.SyncWait(ctx)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 50))
+	// wait for the core block filling process to exit
+	require.NoError(t, <-fillDn)
 }
 
 /*
@@ -264,54 +260,52 @@ Steps:
 3. Check BN is synced to height 20
 4. Create a Full Node(FN) with a connection to BN as a trusted peer
 5. Start a FN
-6. Check FN is synced to height 30
-7. Create a Light Node(LN) with a connection to BN, FN as trusted peers
+6. Check FN is synced to network head
+7. Create a Light Node(LN) with a connection to BN and FN as trusted peers
 8. Start LN
-9. Check LN is synced to height 50
+9. Check LN is synced to network head.
 */
 func TestSyncLightWithTrustedPeers(t *testing.T) {
-	sw := swamp.NewSwamp(t)
-
-	bridge := sw.NewBridgeNode()
-
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
-	sw.WaitTillHeight(ctx, 20)
+	sw := swamp.NewSwamp(t)
+	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, bsize, numBlocks)
+	sw.WaitTillHeight(ctx, numBlocks)
 
+	// create a BN and let it sync to network head
+	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
-
-	h, err := bridge.HeaderServ.WaitForHeight(ctx, 20)
+	err = bridge.HeaderServ.SyncWait(ctx)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 20))
-
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
-	require.NoError(t, err)
-
+	// create a FN with BN as trusted peer
 	cfg := nodebuilder.DefaultConfig(node.Full)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+	bridgeInfo, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
+	require.NoError(t, err)
+	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bridgeInfo[0].String())
 	full := sw.NewNodeWithConfig(node.Full, cfg)
-	require.NoError(t, full.Start(ctx))
 
-	h, err = full.HeaderServ.WaitForHeight(ctx, 30)
+	// let FN sync to network head
+	err = full.Start(ctx)
+	require.NoError(t, err)
+	err = full.HeaderServ.SyncWait(ctx)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
-
-	addrs, err = peer.AddrInfoToP2pAddrs(host.InfoFromHost(full.Host))
-	require.NoError(t, err)
-
+	// create a LN with both FN and BN as trusted peers
 	cfg = nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+	fullInfo, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(full.Host))
+	require.NoError(t, err)
+	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bridgeInfo[0].String(), fullInfo[0].String())
 	light := sw.NewNodeWithConfig(node.Light, cfg)
 
+	// let LN sync to network head
 	err = light.Start(ctx)
 	require.NoError(t, err)
-
-	h, err = light.HeaderServ.WaitForHeight(ctx, 50)
+	err = light.HeaderServ.SyncWait(ctx)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 50))
+	// wait for the core block filling process to exit
+	require.NoError(t, <-fillDn)
 }

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -146,7 +146,7 @@ func TestSyncAgainstBridge_EmptyChain(t *testing.T) {
 	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
-	h, err := bridge.HeaderServ.GetByHeight(ctx, numBlocks)
+	h, err := bridge.HeaderServ.WaitForHeight(ctx, numBlocks)
 	require.NoError(t, err)
 	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
@@ -159,7 +159,7 @@ func TestSyncAgainstBridge_EmptyChain(t *testing.T) {
 		// start light node and wait for it to sync 20 blocks
 		err = light.Start(ctx)
 		require.NoError(t, err)
-		h, err = light.HeaderServ.GetByHeight(ctx, numBlocks)
+		h, err = light.HeaderServ.WaitForHeight(ctx, numBlocks)
 		require.NoError(t, err)
 		assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
@@ -181,7 +181,7 @@ func TestSyncAgainstBridge_EmptyChain(t *testing.T) {
 		// let full node sync 20 blocks
 		err = full.Start(ctx)
 		require.NoError(t, err)
-		h, err = full.HeaderServ.GetByHeight(ctx, numBlocks)
+		h, err = full.HeaderServ.WaitForHeight(ctx, numBlocks)
 		require.NoError(t, err)
 		assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 


### PR DESCRIPTION
This PR is a part of the swamp cleanussy effort to clean up our integration tests and make them more deterministic + readable. 

This PR focuses on `sync_test.go` file.

It also contains a change to fraud proof broadcasting test but I can happily split out into separate PR.