### PR TITLE
fix: removing chainid from default store name for mainnet

### DIFF
--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -87,6 +87,10 @@ func DefaultNodeStorePath(tp string, network string) (string, error) {
 			return "", err
 		}
 	}
+	if network == p2p.Mainnet.String() {
+		return fmt.Sprintf("%s/.celestia-%s", home, strings.ToLower(tp)), nil
+	}
+	// only include network name in path for testnets and custom networks
 	return fmt.Sprintf(
 		"%s/.celestia-%s-%s",
 		home,


### PR DESCRIPTION
Also part of #2823 

Stacked on #2840 