### PR TITLE
fix(modp2p): temporary disable quic

### DIFF
--- a/nodebuilder/p2p/addrs.go
+++ b/nodebuilder/p2p/addrs.go
@@ -2,11 +2,11 @@ package p2p
 
 import (
 	"fmt"
+	"slices"
 
 	p2pconfig "github.com/libp2p/go-libp2p/config"
 	hst "github.com/libp2p/go-libp2p/core/host"
 	ma "github.com/multiformats/go-multiaddr"
-	"golang.org/x/exp/slices"
 )
 
 // Listen returns invoke function that starts listening for inbound connections with libp2p.Host.


### PR DESCRIPTION
Disables QUIC by default yet allows to enable it with ENV var. 
This is temporary and until https://github.com/libp2p/go-libp2p/issues/2591 is investigated and fixed.

The current solution disables QUIC programmatically while we still keep writing in the config QUIC listen addresses by default. This removes the need for users to reinit their configs once we turn QUIC back by default.

This works perfectly fine on mocha.