### PR TITLE
feat(rpc): read token from the keystore if not provided

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -39,7 +39,7 @@ func newToken(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	privKey, err := keystore.Key(StorePath(cmd.Context()), nodemod.SecretName)
+	privKey, err := keystore.GetKey(StorePath(cmd.Context()), nodemod.SecretName)
 	if err != nil {
 		return err
 	}

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -18,6 +18,11 @@ import (
 // PersistentPreRun func on parent command.
 
 func init() {
+	basicFlags := []*pflag.FlagSet{
+		cmdnode.NodeFlags(),
+		p2p.Flags(),
+	}
+
 	flags := []*pflag.FlagSet{
 		cmdnode.NodeFlags(),
 		p2p.Flags(),
@@ -31,6 +36,8 @@ func init() {
 		state.Flags(),
 	}
 
+	flags = append(flags, basicFlags...)
+
 	lightCmd.AddCommand(
 		cmdnode.Init(flags...),
 		cmdnode.Start(flags...),
@@ -38,6 +45,7 @@ func init() {
 		cmdnode.ResetStore(flags...),
 		cmdnode.RemoveConfigCmd(flags...),
 		cmdnode.UpdateConfigCmd(flags...),
+		createRPCCmd(basicFlags...),
 	)
 }
 
@@ -46,6 +54,9 @@ var lightCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Manage your Light node",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		return persistentPreRunEnv(cmd, node.Light, args)
+		if cmd.Name() != rpcCmd.Name() {
+			return persistentPreRunEnv(cmd, node.Light, args)
+		}
+		return persistentPreRunRPC(cmd, node.Light)
 	},
 }

--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -358,7 +358,7 @@ func sendJSONRPCRequest(namespace, method string, params []interface{}) {
 
 	authToken := authTokenFlag
 	if authToken == "" {
-		privKey, err := keystore.Key(storePath, nodemod.SecretName)
+		privKey, err := keystore.GetKey(storePath, nodemod.SecretName)
 		if err != nil {
 			panic(err)
 		}
@@ -370,7 +370,7 @@ func sendJSONRPCRequest(namespace, method string, params []interface{}) {
 
 		token, err := authtoken.NewSignedJWT(signer, perms.AllPerms)
 		if err != nil {
-			panic(err)
+			log.Fatalf("Error creating an auth token: %v", err)
 		}
 		authToken = token
 	}

--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -15,8 +15,8 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
-var (
-	nodeStoreFlag  = "node.store"
+const (
+	NodeStoreFlag  = "node.store"
 	nodeConfigFlag = "node.config"
 )
 
@@ -25,7 +25,7 @@ func NodeFlags() *flag.FlagSet {
 	flags := &flag.FlagSet{}
 
 	flags.String(
-		nodeStoreFlag,
+		NodeStoreFlag,
 		"",
 		"The path to root/home directory of your Celestia Node Store",
 	)
@@ -40,7 +40,7 @@ func NodeFlags() *flag.FlagSet {
 
 // ParseNodeFlags parses Node flags from the given cmd and applies values to Env.
 func ParseNodeFlags(ctx context.Context, cmd *cobra.Command, network p2p.Network) (context.Context, error) {
-	store := cmd.Flag(nodeStoreFlag).Value.String()
+	store := cmd.Flag(NodeStoreFlag).Value.String()
 	if store == "" {
 		tp := NodeType(ctx)
 		var err error

--- a/libs/keystore/fs_keystore.go
+++ b/libs/keystore/fs_keystore.go
@@ -147,7 +147,7 @@ func checkPerms(perms os.FileMode) error {
 	return nil
 }
 
-func Key(path string, keyName KeyName) ([]byte, error) {
+func GetKey(path string, keyName KeyName) ([]byte, error) {
 	expanded, err := homedir.Expand(filepath.Clean(path))
 	if err != nil {
 		return nil, err

--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -14,7 +14,7 @@ import (
 const EnvCustomNetwork = "CELESTIA_CUSTOM"
 
 const (
-	networkFlag = "p2p.network"
+	NetworkFlag = "p2p.network"
 	mutualFlag  = "p2p.mutual"
 )
 
@@ -31,7 +31,7 @@ Peers must bidirectionally point to each other. (Format: multiformats.io/multiad
 `,
 	)
 	flags.String(
-		networkFlag,
+		NetworkFlag,
 		"",
 		"The name of the network to connect to, e.g. "+
 			listProvidedNetworks()+
@@ -67,7 +67,7 @@ func ParseFlags(
 // ParseNetwork tries to parse the network from the flags and environment,
 // and returns either the parsed network or the build's default network
 func ParseNetwork(cmd *cobra.Command) (Network, error) {
-	parsed := cmd.Flag(networkFlag).Value.String()
+	parsed := cmd.Flag(NetworkFlag).Value.String()
 	// no network set through the flags, so check if there is an override in the env
 	if parsed == "" {
 		envNetwork, err := parseNetworkFromEnv()

--- a/nodebuilder/p2p/flags_test.go
+++ b/nodebuilder/p2p/flags_test.go
@@ -14,7 +14,7 @@ import (
 func TestParseNetwork_matchesByAlias(t *testing.T) {
 	cmd := createCmdWithNetworkFlag()
 
-	err := cmd.Flags().Set(networkFlag, "arabica")
+	err := cmd.Flags().Set(NetworkFlag, "arabica")
 	require.NoError(t, err)
 
 	net, err := ParseNetwork(cmd)
@@ -27,7 +27,7 @@ func TestParseNetwork_matchesByAlias(t *testing.T) {
 func TestParseNetwork_matchesByValue(t *testing.T) {
 	cmd := createCmdWithNetworkFlag()
 
-	err := cmd.Flags().Set(networkFlag, string(Arabica))
+	err := cmd.Flags().Set(NetworkFlag, string(Arabica))
 	require.NoError(t, err)
 
 	net, err := ParseNetwork(cmd)
@@ -50,7 +50,7 @@ func TestParseNetwork_parsesFromEnv(t *testing.T) {
 func TestParsedNetwork_invalidNetwork(t *testing.T) {
 	cmd := createCmdWithNetworkFlag()
 
-	err := cmd.Flags().Set(networkFlag, "invalid")
+	err := cmd.Flags().Set(NetworkFlag, "invalid")
 	require.NoError(t, err)
 
 	net, err := ParseNetwork(cmd)
@@ -62,7 +62,7 @@ func createCmdWithNetworkFlag() *cobra.Command {
 	cmd := &cobra.Command{}
 	flags := &flag.FlagSet{}
 	flags.String(
-		networkFlag,
+		NetworkFlag,
 		"",
 		"",
 	)


### PR DESCRIPTION
## Overview
Added an additional flag that specifies store path in order to read auth key

`celestia rpc share GetShare "$(celestia rpc header GetByHeight 101810 --store.path=~/.celestia-light-arabica-9 | jq '.result.dah' -r)" 4 0 --store.path=~/.celestia-light-arabica-9`
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
