### PR TITLE
share: introduce Namespace type

### DIFF
--- a/share/namespace.go
+++ b/share/namespace.go
@@ -39,16 +39,16 @@ func (n Namespace) ID() namespace.ID {
 	return namespace.ID(n[appns.NamespaceVersionSize:])
 }
 
-// AsNMT converts the whole Namespace(both Version and ID parts) into NMT's namespace.ID
+// ToNMT converts the whole Namespace(both Version and ID parts) into NMT's namespace.ID
 // NOTE: Once https://github.com/celestiaorg/nmt/issues/206 is closed Namespace should become NNT's
 // type.
-func (n Namespace) AsNMT() namespace.ID {
+func (n Namespace) ToNMT() namespace.ID {
 	return namespace.ID(n)
 }
 
-// AsAppNamespace converts the Namespace to App's definition of Namespace.
+// ToAppNamespace converts the Namespace to App's definition of Namespace.
 // TODO: Unify types between node and app
-func (n Namespace) AsAppNamespace() appns.Namespace {
+func (n Namespace) ToAppNamespace() appns.Namespace {
 	return appns.Namespace{Version: n.Version(), ID: n.ID()}
 }
 
@@ -90,7 +90,7 @@ func (n Namespace) ValidateDataNamespace() error {
 		return err
 	}
 	if n.Equals(ParitySharesNamespace) || n.Equals(TailPaddingNamespace) {
-		return fmt.Errorf("invalid data namespace(%s): parity and tail padding namespace are fobidden", n)
+		return fmt.Errorf("invalid data namespace(%s): parity and tail padding namespace are forbidden", n)
 	}
 	return nil
 }

--- a/share/namespace.go
+++ b/share/namespace.go
@@ -1,0 +1,134 @@
+package share
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	appns "github.com/celestiaorg/celestia-app/pkg/namespace"
+	"github.com/celestiaorg/nmt/namespace"
+)
+
+// Various reserved namespaces.
+var (
+	MaxReservedNamespace     = appns.MaxReservedNamespace.Bytes()
+	ParitySharesNamespace    = appns.ParitySharesNamespace.Bytes()
+	TailPaddingNamespace     = appns.TailPaddingNamespace.Bytes()
+	ReservedPaddingNamespace = appns.ReservedPaddingNamespace.Bytes()
+	TxNamespace              = appns.TxNamespace.Bytes()
+	PayForBlobNamespace      = appns.PayForBlobNamespace.Bytes()
+)
+
+// Namespace represents namespace of a Share.
+// Consists of version byte and namespace ID.
+type Namespace []byte
+
+// NamespaceFromBytes converts bytes into Namespace and validates it.
+func NamespaceFromBytes(b []byte) (Namespace, error) {
+	n := Namespace(b)
+	return n, n.Validate()
+}
+
+// Version reports version of the Namespace.
+func (n Namespace) Version() byte {
+	return n[appns.NamespaceVersionSize-1]
+}
+
+// ID reports version of the Namespace.
+func (n Namespace) ID() namespace.ID {
+	return namespace.ID(n[appns.NamespaceVersionSize:])
+}
+
+// String stringifies the Namespace.
+func (n Namespace) String() string {
+	return hex.EncodeToString(n)
+}
+
+// Validate checks if the namespace is correct.
+func (n Namespace) Validate() error {
+	if len(n) != NamespaceSize {
+		return fmt.Errorf("invalid namespace length: %v must be %v", len(n), NamespaceSize)
+	}
+	if n.Version() != appns.NamespaceVersionZero && n.Version() != appns.NamespaceVersionMax {
+		return fmt.Errorf("unsupported namespace version %v", n.Version())
+	}
+	if len(n.ID()) != appns.NamespaceIDSize {
+		return fmt.Errorf("unsupported namespace id length: id %v must be %v bytes but it was %v bytes",
+			n.ID(), appns.NamespaceIDSize, len(n.ID()))
+	}
+	if n.Version() == appns.NamespaceVersionZero && !bytes.HasPrefix(n.ID(), appns.NamespaceVersionZeroPrefix) {
+		return fmt.Errorf("unsupported namespace id with version %v. GetNamespace %v must start with %v leading zeros",
+			n.Version(), n.ID(), len(appns.NamespaceVersionZeroPrefix))
+	}
+	return nil
+}
+
+// ValidateBlobNamespace returns an error if this namespace is not a valid blob namespace.
+func (n Namespace) ValidateBlobNamespace() error {
+	if err := n.Validate(); err != nil {
+		return err
+	}
+	if n.IsReserved() {
+		return fmt.Errorf("invalid blob namespace: %v cannot use a reserved namespace, want > %v",
+			n, appns.MaxReservedNamespace.Bytes())
+	}
+	if n.IsParityShares() {
+		return fmt.Errorf("invalid blob namespace: %v cannot use parity shares namespace", n)
+	}
+	if n.IsTailPadding() {
+		return fmt.Errorf("invalid blob namespace: %v cannot use tail padding namespace", n)
+	}
+	return nil
+}
+
+func (n Namespace) IsReserved() bool {
+	return bytes.Compare(n, MaxReservedNamespace) < 1
+}
+
+func (n Namespace) IsParityShares() bool {
+	return bytes.Equal(n, ParitySharesNamespace)
+}
+
+func (n Namespace) IsTailPadding() bool {
+	return bytes.Equal(n, TailPaddingNamespace)
+}
+
+func (n Namespace) IsReservedPadding() bool {
+	return bytes.Equal(n, ReservedPaddingNamespace)
+}
+
+func (n Namespace) IsTx() bool {
+	return bytes.Equal(n, TxNamespace)
+}
+
+func (n Namespace) IsPayForBlob() bool {
+	return bytes.Equal(n, PayForBlobNamespace)
+}
+
+func (n Namespace) Repeat(times int) []Namespace {
+	ns := make([]Namespace, times)
+	for i := 0; i < times; i++ {
+		ns[i] = n
+	}
+	return ns
+}
+
+func (n Namespace) Equals(n2 Namespace) bool {
+	return bytes.Equal(n, n2)
+}
+
+func (n Namespace) IsLessThan(n2 Namespace) bool {
+	return bytes.Compare(n, n2) == -1
+}
+
+func (n Namespace) IsLessOrEqualThan(n2 Namespace) bool {
+	return bytes.Compare(n, n2) < 1
+}
+
+func (n Namespace) IsGreaterThan(n2 Namespace) bool {
+	return bytes.Compare(n, n2) == 1
+}
+
+func (n Namespace) IsGreaterOrEqualThan(n2 Namespace) bool {
+	return bytes.Compare(n, n2) > -1
+}

--- a/share/namespace.go
+++ b/share/namespace.go
@@ -11,12 +11,12 @@ import (
 
 // Various reserved namespaces.
 var (
-	MaxReservedNamespace     = appns.MaxReservedNamespace.Bytes()
-	ParitySharesNamespace    = appns.ParitySharesNamespace.Bytes()
-	TailPaddingNamespace     = appns.TailPaddingNamespace.Bytes()
-	ReservedPaddingNamespace = appns.ReservedPaddingNamespace.Bytes()
-	TxNamespace              = appns.TxNamespace.Bytes()
-	PayForBlobNamespace      = appns.PayForBlobNamespace.Bytes()
+	MaxReservedNamespace     = Namespace(appns.MaxReservedNamespace.Bytes())
+	ParitySharesNamespace    = Namespace(appns.ParitySharesNamespace.Bytes())
+	TailPaddingNamespace     = Namespace(appns.TailPaddingNamespace.Bytes())
+	ReservedPaddingNamespace = Namespace(appns.ReservedPaddingNamespace.Bytes())
+	TxNamespace              = Namespace(appns.TxNamespace.Bytes())
+	PayForBlobNamespace      = Namespace(appns.PayForBlobNamespace.Bytes())
 )
 
 // Namespace represents namespace of a Share.

--- a/share/namespace_test.go
+++ b/share/namespace_test.go
@@ -1,0 +1,84 @@
+package share
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	appns "github.com/celestiaorg/celestia-app/pkg/namespace"
+)
+
+var (
+	validID = append(
+		appns.NamespaceVersionZeroPrefix,
+		bytes.Repeat([]byte{1}, appns.NamespaceVersionZeroIDSize)...,
+	)
+	tooShortID      = append(appns.NamespaceVersionZeroPrefix, []byte{1}...)
+	tooLongID       = append(appns.NamespaceVersionZeroPrefix, bytes.Repeat([]byte{1}, NamespaceSize)...)
+	invalidPrefixID = bytes.Repeat([]byte{1}, NamespaceSize)
+)
+
+func TestFrom(t *testing.T) {
+	type testCase struct {
+		name    string
+		bytes   []byte
+		wantErr bool
+		want    Namespace
+	}
+	validNamespace := []byte{}
+	validNamespace = append(validNamespace, appns.NamespaceVersionZero)
+	validNamespace = append(validNamespace, appns.NamespaceVersionZeroPrefix...)
+	validNamespace = append(validNamespace, bytes.Repeat([]byte{0x1}, appns.NamespaceVersionZeroIDSize)...)
+	parityNamespace := bytes.Repeat([]byte{0xFF}, NamespaceSize)
+
+	testCases := []testCase{
+		{
+			name:    "valid namespace",
+			bytes:   validNamespace,
+			wantErr: false,
+			want:    append([]byte{appns.NamespaceVersionZero}, validID...),
+		},
+		{
+			name:    "parity namespace",
+			bytes:   parityNamespace,
+			wantErr: false,
+			want:    append([]byte{appns.NamespaceVersionMax}, bytes.Repeat([]byte{0xFF}, appns.NamespaceIDSize)...),
+		},
+		{
+			name: "unsupported version",
+			bytes: append([]byte{1}, append(
+				appns.NamespaceVersionZeroPrefix,
+				bytes.Repeat([]byte{1}, NamespaceSize-len(appns.NamespaceVersionZeroPrefix))...,
+			)...),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported id: too short",
+			bytes:   append([]byte{appns.NamespaceVersionZero}, tooShortID...),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported id: too long",
+			bytes:   append([]byte{appns.NamespaceVersionZero}, tooLongID...),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported id: invalid prefix",
+			bytes:   append([]byte{appns.NamespaceVersionZero}, invalidPrefixID...),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NamespaceFromBytes(tc.bytes)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/share/nid.go
+++ b/share/nid.go
@@ -10,6 +10,7 @@ import (
 // NewNamespaceV0 takes a variable size byte slice and creates a version 0 Namespace ID.
 // The byte slice must be <= 10 bytes.
 // If it is less than 10 bytes, it will be left padded to size 10 with 0s.
+// TODO: Adapt for Namespace in the integration PR
 func NewNamespaceV0(subNId []byte) (namespace.ID, error) {
 	if lnid := len(subNId); lnid > appns.NamespaceVersionZeroIDSize {
 		return nil, fmt.Errorf("namespace id must be <= %v, but it was %v bytes", appns.NamespaceVersionZeroIDSize, lnid)


### PR DESCRIPTION
Mostly copied from the app's Namespace type with multiple modifications. In preparation for https://github.com/celestiaorg/celestia-node/issues/2301.

We want a more straightforward Namespace type from what the app provides:
* Repsents 1:1 mapping of the serialized form of Namespace [version byte + namespace id]
* So that it does not allocate on the hot path when getting data by namespace
* and had simpler json serialization
