### PR TITLE
fix(discovery): finxCtx is canceled too early by defer

### DIFF
--- a/share/availability/discovery/discovery.go
+++ b/share/availability/discovery/discovery.go
@@ -241,15 +241,15 @@ func (d *Discovery) discover(ctx context.Context) bool {
 	}
 	log.Infow("discovering peers", "want", want)
 
+	// stop discovery when we are done
+	findCtx, findCancel := context.WithCancel(ctx)
+	defer findCancel()
+
 	// we use errgroup as it provide limits
 	var wg errgroup.Group
 	// limit to minimize chances of overreaching the limit
 	wg.SetLimit(int(d.set.Limit()))
 	defer wg.Wait() //nolint:errcheck
-
-	// stop discovery when we are done
-	findCtx, findCancel := context.WithCancel(ctx)
-	defer findCancel()
 
 	peers, err := d.disc.FindPeers(findCtx, rendezvousPoint)
 	if err != nil {


### PR DESCRIPTION
## Overview
If underlying discovery.FindPeers closes the channel, `discover` call would return calling the defer stack and canceling `fincCtx` too early. This would result in all routines trying to establish connection being canceled before having time to succeed. Fixed by changing defer stack order of `wg.Wait` and `context.Cancel` calls.

The change also fixes flaky `get_peer_from_discovery` test, since flakiness was actually a bug.
