### PR TITLE
fix(discovery): race in discovery tests

### DIFF
--- a/share/availability/discovery/discovery_test.go
+++ b/share/availability/discovery/discovery_test.go
@@ -19,6 +19,8 @@ import (
 func TestDiscovery(t *testing.T) {
 	const nodes = 10 // higher number brings higher coverage
 
+	discoveryRetryTimeout = time.Millisecond * 100 // defined in discovery.go
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	t.Cleanup(cancel)
 
@@ -28,7 +30,6 @@ func TestDiscovery(t *testing.T) {
 		WithPeersLimit(nodes),
 		WithAdvertiseInterval(-1),
 	)
-	discoveryRetryTimeout = time.Millisecond * 100 // defined in discovery.go
 
 	type peerUpdate struct {
 		peerID  peer.ID
@@ -42,7 +43,6 @@ func TestDiscovery(t *testing.T) {
 	discs := make([]*Discovery, nodes)
 	for i := range discs {
 		discs[i] = tn.discovery(WithPeersLimit(0), WithAdvertiseInterval(time.Millisecond*100))
-		discoveryRetryTimeout = -1 // defined in discovery.go
 
 		select {
 		case res := <-updateCh:


### PR DESCRIPTION
## Overview
Fix for error:

```
WARNING: DATA RACE
Read at 0x000001ead5c8 by goroutine 282:
  github.com/celestiaorg/celestia-node/share/availability/discovery.(*Discovery).discoveryLoop()
      /home/runner/work/celestia-node/celestia-node/share/availability/discovery/discovery.go:174 +0x59
  github.com/celestiaorg/celestia-node/share/availability/discovery.(*Discovery).Start.func2()
      /home/runner/work/celestia-node/celestia-node/share/availability/discovery/discovery.go:99 +0x58

Previous write at 0x000001ead5c8 by goroutine 172:
  github.com/celestiaorg/celestia-node/share/availability/discovery.TestDiscovery()
      /home/runner/work/celestia-node/celestia-node/share/availability/discovery/discovery_test.go:31 +0x14c
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1629 +0x47

Goroutine 282 (running) created at:
  github.com/celestiaorg/celestia-node/share/availability/discovery.(*Discovery).Start()
      /home/runner/work/celestia-node/celestia-node/share/availability/discovery/discovery.go:99 +0x3ad
  github.com/celestiaorg/celestia-node/share/availability/discovery.(*testnet).discovery()
      /home/runner/work/celestia-node/celestia-node/share/availability/discovery/discovery_test.go:101 +0xb7
  github.com/celestiaorg/celestia-node/share/availability/discovery.TestDiscovery()
      /home/runner/work/celestia-node/celestia-node/share/availability/discovery/discovery_test.go:27 +0x138
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1629 +0x47

Goroutine 172 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1906 +0xb44
  main.main()
      _testmain.go:63 +0x2e9
```