### PR TITLE
Remove docstring for removed function IsBefore.

### DIFF
--- a/header/header.go
+++ b/header/header.go
@@ -103,8 +103,6 @@ func (eh *ExtendedHeader) LastHeader() libhead.Hash {
 	return libhead.Hash(eh.RawHeader.LastBlockID.Hash)
 }
 
-// IsBefore returns whether the given header is of a higher height.
-
 // Equals returns whether the hash and height of the given header match.
 func (eh *ExtendedHeader) Equals(header *ExtendedHeader) bool {
 	return eh.Height() == header.Height() && bytes.Equal(eh.Hash(), header.Hash())


### PR DESCRIPTION
## Overview

Remove docstring for removed function `IsBefore`.

`IsBefore` was removed in #1304:

> `IsBefore` inlined, so we don't need to include this method in interface (it's a oneliner used once)

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
