### PR TITLE
refactor(modp2p): decouple Bitswap

### DIFF
--- a/nodebuilder/p2p/bitswap.go
+++ b/nodebuilder/p2p/bitswap.go
@@ -30,15 +30,14 @@ const (
 
 // dataExchange provides a constructor for IPFS block's DataExchange over BitSwap.
 func dataExchange(params bitSwapParams) exchange.Interface {
-	prefix := protocol.ID(fmt.Sprintf("/celestia/%s", params.Net))
-
+	prefix := protocolID(params.Net)
 	net := network.NewFromIpfsHost(params.Host, &routinghelpers.Null{}, network.Prefix(prefix))
 	srvr := server.New(
 		params.Ctx,
 		net,
 		params.Bs,
 		server.ProvideEnabled(false), // we don't provide blocks over DHT
-		// NOTE: These below ar required for our protocol to work reliably.
+		// NOTE: These below are required for our protocol to work reliably.
 		// // See https://github.com/celestiaorg/celestia-node/issues/732
 		server.SetSendDontHaves(false),
 	)
@@ -95,4 +94,8 @@ type bitSwapParams struct {
 	Net       Network
 	Host      hst.Host
 	Bs        blockstore.Blockstore
+}
+
+func protocolID(network Network) protocol.ID {
+	return protocol.ID(fmt.Sprintf("/celestia/%s", network))
 }


### PR DESCRIPTION
Decouples Bitswap into Client and Server. This is necessary to provide new custom options to the Client. In particular, this brings `client.WithoutDuplicatedBlockStats()` option to the table as nice little optimization for LNs. It disables one metrics we don't care much about atm, but avoids expensive Has call to DB as profiles show. 