### PR TITLE
fix(core): Increase listener timeout to 3x block time

### DIFF
--- a/core/listener.go
+++ b/core/listener.go
@@ -57,7 +57,7 @@ func NewListener(
 		hashBroadcaster:   hashBroadcaster,
 		construct:         construct,
 		store:             store,
-		listenerTimeout:   3 * blocktime,
+		listenerTimeout:   5 * blocktime,
 	}
 }
 

--- a/core/listener.go
+++ b/core/listener.go
@@ -57,7 +57,7 @@ func NewListener(
 		hashBroadcaster:   hashBroadcaster,
 		construct:         construct,
 		store:             store,
-		listenerTimeout:   2 * blocktime,
+		listenerTimeout:   3 * blocktime,
 	}
 }
 


### PR DESCRIPTION
Block time can vary quite a bit so do not trigger re-subscription unless there's a significant lag (3x blocktime). This issue was found by bridge node runners on `mocha-4` where block time sometimes exceeded 20s