### PR TITLE
ignore otel patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       - renaynay
     labels:
       - kind:deps
+    ignore:
+      - dependency-name: "*otel*"
+        update-types: ["version-update:semver-patch"]
     groups:
       otel:
         patterns:


### PR DESCRIPTION
opening this as a possible solution and to discuss if we want to make the matching more greedy, but this implements a suggestion by @walldiss last week to have dependabot be less aggressive with suggesting EVERY patch release for all dependencies, only limiting to major and minor updates as suggestion. 

Arguably, we could expand the wildcard to more than `*otel*` and apply to everything, but maybe we just let it run on otel for a bit and see what the consequences are before considering applying it more broadly.

Also, i think we should review the security alert configuration side of dependabot as a companion to this to ensure we DO get security alerts if a CVE or issue is patched. But that will be separate  
