### PR TITLE
chore(cmd): add a newline after printing token so it doesn't run into shell prompt

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -55,7 +55,7 @@ func AuthCmd(fsets ...*flag.FlagSet) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%s", token)
+			fmt.Printf("%s\n", token)
 			return nil
 		},
 	}


### PR DESCRIPTION
minor annoyance where running `auth admin` always has the token output run right into the next shell prompt.

