### PR TITLE
fix(header): check that Commit corresponds to Header

### DIFF
--- a/nodebuilder/tests/fraud_test.go
+++ b/nodebuilder/tests/fraud_test.go
@@ -33,6 +33,8 @@ Note: 15 is not available because DASer will be stopped before reaching this hei
 Another note: this test disables share exchange to speed up test results.
 */
 func TestFraudProofBroadcasting(t *testing.T) {
+	t.Skip("requires BEFP generation on app side to work")
+
 	const (
 		blocks = 15
 		bsize  = 2
@@ -109,6 +111,8 @@ Steps:
 Note: this test disables share exchange to speed up test results.
 */
 func TestFraudProofSyncing(t *testing.T) {
+	t.Skip("requires BEFP generation on app side to work")
+
 	const (
 		blocks = 15
 		bsize  = 2


### PR DESCRIPTION
During the BEFP discussion on TG with @vgonkivs, we figured out that with have ___CRITICAL___ vulnerability in the header validation process. The funniest part is that we abuse this vulnerability to make our BEFP test in Swamp work, and the test represents the exact scenario of such vulnerability: a malicious BN/FN can substitute any value in RawHeader it wants like DAH and the verification on the client side still passes. This is because we don't check that BlockID(Hash) in Commit is aligned with recomputed RawHeader hash.

Unfortunately, this breaks our BEFP testing suite, and the only way to reliably produce FPs now is by modifying the Core/App node.

![image](https://github.com/celestiaorg/celestia-node/assets/22449364/a2d4792a-0e05-4b91-b9fe-ba480dfa0a58)
