### PR TITLE
fix(share/getters): short-circuit on empty root in ShrexGetter

### DIFF
--- a/share/getters/shrex.go
+++ b/share/getters/shrex.go
@@ -138,7 +138,6 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, header *header.ExtendedHeader
 	dah := header.DAH
 	// short circuit if the data root is empty
 	if dah.Equals(share.EmptyRoot()) {
-		fmt.Println("hitting")
 		return share.EmptyExtendedDataSquare(), nil
 	}
 	for {

--- a/share/getters/shrex.go
+++ b/share/getters/shrex.go
@@ -136,6 +136,11 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, header *header.ExtendedHeader
 	}()
 
 	dah := header.DAH
+	// short circuit if the data root is empty
+	if dah.Equals(share.EmptyRoot()) {
+		fmt.Println("hitting")
+		return share.EmptyExtendedDataSquare(), nil
+	}
 	for {
 		if ctx.Err() != nil {
 			sg.metrics.recordEDSAttempt(ctx, attempt, false)


### PR DESCRIPTION
Should fix issue where GetEDS hangs on empty data root

To test run:

`celestia share get-eds “$(celestia header get-by-height 500 --node.store ~/.celestia-light-mocha-4 | jq .result)” --node.store ~/.celestia-light-mocha-4`

with and without the PR