### PR TITLE
chore: increase lint timeout

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
+          args: --timeout 10m
           version: v1.55
           skip-pkg-cache: true
           skip-build-cache: true


### PR DESCRIPTION
Today I faced multiple times with `timeout exceeded` error on ci action. Increasing timeout helps to avoid this issue.