### PR TITLE
fix(blob): properly wrap error in GetAll method

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -132,7 +132,7 @@ func (s *Service) GetAll(ctx context.Context, height uint64, namespaces []share.
 			defer wg.Done()
 			blobs, err := s.getBlobs(ctx, namespace, header)
 			if err != nil {
-				resultErr[i] = fmt.Errorf("getting blobs for namespace(%s): %s", namespace.String(), err)
+				resultErr[i] = fmt.Errorf("getting blobs for namespace(%s): %w", namespace.String(), err)
 				return
 			}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Error returned by `GetAll` is not formatted correctly. It's especially important, because users of the method will most probably try to detect `ErrBlobNotFound` (to differentiate from other errors). 

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
