### PR TITLE
refactor(swamp): use RPC instead of service pointers

### DIFF
--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cristalhq/jwt"
 	"github.com/ipfs/go-blockservice"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	logging "github.com/ipfs/go-log/v2"
@@ -48,6 +49,7 @@ type Node struct {
 	Network       p2p.Network
 	Bootstrappers p2p.Bootstrappers
 	Config        *Config
+	AdminSigner   jwt.Signer
 
 	// rpc components
 	RPCServer     *rpc.Server     // not optional

--- a/nodebuilder/tests/api_test.go
+++ b/nodebuilder/tests/api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/celestiaorg/celestia-node/api/rpc/client"
 	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/blob/blobtest"
+	"github.com/celestiaorg/celestia-node/libs/authtoken"
 	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"

--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -59,17 +59,18 @@ func TestFullReconstructFromBridge(t *testing.T) {
 	full := sw.NewNodeWithConfig(node.Full, cfg)
 	err = full.Start(ctx)
 	require.NoError(t, err)
+	fullClient := getAdminClient(ctx, full, t)
 
 	errg, bctx := errgroup.WithContext(ctx)
 	for i := 1; i <= blocks+1; i++ {
 		i := i
 		errg.Go(func() error {
-			h, err := full.HeaderServ.WaitForHeight(bctx, uint64(i))
+			h, err := fullClient.Header.WaitForHeight(bctx, uint64(i))
 			if err != nil {
 				return err
 			}
 
-			return full.ShareServ.SharesAvailable(bctx, h.DAH)
+			return fullClient.Share.SharesAvailable(bctx, h.DAH)
 		})
 	}
 	require.NoError(t, <-fillDn)
@@ -154,6 +155,7 @@ func TestFullReconstructFromLights(t *testing.T) {
 	}
 	require.NoError(t, errg.Wait())
 	require.NoError(t, full.Start(ctx))
+	fullClient := getAdminClient(ctx, full, t)
 	for i := 0; i < lnodes; i++ {
 		select {
 		case <-ctx.Done():
@@ -167,12 +169,12 @@ func TestFullReconstructFromLights(t *testing.T) {
 	for i := 1; i <= blocks+1; i++ {
 		i := i
 		errg.Go(func() error {
-			h, err := full.HeaderServ.WaitForHeight(bctx, uint64(i))
+			h, err := fullClient.Header.WaitForHeight(bctx, uint64(i))
 			if err != nil {
 				return err
 			}
 
-			return full.ShareServ.SharesAvailable(bctx, h.DAH)
+			return fullClient.Share.SharesAvailable(bctx, h.DAH)
 		})
 	}
 	require.NoError(t, <-fillDn)

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -236,6 +236,7 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 
 	light = sw.NewLightNode()
 	require.NoError(t, light.Start(ctx))
+	lightClient = getAdminClient(ctx, light, t)
 
 	// ensure when light node comes back up, it can sync the remainder of the chain it
 	// missed while sleeping

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -236,7 +236,7 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 
 	light = sw.NewLightNode()
 	require.NoError(t, light.Start(ctx))
-	lightClient = getAdminClient(ctx, light, t)
+	//lightClient := getAdminClient(ctx, light, t) // TODO
 
 	// ensure when light node comes back up, it can sync the remainder of the chain it
 	// missed while sleeping


### PR DESCRIPTION
~~This PR refactors the existing swamp tests to use the RPC. Still in draft because it broke a single test (`TestRestartNodeDiscovery`) and I cannot figure out why.~~

Based on #2361 
First step of #2337 