### PR TITLE
fix(libs/utils): Use valid ip4 address

### DIFF
--- a/libs/utils/address.go
+++ b/libs/utils/address.go
@@ -34,14 +34,7 @@ func ValidateAddr(addr string) (string, error) {
 		if err != nil {
 			return addr, err
 		}
-		addrs, err := net.LookupHost(resolved.String())
-		if err != nil {
-			return addr, fmt.Errorf("could not resolve %v: %w", addr, err)
-		}
-		if len(addrs) == 0 {
-			return addr, fmt.Errorf("no IP addresses found for DNS record: %v", addr)
-		}
-		addr = addrs[0]
+		addr = resolved.String()
 	}
 	return addr, nil
 }

--- a/libs/utils/address.go
+++ b/libs/utils/address.go
@@ -29,12 +29,14 @@ func ValidateAddr(addr string) (string, error) {
 		return addr, err
 	}
 
-	if ip := net.ParseIP(addr); ip == nil {
-		resolved, err := net.ResolveIPAddr("ip4", addr)
-		if err != nil {
-			return addr, err
-		}
-		addr = resolved.String()
+	ip := net.ParseIP(addr)
+	if ip != nil {
+		return addr, nil
 	}
-	return addr, nil
+
+	resolved, err := net.ResolveIPAddr("ip4", addr)
+	if err != nil {
+		return addr, err
+	}
+	return resolved.String(), nil
 }

--- a/libs/utils/address.go
+++ b/libs/utils/address.go
@@ -37,7 +37,7 @@ func ValidateAddr(addr string) (string, error) {
 		if len(addrs) == 0 {
 			return addr, fmt.Errorf("no IP addresses found for DNS record: %v", addr)
 		}
-		addr = addrs[0]
+		addr = addrs[1]
 	}
 	return addr, nil
 }

--- a/libs/utils/address.go
+++ b/libs/utils/address.go
@@ -30,14 +30,18 @@ func ValidateAddr(addr string) (string, error) {
 	}
 
 	if ip := net.ParseIP(addr); ip == nil {
-		addrs, err := net.LookupHost(addr)
+		resolved, err := net.ResolveIPAddr("ip4", addr)
+		if err != nil {
+			return addr, err
+		}
+		addrs, err := net.LookupHost(resolved.String())
 		if err != nil {
 			return addr, fmt.Errorf("could not resolve %v: %w", addr, err)
 		}
 		if len(addrs) == 0 {
 			return addr, fmt.Errorf("no IP addresses found for DNS record: %v", addr)
 		}
-		addr = addrs[1]
+		addr = addrs[0]
 	}
 	return addr, nil
 }


### PR DESCRIPTION
Fixes an issue where `localhost` was not accepted as a valid `--gateway.addr`. Uses net.ResolveIPAddr instead.

Found by @tuxcanfly 

