### PR TITLE
fix(dagstore): changing log level to WARN to shorten startup

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -21,6 +21,8 @@ func SetAllLoggers(level logging.LogLevel) {
 	_ = logging.SetLogLevel("net/identify", "ERROR")
 	_ = logging.SetLogLevel("shrex/nd", "WARN")
 	_ = logging.SetLogLevel("shrex/eds", "WARN")
+	_ = logging.SetLogLevel("dagstore", "WARN")
+	_ = logging.SetLogLevel("dagstore/upgrader", "WARN")
 	_ = logging.SetLogLevel("fx", "FATAL")
 }
 


### PR DESCRIPTION
Dagstore's debug logs increase startup time by 3-4x, and dagstore in general produces a lot of debug logs that are not very important for collecting.