### PR TITLE
fix(getter/cascade): cascade getter should return fast on context cancel

### DIFF
--- a/share/getters/cascade.go
+++ b/share/getters/cascade.go
@@ -121,16 +121,18 @@ func cascadeGetters[V any](
 		getCtx, cancel := ctxWithSplitTimeout(ctx, len(getters)-i, 0)
 		val, getErr := get(getCtx, getter)
 		cancel()
-		if getErr == nil {
-			return val, nil
-		}
-		if errors.Is(getErr, share.ErrNamespaceNotFound) || errors.Is(getErr, context.Canceled) {
-			return zero, getErr
+		if getErr == nil || errors.Is(getErr, share.ErrNamespaceNotFound) {
+			return val, getErr
 		}
 
-		if !errors.Is(getErr, errOperationNotSupported) {
-			err = errors.Join(err, getErr)
-			span.RecordError(getErr, trace.WithAttributes(attribute.Int("getter_idx", i)))
+		if errors.Is(getErr, errOperationNotSupported) {
+			continue
+		}
+
+		err = errors.Join(err, getErr)
+		span.RecordError(getErr, trace.WithAttributes(attribute.Int("getter_idx", i)))
+		if errors.Is(getErr, context.Canceled) {
+			return zero, err
 		}
 	}
 	return zero, err

--- a/share/getters/cascade.go
+++ b/share/getters/cascade.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -125,7 +124,7 @@ func cascadeGetters[V any](
 		if getErr == nil {
 			return val, nil
 		}
-		if errors.Is(share.ErrNamespaceNotFound, getErr) {
+		if errors.Is(getErr, share.ErrNamespaceNotFound) || errors.Is(getErr, context.Canceled) {
 			return zero, getErr
 		}
 

--- a/share/getters/cascade.go
+++ b/share/getters/cascade.go
@@ -131,7 +131,7 @@ func cascadeGetters[V any](
 
 		err = errors.Join(err, getErr)
 		span.RecordError(getErr, trace.WithAttributes(attribute.Int("getter_idx", i)))
-		if errors.Is(getErr, context.Canceled) {
+		if ctx.Err() != nil {
 			return zero, err
 		}
 	}

--- a/share/getters/cascade.go
+++ b/share/getters/cascade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 

--- a/share/getters/cascade_test.go
+++ b/share/getters/cascade_test.go
@@ -52,6 +52,7 @@ func TestCascade(t *testing.T) {
 	timeoutGetter := mocks.NewMockGetter(ctrl)
 	immediateFailGetter := mocks.NewMockGetter(ctrl)
 	successGetter := mocks.NewMockGetter(ctrl)
+	ctxGetter := mocks.NewMockGetter(ctrl)
 	timeoutGetter.EXPECT().GetEDS(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, _ *share.Root) (*rsmt2d.ExtendedDataSquare, error) {
 			return nil, context.DeadlineExceeded
@@ -60,6 +61,10 @@ func TestCascade(t *testing.T) {
 		Return(nil, errors.New("second getter fails immediately")).AnyTimes()
 	successGetter.EXPECT().GetEDS(gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
+	ctxGetter.EXPECT().GetEDS(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ *share.Root) (*rsmt2d.ExtendedDataSquare, error) {
+			return nil, ctx.Err()
+		}).AnyTimes()
 
 	get := func(ctx context.Context, get share.Getter) (*rsmt2d.ExtendedDataSquare, error) {
 		return get.GetEDS(ctx, nil)
@@ -94,6 +99,15 @@ func TestCascade(t *testing.T) {
 		_, err := cascadeGetters(ctx, getters, get)
 		assert.Error(t, err)
 		assert.Equal(t, strings.Count(err.Error(), "\n"), 2)
+	})
+
+	t.Run("Context Canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+		getters := []share.Getter{ctxGetter, ctxGetter, ctxGetter}
+		_, err := cascadeGetters(ctx, getters, get)
+		assert.Error(t, err)
+		assert.Equal(t, strings.Count(err.Error(), "\n"), 0)
 	})
 
 	t.Run("Single", func(t *testing.T) {


### PR DESCRIPTION
## Overview

Also fixes incorrect errors.Is for `share.ErrNamespaceNotFound`

Resolves https://github.com/celestiaorg/celestia-node/issues/2174
