### PR TITLE
chore!(gateway): add deprecation notices

### DIFF
--- a/api/gateway/das.go
+++ b/api/gateway/das.go
@@ -10,6 +10,7 @@ const (
 )
 
 func (h *Handler) handleDASStateRequest(w http.ResponseWriter, r *http.Request) {
+	logDeprecation(dasStateEndpoint, "das.SamplingStats")
 	stats, err := h.das.SamplingStats(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, dasStateEndpoint, err)

--- a/api/gateway/endpoints.go
+++ b/api/gateway/endpoints.go
@@ -7,6 +7,7 @@ import (
 
 func (h *Handler) RegisterEndpoints(rpc *Server, deprecatedEndpointsEnabled bool) {
 	if deprecatedEndpointsEnabled {
+		log.Warn("Deprecated endpoints will be removed from the gateway in the next release. Use the RPC instead.")
 		// state endpoints
 		rpc.RegisterHandlerFunc(balanceEndpoint, h.handleBalanceRequest, http.MethodGet)
 		rpc.RegisterHandlerFunc(submitPFBEndpoint, h.handleSubmitPFB, http.MethodPost)

--- a/api/gateway/state.go
+++ b/api/gateway/state.go
@@ -74,6 +74,7 @@ func (h *Handler) handleBalanceRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		bal, err = h.state.BalanceForAddress(r.Context(), addr)
 	} else {
+		logDeprecation(balanceEndpoint, "state.Balance")
 		bal, err = h.state.Balance(r.Context())
 	}
 	if err != nil {
@@ -122,6 +123,7 @@ func (h *Handler) handleSubmitTx(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleSubmitPFB(w http.ResponseWriter, r *http.Request) {
+	logDeprecation(submitPFBEndpoint, "blob.Submit or state.SubmitPayForBlob")
 	// decode request
 	var req submitPFBRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
@@ -171,6 +173,7 @@ func (h *Handler) handleSubmitPFB(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleQueryDelegation(w http.ResponseWriter, r *http.Request) {
+	logDeprecation(queryDelegationEndpoint, "state.QueryDelegation")
 	// read and parse request
 	vars := mux.Vars(r)
 	addrStr, exists := vars[addrKey]
@@ -202,6 +205,7 @@ func (h *Handler) handleQueryDelegation(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *Handler) handleQueryUnbonding(w http.ResponseWriter, r *http.Request) {
+	logDeprecation(queryUnbondingEndpoint, "state.QueryUnbonding")
 	// read and parse request
 	vars := mux.Vars(r)
 	addrStr, exists := vars[addrKey]
@@ -233,6 +237,7 @@ func (h *Handler) handleQueryUnbonding(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleQueryRedelegations(w http.ResponseWriter, r *http.Request) {
+	logDeprecation(queryRedelegationsEndpoint, "state.QueryRedelegations")
 	var req queryRedelegationsRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -263,4 +268,9 @@ func (h *Handler) handleQueryRedelegations(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		log.Errorw("writing response", "endpoint", queryRedelegationsEndpoint, "err", err)
 	}
+}
+
+func logDeprecation(endpoint string, alternative string) {
+	log.Warn("The " + endpoint + " endpoint is deprecated and will be removed in the next release. Please " +
+		"use " + alternative + " from the RPC instead.")
 }

--- a/nodebuilder/gateway/config.go
+++ b/nodebuilder/gateway/config.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Config struct {
-	Address string
-	Port    string
-	Enabled bool
+	Address             string
+	Port                string
+	Enabled             bool
+	deprecatedEndpoints bool
 }
 
 func DefaultConfig() Config {

--- a/nodebuilder/gateway/constructors.go
+++ b/nodebuilder/gateway/constructors.go
@@ -10,6 +10,7 @@ import (
 
 // Handler constructs a new RPC Handler from the given services.
 func Handler(
+	cfg *Config,
 	state state.Module,
 	share share.Module,
 	header header.Module,
@@ -17,7 +18,7 @@ func Handler(
 	serv *gateway.Server,
 ) {
 	handler := gateway.NewHandler(state, share, header, daser)
-	handler.RegisterEndpoints(serv)
+	handler.RegisterEndpoints(serv, cfg.deprecatedEndpoints)
 	handler.RegisterMiddleware(serv)
 }
 

--- a/nodebuilder/gateway/flags.go
+++ b/nodebuilder/gateway/flags.go
@@ -6,9 +6,10 @@ import (
 )
 
 var (
-	enabledFlag = "gateway"
-	addrFlag    = "gateway.addr"
-	portFlag    = "gateway.port"
+	enabledFlag         = "gateway"
+	addrFlag            = "gateway.addr"
+	portFlag            = "gateway.port"
+	deprecatedEndpoints = "gateway.deprecated-endpoints"
 )
 
 // Flags gives a set of hardcoded node/gateway package flags.
@@ -19,6 +20,11 @@ func Flags() *flag.FlagSet {
 		enabledFlag,
 		false,
 		"Enables the REST gateway",
+	)
+	flags.Bool(
+		deprecatedEndpoints,
+		false,
+		"Enables deprecated endpoints on the gateway. These will be removed in the next release.",
 	)
 	flags.String(
 		addrFlag,
@@ -39,6 +45,10 @@ func ParseFlags(cmd *cobra.Command, cfg *Config) {
 	enabled, err := cmd.Flags().GetBool(enabledFlag)
 	if cmd.Flags().Changed(enabledFlag) && err == nil {
 		cfg.Enabled = enabled
+	}
+	deprecatedEndpointsEnabled, err := cmd.Flags().GetBool(deprecatedEndpoints)
+	if cmd.Flags().Changed(deprecatedEndpoints) && err == nil {
+		cfg.deprecatedEndpoints = deprecatedEndpointsEnabled
 	}
 	addr, port := cmd.Flag(addrFlag), cmd.Flag(portFlag)
 	if !cfg.Enabled && (addr.Changed || port.Changed) {

--- a/nodebuilder/gateway/module.go
+++ b/nodebuilder/gateway/module.go
@@ -21,7 +21,6 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	if !cfg.Enabled {
 		return fx.Options()
 	}
-	log.Warn("Many gateway endpoints will be deprecated in the next release. Please use the RPC instead.")
 
 	baseComponents := fx.Options(
 		fx.Supply(cfg),

--- a/nodebuilder/gateway/module.go
+++ b/nodebuilder/gateway/module.go
@@ -21,8 +21,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	if !cfg.Enabled {
 		return fx.Options()
 	}
-	// NOTE @distractedm1nd @renaynay: Remove whenever/if we decide to add auth to gateway
-	log.Warn("Gateway is enabled, however gateway endpoints are not authenticated. Use with caution!")
+	log.Warn("Many gateway endpoints will be deprecated in the next release. Please use the RPC instead.")
 
 	baseComponents := fx.Options(
 		fx.Supply(cfg),
@@ -50,12 +49,13 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 			"gateway",
 			baseComponents,
 			fx.Invoke(func(
+				cfg *Config,
 				state stateServ.Module,
 				share shareServ.Module,
 				header headerServ.Module,
 				serv *gateway.Server,
 			) {
-				Handler(state, share, header, nil, serv)
+				Handler(cfg, state, share, header, nil, serv)
 			}),
 		)
 	default:


### PR DESCRIPTION
- Adds a warn log on startup if --gateway is passed
- Deprecated endpoints are now disabled by default. This includes:
    - /balance
    - /submit_pfd
    - /query_delegation
    - /query_unbonding
    - /query_redelegations
- Deprecated endpoints can be activated by passing `--gateway.deprecated-endpoints`
- When using deprecated endpoints, the node will log a warning, giving the alternative RPC method to call in the future. 

The ugly config change/flag will be removed when fully deprecating the endpoints