### PR TITLE
override organization pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 <!--
 Thank you for submitting a pull request!
 
+Please make sure you have reviewed our contributors guide before submitting your
+first PR.
+
 Please ensure you've addressed or included references to any related issues.
 
 Tips:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!--
+Thank you for submitting a pull request!
+
+Please ensure you've addressed or included references to any related issues.
+
+Tips:
+- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
+- Describe the changes made in the PR.
+- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)
+
+-->


### PR DESCRIPTION
As discussed, overrides the organization wide `.github/pull_request_template.md` with the checklist everyone ignores, instead favoring just a comment when opening the PR and a request to add a reference to an issue for a PR check we'll add shortly, opening a PR should just look like this now:

<img width="854" alt="pr-message" src="https://github.com/celestiaorg/celestia-node/assets/12677/8da9ffb3-ca13-447e-be3e-636475269a9f">
