### PR TITLE
chore: cleanup usage of `share.Root`(DAH)

### DIFF
--- a/core/eds_test.go
+++ b/core/eds_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/pkg/da"
 
 	"github.com/celestiaorg/celestia-node/share"
 )
@@ -47,7 +46,7 @@ func TestEmptySquareWithZeroTxs(t *testing.T) {
 	eds, err = app.ExtendBlock(data, appconsts.LatestVersion)
 	require.NoError(t, err)
 
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 	assert.Equal(t, share.EmptyRoot().Hash(), dah.Hash())
 }

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -37,7 +37,7 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 	headerExt, err := header.MakeExtendedHeader(&b.Header, comm, val, eds)
 	require.NoError(t, err)
 
-	assert.Equal(t, share.EmptyRoot(), *headerExt.DAH)
+	assert.Equal(t, share.EmptyRoot(), headerExt.DAH)
 }
 
 func TestMismatchedDataHash_ComputedRoot(t *testing.T) {

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/headertest"
+	"github.com/celestiaorg/celestia-node/share"
 )
 
 func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
@@ -36,7 +37,7 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 	headerExt, err := header.MakeExtendedHeader(&b.Header, comm, val, eds)
 	require.NoError(t, err)
 
-	assert.Equal(t, header.EmptyDAH(), *headerExt.DAH)
+	assert.Equal(t, share.EmptyRoot(), *headerExt.DAH)
 }
 
 func TestMismatchedDataHash_ComputedRoot(t *testing.T) {

--- a/core/listener_test.go
+++ b/core/listener_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/header"
 	nodep2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds"
 	"github.com/celestiaorg/celestia-node/share/p2p/shrexsub"
 )
@@ -96,7 +97,7 @@ func TestListenerWithNonEmptyBlocks(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(sub.Cancel)
 
-	empty := header.EmptyDAH()
+	empty := share.EmptyRoot()
 	// TODO extract 16
 	for i := 0; i < 16; i++ {
 		_, err := cctx.FillBlock(16, cfg.Accounts, flags.BroadcastBlock)

--- a/das/coordinator_test.go
+++ b/das/coordinator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/p2p/shrexsub"
 )
 
@@ -431,7 +432,7 @@ func (m *mockSampler) discover(ctx context.Context, newHeight uint64, emit liste
 	emit(ctx, &header.ExtendedHeader{
 		Commit:    &types.Commit{},
 		RawHeader: header.RawHeader{Height: int64(newHeight)},
-		DAH:       &header.DataAvailabilityHeader{RowRoots: make([][]byte, 0)},
+		DAH:       &share.Root{RowRoots: make([][]byte, 0)},
 	})
 }
 

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -365,7 +365,7 @@ type benchGetterStub struct {
 
 func newBenchGetter() benchGetterStub {
 	return benchGetterStub{header: &header.ExtendedHeader{
-		DAH: &header.DataAvailabilityHeader{RowRoots: make([][]byte, 0)}}}
+		DAH: &share.Root{RowRoots: make([][]byte, 0)}}}
 }
 
 func (m benchGetterStub) GetByHeight(context.Context, uint64) (*header.ExtendedHeader, error) {
@@ -385,7 +385,7 @@ func (m getterStub) GetByHeight(_ context.Context, height uint64) (*header.Exten
 	return &header.ExtendedHeader{
 		Commit:    &types.Commit{},
 		RawHeader: header.RawHeader{Height: int64(height)},
-		DAH:       &header.DataAvailabilityHeader{RowRoots: make([][]byte, 0)}}, nil
+		DAH:       &share.Root{RowRoots: make([][]byte, 0)}}, nil
 }
 
 func (m getterStub) GetRangeByHeight(context.Context, uint64, uint64) ([]*header.ExtendedHeader, error) {

--- a/header/header.go
+++ b/header/header.go
@@ -55,14 +55,10 @@ func MakeExtendedHeader(
 	case nil:
 		dah = share.EmptyRoot()
 	default:
-		root, err := share.NewRoot(eds)
+		dah, err = share.NewRoot(eds)
 		if err != nil {
 			return nil, err
 		}
-		dah = &root
-	}
-	if err != nil {
-		return nil, err
 	}
 
 	eh := &ExtendedHeader{

--- a/header/header.go
+++ b/header/header.go
@@ -11,9 +11,10 @@ import (
 	core "github.com/tendermint/tendermint/types"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	libhead "github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share"
 )
 
 // ConstructFn aliases a function that creates an ExtendedHeader.
@@ -23,11 +24,6 @@ type ConstructFn = func(
 	*core.ValidatorSet,
 	*rsmt2d.ExtendedDataSquare,
 ) (*ExtendedHeader, error)
-
-type DataAvailabilityHeader = da.DataAvailabilityHeader
-
-// EmptyDAH provides DAH of the empty block.
-var EmptyDAH = da.MinDataAvailabilityHeader
 
 // RawHeader is an alias to core.Header. It is
 // "raw" because it is not yet wrapped to include
@@ -39,9 +35,9 @@ type RawHeader = core.Header
 // block headers and perform Data Availability Sampling.
 type ExtendedHeader struct {
 	RawHeader    `json:"header"`
-	Commit       *core.Commit            `json:"commit"`
-	ValidatorSet *core.ValidatorSet      `json:"validator_set"`
-	DAH          *DataAvailabilityHeader `json:"dah"`
+	Commit       *core.Commit       `json:"commit"`
+	ValidatorSet *core.ValidatorSet `json:"validator_set"`
+	DAH          *share.Root        `json:"dah"`
 }
 
 // MakeExtendedHeader assembles new ExtendedHeader.
@@ -52,14 +48,18 @@ func MakeExtendedHeader(
 	eds *rsmt2d.ExtendedDataSquare,
 ) (*ExtendedHeader, error) {
 	var (
-		dah DataAvailabilityHeader
+		dah *share.Root
 		err error
 	)
 	switch eds {
 	case nil:
-		dah = EmptyDAH()
+		dah = share.EmptyRoot()
 	default:
-		dah, err = da.NewDataAvailabilityHeader(eds)
+		root, err := share.NewRoot(eds)
+		if err != nil {
+			return nil, err
+		}
+		dah = &root
 	}
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func MakeExtendedHeader(
 
 	eh := &ExtendedHeader{
 		RawHeader:    *h,
-		DAH:          &dah,
+		DAH:          dah,
 		Commit:       comm,
 		ValidatorSet: vals,
 	}

--- a/header/headertest/testing.go
+++ b/header/headertest/testing.go
@@ -309,7 +309,7 @@ func ExtendedHeaderFromEDS(t *testing.T, height uint64, eds *rsmt2d.ExtendedData
 		RawHeader:    *gen,
 		Commit:       commit,
 		ValidatorSet: valSet,
-		DAH:          &dah,
+		DAH:          dah,
 	}
 	require.NoError(t, eh.Validate())
 	return eh

--- a/header/headertest/testing.go
+++ b/header/headertest/testing.go
@@ -17,12 +17,12 @@ import (
 	"github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	libhead "github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/go-header/headertest"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share"
 )
 
 // TestSuite provides everything you need to test chain of Headers.
@@ -52,7 +52,7 @@ func NewTestSuite(t *testing.T, num int) *TestSuite {
 }
 
 func (s *TestSuite) genesis() *header.ExtendedHeader {
-	dah := header.EmptyDAH()
+	dah := share.EmptyRoot()
 
 	gen := RandRawHeader(s.t)
 
@@ -70,7 +70,7 @@ func (s *TestSuite) genesis() *header.ExtendedHeader {
 		RawHeader:    *gen,
 		Commit:       commit,
 		ValidatorSet: s.valSet,
-		DAH:          &dah,
+		DAH:          dah,
 	}
 	require.NoError(s.t, eh.Validate())
 	return eh
@@ -137,14 +137,14 @@ func (s *TestSuite) NextHeader() *header.ExtendedHeader {
 		return s.head
 	}
 
-	dah := da.MinDataAvailabilityHeader()
+	dah := share.EmptyRoot()
 	height := s.Head().Height() + 1
 	rh := s.GenRawHeader(height, s.Head().Hash(), libhead.Hash(s.Head().Commit.Hash()), dah.Hash())
 	s.head = &header.ExtendedHeader{
 		RawHeader:    *rh,
 		Commit:       s.Commit(rh),
 		ValidatorSet: s.valSet,
-		DAH:          &dah,
+		DAH:          dah,
 	}
 	require.NoError(s.t, s.head.Validate())
 	return s.head
@@ -203,7 +203,7 @@ func (s *TestSuite) nextProposer() *types.Validator {
 
 // RandExtendedHeader provides an ExtendedHeader fixture.
 func RandExtendedHeader(t *testing.T) *header.ExtendedHeader {
-	dah := header.EmptyDAH()
+	dah := share.EmptyRoot()
 
 	rh := RandRawHeader(t)
 	rh.DataHash = dah.Hash()
@@ -220,7 +220,7 @@ func RandExtendedHeader(t *testing.T) *header.ExtendedHeader {
 		RawHeader:    *rh,
 		Commit:       commit,
 		ValidatorSet: valSet,
-		DAH:          &dah,
+		DAH:          dah,
 	}
 }
 
@@ -292,7 +292,7 @@ func RandBlockID(*testing.T) types.BlockID {
 func ExtendedHeaderFromEDS(t *testing.T, height uint64, eds *rsmt2d.ExtendedDataSquare) *header.ExtendedHeader {
 	valSet, vals := RandValidatorSet(10, 10)
 	gen := RandRawHeader(t)
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 
 	gen.DataHash = dah.Hash()

--- a/nodebuilder/share/share_test.go
+++ b/nodebuilder/share/share_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
-
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds"
 )
@@ -27,7 +25,7 @@ func Test_EmptyCARExists(t *testing.T) {
 	require.NoError(t, err)
 
 	eds := share.EmptyExtendedDataSquare()
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 
 	// add empty EDS to store

--- a/share/availability.go
+++ b/share/availability.go
@@ -14,6 +14,10 @@ var ErrNotAvailable = errors.New("share: data not available")
 // In practice, it is a commitment to all the Data in a square.
 type Root = da.DataAvailabilityHeader
 
+// NewRoot generates Root(DataAvailabilityHeader) using the
+// provided extended data square.
+var NewRoot = da.NewDataAvailabilityHeader
+
 // Availability defines interface for validation of Shares' availability.
 type Availability interface {
 	// SharesAvailable subjectively validates if Shares committed to the given Root are available on

--- a/share/availability.go
+++ b/share/availability.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
+	"github.com/celestiaorg/rsmt2d"
 )
 
 // ErrNotAvailable is returned whenever DA sampling fails.
@@ -16,7 +17,13 @@ type Root = da.DataAvailabilityHeader
 
 // NewRoot generates Root(DataAvailabilityHeader) using the
 // provided extended data square.
-var NewRoot = da.NewDataAvailabilityHeader
+func NewRoot(eds *rsmt2d.ExtendedDataSquare) (*Root, error) {
+	dah, err := da.NewDataAvailabilityHeader(eds)
+	if err != nil {
+		return nil, err
+	}
+	return &dah, nil
+}
 
 // Availability defines interface for validation of Shares' availability.
 type Availability interface {

--- a/share/availability/cache/availability.go
+++ b/share/availability/cache/availability.go
@@ -10,14 +10,11 @@ import (
 	"github.com/ipfs/go-datastore/namespace"
 	logging "github.com/ipfs/go-log/v2"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
-
 	"github.com/celestiaorg/celestia-node/share"
 )
 
 var (
-	log     = logging.Logger("share/cache")
-	minRoot = da.MinDataAvailabilityHeader()
+	log = logging.Logger("share/cache")
 
 	cacheAvailabilityPrefix = datastore.NewKey("sampling_result")
 	writeBatchSize          = 2048
@@ -96,5 +93,5 @@ func rootKey(root *share.Root) datastore.Key {
 // isMinRoot returns whether the given root is a minimum (empty)
 // DataAvailabilityHeader (DAH).
 func isMinRoot(root *share.Root) bool {
-	return bytes.Equal(minRoot.Hash(), root.Hash())
+	return bytes.Equal(share.EmptyRoot().Hash(), root.Hash())
 }

--- a/share/availability/cache/availability_test.go
+++ b/share/availability/cache/availability_test.go
@@ -110,9 +110,7 @@ func TestCacheAvailability_MinRoot(t *testing.T) {
 	defer cancel()
 
 	fullLocalAvail, _ := FullAvailabilityWithLocalRandSquare(t, 16)
-	minDAH := da.MinDataAvailabilityHeader()
-
-	err := fullLocalAvail.SharesAvailable(ctx, &minDAH)
+	err := fullLocalAvail.SharesAvailable(ctx, share.EmptyRoot())
 	assert.NoError(t, err)
 }
 

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -9,9 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
-
-	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/share"
 	availability_test "github.com/celestiaorg/celestia-node/share/availability/test"
 	"github.com/celestiaorg/celestia-node/share/sharetest"
@@ -33,8 +30,8 @@ func TestSharesAvailableFailed(t *testing.T) {
 
 	getter, _ := GetterWithRandSquare(t, 16)
 	avail := TestAvailability(getter)
-	empty := header.EmptyDAH()
-	err := avail.SharesAvailable(ctx, &empty)
+	empty := share.EmptyRoot()
+	err := avail.SharesAvailable(ctx, empty)
 	assert.Error(t, err)
 }
 
@@ -132,7 +129,7 @@ func TestGetShares(t *testing.T) {
 
 	eds, err := getter.GetEDS(ctx, dah)
 	require.NoError(t, err)
-	gotDAH, err := da.NewDataAvailabilityHeader(eds)
+	gotDAH, err := share.NewRoot(eds)
 	require.NoError(t, err)
 
 	require.True(t, dah.Equals(&gotDAH))

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -132,7 +132,7 @@ func TestGetShares(t *testing.T) {
 	gotDAH, err := share.NewRoot(eds)
 	require.NoError(t, err)
 
-	require.True(t, dah.Equals(&gotDAH))
+	require.True(t, dah.Equals(gotDAH))
 }
 
 func TestService_GetSharesByNamespaceNotFound(t *testing.T) {

--- a/share/availability/test/testing.go
+++ b/share/availability/test/testing.go
@@ -34,7 +34,7 @@ func FillBS(t *testing.T, bServ blockservice.BlockService, shares []share.Share)
 	require.NoError(t, err)
 	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
-	return &dah
+	return dah
 }
 
 type TestNode struct {

--- a/share/availability/test/testing.go
+++ b/share/availability/test/testing.go
@@ -17,8 +17,6 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
-
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/ipld"
 	"github.com/celestiaorg/celestia-node/share/sharetest"
@@ -34,7 +32,7 @@ func RandFillBS(t *testing.T, n int, bServ blockservice.BlockService) *share.Roo
 func FillBS(t *testing.T, bServ blockservice.BlockService, shares []share.Share) *share.Root {
 	eds, err := ipld.AddShares(context.TODO(), shares, bServ)
 	require.NoError(t, err)
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 	return &dah
 }

--- a/share/eds/byzantine/bad_encoding_test.go
+++ b/share/eds/byzantine/bad_encoding_test.go
@@ -78,7 +78,7 @@ func TestIncorrectBadEncodingFraudProof(t *testing.T) {
 		RawHeader: core.Header{
 			Height: 420,
 		},
-		DAH: &dah,
+		DAH: dah,
 		Commit: &core.Commit{
 			BlockID: core.BlockID{
 				Hash: []byte("made up hash"),

--- a/share/eds/byzantine/bad_encoding_test.go
+++ b/share/eds/byzantine/bad_encoding_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 	"github.com/celestiaorg/celestia-node/share/ipld"
 	"github.com/celestiaorg/celestia-node/share/sharetest"
@@ -55,7 +56,7 @@ func TestIncorrectBadEncodingFraudProof(t *testing.T) {
 	eds, err := ipld.AddShares(ctx, shares, bServ)
 	require.NoError(t, err)
 
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 
 	// get an arbitrary row

--- a/share/eds/eds.go
+++ b/share/eds/eds.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ipld/go-car"
 	"github.com/ipld/go-car/util"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -260,7 +259,7 @@ func ReadEDS(ctx context.Context, r io.Reader, root share.DataHash) (eds *rsmt2d
 		return nil, fmt.Errorf("share: computing eds: %w", err)
 	}
 
-	newDah, err := da.NewDataAvailabilityHeader(eds)
+	newDah, err := share.NewRoot(eds)
 	if err != nil {
 		return nil, err
 	}

--- a/share/eds/eds_test.go
+++ b/share/eds/eds_test.go
@@ -138,7 +138,7 @@ func TestWriteEDSInQuadrantOrder(t *testing.T) {
 
 func TestReadWriteRoundtrip(t *testing.T) {
 	eds := writeRandomEDS(t)
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 	f := openWrittenEDS(t)
 	defer f.Close()
@@ -196,7 +196,7 @@ func BenchmarkReadWriteEDS(b *testing.B) {
 	b.Cleanup(cancel)
 	for originalDataWidth := 4; originalDataWidth <= 64; originalDataWidth *= 2 {
 		eds := edstest.RandEDS(b, originalDataWidth)
-		dah, err := da.NewDataAvailabilityHeader(eds)
+		dah, err := share.NewRoot(eds)
 		require.NoError(b, err)
 		b.Run(fmt.Sprintf("Writing %dx%d", originalDataWidth, originalDataWidth), func(b *testing.B) {
 			b.ReportAllocs()
@@ -268,7 +268,7 @@ func createTestData(t *testing.T, testDir string) { //nolint:unused
 	err = WriteEDS(ctx, eds, f)
 	require.NoError(t, err, "writing EDS to file")
 	f.Close()
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 
 	header, err := json.MarshalIndent(dah, "", "")

--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -39,11 +38,11 @@ func RandEDSWithNamespace(
 	t require.TestingT,
 	namespace share.Namespace,
 	size int,
-) (*rsmt2d.ExtendedDataSquare, da.DataAvailabilityHeader) {
+) (*rsmt2d.ExtendedDataSquare, *share.Root) {
 	shares := sharetest.RandSharesWithNamespace(t, namespace, size*size)
 	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), wrapper.NewConstructor(uint64(size)))
 	require.NoError(t, err, "failure to recompute the extended data square")
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 	return eds, dah
 }

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/celestiaorg/rsmt2d"
 
-	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/libs/utils"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/ipld"
@@ -394,13 +393,13 @@ func (s *Store) getDAH(ctx context.Context, root share.DataHash) (*share.Root, e
 }
 
 // dahFromCARHeader returns the DataAvailabilityHeader stored in the CIDs of a CARv1 header.
-func dahFromCARHeader(carHeader *carv1.CarHeader) *header.DataAvailabilityHeader {
+func dahFromCARHeader(carHeader *carv1.CarHeader) *share.Root {
 	rootCount := len(carHeader.Roots)
 	rootBytes := make([][]byte, 0, rootCount)
 	for _, root := range carHeader.Roots {
 		rootBytes = append(rootBytes, ipld.NamespacedSha256FromCID(root))
 	}
-	return &header.DataAvailabilityHeader{
+	return &share.Root{
 		RowRoots:    rootBytes[:rootCount/2],
 		ColumnRoots: rootBytes[rootCount/2:],
 	}

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -352,7 +351,7 @@ func BenchmarkStore(b *testing.B) {
 			// pause the timer for initializing test data
 			b.StopTimer()
 			eds := edstest.RandEDS(b, 128)
-			dah, err := da.NewDataAvailabilityHeader(eds)
+			dah, err := share.NewRoot(eds)
 			require.NoError(b, err)
 			b.StartTimer()
 
@@ -368,7 +367,7 @@ func BenchmarkStore(b *testing.B) {
 			// pause the timer for initializing test data
 			b.StopTimer()
 			eds := edstest.RandEDS(b, 128)
-			dah, err := da.NewDataAvailabilityHeader(eds)
+			dah, err := share.NewRoot(eds)
 			require.NoError(b, err)
 			_ = edsStore.Put(ctx, dah.Hash(), eds)
 			b.StartTimer()
@@ -389,7 +388,7 @@ func newStore(t *testing.T) (*Store, error) {
 
 func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, share.Root) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 
 	return eds, dah

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -386,7 +386,7 @@ func newStore(t *testing.T) (*Store, error) {
 	return NewStore(tmpDir, ds)
 }
 
-func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, share.Root) {
+func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.Root) {
 	eds := edstest.RandEDS(t, 4)
 	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)

--- a/share/empty.go
+++ b/share/empty.go
@@ -54,7 +54,7 @@ func initEmpty() {
 	}
 	emptyBlockEDS = eds
 
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := NewRoot(eds)
 	if err != nil {
 		panic(fmt.Errorf("failed to create empty DAH: %w", err))
 	}

--- a/share/empty.go
+++ b/share/empty.go
@@ -54,16 +54,15 @@ func initEmpty() {
 	}
 	emptyBlockEDS = eds
 
-	dah, err := NewRoot(eds)
+	emptyBlockRoot, err = NewRoot(eds)
 	if err != nil {
 		panic(fmt.Errorf("failed to create empty DAH: %w", err))
 	}
 	minDAH := da.MinDataAvailabilityHeader()
-	if !bytes.Equal(minDAH.Hash(), dah.Hash()) {
+	if !bytes.Equal(minDAH.Hash(), emptyBlockRoot.Hash()) {
 		panic(fmt.Sprintf("mismatch in calculated minimum DAH and minimum DAH from celestia-app, "+
-			"expected %s, got %s", minDAH.String(), dah.String()))
+			"expected %s, got %s", minDAH.String(), emptyBlockRoot.String()))
 	}
-	emptyBlockRoot = &dah
 
 	// precompute Hash, so it's cached internally to avoid potential races
 	emptyBlockRoot.Hash()

--- a/share/getters/getter_test.go
+++ b/share/getters/getter_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/rsmt2d"
 
@@ -274,7 +273,7 @@ func TestIPLDGetter(t *testing.T) {
 
 func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, share.Root) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 	return eds, dah
 }
@@ -303,7 +302,7 @@ func randomEDSWithDoubledNamespace(t *testing.T, size int) (*rsmt2d.ExtendedData
 		wrapper.NewConstructor(uint64(size)),
 	)
 	require.NoError(t, err, "failure to recompute the extended data square")
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 
 	return eds, share.GetNamespace(randShares[idx1]), dah

--- a/share/getters/getter_test.go
+++ b/share/getters/getter_test.go
@@ -48,7 +48,7 @@ func TestTeeGetter(t *testing.T) {
 		assert.False(t, ok)
 		assert.NoError(t, err)
 
-		retrievedEDS, err := tg.GetEDS(ctx, &dah)
+		retrievedEDS, err := tg.GetEDS(ctx, dah)
 		require.NoError(t, err)
 		require.True(t, randEds.Equals(retrievedEDS))
 
@@ -66,12 +66,12 @@ func TestTeeGetter(t *testing.T) {
 		_, err := ipld.ImportShares(ctx, randEds.Flattened(), bServ)
 		require.NoError(t, err)
 
-		retrievedEDS, err := tg.GetEDS(ctx, &dah)
+		retrievedEDS, err := tg.GetEDS(ctx, dah)
 		require.NoError(t, err)
 		require.True(t, randEds.Equals(retrievedEDS))
 
 		// no error should be returned, even though the EDS identified by the DAH already exists
-		retrievedEDS, err = tg.GetEDS(ctx, &dah)
+		retrievedEDS, err = tg.GetEDS(ctx, dah)
 		require.NoError(t, err)
 		require.True(t, randEds.Equals(retrievedEDS))
 	})
@@ -99,19 +99,19 @@ func TestStoreGetter(t *testing.T) {
 		squareSize := int(randEds.Width())
 		for i := 0; i < squareSize; i++ {
 			for j := 0; j < squareSize; j++ {
-				share, err := sg.GetShare(ctx, &dah, i, j)
+				share, err := sg.GetShare(ctx, dah, i, j)
 				require.NoError(t, err)
 				assert.Equal(t, randEds.GetCell(uint(i), uint(j)), share)
 			}
 		}
 
 		// doesn't panic on indexes too high
-		_, err := sg.GetShare(ctx, &dah, squareSize, squareSize)
+		_, err := sg.GetShare(ctx, dah, squareSize, squareSize)
 		require.ErrorIs(t, err, share.ErrOutOfBounds)
 
 		// root not found
 		_, dah = randomEDS(t)
-		_, err = sg.GetShare(ctx, &dah, 0, 0)
+		_, err = sg.GetShare(ctx, dah, 0, 0)
 		require.ErrorIs(t, err, share.ErrNotFound)
 	})
 
@@ -120,7 +120,7 @@ func TestStoreGetter(t *testing.T) {
 		err = edsStore.Put(ctx, dah.Hash(), randEds)
 		require.NoError(t, err)
 
-		retrievedEDS, err := sg.GetEDS(ctx, &dah)
+		retrievedEDS, err := sg.GetEDS(ctx, dah)
 		require.NoError(t, err)
 		assert.True(t, randEds.Equals(retrievedEDS))
 
@@ -135,14 +135,14 @@ func TestStoreGetter(t *testing.T) {
 		err = edsStore.Put(ctx, dah.Hash(), randEds)
 		require.NoError(t, err)
 
-		shares, err := sg.GetSharesByNamespace(ctx, &dah, namespace)
+		shares, err := sg.GetSharesByNamespace(ctx, dah, namespace)
 		require.NoError(t, err)
-		require.NoError(t, shares.Verify(&dah, namespace))
+		require.NoError(t, shares.Verify(dah, namespace))
 		assert.Len(t, shares.Flatten(), 2)
 
 		// namespace not found
 		randNamespace := sharetest.RandV0Namespace()
-		emptyShares, err := sg.GetSharesByNamespace(ctx, &dah, randNamespace)
+		emptyShares, err := sg.GetSharesByNamespace(ctx, dah, randNamespace)
 		require.NoError(t, err)
 		require.Empty(t, emptyShares.Flatten())
 
@@ -158,9 +158,9 @@ func TestStoreGetter(t *testing.T) {
 		require.NoError(t, err)
 
 		// available
-		shares, err := sg.GetSharesByNamespace(ctx, &dah, namespace)
+		shares, err := sg.GetSharesByNamespace(ctx, dah, namespace)
 		require.NoError(t, err)
-		require.NoError(t, shares.Verify(&dah, namespace))
+		require.NoError(t, shares.Verify(dah, namespace))
 		assert.Len(t, shares.Flatten(), 2)
 
 		// 'corrupt' existing CAR by overwriting with a random EDS
@@ -170,7 +170,7 @@ func TestStoreGetter(t *testing.T) {
 		err = eds.WriteEDS(ctx, edsToOverwriteWith, f)
 		require.NoError(t, err)
 
-		shares, err = sg.GetSharesByNamespace(ctx, &dah, namespace)
+		shares, err = sg.GetSharesByNamespace(ctx, dah, namespace)
 		require.ErrorIs(t, err, share.ErrNotFound)
 		require.Nil(t, shares)
 
@@ -208,19 +208,19 @@ func TestIPLDGetter(t *testing.T) {
 		squareSize := int(randEds.Width())
 		for i := 0; i < squareSize; i++ {
 			for j := 0; j < squareSize; j++ {
-				share, err := sg.GetShare(ctx, &dah, i, j)
+				share, err := sg.GetShare(ctx, dah, i, j)
 				require.NoError(t, err)
 				assert.Equal(t, randEds.GetCell(uint(i), uint(j)), share)
 			}
 		}
 
 		// doesn't panic on indexes too high
-		_, err := sg.GetShare(ctx, &dah, squareSize+1, squareSize+1)
+		_, err := sg.GetShare(ctx, dah, squareSize+1, squareSize+1)
 		require.ErrorIs(t, err, share.ErrOutOfBounds)
 
 		// root not found
 		_, dah = randomEDS(t)
-		_, err = sg.GetShare(ctx, &dah, 0, 0)
+		_, err = sg.GetShare(ctx, dah, 0, 0)
 		require.ErrorIs(t, err, share.ErrNotFound)
 	})
 
@@ -232,7 +232,7 @@ func TestIPLDGetter(t *testing.T) {
 		err = edsStore.Put(ctx, dah.Hash(), randEds)
 		require.NoError(t, err)
 
-		retrievedEDS, err := sg.GetEDS(ctx, &dah)
+		retrievedEDS, err := sg.GetEDS(ctx, dah)
 		require.NoError(t, err)
 		assert.True(t, randEds.Equals(retrievedEDS))
 
@@ -252,14 +252,14 @@ func TestIPLDGetter(t *testing.T) {
 		require.NoError(t, err)
 
 		// first check that shares are returned correctly if they exist
-		shares, err := sg.GetSharesByNamespace(ctx, &dah, namespace)
+		shares, err := sg.GetSharesByNamespace(ctx, dah, namespace)
 		require.NoError(t, err)
-		require.NoError(t, shares.Verify(&dah, namespace))
+		require.NoError(t, shares.Verify(dah, namespace))
 		assert.Len(t, shares.Flatten(), 2)
 
 		// namespace not found
 		randNamespace := sharetest.RandV0Namespace()
-		emptyShares, err := sg.GetSharesByNamespace(ctx, &dah, randNamespace)
+		emptyShares, err := sg.GetSharesByNamespace(ctx, dah, randNamespace)
 		require.NoError(t, err)
 		require.Empty(t, emptyShares.Flatten())
 
@@ -271,7 +271,7 @@ func TestIPLDGetter(t *testing.T) {
 	})
 }
 
-func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, share.Root) {
+func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.Root) {
 	eds := edstest.RandEDS(t, 4)
 	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
@@ -280,7 +280,7 @@ func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, share.Root) {
 
 // randomEDSWithDoubledNamespace generates a random EDS and ensures that there are two shares in the
 // middle that share a namespace.
-func randomEDSWithDoubledNamespace(t *testing.T, size int) (*rsmt2d.ExtendedDataSquare, []byte, share.Root) {
+func randomEDSWithDoubledNamespace(t *testing.T, size int) (*rsmt2d.ExtendedDataSquare, []byte, *share.Root) {
 	n := size * size
 	randShares := sharetest.RandShares(t, n)
 	idx1 := (n - 1) / 2

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -202,7 +202,7 @@ func newStore(t *testing.T) (*eds.Store, error) {
 
 func generateTestEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, da.DataAvailabilityHeader, share.Namespace) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 	max := nmt.MaxNamespace(dah.RowRoots[(len(dah.RowRoots))/2-1], share.NamespaceSize)
 	return eds, dah, max

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -19,7 +19,6 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	libhead "github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/nmt"
@@ -69,16 +68,16 @@ func TestShrexGetter(t *testing.T) {
 
 		// generate test data
 		namespace := sharetest.RandV0Namespace()
-		randEDS, dah := singleNamespaceEds(t, namespace, 64)
+		randEDS, dah := edstest.RandEDSWithNamespace(t, namespace, 64)
 		require.NoError(t, edsStore.Put(ctx, dah.Hash(), randEDS))
 		peerManager.Validate(ctx, srvHost.ID(), shrexsub.Notification{
 			DataHash: dah.Hash(),
 			Height:   1,
 		})
 
-		got, err := getter.GetSharesByNamespace(ctx, &dah, namespace)
+		got, err := getter.GetSharesByNamespace(ctx, dah, namespace)
 		require.NoError(t, err)
-		require.NoError(t, got.Verify(&dah, namespace))
+		require.NoError(t, got.Verify(dah, namespace))
 	})
 
 	t.Run("ND_err_not_found", func(t *testing.T) {
@@ -92,7 +91,7 @@ func TestShrexGetter(t *testing.T) {
 			Height:   1,
 		})
 
-		_, err := getter.GetSharesByNamespace(ctx, &dah, namespace)
+		_, err := getter.GetSharesByNamespace(ctx, dah, namespace)
 		require.ErrorIs(t, err, share.ErrNotFound)
 	})
 
@@ -108,16 +107,16 @@ func TestShrexGetter(t *testing.T) {
 			Height:   1,
 		})
 
-		namespace, err := addToNamespace(maxNamespace, -1)
+		nID, err := addToNamespace(maxNamespace, -1)
 		require.NoError(t, err)
 		// check for namespace to be between max and min namespace in root
-		require.Len(t, filterRootsByNamespace(&dah, namespace), 1)
+		require.Len(t, filterRootsByNamespace(dah, nID), 1)
 
-		emptyShares, err := getter.GetSharesByNamespace(ctx, &dah, namespace)
+		emptyShares, err := getter.GetSharesByNamespace(ctx, dah, nID)
 		require.NoError(t, err)
 		// no shares should be returned
 		require.Empty(t, emptyShares.Flatten())
-		require.Nil(t, emptyShares.Verify(&dah, namespace))
+		require.Nil(t, emptyShares.Verify(dah, nID))
 	})
 
 	t.Run("ND_namespace_not_in_dah", func(t *testing.T) {
@@ -135,13 +134,13 @@ func TestShrexGetter(t *testing.T) {
 		namespace, err := addToNamespace(maxNamesapce, 1)
 		require.NoError(t, err)
 		// check for namespace to be not in root
-		require.Len(t, filterRootsByNamespace(&dah, namespace), 0)
+		require.Len(t, filterRootsByNamespace(dah, namespace), 0)
 
-		emptyShares, err := getter.GetSharesByNamespace(ctx, &dah, namespace)
+		emptyShares, err := getter.GetSharesByNamespace(ctx, dah, namespace)
 		require.NoError(t, err)
 		// no shares should be returned
 		require.Empty(t, emptyShares.Flatten())
-		require.Nil(t, emptyShares.Verify(&dah, namespace))
+		require.Nil(t, emptyShares.Verify(dah, namespace))
 	})
 
 	t.Run("EDS_Available", func(t *testing.T) {
@@ -156,7 +155,7 @@ func TestShrexGetter(t *testing.T) {
 			Height:   1,
 		})
 
-		got, err := getter.GetEDS(ctx, &dah)
+		got, err := getter.GetEDS(ctx, dah)
 		require.NoError(t, err)
 		require.Equal(t, randEDS.Flattened(), got.Flattened())
 	})
@@ -172,7 +171,7 @@ func TestShrexGetter(t *testing.T) {
 		})
 
 		cancel()
-		_, err := getter.GetEDS(ctx, &dah)
+		_, err := getter.GetEDS(ctx, dah)
 		require.ErrorIs(t, err, context.Canceled)
 	})
 
@@ -187,7 +186,7 @@ func TestShrexGetter(t *testing.T) {
 			Height:   1,
 		})
 
-		_, err := getter.GetEDS(ctx, &dah)
+		_, err := getter.GetEDS(ctx, dah)
 		require.ErrorIs(t, err, share.ErrNotFound)
 	})
 }
@@ -200,7 +199,7 @@ func newStore(t *testing.T) (*eds.Store, error) {
 	return eds.NewStore(tmpDir, ds)
 }
 
-func generateTestEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, da.DataAvailabilityHeader, share.Namespace) {
+func generateTestEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.Root, share.Namespace) {
 	eds := edstest.RandEDS(t, 4)
 	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
@@ -379,7 +378,7 @@ func singleNamespaceEds(
 	t require.TestingT,
 	namespace share.Namespace,
 	size int,
-) (*rsmt2d.ExtendedDataSquare, da.DataAvailabilityHeader) {
+) (*rsmt2d.ExtendedDataSquare, *share.Root) {
 	shares := make([]share.Share, size*size)
 	rnd := rand.New(rand.NewSource(time.Now().Unix()))
 	for i := range shares {
@@ -392,7 +391,7 @@ func singleNamespaceEds(
 	sort.Slice(shares, func(i, j int) bool { return bytes.Compare(shares[i], shares[j]) < 0 })
 	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), wrapper.NewConstructor(uint64(size)))
 	require.NoError(t, err, "failure to recompute the extended data square")
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 	return eds, dah
 }

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -1,12 +1,9 @@
 package getters
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
-	"math/rand"
-	"sort"
 	"testing"
 	"time"
 
@@ -19,7 +16,6 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	libhead "github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -372,26 +368,4 @@ func TestAddToNamespace(t *testing.T) {
 			}
 		})
 	}
-}
-
-func singleNamespaceEds(
-	t require.TestingT,
-	namespace share.Namespace,
-	size int,
-) (*rsmt2d.ExtendedDataSquare, *share.Root) {
-	shares := make([]share.Share, size*size)
-	rnd := rand.New(rand.NewSource(time.Now().Unix()))
-	for i := range shares {
-		shr := make([]byte, share.Size)
-		copy(share.GetNamespace(shr), namespace)
-		_, err := rnd.Read(share.GetData(shr))
-		require.NoError(t, err)
-		shares[i] = shr
-	}
-	sort.Slice(shares, func(i, j int) bool { return bytes.Compare(shares[i], shares[j]) < 0 })
-	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), wrapper.NewConstructor(uint64(size)))
-	require.NoError(t, err, "failure to recompute the extended data square")
-	dah, err := share.NewRoot(eds)
-	require.NoError(t, err)
-	return eds, dah
 }

--- a/share/getters/testing.go
+++ b/share/getters/testing.go
@@ -17,7 +17,7 @@ import (
 // TestGetter provides a testing SingleEDSGetter and the root of the EDS it holds.
 func TestGetter(t *testing.T) (share.Getter, *share.Root) {
 	eds := edstest.RandEDS(t, 8)
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	dah, err := share.NewRoot(eds)
 	require.NoError(t, err)
 	return &SingleEDSGetter{
 		EDS: eds,

--- a/share/getters/testing.go
+++ b/share/getters/testing.go
@@ -21,7 +21,7 @@ func TestGetter(t *testing.T) (share.Getter, *share.Root) {
 	require.NoError(t, err)
 	return &SingleEDSGetter{
 		EDS: eds,
-	}, &dah
+	}, dah
 }
 
 // SingleEDSGetter contains a single EDS where data is retrieved from.

--- a/share/p2p/shrexeds/exchange_test.go
+++ b/share/p2p/shrexeds/exchange_test.go
@@ -14,8 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
-
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 	"github.com/celestiaorg/celestia-node/share/p2p"
@@ -35,7 +34,7 @@ func TestExchange_RequestEDS(t *testing.T) {
 	// Testcase: EDS is immediately available
 	t.Run("EDS_Available", func(t *testing.T) {
 		eds := edstest.RandEDS(t, 4)
-		dah, err := da.NewDataAvailabilityHeader(eds)
+		dah, err := share.NewRoot(eds)
 		require.NoError(t, err)
 		err = store.Put(ctx, dah.Hash(), eds)
 		require.NoError(t, err)
@@ -48,7 +47,7 @@ func TestExchange_RequestEDS(t *testing.T) {
 	// Testcase: EDS is unavailable initially, but is found after multiple requests
 	t.Run("EDS_AvailableAfterDelay", func(t *testing.T) {
 		eds := edstest.RandEDS(t, 4)
-		dah, err := da.NewDataAvailabilityHeader(eds)
+		dah, err := share.NewRoot(eds)
 		require.NoError(t, err)
 
 		lock := make(chan struct{})
@@ -85,7 +84,7 @@ func TestExchange_RequestEDS(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
 		t.Cleanup(cancel)
 		eds := edstest.RandEDS(t, 4)
-		dah, err := da.NewDataAvailabilityHeader(eds)
+		dah, err := share.NewRoot(eds)
 		require.NoError(t, err)
 		_, err = client.RequestEDS(timeoutCtx, dah.Hash(), server.host.ID())
 		require.ErrorIs(t, err, p2p.ErrNotFound)

--- a/share/p2p/shrexnd/exchange_test.go
+++ b/share/p2p/shrexnd/exchange_test.go
@@ -49,7 +49,7 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		require.NoError(t, edsStore.Put(ctx, dah.Hash(), eds))
 
 		randNamespace := dah.RowRoots[(len(dah.RowRoots)-1)/2][:share.NamespaceSize]
-		emptyShares, err := client.RequestND(ctx, &dah, randNamespace, server.host.ID())
+		emptyShares, err := client.RequestND(ctx, dah, randNamespace, server.host.ID())
 		require.NoError(t, err)
 		require.Empty(t, emptyShares.Flatten())
 	})

--- a/share/p2p/shrexnd/exchange_test.go
+++ b/share/p2p/shrexnd/exchange_test.go
@@ -13,7 +13,6 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -45,7 +44,7 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		t.Cleanup(cancel)
 
 		eds := edstest.RandEDS(t, 4)
-		dah, err := da.NewDataAvailabilityHeader(eds)
+		dah, err := share.NewRoot(eds)
 		require.NoError(t, err)
 		require.NoError(t, edsStore.Put(ctx, dah.Hash(), eds))
 


### PR DESCRIPTION
Somewhere we were using Root and somewhere DAH. Also, we mostly use DAH generator from the app. 
These PRs clean up all the usages and localize the Root/DAH type in `share` pkg as was originally intended.

Up to discussion is rename of `share.Root` to `share.DAH` to minimize discrepancies between app and node. Alternatively, if we wanna keep Root naming as it is, we should also rename DAH name on the ExtendedHeader(and son tags) and in other places, which is breaking.

Now, I think that calling it Root was not right and we should be calling the DataHash type Root, which is in fact the Merkle root of all the shares in the EDS.