### PR TITLE
cmd: rpc.go fix error parsing height message

### DIFF
--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -195,7 +195,7 @@ func parseParams(method string, params []string) []interface{} {
 		// 1. Height
 		num, err := strconv.ParseUint(params[0], 10, 64)
 		if err != nil {
-			panic("Error parsing gas limit: uint64 could not be parsed.")
+			panic("Error parsing height: uint64 could not be parsed.")
 		}
 		parsedParams[0] = num
 		// 2. NamespaceID
@@ -215,7 +215,7 @@ func parseParams(method string, params []string) []interface{} {
 		// 1. Height
 		num, err := strconv.ParseUint(params[0], 10, 64)
 		if err != nil {
-			panic("Error parsing gas limit: uint64 could not be parsed.")
+			panic("Error parsing height: uint64 could not be parsed.")
 		}
 		parsedParams[0] = num
 		// 2. Namespace


### PR DESCRIPTION
## Overview

This PR fixes the error message returned by the rpc cli client, when an invalid height is passed to the `Get`, `GetAll` commands of the Blob module.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
