### PR TITLE
fix(daser): do not spawn retry job twice

### DIFF
--- a/das/state.go
+++ b/das/state.go
@@ -96,6 +96,10 @@ func (s *coordinatorState) handleResult(res result) {
 		// if job was already in retry and failed again, carry over attempt count
 		lastRetry, ok := s.inRetry[h]
 		if ok {
+			if res.job.jobType != retryJob {
+				// retry job has been already created by another worker (recent or catchup)
+				continue
+			}
 			delete(s.inRetry, h)
 		}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
In some rare cases when header height was not available for sampling and also picked up by both `recent` and `catchup` workers it could result in two parallel `retry` workers spawned for same header height. This PR fixes given case.
