### PR TITLE
doc(share/p2p/shrexnd): Improve accuracy of RequestND description

### DIFF
--- a/share/p2p/shrexnd/client.go
+++ b/share/p2p/shrexnd/client.go
@@ -46,7 +46,7 @@ func NewClient(params *Parameters, host host.Host) (*Client, error) {
 }
 
 // RequestND requests namespaced data from the given peer.
-// Returns valid data with its verified inclusion against the share.Root.
+// Returns shares with unverified inclusion proofs against the share.Root.
 func (c *Client) RequestND(
 	ctx context.Context,
 	root *share.Root,


### PR DESCRIPTION
`RequestND` doesn't actually verify the inclusion proofs; this is done later in `GetSharesByNamespace`:
https://github.com/celestiaorg/celestia-node/blob/main/share/getters/shrex.go#L237