### PR TITLE
fix(rpc/client): stop overwriting existing clients

### DIFF
--- a/api/rpc/client/client.go
+++ b/api/rpc/client/client.go
@@ -74,8 +74,7 @@ func NewClient(ctx context.Context, addr string, token string) (*Client, error) 
 func newClient(ctx context.Context, addr string, authHeader http.Header) (*Client, error) {
 	var multiCloser multiClientCloser
 	var client Client
-	modules := moduleMap(&client)
-	for name, module := range modules {
+	for name, module := range moduleMap(&client) {
 		closer, err := jsonrpc.NewClient(ctx, addr, name, module, authHeader)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
While working on #2356 I uncovered a bug:

When using the `client.NewClient` constructor, it uses a global static struct to set the modules. This led to clients overwriting each other when multiple are initialized. 