### PR TITLE
tests(fix): use tx sim for populating blocks (BEFP for swamp tests)

### DIFF
--- a/nodebuilder/tests/fraud_test.go
+++ b/nodebuilder/tests/fraud_test.go
@@ -34,7 +34,6 @@ Note: 15 is not available because DASer will be stopped before reaching this hei
 Another note: this test disables share exchange to speed up test results.
 */
 func TestFraudProofBroadcasting(t *testing.T) {
-	t.Skip("requires BEFP generation on app side to work")
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
@@ -45,7 +44,7 @@ func TestFraudProofBroadcasting(t *testing.T) {
 	)
 
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(blockTime), swamp.WithOutOfOrderShares(15))
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts, blockSize, blocks)
+	go swamp.FillBlocksWithMultipleBlobs(t, ctx, sw.Config(), sw.ClientContext)
 
 	cfg := nodebuilder.DefaultConfig(node.Bridge)
 	cfg.Share.UseShareExchange = false
@@ -94,7 +93,6 @@ func TestFraudProofBroadcasting(t *testing.T) {
 	proofs, err := full.FraudServ.Get(ctx, byzantine.BadEncoding)
 	require.NoError(t, err)
 	require.NotNil(t, proofs)
-	require.NoError(t, <-fillDn)
 }
 
 /*

--- a/nodebuilder/tests/swamp/config.go
+++ b/nodebuilder/tests/swamp/config.go
@@ -5,18 +5,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/test/util/malicious"
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
-
-	"github.com/celestiaorg/celestia-node/core"
 )
-
-// DefaultConfig creates a celestia-app instance with a block time of around
-// 100ms
-func DefaultConfig() *testnode.Config {
-	cfg := core.DefaultTestConfig()
-	// timeout commit lower than this tend to be flakier
-	cfg.TmConfig.Consensus.TimeoutCommit = 200 * time.Millisecond
-	return cfg
-}
 
 // Option for modifying Swamp's Config.
 type Option func(*testnode.Config)

--- a/nodebuilder/tests/swamp/config.go
+++ b/nodebuilder/tests/swamp/config.go
@@ -3,6 +3,7 @@ package swamp
 import (
 	"time"
 
+	"github.com/celestiaorg/celestia-app/test/util/malicious"
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
 
 	"github.com/celestiaorg/celestia-node/core"
@@ -28,5 +29,16 @@ func WithBlockTime(t time.Duration) Option {
 		// for filled block
 		c.TmConfig.Consensus.TimeoutCommit = t
 		c.TmConfig.Consensus.SkipTimeoutCommit = false
+	}
+}
+
+// WithOutOfOrderShares sets a height after which app will start producing invalid blocks.
+func WithOutOfOrderShares(startHeight int64) Option {
+	return func(config *testnode.Config) {
+		cfg := malicious.OutOfOrderNamespaceConfig(startHeight)
+		behaviour := cfg.AppOptions.Get(malicious.BehaviorConfigKey)
+
+		config.AppCreator = cfg.AppCreator
+		config.AppOptions.Set(malicious.BehaviorConfigKey, behaviour)
 	}
 }

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -68,7 +68,7 @@ func NewSwamp(t *testing.T, options ...Option) *Swamp {
 		logs.SetDebugLogging()
 	}
 
-	ic := DefaultConfig()
+	ic := core.DefaultTestConfig()
 	for _, option := range options {
 		option(ic)
 	}
@@ -334,4 +334,8 @@ func (s *Swamp) SetBootstrapper(t *testing.T, bootstrappers ...*nodebuilder.Node
 		require.NoError(t, err)
 		s.Bootstrappers = append(s.Bootstrappers, addrs[0])
 	}
+}
+
+func (s *Swamp) Config() *testnode.Config {
+	return s.cfg
 }

--- a/nodebuilder/tests/swamp/swamp_tx.go
+++ b/nodebuilder/tests/swamp/swamp_tx.go
@@ -2,10 +2,13 @@ package swamp
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/celestia-app/test/txsim"
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
 )
 
@@ -31,4 +34,15 @@ func FillBlocks(ctx context.Context, cctx testnode.Context, accounts []string, b
 		}
 	}()
 	return errCh
+}
+
+func FillBlocksWithMultipleBlobs(t *testing.T, ctx context.Context, cfg *testnode.Config, sdkcontext testnode.Context) {
+	err := txsim.Run(
+		ctx,
+		[]string{cfg.TmConfig.RPC.ListenAddress},
+		[]string{cfg.AppConfig.GRPC.Address},
+		sdkcontext.Keyring, 9001, 100*time.Millisecond,
+		txsim.NewBlobSequence(txsim.NewRange(1e3, 1e4), txsim.NewRange(1, 1)).Clone(10)...,
+	)
+	require.Equal(t, context.DeadlineExceeded, err)
 }


### PR DESCRIPTION
This builds on https://github.com/celestiaorg/celestia-node/pull/2553 swapping out FillBlocks by using the `txsim` 