### PR TITLE
fix(share/eds): don't use in-memory buffer for mount after shard recover

### DIFF
--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -569,7 +569,7 @@ type inMemoryOnceMount struct {
 }
 
 func (m *inMemoryOnceMount) Fetch(ctx context.Context) (mount.Reader, error) {
-	if !m.readOnce.Swap(true) {
+	if m.buf != nil && !m.readOnce.Swap(true) {
 		reader := &inMemoryReader{Reader: bytes.NewReader(m.buf.Bytes())}
 		// release memory for gc, otherwise buffer will stick forever
 		m.buf = nil


### PR DESCRIPTION
When shard recovered in dagstore, it was read from in-memory mount, that could have been read 0 times and had no in-memory buffer. 