### PR TITLE
fix(share/eds): fix races in cache tests

### DIFF
--- a/share/eds/blockstore.go
+++ b/share/eds/blockstore.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	bstore "github.com/ipfs/boxo/blockstore"
-	dshelp "github.com/ipfs/boxo/datastore/dshelp"
+	"github.com/ipfs/boxo/datastore/dshelp"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -154,13 +154,13 @@ func (bs *blockstore) getReadOnlyBlockstore(ctx context.Context, cid cid.Cid) (*
 
 	// check if either cache contains an accessor
 	shardKey := keys[0]
-	accessor, err := bs.store.cache.Get(shardKey)
+	accessor, err := bs.store.cache.Load().Get(shardKey)
 	if err == nil {
 		return blockstoreCloser(accessor)
 	}
 
 	// load accessor to the blockstore cache and use it as blockstoreCloser
-	accessor, err = bs.store.cache.Second().GetOrLoad(ctx, shardKey, bs.store.getAccessor)
+	accessor, err = bs.store.cache.Load().Second().GetOrLoad(ctx, shardKey, bs.store.getAccessor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get accessor for shard %s: %w", shardKey, err)
 	}

--- a/share/eds/metrics.go
+++ b/share/eds/metrics.go
@@ -124,7 +124,7 @@ func (s *Store) WithMetrics() error {
 		return err
 	}
 
-	if err = s.cache.EnableMetrics(); err != nil {
+	if err = s.cache.Load().EnableMetrics(); err != nil {
 		return err
 	}
 

--- a/share/p2p/peers/pool.go
+++ b/share/p2p/peers/pool.go
@@ -89,8 +89,11 @@ func (p *pool) next(ctx context.Context) <-chan peer.ID {
 				return
 			}
 
+			p.m.RLock()
+			hasPeerCh := p.hasPeerCh
+			p.m.RUnlock()
 			select {
-			case <-p.hasPeerCh:
+			case <-hasPeerCh:
 			case <-ctx.Done():
 				return
 			}

--- a/share/p2p/peers/pool.go
+++ b/share/p2p/peers/pool.go
@@ -89,11 +89,8 @@ func (p *pool) next(ctx context.Context) <-chan peer.ID {
 				return
 			}
 
-			p.m.RLock()
-			hasPeerCh := p.hasPeerCh
-			p.m.RUnlock()
 			select {
-			case <-hasPeerCh:
+			case <-p.hasPeerCh:
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
Fixes races in eds cache tests:
- read / write isClosed flag in Cache mock
- write / write for error object from 2 goroutines
- read / write of cache object inside edsStore on cache swaps in tests.

Resolves https://github.com/celestiaorg/celestia-node/issues/2833