### PR TITLE
fix(shrexeds): close stream

### DIFF
--- a/share/p2p/shrexeds/client.go
+++ b/share/p2p/shrexeds/client.go
@@ -89,6 +89,7 @@ func (c *Client) doRequest(
 	if err != nil {
 		return nil, fmt.Errorf("failed to open stream: %w", err)
 	}
+	defer stream.Close()
 
 	c.setStreamDeadlines(ctx, stream)
 


### PR DESCRIPTION
If we receive a valid StatusMessage, we only CoseWrite side of the stream, but the stream interface states:
```
	// CloseWrite closes the stream for writing but leaves it open for
	// reading.
	//
	// CloseWrite does not free the stream, users must still call Close or
	// Reset.
	CloseWrite() error
```