### PR TITLE
feat(node): implement node.AuthVerify and node.AuthNew

### DIFF
--- a/libs/authtoken/authtoken.go
+++ b/libs/authtoken/authtoken.go
@@ -1,12 +1,30 @@
 package authtoken
 
 import (
+	"encoding/json"
+
 	"github.com/cristalhq/jwt"
 	"github.com/filecoin-project/go-jsonrpc/auth"
 
 	"github.com/celestiaorg/celestia-node/api/rpc/perms"
 )
 
+// ExtractSignedPermissions returns the permissions granted to the token by the passed signer.
+// If the token isn't signed by the signer, it will not pass verification.
+func ExtractSignedPermissions(signer jwt.Signer, token string) ([]auth.Permission, error) {
+	tk, err := jwt.ParseAndVerifyString(token, signer)
+	if err != nil {
+		return nil, err
+	}
+	p := new(perms.JWTPayload)
+	err = json.Unmarshal(tk.RawClaims(), p)
+	if err != nil {
+		return nil, err
+	}
+	return p.Allow, nil
+}
+
+// NewSignedJWT returns a signed JWT token with the passed permissions and signer.
 func NewSignedJWT(signer jwt.Signer, permissions []auth.Permission) (string, error) {
 	token, err := jwt.NewTokenBuilder(signer).Build(&perms.JWTPayload{
 		Allow: permissions,

--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cristalhq/jwt"
 	"github.com/ipfs/go-blockservice"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	logging "github.com/ipfs/go-log/v2"
@@ -49,7 +48,6 @@ type Node struct {
 	Network       p2p.Network
 	Bootstrappers p2p.Bootstrappers
 	Config        *Config
-	AdminSigner   jwt.Signer
 
 	// rpc components
 	RPCServer     *rpc.Server     // not optional
@@ -70,6 +68,7 @@ type Node struct {
 	FraudServ  fraud.Module  // not optional
 	BlobServ   blob.Module   // not optional
 	DASer      das.Module    // not optional
+	AdminServ  node.Module   // not optional
 
 	// start and stop control ref internal fx.App lifecycle funcs to be called from Start and Stop
 	start, stop lifecycleFunc

--- a/nodebuilder/node/admin.go
+++ b/nodebuilder/node/admin.go
@@ -2,21 +2,25 @@ package node
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/cristalhq/jwt"
 	"github.com/filecoin-project/go-jsonrpc/auth"
 	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/celestiaorg/celestia-node/libs/authtoken"
 )
 
-const APIVersion = "v0.2.0"
+const APIVersion = "v0.2.1"
 
 type module struct {
-	tp Type
+	tp     Type
+	signer jwt.Signer
 }
 
-func newModule(tp Type) Module {
+func newModule(tp Type, signer jwt.Signer) Module {
 	return &module{
-		tp: tp,
+		tp:     tp,
+		signer: signer,
 	}
 }
 
@@ -38,10 +42,10 @@ func (m *module) LogLevelSet(_ context.Context, name, level string) error {
 	return logging.SetLogLevel(name, level)
 }
 
-func (m *module) AuthVerify(context.Context, string) ([]auth.Permission, error) {
-	return []auth.Permission{}, fmt.Errorf("not implemented")
+func (m *module) AuthVerify(_ context.Context, token string) ([]auth.Permission, error) {
+	return authtoken.ExtractSignedPermissions(m.signer, token)
 }
 
-func (m *module) AuthNew(context.Context, []auth.Permission) ([]byte, error) {
-	return nil, fmt.Errorf("not implemented")
+func (m *module) AuthNew(_ context.Context, permissions []auth.Permission) (string, error) {
+	return authtoken.NewSignedJWT(m.signer, permissions)
 }

--- a/nodebuilder/node/mocks/api.go
+++ b/nodebuilder/node/mocks/api.go
@@ -37,10 +37,10 @@ func (m *MockModule) EXPECT() *MockModuleMockRecorder {
 }
 
 // AuthNew mocks base method.
-func (m *MockModule) AuthNew(arg0 context.Context, arg1 []auth.Permission) ([]byte, error) {
+func (m *MockModule) AuthNew(arg0 context.Context, arg1 []auth.Permission) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthNew", arg0, arg1)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/nodebuilder/node/module.go
+++ b/nodebuilder/node/module.go
@@ -9,7 +9,7 @@ func ConstructModule(tp Type) fx.Option {
 	return fx.Module(
 		"node",
 		fx.Provide(func(secret jwt.Signer) Module {
-			return newModule(tp)
+			return newModule(tp, secret)
 		}),
 		fx.Provide(secret),
 	)

--- a/nodebuilder/node/node.go
+++ b/nodebuilder/node/node.go
@@ -20,7 +20,7 @@ type Module interface {
 	// AuthVerify returns the permissions assigned to the given token.
 	AuthVerify(ctx context.Context, token string) ([]auth.Permission, error)
 	// AuthNew signs and returns a new token with the given permissions.
-	AuthNew(ctx context.Context, perms []auth.Permission) ([]byte, error)
+	AuthNew(ctx context.Context, perms []auth.Permission) (string, error)
 }
 
 var _ Module = (*API)(nil)
@@ -30,7 +30,7 @@ type API struct {
 		Info        func(context.Context) (Info, error)                                `perm:"admin"`
 		LogLevelSet func(ctx context.Context, name, level string) error                `perm:"admin"`
 		AuthVerify  func(ctx context.Context, token string) ([]auth.Permission, error) `perm:"admin"`
-		AuthNew     func(ctx context.Context, perms []auth.Permission) ([]byte, error) `perm:"admin"`
+		AuthNew     func(ctx context.Context, perms []auth.Permission) (string, error) `perm:"admin"`
 	}
 }
 
@@ -46,6 +46,6 @@ func (api *API) AuthVerify(ctx context.Context, token string) ([]auth.Permission
 	return api.Internal.AuthVerify(ctx, token)
 }
 
-func (api *API) AuthNew(ctx context.Context, perms []auth.Permission) ([]byte, error) {
+func (api *API) AuthNew(ctx context.Context, perms []auth.Permission) (string, error) {
 	return api.Internal.AuthNew(ctx, perms)
 }

--- a/nodebuilder/node_test.go
+++ b/nodebuilder/node_test.go
@@ -34,7 +34,7 @@ func TestLifecycle(t *testing.T) {
 			require.NotNil(t, node.Host)
 			require.NotNil(t, node.HeaderServ)
 			require.NotNil(t, node.StateServ)
-			require.NotNil(t, node.AdminSigner)
+			require.NotNil(t, node.AdminServ)
 			require.Equal(t, tt.tp, node.Type)
 
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Implements node.AuthVerify and node.AuthNew.
Removes the jwt.Signer from the Node struct and replaces it with the nodebuilder.Node module, along with the other services.

Includes a minor version bump to the API.