### PR TITLE
Feat: `GetSharesByNamespace` by reading shares from the stored CAR file

### DIFF
--- a/share/car/get_shares.go
+++ b/share/car/get_shares.go
@@ -1,0 +1,134 @@
+package car
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-car"
+
+	"github.com/celestiaorg/nmt"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/celestia-node/share/ipld"
+)
+
+// ReadSharesByNamespace reads all shares within the given namespace for the given root
+// by reading them sequentially from the stored CARv1 file in the eds.Store.
+// The shares are read sequentially row by row for each quadrant, and are filtered
+// by the given namespace.
+func ReadSharesByNamespace(
+	ctx context.Context,
+	store *eds.Store,
+	root *share.Root,
+	namespace share.Namespace,
+) (share.NamespacedShares, error) {
+	rowRootCIDs := make([]cid.Cid, 0, len(root.RowRoots))
+	for _, row := range root.RowRoots {
+		if !namespace.IsOutsideRange(row, row) {
+			rowRootCIDs = append(rowRootCIDs, ipld.MustCidFromNamespacedSha256(row))
+		}
+	}
+
+	if len(rowRootCIDs) == 0 {
+		return nil, nil
+	}
+
+	r, err := store.GetCAR(ctx, root.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("car: failed to retrieve CAR for root %s: %w", root.Hash(), err)
+	}
+
+	carReader, err := car.NewCarReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("car: reading car file: %w", err)
+	}
+
+	// shares are ordered by quadrant row-by-row
+	// e.g: [ Q1 R1 | Q1 R2 | Q1 R3 | Q1 R4 | Q2 R1 | Q2 R2 .... ]
+	// thus we read the car file in quadrants
+	odsWidth := len(carReader.Header.Roots) / 4
+	odsSquareSize := odsWidth * odsWidth
+
+	shares := make([][]byte, odsSquareSize*2)
+	// the first and second quadrant are stored directly after the header,
+	// so we can just read the first odsSquareSize*2 blocks
+	for i := 0; i < odsSquareSize*2; i++ {
+		block, err := carReader.Next()
+		if err != nil {
+			return nil, fmt.Errorf("share: reading next car entry: %w", err)
+		}
+		shares[i] = block.RawData()
+	}
+
+	// construct eds rows by concatenating rows of the first
+	// and second quadrant that are on the same level
+	// [ Q1 R1 | Q2 R1 ]
+	// [ Q1 R2 | Q2 R2 ]
+	// [ Q1 R3 | Q2 R3 ]
+	// [ Q1 R4 | Q2 R4 ]
+	// this is done to be able to compute the row roots and proofs
+	rows := make([][][]byte, odsWidth)
+	for i := 0; i < odsWidth; i++ {
+		row := make([][]byte, 0)
+		row = append(row, shares[i*odsWidth:(i+1)*odsWidth]...)
+		row = append(row, shares[odsSquareSize+i*odsWidth:odsSquareSize+(i+1)*odsWidth]...)
+		rows[i] = row
+	}
+
+	namespacedShares := make(share.NamespacedShares, 0)
+	for _, row := range rows {
+		rowRoot, proof, err := getRowRootAndProof(row, namespace)
+		if err != nil {
+			return nil, fmt.Errorf("car: failed to compute row root and proof: %w", err)
+		}
+
+		// skip row if it is outside the namespace
+		if namespace.IsOutsideRange(rowRoot, rowRoot) {
+			continue
+		}
+
+		// remove the prepended namespace from the shares
+		rowShares := make([][]byte, 0)
+		for _, shr := range row {
+			if bytes.Equal(share.GetNamespace(shr), namespace.ToNMT()) {
+				rowShares = append(rowShares, share.GetData(shr))
+			}
+		}
+
+		namespacedShares = append(namespacedShares, share.NamespacedRow{
+			Shares: rowShares,
+			Proof:  proof,
+		})
+	}
+
+	return namespacedShares, nil
+}
+
+// getRowRootAndProof computes the nmt root and proof for a given row of shares.
+func getRowRootAndProof(row [][]byte, namespace share.Namespace) ([]byte, *nmt.Proof, error) {
+	tree := nmt.New(sha256.New(), nmt.NamespaceIDSize(share.NamespaceSize), nmt.IgnoreMaxNamespace(true))
+
+	// we push raw eds shares to the tree, which are wrapped with the namespace twice
+	for _, d := range row {
+		if err := tree.Push(d); err != nil {
+			return nil, nil, fmt.Errorf("car: failed to build nmt tree for namespace proving: %w", err)
+		}
+	}
+
+	// compute the root
+	root, err := tree.Root()
+	if err != nil {
+		return nil, nil, fmt.Errorf("car: failed to compute nmt tree root for row: %w", err)
+	}
+
+	proof, err := tree.ProveNamespace(namespace.ToNMT())
+	if err != nil {
+		return nil, nil, fmt.Errorf("car: failed to compute namespace proof: %w", err)
+	}
+
+	return root, &proof, nil
+}

--- a/share/car/get_shares_test.go
+++ b/share/car/get_shares_test.go
@@ -1,0 +1,144 @@
+package car
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"sort"
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-app/pkg/da"
+	"github.com/celestiaorg/celestia-app/pkg/wrapper"
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/celestia-node/share/sharetest"
+)
+
+type testNamespacedShares struct {
+	ns     share.Namespace
+	shares [][]byte
+}
+
+func TestReadSharesByNamespace(t *testing.T) {
+	// context with timeout
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// initialize eds.Store with random EDS data
+	store, err := newStore(t)
+	require.NoError(t, err)
+
+	// create a random root
+	namespaces := []share.Namespace{
+		sharetest.RandV0Namespace(),
+		sharetest.RandV0Namespace(),
+	}
+
+	nsShares, eds, dah := randEDSWithNamespaces(t, 4, namespaces...)
+	require.NoError(t, err)
+
+	err = store.Start(ctx)
+	require.NoError(t, err)
+
+	// write EDS to store
+	err = store.Put(ctx, dah.Hash(), eds)
+	require.NoError(t, err)
+
+	// read shares by namespace
+	for _, ns := range namespaces {
+		shares, err := ReadSharesByNamespace(ctx, store, &dah, ns)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, len(shares))
+
+		nsshares := nsShares[string(ns)].shares
+		assert.Equal(t, len(nsshares), len(shares.Flatten()))
+
+		require.NoError(t, shares.Verify(&dah, ns))
+
+		for i, shr := range shares.Flatten() {
+			assert.Equal(t, share.GetNamespace(nsshares[i]), share.GetNamespace(shr))
+			assert.Equal(t, nsshares[i], shr)
+		}
+
+		rowRoots, err := eds.RowRoots()
+		require.NoError(t, err)
+
+		roots := make([][]byte, 0)
+		for _, root := range rowRoots {
+			if ns.IsOutsideRange(root, root) {
+				continue
+			}
+			roots = append(roots, root)
+		}
+
+		rows := []share.NamespacedRow(shares)
+		for i, row := range rows {
+			proof := row.Proof.VerifyInclusion(
+				sha256.New(),
+				ns.ToNMT(),
+				row.Shares,
+				roots[i],
+			)
+			assert.True(t, proof)
+
+			leaves := make([][]byte, len(row.Shares))
+			for i := range leaves {
+				shr := row.Shares[i]
+				leaves[i] = append(share.GetNamespace(shr), shr...)
+			}
+
+			proof = row.Proof.VerifyNamespace(
+				sha256.New(),
+				ns.ToNMT(),
+				leaves,
+				roots[i],
+			)
+			assert.True(t, proof)
+		}
+	}
+
+	err = store.Stop(ctx)
+	require.NoError(t, err)
+}
+
+// TODO: we need to generate a random EDS with multiple namespaces
+func randEDSWithNamespaces(
+	t require.TestingT,
+	size int,
+	namespaces ...share.Namespace,
+) (namespacedShares map[string]testNamespacedShares, eds *rsmt2d.ExtendedDataSquare, dah da.DataAvailabilityHeader) {
+	shares := make([][]byte, 0)
+	sharesSize := (size * size) / len(namespaces)
+	namespacedShares = map[string]testNamespacedShares{}
+	for _, ns := range namespaces {
+		nsShares := sharetest.RandSharesWithNamespace(t, ns, sharesSize)
+		namespacedShares[string(ns)] = testNamespacedShares{ns, nsShares}
+		shares = append(shares, nsShares...)
+	}
+	sort.Slice(shares, func(i, j int) bool { return bytes.Compare(shares[i], shares[j]) < 0 })
+	eds, err := rsmt2d.ComputeExtendedDataSquare(
+		shares,
+		share.DefaultRSMT2DCodec(),
+		wrapper.NewConstructor(uint64(size)),
+	)
+	require.NoError(t, err, "failure to recompute the extended data square")
+	dah, err = da.NewDataAvailabilityHeader(eds)
+	require.NoError(t, err)
+	return
+}
+
+func newStore(t *testing.T) (*eds.Store, error) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	return eds.NewStore(tmpDir, ds)
+}


### PR DESCRIPTION
## Overview

Addresses https://github.com/celestiaorg/celestia-node/issues/2618

Implements `ReadSharesByNamespace` which reads shares sequentially from the stored CAR file and updates the store getter to use it instead of `ipld.GetSharesByNamespace`

## TODO:
- [x] Finish implementation 
- [x] Unit tests

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
