### PR TITLE
feat: update Go base alpine - add branch in makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ USER ${USER_NAME}
 EXPOSE 2121
 
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]
-CMD [ "celestia"]
+CMD [ "celestia" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.20-alpine3.17 as builder
+FROM docker.io/golang:1.20-alpine3.18 as builder
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
@@ -49,4 +49,4 @@ USER ${USER_NAME}
 EXPOSE 2121
 
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]
-CMD [ "celestia" ]
+CMD [ "celestia"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/usr/bin/env bash
 PROJECTNAME=$(shell basename "$(PWD)")
-LDFLAGS=-ldflags="-X 'main.buildTime=$(shell date)' -X 'main.lastCommit=$(shell git rev-parse HEAD)' -X 'main.semanticVersion=$(shell git describe --tags --dirty=-dev)'"
+LDFLAGS=-ldflags="-X 'main.buildTime=$(shell date)' -X 'main.lastCommit=$(shell git rev-parse HEAD)' -X 'main.semanticVersion=$(shell git describe --tags --dirty=-dev 2>/dev/null || git rev-parse --abbrev-ref HEAD)'"
 ifeq (${PREFIX},)
 	PREFIX := /usr/local
 endif


### PR DESCRIPTION
hello team!

This PR contains a couple of things:
- Update the base version of Go Alpine to `golang:1.20-alpine3.18`
- In the Makefile, I've added the following line:

```Makefile
main.semanticVersion=$(shell git describe --tags --dirty=-dev 2>/dev/null || git rev-parse --abbrev-ref HEAD)'"
```
Basically what it does is, in case this commit doesn't contain any tag, it uses the branch name.

At the moment we are having some issues using the flag `version`, the output command is:

![Screenshot 2023-06-29 at 17 24 22](https://github.com/celestiaorg/celestia-node/assets/32740567/b6b6f948-fcec-4157-920e-0a9863b8d11f)


With this change, we'll have something like:

![Screenshot 2023-06-29 at 17 08 17](https://github.com/celestiaorg/celestia-node/assets/32740567/7d2de807-f014-444d-8917-6ec45a9d9750)

*Already tested*

Let me know what you think about it and if it's worth it 😊 

Thanks in advance! 🚀 

Jose Ramon Mañes