### PR TITLE
feat(pruner): adding archival-mode flag to cmd

### DIFF
--- a/cmd/celestia/bridge.go
+++ b/cmd/celestia/bridge.go
@@ -9,6 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/gateway"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	"github.com/celestiaorg/celestia-node/nodebuilder/pruner"
 	"github.com/celestiaorg/celestia-node/nodebuilder/rpc"
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
@@ -25,6 +26,7 @@ func init() {
 		rpc.Flags(),
 		gateway.Flags(),
 		state.Flags(),
+		pruner.Flags(),
 	}
 
 	bridgeCmd.AddCommand(

--- a/cmd/celestia/full.go
+++ b/cmd/celestia/full.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	"github.com/celestiaorg/celestia-node/nodebuilder/pruner"
 	"github.com/celestiaorg/celestia-node/nodebuilder/rpc"
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
@@ -29,6 +30,7 @@ func init() {
 		rpc.Flags(),
 		gateway.Flags(),
 		state.Flags(),
+		pruner.Flags(),
 	}
 
 	fullCmd.AddCommand(

--- a/cmd/celestia/light.go
+++ b/cmd/celestia/light.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	"github.com/celestiaorg/celestia-node/nodebuilder/pruner"
 	"github.com/celestiaorg/celestia-node/nodebuilder/rpc"
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
@@ -28,6 +29,7 @@ func init() {
 		core.Flags(),
 		rpc.Flags(),
 		gateway.Flags(),
+		pruner.Flags(),
 		state.Flags(),
 	}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/celestiaorg/celestia-node/nodebuilder/pruner"
 	"os"
 	"strings"
 
@@ -119,6 +120,7 @@ func PersistentPreRunEnv(cmd *cobra.Command, nodeType node.Type, _ []string) err
 	rpc_cfg.ParseFlags(cmd, &cfg.RPC)
 	gateway.ParseFlags(cmd, &cfg.Gateway)
 	state.ParseFlags(cmd, &cfg.State)
+	pruner.ParseFlags(cmd, &cfg.Pruner)
 
 	// set config
 	ctx = WithNodeConfig(ctx, &cfg)


### PR DESCRIPTION
Stacked on https://github.com/celestiaorg/celestia-node/pull/2738 , so in draft

Scope:
`--archival-mode` is introduced for bridges and fulls to disable pruning.