### PR TITLE
fix(blob): ensure that the share sequence is not empty

### DIFF
--- a/blob/helper.go
+++ b/blob/helper.go
@@ -32,6 +32,11 @@ func SharesToBlobs(rawShares []share.Share) ([]*Blob, error) {
 		return nil, err
 	}
 
+	// ensure that sequence length is not 0
+	if len(shareSequences) == 0 {
+		return nil, ErrBlobNotFound
+	}
+
 	blobs := make([]*Blob, len(shareSequences))
 	for i, sequence := range shareSequences {
 		data, err := sequence.RawData()


### PR DESCRIPTION

## Overview
Ensure that the sequence length is not empty

## Checklist


- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
