### PR TITLE
nodebuilder/core: Set default ports for RPC and GRPC

### DIFF
--- a/nodebuilder/core/config.go
+++ b/nodebuilder/core/config.go
@@ -19,8 +19,8 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		IP:       "",
-		RPCPort:  "",
-		GRPCPort: "",
+		RPCPort:  "26657",
+		GRPCPort: "9090",
 	}
 }
 


### PR DESCRIPTION
Now that we short-circuit on the IP address being empty, it's fine to set defaults for RPC and GRPC ports 

This fixes swamp tests as well