### PR TITLE
Revert "fix(modp2p): temporary disable quic (#2837)"

### DIFF
--- a/nodebuilder/p2p/addrs.go
+++ b/nodebuilder/p2p/addrs.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"fmt"
-	"slices"
 
 	p2pconfig "github.com/libp2p/go-libp2p/config"
 	hst "github.com/libp2p/go-libp2p/core/host"
@@ -12,25 +11,13 @@ import (
 // Listen returns invoke function that starts listening for inbound connections with libp2p.Host.
 func Listen(listen []string) func(h hst.Host) (err error) {
 	return func(h hst.Host) (err error) {
-		maListen := make([]ma.Multiaddr, 0, len(listen))
-		for _, addr := range listen {
-			maddr, err := ma.NewMultiaddr(addr)
+		maListen := make([]ma.Multiaddr, len(listen))
+		for i, addr := range listen {
+			maListen[i], err = ma.NewMultiaddr(addr)
 			if err != nil {
 				return fmt.Errorf("failure to parse config.P2P.ListenAddresses: %s", err)
 			}
-
-			if !enableQUIC {
-				// TODO(@WonderTan): Remove this check when QUIC is stable
-				if slices.ContainsFunc(maddr.Protocols(), func(p ma.Protocol) bool {
-					return p.Code == ma.P_QUIC_V1 || p.Code == ma.P_WEBTRANSPORT
-				}) {
-					continue
-				}
-			}
-
-			maListen = append(maListen, maddr)
 		}
-
 		return h.Network().Listen(maListen...)
 	}
 }

--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/libp2p/go-libp2p"
 	p2pconfig "github.com/libp2p/go-libp2p/config"
@@ -17,21 +16,11 @@ import (
 	"github.com/libp2p/go-libp2p/core/routing"
 	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
-	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
-	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
-	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
-
-var enableQUIC bool
-
-func init() {
-	_, ok := os.LookupEnv("CELESTIA_ENABLE_QUIC")
-	enableQUIC = ok
-}
 
 // routedHost constructs a wrapped Host that may fallback to address discovery,
 // if any top-level operation on the Host is provided with PeerID(Hash(PbK)) only.
@@ -55,15 +44,8 @@ func host(params hostParams) (HostBase, error) {
 		libp2p.ResourceManager(params.ResourceManager),
 		// to clearly define what defaults we rely upon
 		libp2p.DefaultSecurity,
+		libp2p.DefaultTransports,
 		libp2p.DefaultMuxers,
-		libp2p.Transport(tcp.NewTCPTransport),
-	}
-
-	if enableQUIC {
-		opts = append(opts,
-			libp2p.Transport(quic.NewTransport),
-			libp2p.Transport(webtransport.New),
-		)
 	}
 
 	if params.Registry != nil {


### PR DESCRIPTION
Reverts disabled quic. We weren't able to reproduce [the issue](https://github.com/libp2p/go-libp2p/issues/2591) since we first observed it, as well as quic released changes to address this. Even if the issue is there, I think it's more or less safe as we always have TCP as fallback