### PR TITLE
feat(nodebuilder): Add jwt.Signer to Node struct for auth token access

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -14,6 +14,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/celestiaorg/celestia-node/api/rpc/perms"
+	"github.com/celestiaorg/celestia-node/libs/authtoken"
 	"github.com/celestiaorg/celestia-node/libs/keystore"
 	nodemod "github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
@@ -70,14 +71,12 @@ func newToken(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	token, err := jwt.NewTokenBuilder(signer).Build(&perms.JWTPayload{
-		Allow: permissions,
-	})
+	token, err := authtoken.NewSignedJWT(signer, permissions)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("%s", token.InsecureString())
+	fmt.Printf("%s", token)
 	return nil
 }
 

--- a/libs/authtoken/authtoken.go
+++ b/libs/authtoken/authtoken.go
@@ -1,0 +1,18 @@
+package authtoken
+
+import (
+	"github.com/cristalhq/jwt"
+	"github.com/filecoin-project/go-jsonrpc/auth"
+
+	"github.com/celestiaorg/celestia-node/api/rpc/perms"
+)
+
+func NewSignedJWT(signer jwt.Signer, permissions []auth.Permission) (string, error) {
+	token, err := jwt.NewTokenBuilder(signer).Build(&perms.JWTPayload{
+		Allow: permissions,
+	})
+	if err != nil {
+		return "", err
+	}
+	return token.InsecureString(), nil
+}

--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cristalhq/jwt"
 	"github.com/ipfs/go-blockservice"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	logging "github.com/ipfs/go-log/v2"
@@ -51,6 +52,7 @@ type Node struct {
 	Network       p2p.Network
 	Bootstrappers p2p.Bootstrappers
 	Config        *Config
+	AdminSigner   jwt.Signer
 
 	// rpc components
 	RPCServer     *rpc.Server     // not optional

--- a/nodebuilder/node_test.go
+++ b/nodebuilder/node_test.go
@@ -34,6 +34,7 @@ func TestLifecycle(t *testing.T) {
 			require.NotNil(t, node.Host)
 			require.NotNil(t, node.HeaderServ)
 			require.NotNil(t, node.StateServ)
+			require.NotNil(t, node.AdminSigner)
 			require.Equal(t, tt.tp, node.Type)
 
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This PR adds the jwt.Signer to the node struct to be able to generate auth tokens for integration tests that use celestia-node's RPC.