### PR TITLE
feat(nodebuilder/header): Bootstrap from previously seen peers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,6 +185,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/golang-lru/arc/v2 v2.0.5 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.5 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 // indirect
@@ -332,8 +333,6 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-require github.com/hashicorp/golang-lru/arc/v2 v2.0.5 // indirect
 
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.18.0-sdk-v0.46.14

--- a/go.mod
+++ b/go.mod
@@ -333,6 +333,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
+require github.com/hashicorp/golang-lru/arc/v2 v2.0.5 // indirect
+
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.18.0-sdk-v0.46.14
 	github.com/filecoin-project/dagstore => github.com/celestiaorg/dagstore v0.0.0-20230824094345-537c012aa403

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,7 @@ github.com/99designs/keyring v1.2.1 h1:tYLp1ULvO7i3fI5vE21ReQuj99QFSs7lGm0xWyJo8
 github.com/99designs/keyring v1.2.1/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
@@ -535,6 +536,7 @@ github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzA
 github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.1/go.mod h1:FRmFw3uxvcpa8zG3Rxs0th+hCLIuaQg8HlNV5bjgnuU=
+github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
 github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=
 github.com/dgraph-io/badger/v2 v2.2007.4 h1:TRWBQg8UrlUhaFdco01nO2uXwzKS7zd+HVdwV/GHc4o=
 github.com/dgraph-io/badger/v2 v2.2007.4/go.mod h1:vSw/ax2qojzbN6eXHIx6KPKtCSHJN/Uz0X0VPruTIhk=
@@ -965,6 +967,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/arc/v2 v2.0.5 h1:l2zaLDubNhW4XO3LnliVj0GXO3+/CGNJAg1dcN2Fpfw=
+github.com/hashicorp/golang-lru/arc/v2 v2.0.5/go.mod h1:ny6zBSQZi2JxIeYcv7kt2sH2PXJtirBN7RDhRpxPkxU=
 github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
 github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
@@ -1081,6 +1085,7 @@ github.com/ipfs/go-ds-badger v0.0.5/go.mod h1:g5AuuCGmr7efyzQhLL8MzwqcauPojGPUaH
 github.com/ipfs/go-ds-badger v0.0.7/go.mod h1:qt0/fWzZDoPW6jpQeqUjR5kBfhDNB65jd9YlmAvpQBk=
 github.com/ipfs/go-ds-badger v0.2.1/go.mod h1:Tx7l3aTph3FMFrRS838dcSJh+jjA7cX9DrGVwx/NOwE=
 github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
+github.com/ipfs/go-ds-badger v0.3.0 h1:xREL3V0EH9S219kFFueOYJJTcjgNSZ2HY1iSvN7U1Ro=
 github.com/ipfs/go-ds-badger v0.3.0/go.mod h1:1ke6mXNqeV8K3y5Ak2bAA0osoTfmxUdupVCGm4QUIek=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=

--- a/libs/pidstore/pidstore.go
+++ b/libs/pidstore/pidstore.go
@@ -24,10 +24,20 @@ type PeerIDStore struct {
 }
 
 // NewPeerIDStore creates a new peer ID store backed by the given datastore.
-func NewPeerIDStore(ds datastore.Datastore) *PeerIDStore {
-	return &PeerIDStore{
+func NewPeerIDStore(ctx context.Context, ds datastore.Datastore) (*PeerIDStore, error) {
+	pidstore := &PeerIDStore{
 		ds: namespace.Wrap(ds, storePrefix),
 	}
+	// check if pidstore is already initialized, and if not,
+	// initialize the pidstore
+	exists, err := pidstore.ds.Has(ctx, peersKey)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return pidstore, pidstore.Put(ctx, []peer.ID{})
+	}
+	return pidstore, nil
 }
 
 // Load loads the peers from datastore and returns them.

--- a/libs/pidstore/pidstore_test.go
+++ b/libs/pidstore/pidstore_test.go
@@ -19,7 +19,19 @@ func TestPutLoad(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer t.Cleanup(cancel)
 
-	peerstore := NewPeerIDStore(sync.MutexWrap(datastore.NewMapDatastore()))
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+
+	t.Run("unitialized-pidstore", func(t *testing.T) {
+		testPutLoad(ctx, ds, t)
+	})
+	t.Run("initialized-pidstore", func(t *testing.T) {
+		testPutLoad(ctx, ds, t)
+	})
+}
+
+func testPutLoad(ctx context.Context, ds datastore.Datastore, t *testing.T) {
+	peerstore, err := NewPeerIDStore(ctx, ds)
+	require.NoError(t, err)
 
 	ids, err := generateRandomPeerList(10)
 	require.NoError(t, err)

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -23,12 +23,13 @@ import (
 // newP2PExchange constructs a new Exchange for headers.
 func newP2PExchange[H libhead.Header[H]](
 	lc fx.Lifecycle,
+	cfg Config,
 	bpeers modp2p.Bootstrappers,
 	network modp2p.Network,
 	host host.Host,
 	conngater *conngater.BasicConnectionGater,
-	cfg Config,
-) (libhead.Exchange[H], error) {
+	pidstore p2p.PeerIDStore,
+) (libhead.Exchange[*header.ExtendedHeader], error) {
 	peers, err := cfg.trustedPeers(bpeers)
 	if err != nil {
 		return nil, err
@@ -42,6 +43,7 @@ func newP2PExchange[H libhead.Header[H]](
 		p2p.WithParams(cfg.Client),
 		p2p.WithNetworkID[p2p.ClientParameters](network.String()),
 		p2p.WithChainID(network.String()),
+		p2p.WithPeerIDStore[p2p.ClientParameters](pidstore),
 	)
 	if err != nil {
 		return nil, err
@@ -55,7 +57,6 @@ func newP2PExchange[H libhead.Header[H]](
 		},
 	})
 	return exchange, nil
-
 }
 
 // newSyncer constructs new Syncer for headers.

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -15,6 +15,7 @@ import (
 	"github.com/celestiaorg/go-header/store"
 	"github.com/celestiaorg/go-header/sync"
 
+	"github.com/celestiaorg/celestia-node/header"
 	modfraud "github.com/celestiaorg/celestia-node/nodebuilder/fraud"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
@@ -39,7 +40,7 @@ func newP2PExchange[H libhead.Header[H]](
 		ids[index] = peer.ID
 		host.Peerstore().AddAddrs(peer.ID, peer.Addrs, peerstore.PermanentAddrTTL)
 	}
-	exchange, err := p2p.NewExchange[H](host, ids, conngater,
+	exchange, err := p2p.NewExchange[*header.ExtendedHeader](host, ids, conngater,
 		p2p.WithParams(cfg.Client),
 		p2p.WithNetworkID[p2p.ClientParameters](network.String()),
 		p2p.WithChainID(network.String()),

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -15,7 +15,6 @@ import (
 	"github.com/celestiaorg/go-header/store"
 	"github.com/celestiaorg/go-header/sync"
 
-	"github.com/celestiaorg/celestia-node/header"
 	modfraud "github.com/celestiaorg/celestia-node/nodebuilder/fraud"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
@@ -30,7 +29,7 @@ func newP2PExchange[H libhead.Header[H]](
 	host host.Host,
 	conngater *conngater.BasicConnectionGater,
 	pidstore p2p.PeerIDStore,
-) (libhead.Exchange[*header.ExtendedHeader], error) {
+) (libhead.Exchange[H], error) {
 	peers, err := cfg.trustedPeers(bpeers)
 	if err != nil {
 		return nil, err
@@ -40,7 +39,7 @@ func newP2PExchange[H libhead.Header[H]](
 		ids[index] = peer.ID
 		host.Peerstore().AddAddrs(peer.ID, peer.Addrs, peerstore.PermanentAddrTTL)
 	}
-	exchange, err := p2p.NewExchange[*header.ExtendedHeader](host, ids, conngater,
+	exchange, err := p2p.NewExchange[H](host, ids, conngater,
 		p2p.WithParams(cfg.Client),
 		p2p.WithNetworkID[p2p.ClientParameters](network.String()),
 		p2p.WithChainID(network.String()),

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -15,6 +15,7 @@ import (
 	"github.com/celestiaorg/go-header/sync"
 
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/libs/pidstore"
 	modfraud "github.com/celestiaorg/celestia-node/nodebuilder/fraud"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
@@ -99,6 +100,9 @@ func ConstructModule[H libhead.Header[H]](tp node.Type, cfg *Config) fx.Option {
 			"header",
 			baseComponents,
 			fx.Provide(newP2PExchange[H]),
+			fx.Provide(func(ctx context.Context, ds datastore.Batching) (p2p.PeerIDStore, error) {
+				return pidstore.NewPeerIDStore(ctx, ds)
+			}),
 		)
 	case node.Bridge:
 		return fx.Module(

--- a/nodebuilder/header/module_test.go
+++ b/nodebuilder/header/module_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/celestiaorg/go-header/sync"
 
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/libs/pidstore"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
@@ -94,6 +95,8 @@ func TestConstructModule_ExchangeParams(t *testing.T) {
 	var exchangeServer *p2p.ExchangeServer[*header.ExtendedHeader]
 
 	app := fxtest.New(t,
+		fx.Provide(pidstore.NewPeerIDStore),
+		fx.Provide(context.Background),
 		fx.Supply(modp2p.Private),
 		fx.Supply(modp2p.Bootstrappers{}),
 		fx.Provide(libp2p.New),

--- a/nodebuilder/p2p/misc.go
+++ b/nodebuilder/p2p/misc.go
@@ -1,12 +1,13 @@
 package p2p
 
 import (
+	"context"
 	"time"
 
 	"github.com/ipfs/go-datastore"
 	connmgri "github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/peerstore"
-	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 
@@ -71,7 +72,7 @@ func connectionGater(ds datastore.Batching) (*conngater.BasicConnectionGater, er
 	return conngater.NewBasicConnectionGater(ds)
 }
 
-// peerStore constructs a PeerStore.
-func peerStore() (peerstore.Peerstore, error) {
-	return pstoremem.NewPeerstore()
+// peerStore constructs an on-disk PeerStore.
+func peerStore(ctx context.Context, ds datastore.Batching) (peerstore.Peerstore, error) {
+	return pstoreds.NewPeerstore(ctx, ds, pstoreds.DefaultOpts())
 }

--- a/nodebuilder/p2p/misc.go
+++ b/nodebuilder/p2p/misc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	connmgri "github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/peerstore"
-	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds" //nolint:staticcheck
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 


### PR DESCRIPTION
Provides `PIDStore` to header module so that it can be used in `peerTracker` and replaces mem `peerstore.Peerstore` with on-disk `peerstore.Peerstore` so that `peerTracker` can quickly bootstrap itself with previously-seen peers and allow syncer to initialise its sync target from tracked peers rather than trusted so long as it has a subjective head within the trusting period.

Overrides #2133 

Closes #1851, mitigates issues resulting from #1623

Swamp integration tests to follow (tracked in #2506)

### Future note: 

This PR introduces a soon-to-be deprecated feature from libp2p (on-disk peerstore). Once libp2p deprecates and removes this feature, the PIDStore will have to become a PeerAddrStore such that it can save addr info of good peers to disk instead of just their IDs.