### PR TITLE
feat(nodebuilder/header): Add `WaitForHeight` endpoint

### DIFF
--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -95,8 +95,7 @@ type HeaderModule interface {
 LocalHead(ctx context.Context) (*header.ExtendedHeader, error)
 // GetByHash returns the header of the given hash from the node's header store.
 GetByHash(ctx context.Context, hash tmbytes.HexBytes) (*header.ExtendedHeader, error)
-// GetByHeight returns the header of the given height if it is available as either
-// the syncer's head or as the chain head of the node's header store. 
+// GetByHeight returns the header of the given height if it is available.
 GetByHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error)
 // WaitForHeight blocks until the header at the given height has been processed
 // by the node's header store or until context deadline is exceeded.
@@ -115,6 +114,7 @@ SyncWait(ctx context.Context) error
 // NetworkHead provides the Syncer's view of the current network head.
 NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
 }
+
 ```
 
 ##### Shares

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -95,10 +95,12 @@ type HeaderModule interface {
 LocalHead(ctx context.Context) (*header.ExtendedHeader, error)
 // GetByHash returns the header of the given hash from the node's header store.
 GetByHash(ctx context.Context, hash tmbytes.HexBytes) (*header.ExtendedHeader, error)
-// GetByHeight returns the header of the given height from the node's header store.
-// If the header of the given height is not yet available, the request will hang
-// until it becomes available in the node's header store.
+// GetByHeight returns the header of the given height if it is available as either
+// the syncer's head or as the chain head of the node's header store. 
 GetByHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error)
+// WaitForHeight blocks until the header at the given height has been processed
+// by the node's header store or until context deadline is exceeded.
+WaitForHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error)
 // GetVerifiedRangeByHeight returns the given range [from:to) of ExtendedHeaders
 // from the node's header store and verifies that the returned headers are 
 // adjacent to each other.

--- a/nodebuilder/header/header.go
+++ b/nodebuilder/header/header.go
@@ -27,9 +27,12 @@ type Module interface {
 		from *header.ExtendedHeader,
 		to uint64,
 	) ([]*header.ExtendedHeader, error)
-	// GetByHeight returns the ExtendedHeader at the given height, blocking
-	// until header has been processed by the store or context deadline is exceeded.
+	// GetByHeight returns the ExtendedHeader at the given height if it is
+	// currently available.
 	GetByHeight(context.Context, uint64) (*header.ExtendedHeader, error)
+	// WaitForHeight blocks until the header at the given height has been processed
+	// by the store or context deadline is exceeded.
+	WaitForHeight(context.Context, uint64) (*header.ExtendedHeader, error)
 
 	// SyncState returns the current state of the header Syncer.
 	SyncState(context.Context) (sync.State, error)
@@ -56,11 +59,12 @@ type API struct {
 			*header.ExtendedHeader,
 			uint64,
 		) ([]*header.ExtendedHeader, error) `perm:"public"`
-		GetByHeight func(context.Context, uint64) (*header.ExtendedHeader, error)    `perm:"public"`
-		SyncState   func(ctx context.Context) (sync.State, error)                    `perm:"read"`
-		SyncWait    func(ctx context.Context) error                                  `perm:"read"`
-		NetworkHead func(ctx context.Context) (*header.ExtendedHeader, error)        `perm:"public"`
-		Subscribe   func(ctx context.Context) (<-chan *header.ExtendedHeader, error) `perm:"public"`
+		GetByHeight   func(context.Context, uint64) (*header.ExtendedHeader, error)    `perm:"public"`
+		WaitForHeight func(context.Context, uint64) (*header.ExtendedHeader, error)    `perm:"read"`
+		SyncState     func(ctx context.Context) (sync.State, error)                    `perm:"read"`
+		SyncWait      func(ctx context.Context) error                                  `perm:"read"`
+		NetworkHead   func(ctx context.Context) (*header.ExtendedHeader, error)        `perm:"public"`
+		Subscribe     func(ctx context.Context) (<-chan *header.ExtendedHeader, error) `perm:"public"`
 	}
 }
 
@@ -78,6 +82,10 @@ func (api *API) GetVerifiedRangeByHeight(
 
 func (api *API) GetByHeight(ctx context.Context, u uint64) (*header.ExtendedHeader, error) {
 	return api.Internal.GetByHeight(ctx, u)
+}
+
+func (api *API) WaitForHeight(ctx context.Context, u uint64) (*header.ExtendedHeader, error) {
+	return api.Internal.WaitForHeight(ctx, u)
 }
 
 func (api *API) LocalHead(ctx context.Context) (*header.ExtendedHeader, error) {

--- a/nodebuilder/header/service.go
+++ b/nodebuilder/header/service.go
@@ -76,6 +76,10 @@ func (s *Service) GetByHeight(ctx context.Context, height uint64) (*header.Exten
 	}
 }
 
+func (s *Service) WaitForHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
+	return s.store.GetByHeight(ctx, height)
+}
+
 func (s *Service) LocalHead(ctx context.Context) (*header.ExtendedHeader, error) {
 	return s.store.Head(ctx)
 }


### PR DESCRIPTION
Adds`WaitForHeight` endpoint which was formerly `GetByHeight` that just exposes store.GetByHeight