### PR TITLE
ci: configure prerelease-suffix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,3 +65,5 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+git:
+  prerelease_suffix: "-"


### PR DESCRIPTION
Configure GoReleaser's prerelease-suffix: https://goreleaser.com/customization/git/#git

If the prerelease-suffix is not configured, then GoReleaser will treat `v1.5.0-rc0` as more recent than `v1.5.0`. This is problematic because if the real release is cut after the release candidate, then GoReleaser won't attach pre-built binaries to the real release. This just happened on celestia-app v1.5.0 so ideally this saves ya'll some time when celestia-node starts publishing pre-built binaries.

Motivating issue: https://github.com/celestiaorg/celestia-app/issues/2897