### PR TITLE
refactor(rpc/blob) extend docs in blob

### DIFF
--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -41,14 +41,15 @@ func init() {
 		&fee,
 		"fee",
 		-1,
-		"specifies fee (in TIA) for blob submission [optional]",
+		"specifies fee (in utia) for blob submission.\n"+
+			"Fee will be automatically calculated if negative value is passed [optional]",
 	)
 
 	submitCmd.PersistentFlags().Uint64Var(
 		&gasLimit,
 		"gas.limit",
 		0,
-		"sets the maximum amount of gas that is allowed to consume during blob submission [optional]",
+		"sets the amount of gas that is consumed during blob submission [optional]",
 	)
 
 	// unset the default value to avoid users confusion

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -57,7 +57,7 @@ func init() {
 		"      --fee       int      specifies fee(in TIA) for blob submission(optional)\n" +
 		"      --gas.limit uint64   sets the maximum amount of that gas is allowed to consume during blob submission(optional)\n" +
 		"      -h, --help           help for submit\n" +
-		"NOTE: fee and gas.limit params will be calculated automatically if they will not be provided.\n\n" +
+		"NOTE: fee and gas.limit params will be calculated automatically if they are not provided as arguments.\n\n" +
 		"Global Flags:\n" +
 		"      --token string    Authorization token (if not provided, the CELESTIA_NODE_AUTH_TOKEN environment variable will be used)\n" +
 		"      --url   string    Request URL (default \"http://localhost:26658\")",

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -41,14 +41,26 @@ func init() {
 		&fee,
 		"fee",
 		-1,
-		"specifies fee for blob submission",
+		"specifies fee(in TIA) for blob submission",
 	)
 
 	submitCmd.PersistentFlags().Uint64Var(
 		&gasLimit,
 		"gas.limit",
 		0,
-		"specifies max gas for the blob submission",
+		"sets the maximum amount of gas that is allowed to consume during blob submission",
+	)
+
+	submitCmd.SetUsageTemplate("" +
+		"celestia blob submit [namespace] [blobData] [flags]\n\n " +
+		"Flags:\n" +
+		"      --fee       int      specifies fee(in TIA) for blob submission(optional)\n" +
+		"      --gas.limit uint64   sets the maximum amount of that gas is allowed to consume during blob submission(optional)\n" +
+		"      -h, --help           help for submit\n" +
+		"NOTE: fee and gas.limit params will be calculated automatically if they will not be provided.\n\n" +
+		"Global Flags:\n" +
+		"      --token string    Authorization token (if not provided, the CELESTIA_NODE_AUTH_TOKEN environment variable will be used)\n" +
+		"      --url   string    Request URL (default \"http://localhost:26658\")",
 	)
 }
 

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -151,9 +151,7 @@ var submitCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error creating a blob:%v", err)
 		}
-		if fee != -1 {
-			panic(fee)
-		}
+
 		height, err := client.Blob.Submit(
 			cmd.Context(),
 			[]*blob.Blob{parsedBlob},

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -55,11 +55,13 @@ func init() {
 		"celestia blob submit [namespace] [blobData] [flags]\n\n " +
 		"Flags:\n" +
 		"      --fee       int      specifies fee(in TIA) for blob submission(optional)\n" +
-		"      --gas.limit uint64   sets the maximum amount of that gas is allowed to consume during blob submission(optional)\n" +
+		"      --gas.limit uint64   sets the maximum amount of that gas is allowed " +
+		"to consume during blob submission(optional)\n" +
 		"      -h, --help           help for submit\n" +
 		"NOTE: fee and gas.limit params will be calculated automatically if they are not provided as arguments.\n\n" +
 		"Global Flags:\n" +
-		"      --token string    Authorization token (if not provided, the CELESTIA_NODE_AUTH_TOKEN environment variable will be used)\n" +
+		"      --token string    Authorization token (if not provided, " +
+		"the CELESTIA_NODE_AUTH_TOKEN environment variable will be used)\n" +
 		"      --url   string    Request URL (default \"http://localhost:26658\")",
 	)
 }


### PR DESCRIPTION
## Overview
Closes #2707
Added usage template for `blob.submit`, that allows to hide confusing -1 param for a fee and add an extra line that explains what will happen if `fee` and `gas.Limit` won't  be provided

```
Submit the blob at the given namespace.
Note:
* only one blob is allowed to submit through the RPC.
* fee and gas.limit params will be calculated automatically if they are not provided as arguments

Usage:
  celestia blob submit [namespace] [blobData] [flags]

Flags:
      --fee int          specifies fee (in TIA) for blob submission [optional]
      --gas.limit uint   sets the maximum amount of gas that is allowed to consume during blob submission [optional]
  -h, --help             help for submit

Global Flags:
      --token string   Authorization token (if not provided, the CELESTIA_NODE_AUTH_TOKEN environment variable will be used)
      --url string     Request URL (default "http://localhost:26658")
```
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
