### PR TITLE
header: Remove unnecessary VerifyCommitLightTrusting, use light.VerifyAdjacent

### DIFF
--- a/header/headertest/verify_test.go
+++ b/header/headertest/verify_test.go
@@ -39,14 +39,6 @@ func TestVerify(t *testing.T) {
 		},
 		{
 			prepare: func() libhead.Header {
-				untrusted := *untrustedNonAdj
-				untrusted.Commit = NewTestSuite(t, 2).Commit(RandRawHeader(t))
-				return &untrusted
-			},
-			err: true,
-		},
-		{
-			prepare: func() libhead.Header {
 				untrusted := *untrustedAdj
 				untrusted.RawHeader.LastBlockID.Hash = tmrand.Bytes(32)
 				return &untrusted

--- a/nodebuilder/p2p/genesis.go
+++ b/nodebuilder/p2p/genesis.go
@@ -24,7 +24,7 @@ func GenesisFor(net Network) (string, error) {
 // NOTE: Every time we add a new long-running network, its genesis hash has to be added here.
 var genesisList = map[Network]string{
 	Arabica:        "7A5FABB19713D732D967B1DA84FA0DF5E87A7B62302D783F78743E216C1A3550",
-	Mocha:          "831B81ADDC5CE999EBB0C150B778F76DAAD9E09DF75FACF164B1F11DCE93E2E1",
+	Mocha:          "79A97034D569C4199A867439B1B7B77D4E1E1D9697212755E1CE6D920CDBB541",
 	BlockspaceRace: "1A8491A72F73929680DAA6C93E3B593579261B2E76536BFA4F5B97D6FE76E088",
 	Private:        "",
 }


### PR DESCRIPTION
This PR reworks header.Verify such that non-adjacent headers do not need to pass VerifyCommitLightTrusting in order to pass verification as the Syncer in go-header performs sequential verification anyway on all headers synced from genesis -> syncTarget. 

This PR also introduces light.VerifyAdjacent method to the verification logic for adjacent headers as it is audited.