### PR TITLE
update golangci-lint

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: v1.54.2
+          version: v1.55
 
   go_mod_tidy_check:
     name: Go Mod Tidy Check

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,6 +26,8 @@ jobs:
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: v1.55
+          skip-pkg-cache: true
+          skip-build-cache: true
 
   go_mod_tidy_check:
     name: Go Mod Tidy Check

--- a/share/availability/test/corrupt_data.go
+++ b/share/availability/test/corrupt_data.go
@@ -63,7 +63,7 @@ func (fb FraudulentBlockstore) Has(context.Context, cid.Cid) (bool, error) {
 func (fb FraudulentBlockstore) Get(ctx context.Context, cid cid.Cid) (blocks.Block, error) {
 	key := cid.String()
 	if fb.Attacking {
-		key = "corrupt" + key
+		key = "corrupt_get" + key
 	}
 
 	data, err := fb.Datastore.Get(ctx, ds.NewKey(key))
@@ -76,7 +76,7 @@ func (fb FraudulentBlockstore) Get(ctx context.Context, cid cid.Cid) (blocks.Blo
 func (fb FraudulentBlockstore) GetSize(ctx context.Context, cid cid.Cid) (int, error) {
 	key := cid.String()
 	if fb.Attacking {
-		key = "corrupt" + key
+		key = "corrupt_size" + key
 	}
 
 	return fb.Datastore.GetSize(ctx, ds.NewKey(key))

--- a/share/eds/cache/metrics.go
+++ b/share/eds/cache/metrics.go
@@ -18,19 +18,21 @@ type metrics struct {
 }
 
 func newMetrics(bc *AccessorCache) (*metrics, error) {
-	evictedCounter, err := meter.Int64Counter("eds_blockstore_cache_"+bc.name+"_evicted_counter",
+	metricsPrefix := "eds_blockstore_cache_" + bc.name
+
+	evictedCounter, err := meter.Int64Counter(metricsPrefix+"_evicted_counter",
 		metric.WithDescription("eds blockstore cache evicted event counter"))
 	if err != nil {
 		return nil, err
 	}
 
-	getCounter, err := meter.Int64Counter("eds_blockstore_cache_"+bc.name+"_get_counter",
+	getCounter, err := meter.Int64Counter(metricsPrefix+"_get_counter",
 		metric.WithDescription("eds blockstore cache evicted event counter"))
 	if err != nil {
 		return nil, err
 	}
 
-	cacheSize, err := meter.Int64ObservableGauge("eds_blockstore_cache_"+bc.name+"_size",
+	cacheSize, err := meter.Int64ObservableGauge(metricsPrefix+"_size",
 		metric.WithDescription("total amount of items in blockstore cache"),
 	)
 	if err != nil {


### PR DESCRIPTION
- updates `golangci-lint` to 1.55 
- removes "double cache" when setting up golang, thus removing linter noise (`Cannot open file...file exists`) so easier to see actual lint errors

closes https://github.com/celestiaorg/celestia-node/issues/2590