### PR TITLE
refactor(share/availability): don't log error canceled operation

### DIFF
--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -72,7 +72,9 @@ func (fa *ShareAvailability) SharesAvailable(ctx context.Context, root *share.Ro
 
 	_, err := fa.getter.GetEDS(ctx, root)
 	if err != nil {
-		log.Errorw("availability validation failed", "root", root.String(), "err", err.Error())
+		if !errors.Is(err, context.Canceled) {
+			log.Errorw("availability validation failed", "root", root.String(), "err", err.Error())
+		}
 		var byzantineErr *byzantine.ErrByzantine
 		if ipldFormat.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) && !errors.As(err, &byzantineErr) {
 			return share.ErrNotAvailable

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -80,8 +80,6 @@ func (fa *ShareAvailability) SharesAvailable(ctx context.Context, root *share.Ro
 		if ipldFormat.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) && !errors.As(err, &byzantineErr) {
 			return share.ErrNotAvailable
 		}
-
-		return err
 	}
 	return err
 }

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -72,9 +72,10 @@ func (fa *ShareAvailability) SharesAvailable(ctx context.Context, root *share.Ro
 
 	_, err := fa.getter.GetEDS(ctx, root)
 	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			log.Errorw("availability validation failed", "root", root.String(), "err", err.Error())
+		if errors.Is(err, context.Canceled) {
+			return err
 		}
+		log.Errorw("availability validation failed", "root", root.String(), "err", err.Error())
 		var byzantineErr *byzantine.ErrByzantine
 		if ipldFormat.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) && !errors.As(err, &byzantineErr) {
 			return share.ErrNotAvailable

--- a/share/availability/light/availability.go
+++ b/share/availability/light/availability.go
@@ -84,13 +84,13 @@ func (la *ShareAvailability) SharesAvailable(ctx context.Context, dah *share.Roo
 		}
 
 		if err != nil {
-			if !errors.Is(err, context.Canceled) {
-				log.Errorw("availability validation failed", "root", dah.String(), "err", err.Error())
+			if errors.Is(err, context.Canceled) {
+				return err
 			}
+			log.Errorw("availability validation failed", "root", dah.String(), "err", err.Error())
 			if ipldFormat.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) {
 				return share.ErrNotAvailable
 			}
-
 			return err
 		}
 	}


### PR DESCRIPTION
Small cleanup to prevent node from spamming error availability logs on shutdown. 