### PR TITLE
chore(deps): bump golanci-lint workflow

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:
-          version: v1.52.2
+          version: v1.54.2
 
   go_mod_tidy_check:
     name: Go Mod Tidy Check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
 linters:
   enable:
     - bodyclose
-     # - depguard as of v1.54.2, the default config throws errors on our repository
+     # - depguard as of v1.54.2, the default config throws errors on our repo
     - dogsled
     - dupl
     - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
 linters:
   enable:
     - bodyclose
-    - depguard
+     # - depguard as of v1.54.2, the default config throws errors on our repository
     - dogsled
     - dupl
     - errcheck

--- a/cmd/celestia/rpc.go
+++ b/cmd/celestia/rpc.go
@@ -23,7 +23,7 @@ import (
 	"github.com/celestiaorg/celestia-node/state"
 )
 
-const authEnvKey = "CELESTIA_NODE_AUTH_TOKEN"
+const authEnvKey = "CELESTIA_NODE_AUTH_TOKEN" //nolint:gosec
 
 var requestURL string
 var authTokenFlag string

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -114,7 +114,7 @@ func removeConfig(path string) error {
 func UpdateConfig(tp node.Type, path string) (err error) {
 	path, err = storePath(path)
 	if err != nil {
-		return
+		return err
 	}
 
 	flock, err := fslock.Lock(lockPath(path))
@@ -122,7 +122,7 @@ func UpdateConfig(tp node.Type, path string) (err error) {
 		if err == fslock.ErrLocked {
 			err = ErrOpened
 		}
-		return
+		return err
 	}
 	defer flock.Unlock() //nolint: errcheck
 
@@ -131,18 +131,18 @@ func UpdateConfig(tp node.Type, path string) (err error) {
 	cfgPath := configPath(path)
 	cfg, err := LoadConfig(cfgPath)
 	if err != nil {
-		return
+		return err
 	}
 
 	cfg, err = updateConfig(cfg, newCfg)
 	if err != nil {
-		return
+		return err
 	}
 
 	// save the updated config
 	err = removeConfig(cfgPath)
 	if err != nil {
-		return
+		return err
 	}
 	return SaveConfig(cfgPath, cfg)
 }

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -195,11 +195,11 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 	}
 
 	appblobs := make([]*apptypes.Blob, len(blobs))
-	for i, b := range blobs {
-		if err := b.Namespace().ValidateForBlob(); err != nil {
+	for i := range blobs {
+		if err := blobs[i].Namespace().ValidateForBlob(); err != nil {
 			return nil, err
 		}
-		appblobs[i] = &b.Blob
+		appblobs[i] = &blobs[i].Blob
 	}
 
 	// we only estimate gas if the user wants us to (by setting the gasLim to 0). In the future we may


### PR DESCRIPTION
Self explanatory. The reason for the fix in core_accessor was an implicit memory aliasing. It was taking the address of the loop variable, which doesn't change in between iterations ofc, so the every blob pointed to the last blob