### PR TITLE
signed binaries for goreleaser

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -87,6 +87,12 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: 1.21
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       # Generate the binaries and release
       - uses: goreleaser/goreleaser-action@v5
         with:
@@ -95,6 +101,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
 
   # TODO: permission issue, but not worth fixing as this should be refactored
   # into the celestiaorg/.github repo, at which point any permission issues will

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,18 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 checksum:
   name_template: "checksums.txt"
+signs:
+  - artifacts: checksum
+    args:
+      [
+        "--batch",
+        "-u",
+        "{{ .Env.GPG_FINGERPRINT }}",
+        "--output",
+        "${signature}",
+        "--detach-sign",
+        "${artifact}",
+      ]
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:


### PR DESCRIPTION
mimics the signed binaries by goreleaser as implemented in `celestia-app` so node can also generate signed binaries

@MSevey confirmed that we have an org level secret for `GPG_SIGNING_KEY` and `GPG_PASSPHRASE` so should require no repo setup

implementation for app: https://github.com/celestiaorg/celestia-app/commit/934fdeda062229f5c150e9dce74f05b0557ea123

Will follow up with some work to ensure this workflow actually gets triggered (currently the steps before do not pass and generate binaries)

closes: https://github.com/celestiaorg/celestia-node/issues/2679