### PR TITLE
fix(p2p): Start listening to QUIC when CELESTIA_ENABLE_QUIC is set

### DIFF
--- a/nodebuilder/p2p/addrs.go
+++ b/nodebuilder/p2p/addrs.go
@@ -19,11 +19,13 @@ func Listen(listen []string) func(h hst.Host) (err error) {
 				return fmt.Errorf("failure to parse config.P2P.ListenAddresses: %s", err)
 			}
 
-			// TODO(@WonderTan): Remove this check when QUIC is stable
-			if slices.ContainsFunc(maddr.Protocols(), func(p ma.Protocol) bool {
-				return p.Code == ma.P_QUIC_V1 || p.Code == ma.P_WEBTRANSPORT
-			}) {
-				continue
+			if !enableQUIC {
+				// TODO(@WonderTan): Remove this check when QUIC is stable
+				if slices.ContainsFunc(maddr.Protocols(), func(p ma.Protocol) bool {
+					return p.Code == ma.P_QUIC_V1 || p.Code == ma.P_WEBTRANSPORT
+				}) {
+					continue
+				}
 			}
 
 			maListen = append(maListen, maddr)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The `enableQUIC` was not applied in the `Listen`.

Related: https://github.com/celestiaorg/celestia-node/pull/2837

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
