### PR TITLE
chore(.github): Fix coverage run to separate unit test and coverage upload to codecov

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -55,10 +55,13 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Test & Coverage
-        run: make cover
-      - uses: codecov/codecov-action@v3.1.3
+      - name: run unit tests
+        run: make test-unit
+
+      - name: upload coverage
+        uses: codecov/codecov-action@v3.1.3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
 
   unit_race_test:

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ lint: lint-imports
 ## test-unit: Running unit tests
 test-unit:
 	@echo "--> Running unit tests"
-	@go test `go list ./... | grep -v nodebuilder/tests` -covermode=atomic -coverprofile=coverage.out
+	@go test -covermode=atomic -coverprofile=coverage.txt `go list ./... | grep -v nodebuilder/tests`
 .PHONY: test-unit
 
 ## test-unit-race: Running unit tests with data race detector


### PR DESCRIPTION
Separate unit test coverage run to two separate steps: unit test and then upload code coverage report. Adds the token so that code coverage actually gets pushed to codecov.