### PR TITLE
fix(header): temporary disable skipping verification

### DIFF
--- a/header/headertest/verify_test.go
+++ b/header/headertest/verify_test.go
@@ -39,14 +39,6 @@ func TestVerify(t *testing.T) {
 		},
 		{
 			prepare: func() libhead.Header {
-				untrusted := *untrustedNonAdj
-				untrusted.Commit = NewTestSuite(t, 2).Commit(RandRawHeader(t))
-				return &untrusted
-			},
-			err: true,
-		},
-		{
-			prepare: func() libhead.Header {
 				untrusted := *untrustedAdj
 				untrusted.RawHeader.LastBlockID.Hash = tmrand.Bytes(32)
 				return &untrusted

--- a/header/verify.go
+++ b/header/verify.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tendermint/tendermint/light"
-
 	libhead "github.com/celestiaorg/go-header"
 )
 
@@ -45,12 +43,6 @@ func (eh *ExtendedHeader) Verify(untrusted libhead.Header) error {
 		}
 
 		return nil
-	}
-
-	// Ensure that untrusted commit has enough of trusted commit's power.
-	err := eh.ValidatorSet.VerifyCommitLightTrusting(eh.ChainID(), untrst.Commit, light.DefaultTrustLevel)
-	if err != nil {
-		return &libhead.VerifyError{Reason: err}
 	}
 
 	return nil

--- a/nodebuilder/p2p/genesis.go
+++ b/nodebuilder/p2p/genesis.go
@@ -24,7 +24,7 @@ func GenesisFor(net Network) (string, error) {
 // NOTE: Every time we add a new long-running network, its genesis hash has to be added here.
 var genesisList = map[Network]string{
 	Arabica:        "7A5FABB19713D732D967B1DA84FA0DF5E87A7B62302D783F78743E216C1A3550",
-	Mocha:          "831B81ADDC5CE999EBB0C150B778F76DAAD9E09DF75FACF164B1F11DCE93E2E1",
+	Mocha:          "79A97034D569C4199A867439B1B7B77D4E1E1D9697212755E1CE6D920CDBB541",
 	BlockspaceRace: "1A8491A72F73929680DAA6C93E3B593579261B2E76536BFA4F5B97D6FE76E088",
 	Private:        "",
 }


### PR DESCRIPTION
This PR disables skipping verification and accepts all the incoming non-adjacent headers. These headers will later be verified via adjacent verification and rejected if invalid. 

Test that proves that Syncer rejects and continues to work with a fault header: https://github.com/celestiaorg/go-header/pull/76

Potential outcomes of doing so: https://github.com/celestiaorg/go-header/issues/79

Additionally, the PR reverts the genesis hash change to the hash pointing to height 1.

Supersedes #2449, which became zombie