### PR TITLE
fix: fixing panic on GetShare with out of bounds indexes

### DIFF
--- a/share/getter.go
+++ b/share/getter.go
@@ -13,6 +13,8 @@ import (
 var (
 	// ErrNotFound is used to indicate that requested data could not be found.
 	ErrNotFound = errors.New("share: data not found")
+	// ErrOutOfBounds is used to indicate that a passed row or column index is out of bounds of the square size.
+	ErrOutOfBounds = errors.New("share: row or column index is larger than square size")
 )
 
 // Getter interface provides a set of accessors for shares by the Root.

--- a/share/getters/cascade.go
+++ b/share/getters/cascade.go
@@ -3,8 +3,6 @@ package getters
 import (
 	"context"
 	"errors"
-	"fmt"
-
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -38,9 +36,10 @@ func (cg *CascadeGetter) GetShare(ctx context.Context, root *share.Root, row, co
 		attribute.Int("col", col),
 	))
 	defer span.End()
-	if row >= len(root.RowRoots) || col >= len(root.ColumnRoots) {
-		err := fmt.Errorf("cascade/get-share: invalid indexes were provided:rowIndex=%d, colIndex=%d."+
-			"squarewidth=%d", row, col, len(root.RowRoots))
+
+	upperBound := len(root.RowRoots)
+	if row >= upperBound || col >= upperBound {
+		err := share.ErrOutOfBounds
 		span.RecordError(err)
 		return nil, err
 	}

--- a/share/getters/cascade.go
+++ b/share/getters/cascade.go
@@ -3,6 +3,7 @@ package getters
 import (
 	"context"
 	"errors"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 

--- a/share/getters/getter_test.go
+++ b/share/getters/getter_test.go
@@ -107,6 +107,10 @@ func TestStoreGetter(t *testing.T) {
 			}
 		}
 
+		// doesn't panic on indexes too high
+		_, err := sg.GetShare(ctx, &dah, squareSize, squareSize)
+		require.ErrorIs(t, err, share.ErrOutOfBounds)
+
 		// root not found
 		_, dah = randomEDS(t)
 		_, err = sg.GetShare(ctx, &dah, 0, 0)
@@ -182,6 +186,10 @@ func TestIPLDGetter(t *testing.T) {
 				assert.Equal(t, randEds.GetCell(uint(i), uint(j)), share)
 			}
 		}
+
+		// doesn't panic on indexes too high
+		_, err := sg.GetShare(ctx, &dah, squareSize+1, squareSize+1)
+		require.ErrorIs(t, err, share.ErrOutOfBounds)
 
 		// root not found
 		_, dah = randomEDS(t)

--- a/share/getters/ipld.go
+++ b/share/getters/ipld.go
@@ -48,6 +48,10 @@ func (ig *IPLDGetter) GetShare(ctx context.Context, dah *share.Root, row, col in
 		utils.SetStatusAndEnd(span, err)
 	}()
 
+	upperBound := len(dah.RowRoots)
+	if row >= upperBound || col >= upperBound {
+		return nil, share.ErrOutOfBounds
+	}
 	root, leaf := ipld.Translate(dah, row, col)
 
 	// wrap the blockservice in a session if it has been signaled in the context.

--- a/share/getters/ipld.go
+++ b/share/getters/ipld.go
@@ -50,7 +50,9 @@ func (ig *IPLDGetter) GetShare(ctx context.Context, dah *share.Root, row, col in
 
 	upperBound := len(dah.RowRoots)
 	if row >= upperBound || col >= upperBound {
-		return nil, share.ErrOutOfBounds
+		err := share.ErrOutOfBounds
+		span.RecordError(err)
+		return nil, err
 	}
 	root, leaf := ipld.Translate(dah, row, col)
 

--- a/share/getters/store.go
+++ b/share/getters/store.go
@@ -43,6 +43,10 @@ func (sg *StoreGetter) GetShare(ctx context.Context, dah *share.Root, row, col i
 		utils.SetStatusAndEnd(span, err)
 	}()
 
+	upperBound := len(dah.RowRoots)
+	if row >= upperBound || col >= upperBound {
+		return nil, share.ErrOutOfBounds
+	}
 	root, leaf := ipld.Translate(dah, row, col)
 	bs, err := sg.store.CARBlockstore(ctx, dah.Hash())
 	if errors.Is(err, eds.ErrNotFound) {

--- a/share/getters/store.go
+++ b/share/getters/store.go
@@ -45,7 +45,9 @@ func (sg *StoreGetter) GetShare(ctx context.Context, dah *share.Root, row, col i
 
 	upperBound := len(dah.RowRoots)
 	if row >= upperBound || col >= upperBound {
-		return nil, share.ErrOutOfBounds
+		err := share.ErrOutOfBounds
+		span.RecordError(err)
+		return nil, err
 	}
 	root, leaf := ipld.Translate(dah, row, col)
 	bs, err := sg.store.CARBlockstore(ctx, dah.Hash())


### PR DESCRIPTION
GetShare would panic on RPC calls if the passed indicies were out of bounds.