### PR TITLE
feat!(nodbuilder): making lifecycle timeouts configurable

### DIFF
--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -25,6 +25,7 @@ type ConfigLoader func() (*Config, error)
 // Config is main configuration structure for a Node.
 // It combines configuration units for all Node subsystems.
 type Config struct {
+	Node    node.Config
 	Core    core.Config
 	State   state.Config
 	P2P     p2p.Config
@@ -39,6 +40,7 @@ type Config struct {
 // NOTE: Currently, configs are identical, but this will change.
 func DefaultConfig(tp node.Type) *Config {
 	commonConfig := &Config{
+		Node:    node.DefaultConfig(tp),
 		Core:    core.DefaultConfig(),
 		State:   state.DefaultConfig(),
 		P2P:     p2p.DefaultConfig(tp),

--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cristalhq/jwt"
 	"github.com/ipfs/go-blockservice"
@@ -95,7 +94,7 @@ func NewWithConfig(tp node.Type, network p2p.Network, store Store, cfg *Config, 
 
 // Start launches the Node and all its components and services.
 func (n *Node) Start(ctx context.Context) error {
-	to := timeout(n.Type)
+	to := n.Config.Node.StartupTimeout
 	ctx, cancel := context.WithTimeout(ctx, to)
 	defer cancel()
 
@@ -141,7 +140,7 @@ func (n *Node) Run(ctx context.Context) error {
 // Canceling the given context earlier 'ctx' unblocks the Stop and aborts graceful shutdown forcing
 // remaining Modules/Services to close immediately.
 func (n *Node) Stop(ctx context.Context) error {
-	to := timeout(n.Type)
+	to := n.Config.Node.ShutdownTimeout
 	ctx, cancel := context.WithTimeout(ctx, to)
 	defer cancel()
 
@@ -183,14 +182,3 @@ func newNode(opts ...fx.Option) (*Node, error) {
 
 // lifecycleFunc defines a type for common lifecycle funcs.
 type lifecycleFunc func(context.Context) error
-
-var DefaultLifecycleTimeout = time.Minute * 2
-
-func timeout(tp node.Type) time.Duration {
-	switch tp {
-	case node.Light:
-		return time.Second * 20
-	default:
-		return DefaultLifecycleTimeout
-	}
-}

--- a/nodebuilder/node/config.go
+++ b/nodebuilder/node/config.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var DefaultLifecycleTimeout = time.Minute * 2
+var defaultLifecycleTimeout = time.Minute * 2
 
 type Config struct {
 	StartupTimeout  time.Duration
@@ -19,7 +19,7 @@ func DefaultConfig(tp Type) Config {
 	case Light:
 		timeout = time.Second * 20
 	default:
-		timeout = DefaultLifecycleTimeout
+		timeout = defaultLifecycleTimeout
 	}
 	return Config{
 		StartupTimeout:  timeout,

--- a/nodebuilder/node/config.go
+++ b/nodebuilder/node/config.go
@@ -1,0 +1,38 @@
+package node
+
+import (
+	"fmt"
+	"time"
+)
+
+var DefaultLifecycleTimeout = time.Minute * 2
+
+type Config struct {
+	StartupTimeout  time.Duration
+	ShutdownTimeout time.Duration
+}
+
+// DefaultConfig returns the default node configuration for a given node type.
+func DefaultConfig(tp Type) Config {
+	var timeout time.Duration
+	switch tp {
+	case Light:
+		timeout = time.Second * 20
+	default:
+		timeout = DefaultLifecycleTimeout
+	}
+	return Config{
+		StartupTimeout:  timeout,
+		ShutdownTimeout: timeout,
+	}
+}
+
+func (c *Config) Validate() error {
+	if c.StartupTimeout == 0 {
+		return fmt.Errorf("invalid startup timeout: %v", c.StartupTimeout)
+	}
+	if c.ShutdownTimeout == 0 {
+		return fmt.Errorf("invalid shutdown timeout: %v", c.ShutdownTimeout)
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #2315 

Doing this proactively even though it is a good-first issue in case other dagstore startup issues are not fixed in time. Breaks the config.