### PR TITLE
refactor(metrics): use user context for metrics observation

### DIFF
--- a/das/metrics.go
+++ b/das/metrics.go
@@ -149,6 +149,9 @@ func (m *metrics) observeSample(
 	if m == nil {
 		return
 	}
+	if ctx.Err() != nil {
+		ctx = context.Background()
+	}
 	m.sampleTime.Record(ctx, sampleTime.Seconds(),
 		attribute.Bool(failedLabel, err != nil),
 		attribute.Int(headerWidthLabel, len(h.DAH.RowsRoots)),
@@ -169,6 +172,9 @@ func (m *metrics) observeGetHeader(ctx context.Context, d time.Duration) {
 	if m == nil {
 		return
 	}
+	if ctx.Err() != nil {
+		ctx = context.Background()
+	}
 	m.getHeaderTime.Record(ctx, d.Seconds())
 }
 
@@ -176,6 +182,9 @@ func (m *metrics) observeGetHeader(ctx context.Context, d time.Duration) {
 func (m *metrics) observeNewHead(ctx context.Context) {
 	if m == nil {
 		return
+	}
+	if ctx.Err() != nil {
+		ctx = context.Background()
 	}
 	m.newHead.Add(ctx, 1)
 }

--- a/share/getters/shrex.go
+++ b/share/getters/shrex.go
@@ -29,7 +29,6 @@ const (
 	// serve getEDS request for block size 256
 	defaultMinRequestTimeout = time.Minute // should be >= shrexeds server write timeout
 	defaultMinAttemptsCount  = 3
-	metricObservationTimeout = 100 * time.Millisecond
 )
 
 var meter = global.MeterProvider().Meter("shrex/getter")
@@ -39,22 +38,23 @@ type metrics struct {
 	ndAttempts  syncint64.Histogram
 }
 
-func (m *metrics) recordEDSAttempt(attemptCount int, success bool) {
+func (m *metrics) recordEDSAttempt(ctx context.Context, attemptCount int, success bool) {
 	if m == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), metricObservationTimeout)
-	defer cancel()
+	if ctx.Err() != nil {
+		ctx = context.Background()
+	}
 	m.edsAttempts.Record(ctx, int64(attemptCount), attribute.Bool("success", success))
 }
 
-func (m *metrics) recordNDAttempt(attemptCount int, success bool) {
+func (m *metrics) recordNDAttempt(ctx context.Context, attemptCount int, success bool) {
 	if m == nil {
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), metricObservationTimeout)
-	defer cancel()
+	if ctx.Err() != nil {
+		ctx = context.Background()
+	}
 	m.ndAttempts.Record(ctx, int64(attemptCount), attribute.Bool("success", success))
 }
 
@@ -140,7 +140,7 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, root *share.Root) (*rsmt2d.Ex
 				"hash", root.String(),
 				"err", getErr,
 				"finished (s)", time.Since(start))
-			sg.metrics.recordEDSAttempt(attempt, false)
+			sg.metrics.recordEDSAttempt(ctx, attempt, false)
 			return nil, fmt.Errorf("getter/shrex: %w", err)
 		}
 
@@ -151,7 +151,7 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, root *share.Root) (*rsmt2d.Ex
 		switch {
 		case getErr == nil:
 			setStatus(peers.ResultSynced)
-			sg.metrics.recordEDSAttempt(attempt, true)
+			sg.metrics.recordEDSAttempt(ctx, attempt, true)
 			return eds, nil
 		case errors.Is(getErr, context.DeadlineExceeded),
 			errors.Is(getErr, context.Canceled):
@@ -198,7 +198,7 @@ func (sg *ShrexGetter) GetSharesByNamespace(
 				"hash", root.String(),
 				"err", getErr,
 				"finished (s)", time.Since(start))
-			sg.metrics.recordNDAttempt(attempt, false)
+			sg.metrics.recordNDAttempt(ctx, attempt, false)
 			return nil, fmt.Errorf("getter/shrex: %w", err)
 		}
 
@@ -209,7 +209,7 @@ func (sg *ShrexGetter) GetSharesByNamespace(
 		switch {
 		case getErr == nil:
 			setStatus(peers.ResultNoop)
-			sg.metrics.recordNDAttempt(attempt, true)
+			sg.metrics.recordNDAttempt(ctx, attempt, true)
 			return nd, nil
 		case errors.Is(getErr, context.DeadlineExceeded),
 			errors.Is(getErr, context.Canceled):

--- a/share/p2p/metrics.go
+++ b/share/p2p/metrics.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/global"
@@ -13,8 +12,6 @@ import (
 )
 
 var meter = global.MeterProvider().Meter("shrex/eds")
-
-var observationTimeout = 100 * time.Millisecond
 
 type status string
 
@@ -30,14 +27,15 @@ type Metrics struct {
 	totalRequestCounter syncint64.Counter
 }
 
-// ObserveRequests increments the total number of requests sent with the given status as an attribute.
-func (m *Metrics) ObserveRequests(count int64, status status) {
+// ObserveRequests increments the total number of requests sent with the given status as an
+// attribute.
+func (m *Metrics) ObserveRequests(ctx context.Context, count int64, status status) {
 	if m == nil {
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), observationTimeout)
-	defer cancel()
+	if ctx.Err() != nil {
+		ctx = context.Background()
+	}
 	m.totalRequestCounter.Add(ctx, count, attribute.String("status", string(status)))
 }
 

--- a/share/p2p/shrexeds/client.go
+++ b/share/p2p/shrexeds/client.go
@@ -56,7 +56,7 @@ func (c *Client) RequestEDS(
 	}
 	log.Debugw("client: eds request to peer failed", "peer", peer, "hash", dataHash.String(), "error", err)
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-		c.metrics.ObserveRequests(1, p2p.StatusTimeout)
+		c.metrics.ObserveRequests(ctx, 1, p2p.StatusTimeout)
 		return nil, ctx.Err()
 	}
 	// some net.Errors also mean the context deadline was exceeded, but yamux/mocknet do not
@@ -64,7 +64,7 @@ func (c *Client) RequestEDS(
 	var ne net.Error
 	if errors.As(err, &ne) && ne.Timeout() {
 		if deadline, _ := ctx.Deadline(); deadline.Before(time.Now()) {
-			c.metrics.ObserveRequests(1, p2p.StatusTimeout)
+			c.metrics.ObserveRequests(ctx, 1, p2p.StatusTimeout)
 			return nil, context.DeadlineExceeded
 		}
 	}
@@ -110,7 +110,7 @@ func (c *Client) doRequest(
 	if err != nil {
 		// server is overloaded and closed the stream
 		if errors.Is(err, io.EOF) {
-			c.metrics.ObserveRequests(1, p2p.StatusRateLimited)
+			c.metrics.ObserveRequests(ctx, 1, p2p.StatusRateLimited)
 			return nil, p2p.ErrNotFound
 		}
 		stream.Reset() //nolint:errcheck
@@ -124,10 +124,10 @@ func (c *Client) doRequest(
 		if err != nil {
 			return nil, fmt.Errorf("failed to read eds from ods bytes: %w", err)
 		}
-		c.metrics.ObserveRequests(1, p2p.StatusSuccess)
+		c.metrics.ObserveRequests(ctx, 1, p2p.StatusSuccess)
 		return eds, nil
 	case pb.Status_NOT_FOUND:
-		c.metrics.ObserveRequests(1, p2p.StatusNotFound)
+		c.metrics.ObserveRequests(ctx, 1, p2p.StatusNotFound)
 		return nil, p2p.ErrNotFound
 	case pb.Status_INVALID:
 		log.Debug("client: invalid request")
@@ -135,7 +135,7 @@ func (c *Client) doRequest(
 	case pb.Status_INTERNAL:
 		fallthrough
 	default:
-		c.metrics.ObserveRequests(1, p2p.StatusInternalErr)
+		c.metrics.ObserveRequests(ctx, 1, p2p.StatusInternalErr)
 		return nil, p2p.ErrInvalidResponse
 	}
 }

--- a/share/p2p/shrexeds/server.go
+++ b/share/p2p/shrexeds/server.go
@@ -65,7 +65,7 @@ func (s *Server) Stop(context.Context) error {
 func (s *Server) observeRateLimitedRequests() {
 	numRateLimited := s.middleware.DrainCounter()
 	if numRateLimited > 0 {
-		s.metrics.ObserveRequests(numRateLimited, p2p.StatusRateLimited)
+		s.metrics.ObserveRequests(context.Background(), numRateLimited, p2p.StatusRateLimited)
 	}
 }
 
@@ -103,7 +103,7 @@ func (s *Server) handleStream(stream network.Stream) {
 	status := p2p_pb.Status_OK
 	switch {
 	case errors.Is(err, eds.ErrNotFound):
-		s.metrics.ObserveRequests(1, p2p.StatusNotFound)
+		s.metrics.ObserveRequests(ctx, 1, p2p.StatusNotFound)
 		status = p2p_pb.Status_NOT_FOUND
 	case err != nil:
 		logger.Errorw("server: get CAR", "err", err)
@@ -134,7 +134,7 @@ func (s *Server) handleStream(stream network.Stream) {
 		return
 	}
 
-	s.metrics.ObserveRequests(1, p2p.StatusSuccess)
+	s.metrics.ObserveRequests(ctx, 1, p2p.StatusSuccess)
 	err = stream.Close()
 	if err != nil {
 		logger.Debugw("server: closing stream", "err", err)

--- a/share/p2p/shrexnd/server.go
+++ b/share/p2p/shrexnd/server.go
@@ -77,7 +77,7 @@ func (srv *Server) Stop(context.Context) error {
 func (srv *Server) observeRateLimitedRequests() {
 	numRateLimited := srv.middleware.DrainCounter()
 	if numRateLimited > 0 {
-		srv.metrics.ObserveRequests(numRateLimited, p2p.StatusRateLimited)
+		srv.metrics.ObserveRequests(context.Background(), numRateLimited, p2p.StatusRateLimited)
 	}
 }
 
@@ -120,27 +120,27 @@ func (srv *Server) handleNamespacedData(ctx context.Context, stream network.Stre
 	dah, err := srv.store.GetDAH(ctx, req.RootHash)
 	if err != nil {
 		if errors.Is(err, eds.ErrNotFound) {
-			srv.respondNotFoundError(logger, stream)
+			srv.respondNotFoundError(ctx, logger, stream)
 			return
 		}
 		logger.Errorw("server: retrieving DAH", "err", err)
-		srv.respondInternalError(logger, stream)
+		srv.respondInternalError(ctx, logger, stream)
 		return
 	}
 
 	shares, err := srv.getter.GetSharesByNamespace(ctx, dah, req.NamespaceId)
 	if errors.Is(err, share.ErrNotFound) {
-		srv.respondNotFoundError(logger, stream)
+		srv.respondNotFoundError(ctx, logger, stream)
 		return
 	}
 	if err != nil {
 		logger.Errorw("server: retrieving shares", "err", err)
-		srv.respondInternalError(logger, stream)
+		srv.respondInternalError(ctx, logger, stream)
 		return
 	}
 
 	resp := namespacedSharesToResponse(shares)
-	srv.respond(logger, stream, resp)
+	srv.respond(ctx, logger, stream, resp)
 }
 
 // validateRequest checks correctness of the request
@@ -156,19 +156,21 @@ func validateRequest(req pb.GetSharesByNamespaceRequest) error {
 }
 
 // respondNotFoundError sends internal error response to client
-func (srv *Server) respondNotFoundError(logger *zap.SugaredLogger, stream network.Stream) {
+func (srv *Server) respondNotFoundError(ctx context.Context,
+	logger *zap.SugaredLogger, stream network.Stream) {
 	resp := &pb.GetSharesByNamespaceResponse{
 		Status: pb.StatusCode_NOT_FOUND,
 	}
-	srv.respond(logger, stream, resp)
+	srv.respond(ctx, logger, stream, resp)
 }
 
 // respondInternalError sends internal error response to client
-func (srv *Server) respondInternalError(logger *zap.SugaredLogger, stream network.Stream) {
+func (srv *Server) respondInternalError(ctx context.Context,
+	logger *zap.SugaredLogger, stream network.Stream) {
 	resp := &pb.GetSharesByNamespaceResponse{
 		Status: pb.StatusCode_INTERNAL,
 	}
-	srv.respond(logger, stream, resp)
+	srv.respond(ctx, logger, stream, resp)
 }
 
 // namespacedSharesToResponse encodes shares into proto and sends it to client with OK status code
@@ -195,7 +197,8 @@ func namespacedSharesToResponse(shares share.NamespacedShares) *pb.GetSharesByNa
 	}
 }
 
-func (srv *Server) respond(logger *zap.SugaredLogger, stream network.Stream, resp *pb.GetSharesByNamespaceResponse) {
+func (srv *Server) respond(ctx context.Context,
+	logger *zap.SugaredLogger, stream network.Stream, resp *pb.GetSharesByNamespaceResponse) {
 	err := stream.SetWriteDeadline(time.Now().Add(srv.params.ServerWriteTimeout))
 	if err != nil {
 		logger.Debugw("server: setting write deadline", "err", err)
@@ -210,11 +213,11 @@ func (srv *Server) respond(logger *zap.SugaredLogger, stream network.Stream, res
 
 	switch {
 	case resp.Status == pb.StatusCode_OK:
-		srv.metrics.ObserveRequests(1, p2p.StatusSuccess)
+		srv.metrics.ObserveRequests(ctx, 1, p2p.StatusSuccess)
 	case resp.Status == pb.StatusCode_NOT_FOUND:
-		srv.metrics.ObserveRequests(1, p2p.StatusNotFound)
+		srv.metrics.ObserveRequests(ctx, 1, p2p.StatusNotFound)
 	case resp.Status == pb.StatusCode_INTERNAL:
-		srv.metrics.ObserveRequests(1, p2p.StatusInternalErr)
+		srv.metrics.ObserveRequests(ctx, 1, p2p.StatusInternalErr)
 	}
 	if err = stream.Close(); err != nil {
 		logger.Debugw("server: closing stream", "err", err)


### PR DESCRIPTION

## Overview

Use same approach as discussed in https://github.com/celestiaorg/celestia-node/pull/2155#discussion_r1188313387

