### PR TITLE
fix: update the header hash in mocha-3 to be for height 15045

### DIFF
--- a/nodebuilder/p2p/genesis.go
+++ b/nodebuilder/p2p/genesis.go
@@ -24,7 +24,7 @@ func GenesisFor(net Network) (string, error) {
 // NOTE: Every time we add a new long-running network, its genesis hash has to be added here.
 var genesisList = map[Network]string{
 	Arabica:        "7A5FABB19713D732D967B1DA84FA0DF5E87A7B62302D783F78743E216C1A3550",
-	Mocha:          "79A97034D569C4199A867439B1B7B77D4E1E1D9697212755E1CE6D920CDBB541",
+	Mocha:          "831B81ADDC5CE999EBB0C150B778F76DAAD9E09DF75FACF164B1F11DCE93E2E1", // this is for height 15045 of mocha-3
 	BlockspaceRace: "1A8491A72F73929680DAA6C93E3B593579261B2E76536BFA4F5B97D6FE76E088",
 	Private:        "",
 }


### PR DESCRIPTION
## Overview

changes the trusted hash for mocha-3 to that of height 15045. this is a temporary fix the issue experienced on mocha-3 where commit verification fails because the validator set changed >2/3 in a single block

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
