### PR TITLE
fix: improve ErrNoStateAccess message

### DIFF
--- a/nodebuilder/state/stub.go
+++ b/nodebuilder/state/stub.go
@@ -10,7 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-node/state"
 )
 
-var ErrNoStateAccess = errors.New("node is running without state access")
+var ErrNoStateAccess = errors.New("node is running without state access. run with --core.ip <CORE NODE IP> to resolve")
 
 // stubbedStateModule provides a stub for the state module to return
 // errors when state endpoints are accessed without a running connection


### PR DESCRIPTION
After getting the following response from the RPC
```
➜ celestia rpc state AccountAddress
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": 1,
    "message": "node is running without state access"
  }
}
```

I realized it would be more helpful to tell users what they can do to resolve the issue. Knowing that the node needs to be passed --core.ip when you see "node is running without state access" is not something obvious