### PR TITLE
feat(share/store): store eds in memory for index builder

### DIFF
--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -263,7 +263,7 @@ func BenchmarkStore(b *testing.B) {
 	err = edsStore.Start(ctx)
 	require.NoError(b, err)
 
-	// BenchmarkStore/bench_put-10         	      10	3231859283 ns/op (~3sec)
+	// BenchmarkStore/bench_put_128-10         	      10	 1060473754 ns/op (~1s)
 	b.Run("bench put 128", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -278,7 +278,7 @@ func BenchmarkStore(b *testing.B) {
 		}
 	})
 
-	// BenchmarkStore/bench_read-10         	      14	  78970661 ns/op (~70ms)
+	// BenchmarkStore/bench_read_128-10         	      14	  78970661 ns/op (~70ms)
 	b.Run("bench read 128", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -263,11 +263,11 @@ func BenchmarkStore(b *testing.B) {
 	err = edsStore.Start(ctx)
 	require.NoError(b, err)
 
-	//BenchmarkStore/bench_put-10         	      10	3231859283 ns/op (~3sec)
+	// BenchmarkStore/bench_put-10         	      10	3231859283 ns/op (~3sec)
 	b.Run("bench put 128", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			// pause the timer for initialising test data
+			// pause the timer for initializing test data
 			b.StopTimer()
 			eds := share.RandEDS(b, 128)
 			dah := da.NewDataAvailabilityHeader(eds)
@@ -278,15 +278,15 @@ func BenchmarkStore(b *testing.B) {
 		}
 	})
 
-	//BenchmarkStore/bench_read-10         	      14	  78970661 ns/op (~70ms)
+	// BenchmarkStore/bench_read-10         	      14	  78970661 ns/op (~70ms)
 	b.Run("bench read 128", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			// pause the timer for initialising test data
+			// pause the timer for initializing test data
 			b.StopTimer()
 			eds := share.RandEDS(b, 128)
 			dah := da.NewDataAvailabilityHeader(eds)
-			edsStore.Put(ctx, dah.Hash(), eds)
+			_ = edsStore.Put(ctx, dah.Hash(), eds)
 			b.StartTimer()
 
 			_, err := edsStore.Get(ctx, dah.Hash())


### PR DESCRIPTION
## Overview

Previously generated eds was first store to disk and then was read again while building car index for dagstore.
This PR contains 2 changes:
- writes eds into buffer to write it as 1 chunk instead of many small writes to disk to reduce disk i/o pressure. 
- introduces in-memory cache that will be used to read eds for building car index.

Combined changes brings 3x performance improvement for eds.Put operation

