### PR TITLE
fix(modshare): start peer manager after Syncer

### DIFF
--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/fx"
 
 	libhead "github.com/celestiaorg/go-header"
+	"github.com/celestiaorg/go-header/sync"
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -151,6 +152,9 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 				connGater *conngater.BasicConnectionGater,
 				shrexSub *shrexsub.PubSub,
 				headerSub libhead.Subscriber[*header.ExtendedHeader],
+				// we must ensure Syncer is started before PeerManager
+				// so that Syncer registers header validator before PeerManager subscribes to headers
+				_ *sync.Syncer[*header.ExtendedHeader],
 			) (*peers.Manager, error) {
 				return peers.NewManager(
 					params,


### PR DESCRIPTION
Fixes panic:

```
panic: invalid type received %!s(<nil>)

goroutine 602 [running]:
github.com/celestiaorg/go-header/p2p.(*subscription[...]).NextHeader(0x103fbeaa0?, {0x103fdcd50, 0x14000723310?})
	/Users/rford/go/pkg/mod/github.com/celestiaorg/go-header@v0.3.1/p2p/subscription.go:44 +0x2ac
github.com/celestiaorg/celestia-node/share/p2p/peers.(*Manager).subscribeHeader(0x1400158c960, {0x103fdcd50, 0x14000723310}, {0x103fbe928?, 0x14000676250?})
	/Users/rford/Programming/Celestia/celestia-node/share/p2p/peers/manager.go:299 +0xc0
created by github.com/celestiaorg/celestia-node/share/p2p/peers.(*Manager).Start in goroutine 262
	/Users/rford/Programming/Celestia/celestia-node/share/p2p/peers/manager.go:180 +0x410
```