### PR TITLE
WIP: POC Storage Pruning

### DIFF
--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -24,7 +24,7 @@ func TestCoreExchange_RequestHeaders(t *testing.T) {
 
 	store := createStore(t)
 
-	ce := NewExchange(fetcher, store, header.MakeExtendedHeader)
+	ce := NewExchange(fetcher, store, nil, header.MakeExtendedHeader)
 	headers, err := ce.GetRangeByHeight(context.Background(), 1, 10)
 	require.NoError(t, err)
 

--- a/core/listener_test.go
+++ b/core/listener_test.go
@@ -169,7 +169,7 @@ func createListener(
 		require.NoError(t, p2pSub.Stop(ctx))
 	})
 
-	return NewListener(p2pSub, fetcher, edsSub.Broadcast, header.MakeExtendedHeader, store, nodep2p.BlockTime)
+	return NewListener(p2pSub, fetcher, edsSub.Broadcast, header.MakeExtendedHeader, store, nil, nodep2p.BlockTime)
 }
 
 func createEdsPubSub(ctx context.Context, t *testing.T) *shrexsub.PubSub {

--- a/das/daser.go
+++ b/das/daser.go
@@ -153,12 +153,14 @@ func (d *DASer) Stop(ctx context.Context) error {
 }
 
 func (d *DASer) sample(ctx context.Context, h *header.ExtendedHeader) error {
-	var err error
 	if d.pruner != nil {
-		err = d.pruner.SampleAndRegister(ctx, h)
-	} else {
-		err = d.da.SharesAvailable(ctx, h.DAH)
+		err := d.pruner.Register(ctx, h)
+		if err != nil {
+			return err
+		}
 	}
+
+	err := d.da.SharesAvailable(ctx, h.DAH)
 	if err != nil {
 		var byzantineErr *byzantine.ErrByzantine
 		if errors.As(err, &byzantineErr) {

--- a/das/daser.go
+++ b/das/daser.go
@@ -102,6 +102,10 @@ func (d *DASer) Start(ctx context.Context) error {
 		// will be able to find new head from subscriber after it is started
 		if h, err := d.getter.Head(ctx); err == nil {
 			cp.NetworkHead = h.Height()
+			// underflow protection
+			if h.Height() > d.params.RecencyWindow {
+				cp.SampleFrom = max(cp.SampleFrom, cp.NetworkHead-d.params.RecencyWindow)
+			}
 		}
 	}
 	log.Info("starting DASer from checkpoint: ", cp.String())

--- a/das/options.go
+++ b/das/options.go
@@ -64,7 +64,7 @@ func DefaultParameters() Parameters {
 		SampleFrom:              1,
 		// TODO: this should inherit block time from p2p config
 		// SampleTimeout = block time * max amount of catchup workers
-		SampleTimeout:  15 * time.Second * time.Duration(concurrencyLimit),
+		SampleTimeout: 15 * time.Second * time.Duration(concurrencyLimit),
 		RecencyWindow:  uint64((time.Hour * 24 * 28) / (15 * time.Second)),
 		PruningEnabled: false,
 	}

--- a/das/options.go
+++ b/das/options.go
@@ -64,7 +64,7 @@ func DefaultParameters() Parameters {
 		SampleFrom:              1,
 		// TODO: this should inherit block time from p2p config
 		// SampleTimeout = block time * max amount of catchup workers
-		SampleTimeout: 15 * time.Second * time.Duration(concurrencyLimit),
+		SampleTimeout:  15 * time.Second * time.Duration(concurrencyLimit),
 		RecencyWindow:  uint64((time.Hour * 24 * 28) / (15 * time.Second)),
 		PruningEnabled: false,
 	}

--- a/das/pruner/pruner.go
+++ b/das/pruner/pruner.go
@@ -1,0 +1,85 @@
+package pruner
+
+import (
+	"context"
+
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	libhead "github.com/celestiaorg/go-header"
+	"github.com/ipfs/go-datastore"
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("pruner")
+
+type Config struct {
+	RecencyWindow uint64
+	BatchSize    uint64
+}
+
+type StoragePruner struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	cfg *Config
+
+	edsStore *eds.Store
+	hsub     libhead.Subscriber[*header.ExtendedHeader]
+	da 		 share.Availability
+	ds       datastore.Batching
+
+	networkHead      uint64
+	lastPrunedHeight uint64
+}
+
+func NewStoragePruner(edsStore *eds.Store, hsub libhead.Subscriber[*header.ExtendedHeader], ds datastore.Batching) *StoragePruner {
+	return &StoragePruner{
+		edsStore: edsStore,
+		hsub:     hsub,
+		ds:       ds,
+	}
+}
+
+func (sp *StoragePruner) Start(ctx context.Context) error {
+	sp.ctx, sp.cancel = context.WithCancel(context.Background())
+
+	sub, err := sp.hsub.Subscribe()
+	if err != nil {
+		return err
+	}
+
+	go sp.listenForHeaders(sp.ctx, sub)
+	return nil
+}
+
+func (sp *StoragePruner) Stop(ctx context.Context) error {
+	// TODO: Should we do done channels and a select to ensure services are fully stopped before returning?
+	sp.cancel()
+	return nil
+}
+
+func (sp *StoragePruner) SampleAndRegister(ctx context.Context, h *header.ExtendedHeader) error {
+	
+}
+
+func (sp *StoragePruner) listenForHeaders(ctx context.Context, sub libhead.Subscription[*header.ExtendedHeader]) {
+	for {
+		h, err := sub.NextHeader(ctx)
+		if err != nil {
+			if err == context.Canceled {
+				return
+			}
+
+			log.Errorw("failed to get next header", "err", err)
+			continue
+		}
+		newHeight := h.Height()
+		if newHeight <= sp.networkHead {
+			log.Warnf("received head height: %v, which is lower or the same as previously known: %v", newHeight, sp.networkHead)
+			continue
+		}
+
+		sp.networkHead = newHeight
+	}
+}

--- a/das/pruner/pruner.go
+++ b/das/pruner/pruner.go
@@ -2,10 +2,14 @@ package pruner
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/availability/full"
 	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/celestia-node/share/getters"
+	"github.com/celestiaorg/celestia-node/share/p2p/discovery"
 	libhead "github.com/celestiaorg/go-header"
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
@@ -13,9 +17,12 @@ import (
 
 var log = logging.Logger("pruner")
 
+// TODO: Find sensible default
+var defaultBufferSize = 20
+
 type Config struct {
 	RecencyWindow uint64
-	BatchSize    uint64
+	BatchSize     uint64
 }
 
 type StoragePruner struct {
@@ -26,19 +33,33 @@ type StoragePruner struct {
 
 	edsStore *eds.Store
 	hsub     libhead.Subscriber[*header.ExtendedHeader]
-	da 		 share.Availability
 	ds       datastore.Batching
 
-	networkHead      uint64
-	lastPrunedHeight uint64
+	// TO DISCUSS: Maybe we should just modify full ShareAvailability to have methods for both GetAndPut and Get, and then use full Avail directly
+	getter *full.ShareAvailability
+	putter *full.ShareAvailability
+
+	networkHead uint64
+	registeredHeights chan uint64
 }
 
-func NewStoragePruner(edsStore *eds.Store, hsub libhead.Subscriber[*header.ExtendedHeader], ds datastore.Batching) *StoragePruner {
+func NewStoragePruner(
+	edsStore *eds.Store,
+	hsub libhead.Subscriber[*header.ExtendedHeader],
+	ds datastore.Batching,
+	disc *discovery.Discovery,
+	getter share.Getter,
+	originalAvail *full.ShareAvailability,
+) (*StoragePruner, error) {
+	teeGetter := getters.NewTeeGetter(getter, edsStore)
 	return &StoragePruner{
-		edsStore: edsStore,
-		hsub:     hsub,
-		ds:       ds,
-	}
+		edsStore:          edsStore,
+		hsub:              hsub,
+		ds:                ds,
+		getter:            originalAvail,
+		putter:            full.NewShareAvailability(edsStore, teeGetter, disc),
+		registeredHeights: make(chan uint64, defaultBufferSize),
+	}, nil
 }
 
 func (sp *StoragePruner) Start(ctx context.Context) error {
@@ -50,6 +71,7 @@ func (sp *StoragePruner) Start(ctx context.Context) error {
 	}
 
 	go sp.listenForHeaders(sp.ctx, sub)
+	go sp.prune(sp.ctx)
 	return nil
 }
 
@@ -60,7 +82,81 @@ func (sp *StoragePruner) Stop(ctx context.Context) error {
 }
 
 func (sp *StoragePruner) SampleAndRegister(ctx context.Context, h *header.ExtendedHeader) error {
-	
+	if sp.isRecent(h.Height()) {
+		err := sp.indexDAH(ctx, h)
+		if err != nil {
+			return err
+		}
+		// data only gets tee'd to storage if it is inside recency window
+		err = sp.putter.SharesAvailable(ctx, h.DAH)
+		if err != nil {
+			return err
+		}
+
+		sp.registeredHeights <- h.Height()
+		return nil
+	}
+
+	err := sp.getter.SharesAvailable(ctx, h.DAH)
+	if err != nil {
+		return err
+	}
+	// even heights that are not stored must be registered on the channel, so that the pruner knows to prune h.Height() - RecencyWindow
+	sp.registeredHeights <- h.Height()
+}
+
+func (sp *StoragePruner) indexDAH(ctx context.Context, h *header.ExtendedHeader) error {
+	k := datastore.NewKey(fmt.Sprintf("%d", h.Height()))
+	return sp.ds.Put(ctx, k, h.DAH.Hash())
+}
+
+func (sp *StoragePruner) isRecent(height uint64) bool {
+	return height > sp.networkHead-sp.cfg.RecencyWindow
+}
+
+// note: does not set sp.lastPrunedHeight
+func (sp *StoragePruner) pruneHeight(ctx context.Context, height uint64) error {
+	k := datastore.NewKey(fmt.Sprintf("%d", height))
+	// TODO(optimization): Use a counting bloom filter to check if the key exists in the datastore.
+	// This would avoid a hit to disk, and we can remove heights from the filter as we prune them to maintain a healthy false positive rate.
+	exists, err := sp.ds.Has(ctx, k)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		dah, err := sp.ds.Get(ctx, k)
+		if err != nil {
+			return err
+		}
+		err = sp.edsStore.Remove(ctx, dah)
+		if err != nil {
+			return err
+		}
+
+		// TODO(Optimization): Queue ds deletes for batch removal
+		err = sp.ds.Delete(ctx, k)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (sp *StoragePruner) prune(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		// TODO: Investigate edge cases where a height may not be removed.
+		// note: this means that pruning does not happen when a new header is received, but first when that height is stored
+		case height := <-sp.registeredHeights:
+			// TODO: batches
+			// TODO: ctx timeout
+			err := sp.pruneHeight(ctx, height-sp.cfg.RecencyWindow)
+			log.Errorw("failed to prune height", "height", height, "err", err)
+		}
+	}
 }
 
 func (sp *StoragePruner) listenForHeaders(ctx context.Context, sub libhead.Subscription[*header.ExtendedHeader]) {

--- a/das/pruner/pruner.go
+++ b/das/pruner/pruner.go
@@ -8,9 +8,6 @@ import (
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/availability/full"
 	"github.com/celestiaorg/celestia-node/share/eds"
-	"github.com/celestiaorg/celestia-node/share/getters"
-	"github.com/celestiaorg/celestia-node/share/p2p/discovery"
-	libhead "github.com/celestiaorg/go-header"
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 )
@@ -22,55 +19,43 @@ var defaultBufferSize = 20
 
 type Config struct {
 	RecencyWindow uint64
-	BatchSize     uint64
 }
 
 type StoragePruner struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	cfg *Config
+	cfg Config
 
 	edsStore *eds.Store
-	hsub     libhead.Subscriber[*header.ExtendedHeader]
 	ds       datastore.Batching
+	sa       *full.ShareAvailability
 
-	// TO DISCUSS: Maybe we should just modify full ShareAvailability to have methods for both GetAndPut and Get, and then use full Avail directly
-	getter *full.ShareAvailability
-	putter *full.ShareAvailability
-
-	networkHead uint64
 	registeredHeights chan uint64
+
+	// TODO: hsub is not necessary because we are working under the assumption that the DASer only syncs heights inside of the recency window anyways.
+	// remove after deciding completely on this assumption
+	// hsub     libhead.Subscriber[*header.ExtendedHeader]
+	// networkHead       uint64
 }
 
 func NewStoragePruner(
 	edsStore *eds.Store,
-	hsub libhead.Subscriber[*header.ExtendedHeader],
 	ds datastore.Batching,
-	disc *discovery.Discovery,
 	getter share.Getter,
-	originalAvail *full.ShareAvailability,
+	availability *full.ShareAvailability,
+	config Config,
 ) (*StoragePruner, error) {
-	teeGetter := getters.NewTeeGetter(getter, edsStore)
 	return &StoragePruner{
 		edsStore:          edsStore,
-		hsub:              hsub,
 		ds:                ds,
-		getter:            originalAvail,
-		putter:            full.NewShareAvailability(edsStore, teeGetter, disc),
+		sa:                availability,
 		registeredHeights: make(chan uint64, defaultBufferSize),
 	}, nil
 }
 
 func (sp *StoragePruner) Start(ctx context.Context) error {
 	sp.ctx, sp.cancel = context.WithCancel(context.Background())
-
-	sub, err := sp.hsub.Subscribe()
-	if err != nil {
-		return err
-	}
-
-	go sp.listenForHeaders(sp.ctx, sub)
 	go sp.prune(sp.ctx)
 	return nil
 }
@@ -82,27 +67,18 @@ func (sp *StoragePruner) Stop(ctx context.Context) error {
 }
 
 func (sp *StoragePruner) SampleAndRegister(ctx context.Context, h *header.ExtendedHeader) error {
-	if sp.isRecent(h.Height()) {
-		err := sp.indexDAH(ctx, h)
-		if err != nil {
-			return err
-		}
-		// data only gets tee'd to storage if it is inside recency window
-		err = sp.putter.SharesAvailable(ctx, h.DAH)
-		if err != nil {
-			return err
-		}
-
-		sp.registeredHeights <- h.Height()
-		return nil
-	}
-
-	err := sp.getter.SharesAvailable(ctx, h.DAH)
+	err := sp.indexDAH(ctx, h)
 	if err != nil {
 		return err
 	}
-	// even heights that are not stored must be registered on the channel, so that the pruner knows to prune h.Height() - RecencyWindow
+
+	err = sp.sa.SharesAvailable(ctx, h.DAH)
+	if err != nil {
+		return err
+	}
+
 	sp.registeredHeights <- h.Height()
+	return nil
 }
 
 func (sp *StoragePruner) indexDAH(ctx context.Context, h *header.ExtendedHeader) error {
@@ -110,15 +86,12 @@ func (sp *StoragePruner) indexDAH(ctx context.Context, h *header.ExtendedHeader)
 	return sp.ds.Put(ctx, k, h.DAH.Hash())
 }
 
-func (sp *StoragePruner) isRecent(height uint64) bool {
-	return height > sp.networkHead-sp.cfg.RecencyWindow
-}
-
 // note: does not set sp.lastPrunedHeight
 func (sp *StoragePruner) pruneHeight(ctx context.Context, height uint64) error {
 	k := datastore.NewKey(fmt.Sprintf("%d", height))
 	// TODO(optimization): Use a counting bloom filter to check if the key exists in the datastore.
 	// This would avoid a hit to disk, and we can remove heights from the filter as we prune them to maintain a healthy false positive rate.
+	// would also maybe allow for a more robust solution for pruning ranges so that we don't need to hit the disk for every height to check
 	exists, err := sp.ds.Has(ctx, k)
 	if err != nil {
 		return err
@@ -148,34 +121,14 @@ func (sp *StoragePruner) prune(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		// TODO: Investigate edge cases where a height may not be removed.
-		// note: this means that pruning does not happen when a new header is received, but first when that height is stored
+		// note: this means that pruning does not happen when a new header is received, but first when that height + RecencyWindow is stored
+		// the edge case here is that if a node goes offline for the length of the RecencyWindow, some blocks will not be pruned.
 		case height := <-sp.registeredHeights:
-			// TODO: batches
 			// TODO: ctx timeout
 			err := sp.pruneHeight(ctx, height-sp.cfg.RecencyWindow)
-			log.Errorw("failed to prune height", "height", height, "err", err)
-		}
-	}
-}
-
-func (sp *StoragePruner) listenForHeaders(ctx context.Context, sub libhead.Subscription[*header.ExtendedHeader]) {
-	for {
-		h, err := sub.NextHeader(ctx)
-		if err != nil {
-			if err == context.Canceled {
-				return
+			if err != nil {
+				log.Errorw("failed to prune height", "height", height, "err", err)
 			}
-
-			log.Errorw("failed to get next header", "err", err)
-			continue
 		}
-		newHeight := h.Height()
-		if newHeight <= sp.networkHead {
-			log.Warnf("received head height: %v, which is lower or the same as previously known: %v", newHeight, sp.networkHead)
-			continue
-		}
-
-		sp.networkHead = newHeight
 	}
 }

--- a/das/pruner/pruner_test.go
+++ b/das/pruner/pruner_test.go
@@ -1,0 +1,105 @@
+package pruner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	routinghelpers "github.com/libp2p/go-libp2p-routing-helpers"
+	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
+
+	"github.com/celestiaorg/celestia-app/pkg/da"
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/header/headertest"
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/availability/full"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	"github.com/celestiaorg/celestia-node/share/mocks"
+	"github.com/celestiaorg/celestia-node/share/p2p/discovery"
+	"github.com/celestiaorg/rsmt2d"
+	"github.com/ipfs/go-datastore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoragePruner_Prunes(t *testing.T) {
+	var (
+		count         = 20
+		recencyWindow = 5
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ctrl := gomock.NewController(t)
+	getter := mocks.NewMockGetter(ctrl)
+	tmpDir := t.TempDir()
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	edsStore, err := eds.NewStore(tmpDir, ds)
+	require.NoError(t, err)
+	availability := testAvailability(edsStore, getter)
+
+	// Create a new StoragePruner
+	sp, err := NewStoragePruner(edsStore, ds, getter, availability, &Config{
+		RecencyWindow: uint64(recencyWindow),
+	})
+	require.NoError(t, err)
+
+	err = edsStore.Start(ctx)
+	require.NoError(t, err)
+	err = sp.Start(ctx)
+	require.NoError(t, err)
+
+	// Setup: Generate count test EDSes and make the mock getter expect them
+	edses := make([]*rsmt2d.ExtendedDataSquare, count)
+	extendedHeaders := make([]*header.ExtendedHeader, count)
+	for i := 0; i < count; i++ {
+		eds := edstest.RandEDS(t, 16)
+		edses[i] = eds
+		dah, err := da.NewDataAvailabilityHeader(eds)
+
+		randHeader := headertest.RandExtendedHeader(t)
+		randHeader.DataHash = dah.Hash()
+		randHeader.DAH = &dah
+		randHeader.RawHeader.Height = int64(i + 1)
+		extendedHeaders[i] = randHeader
+
+		require.NoError(t, err)
+
+		getter.EXPECT().GetEDS(gomock.Any(), &dah).Return(eds, nil).AnyTimes()
+	}
+
+	// 1. Verify that the first EDSes get stored and are retrievable.
+	for i := 0; i < recencyWindow; i++ {
+		sp.SampleAndRegister(ctx, extendedHeaders[i])
+	}
+
+	for i := 0; i < recencyWindow; i++ {
+		has, err := edsStore.Has(ctx, extendedHeaders[i].DAH.Hash())
+		require.True(t, has)
+		require.NoError(t, err)
+	}
+
+	// 2. Verify that after RecencyWindow EDSes, the oldest EDSes get pruned.
+	for i := recencyWindow; i < count; i++ {
+		sp.SampleAndRegister(ctx, extendedHeaders[i])
+		// It takes time for the old data to be pruned, so check 10 times
+		for j := 0; j < 10; j++ {
+			time.Sleep(100 * time.Millisecond)
+			has, err := edsStore.Has(ctx, extendedHeaders[i-recencyWindow].DAH.Hash())
+			require.False(t, has)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func testAvailability(store *eds.Store, getter share.Getter) *full.ShareAvailability {
+	disc := discovery.NewDiscovery(
+		nil,
+		routing.NewRoutingDiscovery(routinghelpers.Null{}),
+		discovery.WithAdvertiseInterval(time.Second),
+		discovery.WithPeersLimit(10),
+	)
+	return full.NewShareAvailability(store, getter, disc)
+}

--- a/das/pruner/pruner_test.go
+++ b/das/pruner/pruner_test.go
@@ -41,7 +41,7 @@ func TestStoragePruner_Prunes(t *testing.T) {
 	availability := testAvailability(edsStore, getter)
 
 	// Create a new StoragePruner
-	sp, err := NewStoragePruner(edsStore, ds, getter, availability, &Config{
+	sp, err := NewStoragePruner(edsStore, ds, getter, availability, Config{
 		RecencyWindow: uint64(recencyWindow),
 	})
 	require.NoError(t, err)

--- a/das/state.go
+++ b/das/state.go
@@ -141,7 +141,7 @@ func (s *coordinatorState) isNewHead(newHead uint64) bool {
 	return true
 }
 
-func (s *coordinatorState) updateHead(newHead uint64) {
+func (s *coordinatorState)  updateHead(newHead uint64) {
 	if s.networkHead == s.sampleFrom {
 		log.Infow("found first header, starting sampling")
 	}

--- a/nodebuilder/core/module.go
+++ b/nodebuilder/core/module.go
@@ -8,6 +8,7 @@ import (
 	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/core"
+	"github.com/celestiaorg/celestia-node/das/pruner"
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -43,8 +44,10 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 					pubsub *shrexsub.PubSub,
 					construct header.ConstructFn,
 					store *eds.Store,
+					// TODO: Pruner is not always supplied, so find a way to make it optional
+					pruner *pruner.StoragePruner,
 				) *core.Listener {
-					return core.NewListener(bcast, fetcher, pubsub.Broadcast, construct, store, p2p.BlockTime)
+					return core.NewListener(bcast, fetcher, pubsub.Broadcast, construct, store, pruner, p2p.BlockTime)
 				},
 				fx.OnStart(func(ctx context.Context, listener *core.Listener) error {
 					return listener.Start(ctx)

--- a/nodebuilder/das/config.go
+++ b/nodebuilder/das/config.go
@@ -31,6 +31,7 @@ func DefaultConfig(tp node.Type) Config {
 		// Full node uses shrex with fallback to ipld to sample, so need 2x amount of time in worst case
 		// scenario
 		cfg.SampleTimeout = 2 * modp2p.BlockTime * time.Duration(cfg.ConcurrencyLimit)
+		cfg.PruningEnabled = true
 	}
 	return Config(cfg)
 }

--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -92,7 +92,6 @@ func lightGetter(
 // by shrex the next time the data is retrieved (meaning shard recovery is
 // manual after corruption is detected).
 func bridgeGetter(
-	store *eds.Store,
 	storeGetter *getters.StoreGetter,
 	shrexGetter *getters.ShrexGetter,
 	cfg Config,
@@ -100,13 +99,12 @@ func bridgeGetter(
 	var cascade []share.Getter
 	cascade = append(cascade, storeGetter)
 	if cfg.UseShareExchange {
-		cascade = append(cascade, getters.NewTeeGetter(shrexGetter, store))
+		cascade = append(cascade, shrexGetter)
 	}
 	return getters.NewCascadeGetter(cascade)
 }
 
 func fullGetter(
-	store *eds.Store,
 	storeGetter *getters.StoreGetter,
 	shrexGetter *getters.ShrexGetter,
 	ipldGetter *getters.IPLDGetter,
@@ -115,8 +113,8 @@ func fullGetter(
 	var cascade []share.Getter
 	cascade = append(cascade, storeGetter)
 	if cfg.UseShareExchange {
-		cascade = append(cascade, getters.NewTeeGetter(shrexGetter, store))
+		cascade = append(cascade, shrexGetter)
 	}
-	cascade = append(cascade, getters.NewTeeGetter(ipldGetter, store))
+	cascade = append(cascade, ipldGetter)
 	return getters.NewCascadeGetter(cascade)
 }

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -178,6 +178,7 @@ func (s *Swamp) setupGenesis() {
 	ex := core.NewExchange(
 		core.NewBlockFetcher(s.ClientContext.Client),
 		store,
+		nil,
 		header.MakeExtendedHeader,
 	)
 

--- a/share/getters/store.go
+++ b/share/getters/store.go
@@ -122,11 +122,13 @@ func (sg *StoreGetter) GetSharesByNamespace(
 	blockGetter := eds.NewBlockGetter(bs)
 	shares, err = collectSharesByNamespace(ctx, blockGetter, root, namespace)
 	if errors.Is(err, ipld.ErrNodeNotFound) {
-		// IPLD node not found after the index pointed to this shard and the CAR blockstore has been
-		// opened successfully is a strong indicator of corruption. We remove the block on bridges
-		// and fulls and return share.ErrNotFound to ensure the data is retrieved by the next
-		// getter. Note that this recovery is manual and will only be restored by an RPC call to
-		// fetch the same datahash that was removed.
+		// IPLD node not found after the index pointed to this shard and the CAR
+		// blockstore has been opened successfully is a strong indicator of
+		// corruption. We remove the block on bridges and fulls and return
+		// share.ErrNotFound to ensure the data is retrieved by the next getter.
+		// Note that this recovery is manual and will only be restored by an RPC
+		// call to share.SharesAvailble in order to fetch and store the same
+		// datahash that was removed.
 		err = sg.store.Remove(ctx, root.Hash())
 		if err != nil {
 			log.Errorf("getter/store: failed to remove CAR after detected corruption: %w", err)


### PR DESCRIPTION
Super simple storage pruning POC. Has already been rewritten a few times. It works under the following assumptions:
1. Only heights inside recency window are DASed
2. Upon registering height h, height (h - RecencyWindow) gets queued to be pruned <- this causes some edge cases, but is a super simple, readable mechanism

There are some edge cases this does not cover, but these known edge cases only occur on startup and could be fixed by some sort of cleanup routine that runs once some period after startup. Alternatively we can make a more complicated tracker, that catches the edge cases "correctly", but it would be really nice to keep the pruning mechanism simple.

This PR needs to be split up because it contains a lot of parts, some of which are unfinished:
- Fulls/Lights DASing only inside recency window
- RecencyWindow config
- Pruning on Bridge/Full nodes

Unfinished:
- Bridges still sync all heights
- RN, pruning is mandatory on bridge nodes the way the DI is set up.
- Pruning flag
- Mechanism to clean up edge cases
- DASer tests

Things it does not/will not handle:
- Optimizations using bloom/cuckoo filter
- Pruning of inverted indec

This PR needs to be split into many and is only here to start discussions/save as a checkpoint on the repo.