### PR TITLE
feat(share/eds): introduce List method for the Store

### DIFF
--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -401,6 +402,20 @@ func (s *Store) Has(ctx context.Context, root share.DataHash) (bool, error) {
 	default:
 		return false, err
 	}
+}
+
+// List lists all the registered EDSes.
+func (s *Store) List() ([]share.DataHash, error) {
+	shards := s.dgstr.AllShardsInfo()
+	hashes := make([]share.DataHash, 0, len(shards))
+	for shrd := range shards {
+		hash, err := hex.DecodeString(shrd.String())
+		if err != nil {
+			return nil, err
+		}
+		hashes = append(hashes, hash)
+	}
+	return hashes, nil
 }
 
 func setupPath(basepath string) error {

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -154,6 +154,23 @@ func TestEDSStore(t *testing.T) {
 		_, err = edsStore.cache.Get(shardKey)
 		assert.NoError(t, err, errCacheMiss)
 	})
+
+	t.Run("List", func(t *testing.T) {
+		const amount = 10
+		hashes := make([]share.DataHash, 0, amount)
+		for range make([]byte, amount) {
+			eds, dah := randomEDS(t)
+			err = edsStore.Put(ctx, dah.Hash(), eds)
+			require.NoError(t, err)
+			hashes = append(hashes, dah.Hash())
+		}
+
+		hashesOut, err := edsStore.List()
+		require.NoError(t, err)
+		for _, hash := range hashes {
+			assert.Contains(t, hashesOut, hash)
+		}
+	})
 }
 
 // TestEDSStore_GC verifies that unused transient shards are collected by the GC periodically.


### PR DESCRIPTION
Needed fro and extracted from #2482 

I honestly have a concern about DagStore scalability. It loads *all* the shard's info on the map, which long term will have to store all the edses we ever stored, which will be a looot.