### PR TITLE
fix(swamp): use synchronized map as container for nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	go.uber.org/fx v1.19.3
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.9.0
+	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
 	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.9.0
 	google.golang.org/grpc v1.53.0
@@ -309,7 +310,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/dig v1.16.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.4.0 // indirect

--- a/nodebuilder/tests/fraud_test.go
+++ b/nodebuilder/tests/fraud_test.go
@@ -84,8 +84,7 @@ func TestFraudProofBroadcasting(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	syncCancel()
 
-	require.NoError(t, full.Stop(ctx))
-	require.NoError(t, sw.RemoveNode(full, node.Full))
+	sw.StopNode(ctx, full)
 
 	full = sw.NewNodeWithStore(node.Full, store)
 

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -48,7 +48,7 @@ const DefaultTestTimeout = time.Minute * 5
 // - trustedHash taken from the CoreClient and shared between nodes
 type Swamp struct {
 	t   *testing.T
-	cgf *Config
+	cfg *Config
 
 	Network       mocknet.Mocknet
 	ClientContext testnode.Context
@@ -77,7 +77,7 @@ func NewSwamp(t *testing.T, options ...Option) *Swamp {
 	cctx := core.StartTestNodeWithConfig(t, ic.TestConfig)
 	swp := &Swamp{
 		t:             t,
-		cgf:           ic,
+		cfg:           ic,
 		Network:       mocknet.New(),
 		ClientContext: cctx,
 		Accounts:      ic.Accounts,
@@ -186,7 +186,7 @@ func (s *Swamp) setupGenesis() {
 func (s *Swamp) DefaultTestConfig(tp node.Type) *nodebuilder.Config {
 	cfg := nodebuilder.DefaultConfig(tp)
 
-	ip, port, err := net.SplitHostPort(s.cgf.App.GRPC.Address)
+	ip, port, err := net.SplitHostPort(s.cfg.App.GRPC.Address)
 	require.NoError(s.t, err)
 
 	cfg.Core.IP = ip

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -249,6 +249,7 @@ func (s *Swamp) NewNodeWithStore(
 		options = append(options,
 			coremodule.WithClient(s.ClientContext.Client),
 		)
+	default:
 	}
 
 	nd := s.newNode(tp, store, options...)

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -121,8 +121,7 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 
 	require.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, 30))
 
-	require.NoError(t, light.Stop(ctx))
-	require.NoError(t, sw.RemoveNode(light, node.Light))
+	sw.StopNode(ctx, light)
 
 	cfg = nodebuilder.DefaultConfig(node.Light)
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())


### PR DESCRIPTION
While fixing https://github.com/celestiaorg/celestia-node/issues/825, I discovered a race. We were not synchronizing writes to containers on the node. Additionally, I simplified storing of registered nodes by using map instead of per type slices. We don't use this per type separation anyhow