### PR TITLE
(chore) ensure all dependency group PRs get the default label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: monday
       time: "11:00"
     open-pull-requests-limit: 10
+    labels:
+      - kind:deps
   - package-ecosystem: gomod
     directory: "/"
     schedule:
@@ -30,3 +32,5 @@ updates:
       day: monday
       time: "11:00"
     open-pull-requests-limit: 10
+    labels:
+      - kind:deps


### PR DESCRIPTION
currently only the go.mod dependabot PRs were getting the `kind:deps` label, so others that targer Docker or github actions would fail a label check

eg: https://github.com/celestiaorg/celestia-node/pull/2794

this should fix that. minor tweak.