### PR TITLE
feat(cmd/blob): add fee and gasLimit flags

### DIFF
--- a/cmd/celestia/blob.go
+++ b/cmd/celestia/blob.go
@@ -46,7 +46,7 @@ func init() {
 
 	submitCmd.PersistentFlags().Uint64Var(
 		&gasLimit,
-		"gas-limit",
+		"gas.limit",
 		0,
 		"specifies max gas for the blob submission",
 	)

--- a/cmd/celestia/blob.go
+++ b/cmd/celestia/blob.go
@@ -14,7 +14,12 @@ import (
 	"github.com/celestiaorg/celestia-node/share"
 )
 
-var base64Flag bool
+var (
+	base64Flag bool
+
+	fee      int64
+	gasLimit uint64
+)
 
 func init() {
 	blobCmd.AddCommand(getCmd, getAllCmd, submitCmd, getProofCmd)
@@ -30,6 +35,20 @@ func init() {
 		"base64",
 		false,
 		"printed blob's data as a base64 string",
+	)
+
+	submitCmd.PersistentFlags().Int64Var(
+		&fee,
+		"fee",
+		-1,
+		"specifies fee for blob submission",
+	)
+
+	submitCmd.PersistentFlags().Uint64Var(
+		&gasLimit,
+		"gas-limit",
+		0,
+		"specifies max gas for the blob submission",
 	)
 }
 
@@ -118,7 +137,11 @@ var submitCmd = &cobra.Command{
 			return fmt.Errorf("error creating a blob:%v", err)
 		}
 
-		height, err := client.Blob.Submit(cmd.Context(), []*blob.Blob{parsedBlob}, nil)
+		height, err := client.Blob.Submit(
+			cmd.Context(),
+			[]*blob.Blob{parsedBlob},
+			&blob.SubmitOptions{Fee: fee, GasLimit: gasLimit},
+		)
 
 		response := struct {
 			Height     uint64          `json:"height"`


### PR DESCRIPTION
## Overview
Added fee and gasLimit flags to submit the blob

Tested on arabica-10:

```go
celestia rpc blob submit 0x42690c204d39600fddd3 'gm' --fee 10000
{
  "result": {
    "height": 62559,
    "commitment": "IXg+08HV5RsPF3Lle8PH+B2TUGsGUsBiseflxh6wB5E="
  }
}

celestia rpc blob submit 0x42690c204d39600fddd3 'gm' --fee 10000 --gas.limit 100000
{
  "result": {
    "height": 62561,
    "commitment": "IXg+08HV5RsPF3Lle8PH+B2TUGsGUsBiseflxh6wB5E="
  }
}

celestia rpc blob submit 0x42690c204d39600fddd3 'gm' --gas.limit 100000
{
  "result": {
    "height": 62562,
    "commitment": "IXg+08HV5RsPF3Lle8PH+B2TUGsGUsBiseflxh6wB5E="
  }
}
```
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords

cc @jcstein 