### PR TITLE
fix(nodebuilder/tests/swamp): Bump timeout

### DIFF
--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -164,7 +164,7 @@ func (s *Swamp) createPeer(ks keystore.Keystore) host.Host {
 // setupGenesis sets up genesis Header.
 // This is required to initialize and start correctly.
 func (s *Swamp) setupGenesis() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
 	// ensure core has surpassed genesis block


### PR DESCRIPTION
Necessary to get core client to produce blocks in swamp at the moment.

Found by @rootulp 