### PR TITLE
(ci) matrix tests for different OS

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -63,6 +63,7 @@ jobs:
         run: make test-unit
 
       - name: upload coverage
+        if: ${{ matrix.os == 'macos-latest' }}
         uses: codecov/codecov-action@v3.1.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -70,6 +70,7 @@ jobs:
           env_vars: OS
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
+          name: coverage-${{ matrix.os }}
 
   unit_race_test:
     needs: [lint, go_mod_tidy_check]

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -44,8 +44,11 @@ jobs:
         run: git diff --exit-code
 
   test_coverage:
+    needs: [lint, go_mod_tidy_check]
     name: Unit Tests Coverage
-    runs-on: ubuntu-latest
+    matrix:
+      os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -65,6 +68,7 @@ jobs:
           file: ./coverage.txt
 
   unit_race_test:
+    needs: [lint, go_mod_tidy_check]
     name: Run Unit Tests with Race Detector
     runs-on: ubuntu-latest
 
@@ -80,6 +84,7 @@ jobs:
         run: make test-unit-race
 
   integration_test:
+    needs: [lint, go_mod_tidy_check]
     name: Run Integration Tests
     runs-on: ubuntu-latest
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -50,6 +50,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      OS: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -63,9 +65,9 @@ jobs:
         run: make test-unit
 
       - name: upload coverage
-        if: ${{ matrix.os == 'macos-latest' }}
         uses: codecov/codecov-action@v3.1.4
         with:
+          env_vars: OS
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -46,8 +46,9 @@ jobs:
   test_coverage:
     needs: [lint, go_mod_tidy_check]
     name: Unit Tests Coverage
-    matrix:
-      os: [ubuntu-latest, macos-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package blob
 
 import (


### PR DESCRIPTION
Refs https://github.com/celestiaorg/celestia-node/issues/1584

Lets run our test suite on multi configurations as they sometimes pass one not other (as reported by @vgonkivs)

- Task: run tests on > 1 OS (previously ubuntu-latest only) now `ubuntu-latest` and `macos-latest`
- currently ONLY for the unit tests (do we want to change this for all the tests?)
- also makes a small unrequested tweak to make the execution in go-ci run AFTER the mod and lint checks, so it'll pause if those two fail and fail the entire pipeline faster. Save some wasted compute time, which will be at least x2 worse once we matrix these

example run: https://github.com/celestiaorg/celestia-node/actions/runs/6559066381/job/17813974060