### PR TITLE
feat(modp2p): listen on WebTransport by default

### DIFF
--- a/nodebuilder/p2p/config.go
+++ b/nodebuilder/p2p/config.go
@@ -40,6 +40,8 @@ type Config struct {
 func DefaultConfig(tp node.Type) Config {
 	return Config{
 		ListenAddresses: []string{
+			"/ip4/0.0.0.0/udp/2121/quic-v1/webtransport",
+			"/ip6/::/udp/2121/quic-v1/webtransport",
 			"/ip4/0.0.0.0/udp/2121/quic-v1",
 			"/ip6/::/udp/2121/quic-v1",
 			"/ip4/0.0.0.0/tcp/2121",
@@ -47,6 +49,9 @@ func DefaultConfig(tp node.Type) Config {
 		},
 		AnnounceAddresses: []string{},
 		NoAnnounceAddresses: []string{
+			"/ip4/127.0.0.1/udp/2121/quic-v1/webtransport",
+			"/ip4/0.0.0.0/udp/2121/quic-v1/webtransport",
+			"/ip6/::/udp/2121/quic-v1/webtransport",
 			"/ip4/0.0.0.0/udp/2121/quic-v1",
 			"/ip4/127.0.0.1/udp/2121/quic-v1",
 			"/ip6/::/udp/2121/quic-v1",


### PR DESCRIPTION
We already support WT as part of default libp2p supported transport, but node won't receive any connections unless they explicitly listen to them and this PR changes that/