### PR TITLE
chore(nodebuilder/header): Update trusting period to two weeks

### DIFF
--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -69,7 +69,7 @@ func newSyncer[H libhead.Header[H]](
 ) (*sync.Syncer[H], *modfraud.ServiceBreaker[*sync.Syncer[H], H], error) {
 	syncer, err := sync.NewSyncer[H](ex, store, sub,
 		sync.WithParams(cfg.Syncer),
-		sync.WithTrustingPeriod(time.Hour*336),
+		sync.WithTrustingPeriod(time.Hour*336), // set a trusting period of two weeks
 		sync.WithBlockTime(modp2p.BlockTime),
 	)
 	if err != nil {

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -2,6 +2,7 @@ package header
 
 import (
 	"context"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -68,6 +69,7 @@ func newSyncer[H libhead.Header[H]](
 ) (*sync.Syncer[H], *modfraud.ServiceBreaker[*sync.Syncer[H], H], error) {
 	syncer, err := sync.NewSyncer[H](ex, store, sub,
 		sync.WithParams(cfg.Syncer),
+		sync.WithTrustingPeriod(time.Hour*336),
 		sync.WithBlockTime(modp2p.BlockTime),
 	)
 	if err != nil {


### PR DESCRIPTION
Updates trusting period to two weeks instead of one week for celestia-node

Closes #2610 