### PR TITLE
chore(deps): fix dependabot otel grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
     groups:
       otel:
         patterns:
-          - "^go.opentelemetry.io/otel*"
+          - "go.opentelemetry.io/otel*"
   - package-ecosystem: docker
     directory: "/"
     schedule:


### PR DESCRIPTION
Fixes dependabot regex to not use`^`, since it seems to not support anything but `*` wildcard