### PR TITLE
chore(ci): disable fail-fast on matrix tests

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -52,6 +52,7 @@ jobs:
     needs: [lint, go_mod_tidy_check]
     name: Unit Tests Coverage
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

Disable "fail-fast" so if the `ubuntu-latest` matrix unit test fails then it wont cancel the run of `macos-latest`, this will help with easing ability to merge as we've reduced the requirement for both to merge