### PR TITLE
fix(test/daser): stop the eds store before finishing the test

### DIFF
--- a/share/availability/full/testing.go
+++ b/share/availability/full/testing.go
@@ -55,5 +55,10 @@ func TestAvailability(t *testing.T, getter share.Getter) *ShareAvailability {
 	require.NoError(t, err)
 	err = store.Start(context.Background())
 	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = store.Stop(context.Background())
+		require.NoError(t, err)
+	})
 	return NewShareAvailability(store, getter, disc)
 }


### PR DESCRIPTION
All tests that used TestAvailability were flaky. They could randomly receive `tempdir remove all cleanup unlinkat directory not empty`. It happened to me 100% time when I was running a test with `--count > 50`. It happened because the eds store was storing the data and the temp folder could not be deleted.

![Снимок экрана 2023-11-08 в 19 22 57](https://github.com/celestiaorg/celestia-node/assets/40579846/f959fe49-457c-4e4b-ae00-5b119502d0a5)

