### PR TITLE
fix(share/eds): fix test flake

### DIFF
--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -119,6 +119,10 @@ func (s *Store) Start(ctx context.Context) error {
 	// start Store only if DagStore succeeds
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
+	// initialize empty gc result to avoid panic on access
+	s.lastGCResult.Store(&dagstore.GCResult{
+		Shards: make(map[shard.Key]error),
+	})
 	go s.gc(ctx)
 	return nil
 }
@@ -132,10 +136,6 @@ func (s *Store) Stop(context.Context) error {
 // gc periodically removes all inactive or errored shards.
 func (s *Store) gc(ctx context.Context) {
 	ticker := time.NewTicker(s.gcInterval)
-	// initialize empty gc result to avoid panic on access
-	s.lastGCResult.Store(&dagstore.GCResult{
-		Shards: make(map[shard.Key]error),
-	})
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Caught a flake, and here is a fix: init map on Start, rather than in gc routine 

```
 --- FAIL: TestEDSStore_GC (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1011ad8]

goroutine 15855 [running]:
testing.tRunner.func1.2({0x110b7a0, 0x1d73c30})
	/opt/hostedtoolcache/go/1.20.4/x64/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.20.4/x64/src/testing/testing.go:1529 +0x39f
panic({0x110b7a0, 0x1d73c30})
	/opt/hostedtoolcache/go/1.20.4/x64/src/runtime/panic.go:884 +0x213
github.com/celestiaorg/celestia-node/share/eds.TestEDSStore_GC(0xc01f719860)
	/home/runner/work/celestia-node/celestia-node/share/eds/store_test.go:178 +0x258
testing.tRunner(0xc01f719860, 0x13c1488)
	/opt/hostedtoolcache/go/1.20.4/x64/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.20.4/x64/src/testing/testing.go:1629 +0x3ea
```