### PR TITLE
feat(share/discovery): Discard method

### DIFF
--- a/share/availability/discovery/discovery.go
+++ b/share/availability/discovery/discovery.go
@@ -122,6 +122,28 @@ func (d *Discovery) Peers(ctx context.Context) ([]peer.ID, error) {
 	return d.set.Peers(ctx)
 }
 
+// Discard removes the peer from the peer set and rediscovers more if soft peer limit is not
+// reached.
+func (d *Discovery) Discard(id peer.ID) {
+	if !d.set.Contains(id) {
+		return
+	}
+
+	d.host.ConnManager().Unprotect(id, rendezvousPoint)
+	d.connector.Backoff(id)
+	d.set.Remove(id)
+	d.onUpdatedPeers(id, false)
+	log.Debugw("removed peer from the peer set", "peer", id)
+
+	if d.set.Size() < d.set.Limit() {
+		// trigger discovery
+		select {
+		case d.triggerDisc <- struct{}{}:
+		default:
+		}
+	}
+}
+
 // Advertise is a utility function that persistently advertises a service through an Advertiser.
 // TODO: Start advertising only after the reachability is confirmed by AutoNAT
 func (d *Discovery) Advertise(ctx context.Context) {
@@ -210,22 +232,8 @@ func (d *Discovery) disconnectsLoop(ctx context.Context, sub event.Subscription)
 				return
 			}
 
-			evnt := e.(event.EvtPeerConnectednessChanged)
-			if evnt.Connectedness == network.NotConnected && d.set.Contains(evnt.Peer) {
-				d.host.ConnManager().Unprotect(evnt.Peer, rendezvousPoint)
-				d.connector.Backoff(evnt.Peer)
-				d.set.Remove(evnt.Peer)
-				d.onUpdatedPeers(evnt.Peer, false)
-				log.Debugw("removed peer from the peer set",
-					"peer", evnt.Peer, "status", evnt.Connectedness.String())
-
-				if d.set.Size() < d.set.Limit() {
-					// trigger discovery
-					select {
-					case d.triggerDisc <- struct{}{}:
-					default:
-					}
-				}
+			if evnt := e.(event.EvtPeerConnectednessChanged); evnt.Connectedness == network.NotConnected {
+				d.Discard(evnt.Peer)
 			}
 		}
 	}

--- a/share/availability/discovery/discovery.go
+++ b/share/availability/discovery/discovery.go
@@ -123,10 +123,10 @@ func (d *Discovery) Peers(ctx context.Context) ([]peer.ID, error) {
 }
 
 // Discard removes the peer from the peer set and rediscovers more if soft peer limit is not
-// reached.
-func (d *Discovery) Discard(id peer.ID) {
+// reached. Reports whether peer was removed with bool.
+func (d *Discovery) Discard(id peer.ID) bool {
 	if !d.set.Contains(id) {
-		return
+		return false
 	}
 
 	d.host.ConnManager().Unprotect(id, rendezvousPoint)
@@ -142,6 +142,8 @@ func (d *Discovery) Discard(id peer.ID) {
 		default:
 		}
 	}
+
+	return true
 }
 
 // Advertise is a utility function that persistently advertises a service through an Advertiser.


### PR DESCRIPTION
Fixes #2204 

Regarding the case where we exhausted all the peers on the network and backed them all off. It can happen on the smaller network, and in the worst case, the node will wait 10 minutes(the default backoff time), which is acceptable considering peers from shrexsub #2105 