### PR TITLE
refactor(libs/pidstore)!: PIDStore takes `peer.AddrInfo` instead of `peer.ID`

### DIFF
--- a/libs/pidstore/pidstore.go
+++ b/libs/pidstore/pidstore.go
@@ -23,7 +23,8 @@ type PeerIDStore struct {
 	ds datastore.Datastore
 }
 
-// NewPeerIDStore creates a new peer ID store backed by the given datastore.
+// NewPeerIDStore creates a new peer AddrInfo store backed by the given
+// datastore.
 func NewPeerIDStore(ds datastore.Datastore) *PeerIDStore {
 	return &PeerIDStore{
 		ds: namespace.Wrap(ds, storePrefix),
@@ -31,7 +32,7 @@ func NewPeerIDStore(ds datastore.Datastore) *PeerIDStore {
 }
 
 // Load loads the peers from datastore and returns them.
-func (p *PeerIDStore) Load(ctx context.Context) ([]peer.ID, error) {
+func (p *PeerIDStore) Load(ctx context.Context) ([]peer.AddrInfo, error) {
 	log.Debug("Loading peers")
 
 	bin, err := p.ds.Get(ctx, peersKey)
@@ -39,7 +40,7 @@ func (p *PeerIDStore) Load(ctx context.Context) ([]peer.ID, error) {
 		return nil, fmt.Errorf("pidstore: loading peers from datastore: %w", err)
 	}
 
-	var peers []peer.ID
+	var peers []peer.AddrInfo
 	err = json.Unmarshal(bin, &peers)
 	if err != nil {
 		return nil, fmt.Errorf("pidstore: unmarshalling peer IDs: %w", err)
@@ -49,8 +50,8 @@ func (p *PeerIDStore) Load(ctx context.Context) ([]peer.ID, error) {
 	return peers, nil
 }
 
-// Put persists the given peer IDs to the datastore.
-func (p *PeerIDStore) Put(ctx context.Context, peers []peer.ID) error {
+// Put persists the given peers' AddrInfo to the datastore.
+func (p *PeerIDStore) Put(ctx context.Context, peers []peer.AddrInfo) error {
 	log.Debugw("Persisting peers to disk", "amount", len(peers))
 
 	bin, err := json.Marshal(peers)

--- a/libs/pidstore/pidstore_test.go
+++ b/libs/pidstore/pidstore_test.go
@@ -2,15 +2,14 @@ package pidstore
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"testing"
 	"time"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
-	"github.com/libp2p/go-libp2p/core/crypto"
+	libhost "github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,41 +18,22 @@ func TestPutLoad(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer t.Cleanup(cancel)
 
-	peerstore := NewPeerIDStore(sync.MutexWrap(datastore.NewMapDatastore()))
-
-	ids, err := generateRandomPeerList(10)
+	mn, err := mocknet.FullMeshConnected(5)
 	require.NoError(t, err)
 
-	err = peerstore.Put(ctx, ids)
+	addrinfos := make([]peer.AddrInfo, 5)
+	for i, host := range mn.Hosts() {
+		addrinfos[i] = *libhost.InfoFromHost(host)
+	}
+
+	peerstore := NewPeerIDStore(sync.MutexWrap(datastore.NewMapDatastore()))
+
+	err = peerstore.Put(ctx, addrinfos)
 	require.NoError(t, err)
 
 	retrievedPeerlist, err := peerstore.Load(ctx)
 	require.NoError(t, err)
 
-	assert.Equal(t, len(ids), len(retrievedPeerlist))
-	assert.Equal(t, ids, retrievedPeerlist)
-}
-
-func generateRandomPeerList(length int) ([]peer.ID, error) {
-	peerlist := make([]peer.ID, length)
-	for i := range peerlist {
-		key, err := rsa.GenerateKey(rand.Reader, 2096)
-		if err != nil {
-			return nil, err
-		}
-
-		_, pubkey, err := crypto.KeyPairFromStdKey(key)
-		if err != nil {
-			return nil, err
-		}
-
-		peerID, err := peer.IDFromPublicKey(pubkey)
-		if err != nil {
-			return nil, err
-		}
-
-		peerlist[i] = peerID
-	}
-
-	return peerlist, nil
+	assert.Equal(t, len(addrinfos), len(retrievedPeerlist))
+	assert.Equal(t, addrinfos, retrievedPeerlist)
 }


### PR DESCRIPTION
Blocked on https://github.com/celestiaorg/go-header/pull/86 and a release from go-header. 

Refer to description of go-header PR as to why this is necessary.

This is technically breaking, but it's not currently in use, so not marking it as such in the labels.