### PR TITLE
feat(daser): only DAS recent heights 

### DIFF
--- a/das/daser.go
+++ b/das/daser.go
@@ -100,6 +100,11 @@ func (d *DASer) Start(ctx context.Context) error {
 		// will be able to find new head from subscriber after it is started
 		if h, err := d.getter.Head(ctx); err == nil {
 			cp.NetworkHead = h.Height()
+			// underflow protection
+			if h.Height() > d.params.RecencyWindow {
+				cp.SampleFrom = max(cp.SampleFrom, cp.NetworkHead-d.params.RecencyWindow)
+				d.sampler.state.sampleFrom = cp.SampleFrom
+			}
 		}
 	}
 	log.Info("starting DASer from checkpoint: ", cp.String())

--- a/das/options.go
+++ b/das/options.go
@@ -40,6 +40,10 @@ type Parameters struct {
 	// divided between parallel workers. SampleTimeout should be adjusted proportionally to
 	// ConcurrencyLimit.
 	SampleTimeout time.Duration
+
+	// RecencyWindow is the amount of blocks under the network head that will be
+	// sampled and stored.
+	RecencyWindow uint64
 }
 
 // DefaultParameters returns the default configuration values for the daser parameters
@@ -54,6 +58,8 @@ func DefaultParameters() Parameters {
 		SampleFrom:              1,
 		// SampleTimeout = approximate block time (with a bit of wiggle room) * max amount of catchup workers
 		SampleTimeout: 15 * time.Second * time.Duration(concurrencyLimit),
+		// TODO: this should inherit block time from p2p config
+		RecencyWindow: uint64((time.Hour * 24 * 28) / (15 * time.Second)),
 	}
 }
 
@@ -152,5 +158,13 @@ func WithSampleFrom(sampleFrom uint64) Option {
 func WithSampleTimeout(sampleTimeout time.Duration) Option {
 	return func(d *DASer) {
 		d.params.SampleTimeout = sampleTimeout
+	}
+}
+
+// WithRecencyWindow is a functional option to configure the daser's `RecencyWindow` parameter
+// Refer to WithSamplingRange documentation to see an example of how to use this
+func WithRecencyWindow(recencyWindow uint64) Option {
+	return func(d *DASer) {
+		d.params.RecencyWindow = recencyWindow
 	}
 }

--- a/das/state.go
+++ b/das/state.go
@@ -32,6 +32,9 @@ type coordinatorState struct {
 	next uint64
 	// networkHead is the height of the latest known network head
 	networkHead uint64
+	// recencyWindow is the amount of blocks below the network head that will be
+	// sampled
+	recencyWindow uint64
 
 	// catchUpDone indicates if all headers are sampled
 	catchUpDone atomic.Bool
@@ -62,6 +65,7 @@ func newCoordinatorState(params Parameters) coordinatorState {
 		nextJobID:     0,
 		next:          params.SampleFrom,
 		networkHead:   params.SampleFrom,
+		recencyWindow: params.RecencyWindow,
 		catchUpDoneCh: make(chan struct{}),
 	}
 }
@@ -144,6 +148,7 @@ func (s *coordinatorState) isNewHead(newHead uint64) bool {
 func (s *coordinatorState) updateHead(newHead uint64) {
 	if s.networkHead == s.sampleFrom {
 		log.Infow("found first header, starting sampling")
+		s.next = s.networkHead - s.recencyWindow
 	}
 
 	s.networkHead = newHead
@@ -182,6 +187,10 @@ func (s *coordinatorState) nextJob() (next job, found bool) {
 func (s *coordinatorState) catchupJob() (next job, found bool) {
 	if s.next > s.networkHead {
 		return job{}, false
+	}
+	// blocks below network head - recencyWindow do not need to be sampled
+	if s.networkHead > s.recencyWindow && s.next < s.networkHead-s.recencyWindow {
+		s.next = s.networkHead - s.recencyWindow
 	}
 
 	to := s.next + s.samplingRange - 1

--- a/nodebuilder/das/module.go
+++ b/nodebuilder/das/module.go
@@ -30,6 +30,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 					das.WithBackgroundStoreInterval(c.BackgroundStoreInterval),
 					das.WithSampleFrom(c.SampleFrom),
 					das.WithSampleTimeout(c.SampleTimeout),
+					das.WithRecencyWindow(c.RecencyWindow),
 				}
 			},
 		),


### PR DESCRIPTION
I have extracted the FN/LNs sampling only inside the recency window from the POC. 

This targets the new pruning feature branch, as it starts introducing pruning config values and is the base for the next steps. 

It is not too bad if a few headers outside of the window are sampled first, in case I am missing anything. 

Special call to @walldiss to make sure there isn't a better way without introducing too much complexity.