### PR TITLE
fix(share/discovery): discovery should try to connect to empty hosts peers

### DIFF
--- a/share/p2p/discovery/discovery.go
+++ b/share/p2p/discovery/discovery.go
@@ -325,10 +325,6 @@ func (d *Discovery) handleDiscoveredPeer(ctx context.Context, peer peer.AddrInfo
 		d.metrics.observeHandlePeer(ctx, handlePeerSkipSelf)
 		logger.Debug("skip handle: self discovery")
 		return false
-	case len(peer.Addrs) == 0:
-		d.metrics.observeHandlePeer(ctx, handlePeerEmptyAddrs)
-		logger.Debug("skip handle: empty address list")
-		return false
 	case d.set.Size() >= d.set.Limit():
 		d.metrics.observeHandlePeer(ctx, handlePeerEnoughPeers)
 		logger.Debug("skip handle: enough peers found")


### PR DESCRIPTION
libp2p routed host will attempt to find address, if none are provided. First in `Peerstore`, then by calling `FindPeer`:
```
// if we were given some addresses, keep + use them.
	if len(pi.Addrs) > 0 {
		rh.Peerstore().AddAddrs(pi.ID, pi.Addrs, peerstore.TempAddrTTL)
	}

	// Check if we have some addresses in our recent memory.
	addrs := rh.Peerstore().Addrs(pi.ID)
	if len(addrs) < 1 {
		// no addrs? find some with the routing system.
		var err error
		addrs, err = rh.findPeerAddrs(ctx, pi.ID)
		if err != nil {
			return err
		}
	}
```
It is worth to try to connect in such case.