### PR TITLE
chore(share/ipld): obliterate expensive ipld getter tracing

### DIFF
--- a/share/ipld/get_shares.go
+++ b/share/ipld/get_shares.go
@@ -32,9 +32,6 @@ func GetShare(
 // Does not return any error, and returns/unblocks only on success
 // (got all shares) or on context cancellation.
 func GetShares(ctx context.Context, bg blockservice.BlockGetter, root cid.Cid, shares int, put func(int, share.Share)) {
-	ctx, span := tracer.Start(ctx, "get-shares")
-	defer span.End()
-
 	putNode := func(i int, leaf format.Node) {
 		put(i, leafToShare(leaf))
 	}
@@ -51,9 +48,6 @@ func GetSharesByNamespace(
 	namespace share.Namespace,
 	maxShares int,
 ) ([]share.Share, *nmt.Proof, error) {
-	ctx, span := tracer.Start(ctx, "get-shares-by-namespace")
-	defer span.End()
-
 	data := NewNamespaceData(maxShares, namespace, WithLeaves(), WithProofs())
 	err := data.CollectLeavesByNamespace(ctx, bGetter, root)
 	if err != nil {

--- a/share/ipld/nmt.go
+++ b/share/ipld/nmt.go
@@ -15,7 +15,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	mh "github.com/multiformats/go-multihash"
 	mhcore "github.com/multiformats/go-multihash/core"
-	"go.opentelemetry.io/otel"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/da"
@@ -25,8 +24,7 @@ import (
 )
 
 var (
-	tracer = otel.Tracer("ipld")
-	log    = logging.Logger("ipld")
+	log = logging.Logger("ipld")
 )
 
 const (


### PR DESCRIPTION
The load these traces can produce is massive. In the case of ODS size 128 and the whole block is sampled for namespace data, it will be **48896** spans `(128*2-1)*128*2 - (128 * 128)`. Besides, there is zero value this tracing brought us so far.