### PR TITLE
chore verify linked issue

### DIFF
--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -1,4 +1,4 @@
-name: Required Labels
+name: pull request verification
 
 on:
   pull_request:
@@ -9,11 +9,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  label:
+  verification:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - name: require label
+        uses: mheap/github-action-required-labels@v5
         with:
           mode: minimum
           count: 1
           labels: "kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing" # yamllint disable-line rule:line-length
+
+      - name: verify referenced issue
+        uses: ramin/verify-linked-issue-action@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -20,6 +20,6 @@ jobs:
           labels: "kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing" # yamllint disable-line rule:line-length
 
       - name: verify referenced issue
-        uses: ramin/verify-linked-issue-action@v1.0.0
+        uses: ramin/verify-referenced-issue-exists@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this update the `labels.yml` workflow in `.github/workflows` to:

- rename file to `pr-verification.yaml`
- changes the name to "pull request validation"
- updates job to be multi step and no renamed "verify"
- leaves the PR required label check the same
- adds a "verify-linked-issue" step that looks for a referenced issue in the PR body and fails verification if missing

I forked an out of date github action and updated it to be more modern and not add comments everywhere, found here  https://github.com/ramin/verify-referenced-issue-exists

refs: https://github.com/celestiaorg/celestia-node/issues/2804

<img width="857" alt="failure" src="https://github.com/celestiaorg/celestia-node/assets/12677/feb2429e-d8b9-4953-a0ce-0e14f3857d47">

