### PR TITLE
chore(.github): Suppress unit test coverage verbosity

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: codecov/codecov-action@v3.1.3
         with:
           file: ./coverage.txt
-          verbose: false # this is technically the default, but the output is currently too verbose, so trying this way
+          verbose: false
 
   unit_race_test:
     name: Run Unit Tests with Race Detector

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: codecov/codecov-action@v3.1.3
         with:
           file: ./coverage.txt
+          verbose: false # this is technically the default, but the output is currently too verbose, so trying this way
 
   unit_race_test:
     name: Run Unit Tests with Race Detector


### PR DESCRIPTION
Technically `verbose` default should be false but the output looks verbose to me, so let's see if making it explicit works.