### PR TITLE
feat(cmd/rpc): adding blob module to rpc cli and fixing namespace parsing

### DIFF
--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/api/rpc/client"
 	"github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/state"
 )
 
@@ -441,7 +442,10 @@ func parseNamespace(param string) (namespace.ID, error) {
 	}
 	// if the namespace ID is 8 bytes, add v0 share + namespace prefix and zero pad
 	if len(nID) == 8 {
-		nID = append(make([]byte, 21), nID...)
+		nID, err = share.NewNamespaceV0(nID)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return nID, nil
 }

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/celestiaorg/nmt/namespace"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/nmt/namespace"
 
 	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/blob/blobtest"


### PR DESCRIPTION
This PR does the following:

### Adds blob module support
`blob.Submit` has been added with custom parsing for posting a single blob.
`blob.GetAll` also only takes a single namespace id for now. This will make devx easier

### Adds --print-request flag
Now the request can also be displayed along with the json response. This will both help for debugging and building things that need to build the requests themselves

### Fixes namespace parsing
Namespaces are now encoded correctly again. In addition, if you pass a namespace of 8 bytes, it will zero-pad and use share/nID version 0.

### Fixes `state.SubmitPayForBlob`
Another issue was the change to an array. We now submit an array of a single blob, and changed the order of the arguments.
The order is now: fee, gasLimit, namespaceID, blob data

### Adds formatted output
JQ is no longer needed to have an indented output. But colors are missing