### PR TITLE
chore(nodebuilder/p2p): BlockTime from 15 sec --> 10 sec

### DIFF
--- a/das/options.go
+++ b/das/options.go
@@ -52,7 +52,7 @@ func DefaultParameters() Parameters {
 		ConcurrencyLimit:        concurrencyLimit,
 		BackgroundStoreInterval: 10 * time.Minute,
 		SampleFrom:              1,
-		// SampleTimeout = block time * max amount of catchup workers
+		// SampleTimeout = approximate block time (with a bit of wiggle room) * max amount of catchup workers
 		SampleTimeout: 15 * time.Second * time.Duration(concurrencyLimit),
 	}
 }

--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -21,7 +21,7 @@ const (
 	Private Network = "private"
 	// BlockTime is a network block time.
 	// TODO @renaynay @Wondertan (#790)
-	BlockTime = time.Second * 15
+	BlockTime = time.Second * 10
 )
 
 // Network is a type definition for DA network run by Celestia Node.


### PR DESCRIPTION
Block times will be closer to 10 seconds on average than 15, so we should shift this to make calculations based on block time in our codebase more accurate.

This will also fix issues with syncing `arabica-10`