### PR TITLE
feat(shwap/file): add ods file

### DIFF
--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -34,8 +34,8 @@ func RandEDS(t require.TestingT, size int) *rsmt2d.ExtendedDataSquare {
 	return eds
 }
 
-// RandEDSWithNamespace generates EDS with given square size. Returned EDS will have namespacedAmount of
-// shares with the given namespace.
+// RandEDSWithNamespace generates EDS with given square size. Returned EDS will have
+// namespacedAmount of shares with the given namespace.
 func RandEDSWithNamespace(
 	t require.TestingT,
 	namespace share.Namespace,

--- a/share/store/codec.go
+++ b/share/store/codec.go
@@ -22,7 +22,7 @@ func (l *codec) Encoder(len int) (reedsolomon.Encoder, error) {
 	enc, ok := l.encCache.Load(len)
 	if !ok {
 		var err error
-		enc, err = reedsolomon.New(len/2, len/2, reedsolomon.WithLeopardGF(true))
+		enc, err = reedsolomon.New(len/2, len/2, reedsolomon.WithLeopardGF(false))
 		if err != nil {
 			return nil, err
 		}

--- a/share/store/codec.go
+++ b/share/store/codec.go
@@ -1,0 +1,32 @@
+package store
+
+import (
+	"sync"
+
+	"github.com/klauspost/reedsolomon"
+)
+
+type Codec interface {
+	Encoder(len int) (reedsolomon.Encoder, error)
+}
+
+type codec struct {
+	encCache sync.Map
+}
+
+func NewCodec() Codec {
+	return &codec{}
+}
+
+func (l *codec) Encoder(len int) (reedsolomon.Encoder, error) {
+	enc, ok := l.encCache.Load(len)
+	if !ok {
+		var err error
+		enc, err = reedsolomon.New(len/2, len/2, reedsolomon.WithLeopardGF(true))
+		if err != nil {
+			return nil, err
+		}
+		l.encCache.Store(len, enc)
+	}
+	return enc.(reedsolomon.Encoder), nil
+}

--- a/share/store/codec_test.go
+++ b/share/store/codec_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/klauspost/reedsolomon"
@@ -10,59 +11,73 @@ import (
 )
 
 func BenchmarkCodec(b *testing.B) {
-	size := 128
+	minSize, maxSize := 32, 128
 
+	for size := minSize; size <= maxSize; size *= 2 {
+		// BenchmarkCodec/Leopard/size:32-10         					  409194	      2793 ns/op
+		// BenchmarkCodec/Leopard/size:64-10                         	  190969	      6170 ns/op
+		// BenchmarkCodec/Leopard/size:128-10                        	   82821	     14287 ns/op
+		b.Run(fmt.Sprintf("Leopard/size:%v", size), func(b *testing.B) {
+			enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(true))
+			require.NoError(b, err)
+
+			shards := newShards(b, size, true)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				err = enc.Encode(shards)
+				require.NoError(b, err)
+			}
+		})
+
+		// BenchmarkCodec/default/size:32-10       					  	  222153	      5364 ns/op
+		// BenchmarkCodec/default/size:64-10                         	   58831	     20349 ns/op
+		// BenchmarkCodec/default/size:128-10                        	   14940	     80471 ns/op
+		b.Run(fmt.Sprintf("default/size:%v", size), func(b *testing.B) {
+			enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(false))
+			require.NoError(b, err)
+
+			shards := newShards(b, size, true)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				err = enc.Encode(shards)
+				require.NoError(b, err)
+			}
+		})
+
+		// BenchmarkCodec/default-reconstructSome/size:32-10         	 1263585	       954.4 ns/op
+		// BenchmarkCodec/default-reconstructSome/size:64-10         	  762273	      1554 ns/op
+		// BenchmarkCodec/default-reconstructSome/size:128-10        	  429268	      2974 ns/op
+		b.Run(fmt.Sprintf("default-reconstructSome/size:%v", size), func(b *testing.B) {
+			enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(false))
+			require.NoError(b, err)
+
+			shards := newShards(b, size, false)
+			targets := make([]bool, size)
+			target := size - 2
+			targets[target] = true
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				err = enc.ReconstructSome(shards, targets)
+				require.NoError(b, err)
+				shards[target] = nil
+			}
+		})
+	}
+}
+
+func newShards(b require.TestingT, size int, fillParity bool) [][]byte {
 	shards := make([][]byte, size)
 	original := sharetest.RandShares(b, size/2)
 	copy(shards, original)
 
-	// BenchmarkLeoCodec/Leopard-10         	   81866	     14611 ns/op
-	b.Run("Leopard", func(b *testing.B) {
-		enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(true))
-		require.NoError(b, err)
-
+	if fillParity {
 		// fill with parity empty shares
 		for j := len(original); j < len(shards); j++ {
 			shards[j] = make([]byte, len(original[0]))
 		}
-
-		for i := 0; i < b.N; i++ {
-			err = enc.Encode(shards)
-			require.NoError(b, err)
-		}
-	})
-
-	// BenchmarkLeoCodec/Leopard-10         	   81646	     14641 ns/op
-	b.Run("default", func(b *testing.B) {
-		enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(false))
-		require.NoError(b, err)
-
-		// fill with parity empty shares
-		for j := len(original); j < len(shards); j++ {
-			shards[j] = make([]byte, len(original[0]))
-		}
-
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			err = enc.Encode(shards)
-			require.NoError(b, err)
-		}
-	})
-
-	// BenchmarkLeoCodec/default,_reconstructSome-10         	  407635	      2728 ns/op
-	b.Run("default, reconstructSome", func(b *testing.B) {
-		enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(false))
-		require.NoError(b, err)
-
-		targets := make([]bool, size)
-		target := size - 2
-		targets[target] = true
-
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			err = enc.ReconstructSome(shards, targets)
-			require.NoError(b, err)
-			shards[target] = nil
-		}
-	})
+	}
+	return shards
 }

--- a/share/store/codec_test.go
+++ b/share/store/codec_test.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/klauspost/reedsolomon"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/share/sharetest"
+)
+
+func BenchmarkCodec(b *testing.B) {
+	size := 128
+
+	shards := make([][]byte, size)
+	original := sharetest.RandShares(b, size/2)
+	copy(shards, original)
+
+	// BenchmarkLeoCodec/Leopard-10         	   81866	     14611 ns/op
+	b.Run("Leopard", func(b *testing.B) {
+		enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(true))
+		require.NoError(b, err)
+
+		// fill with parity empty shares
+		for j := len(original); j < len(shards); j++ {
+			shards[j] = make([]byte, len(original[0]))
+		}
+
+		for i := 0; i < b.N; i++ {
+			err = enc.Encode(shards)
+			require.NoError(b, err)
+		}
+	})
+
+	// BenchmarkLeoCodec/Leopard-10         	   81646	     14641 ns/op
+	b.Run("default", func(b *testing.B) {
+		enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(false))
+		require.NoError(b, err)
+
+		// fill with parity empty shares
+		for j := len(original); j < len(shards); j++ {
+			shards[j] = make([]byte, len(original[0]))
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			err = enc.Encode(shards)
+			require.NoError(b, err)
+		}
+	})
+
+	// BenchmarkLeoCodec/default,_reconstructSome-10         	  407635	      2728 ns/op
+	b.Run("default, reconstructSome", func(b *testing.B) {
+		enc, err := reedsolomon.New(size/2, size/2, reedsolomon.WithLeopardGF(false))
+		require.NoError(b, err)
+
+		targets := make([]bool, size)
+		target := size - 2
+		targets[target] = true
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			err = enc.ReconstructSome(shards, targets)
+			require.NoError(b, err)
+			shards[target] = nil
+		}
+	})
+}

--- a/share/store/eds_file.go
+++ b/share/store/eds_file.go
@@ -2,24 +2,199 @@ package store
 
 import (
 	"context"
-	"io"
+	"fmt"
+	"os"
 
+	"golang.org/x/exp/mmap"
+
+	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
 )
 
-type EdsFile interface {
-	io.Closer
-	// Size returns square size of the file.
-	Size() int
-	// Share returns share and corresponding proof for the given axis and share index in this axis.
-	Share(ctx context.Context, axisType rsmt2d.Axis, axisIdx, shrIdx int) (share.Share, nmt.Proof, error)
-	// AxisHalf returns shares for the first half of the axis of the given type and index.
-	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) ([]share.Share, error)
-	// Data returns data for the given namespace and row index.
-	Data(ctx context.Context, namespace share.Namespace, rowIdx int) (share.NamespacedRow, error)
-	// EDS returns extended data square stored in the file.
-	EDS(ctx context.Context) (*rsmt2d.ExtendedDataSquare, error)
+var _ File = (*EdsFile)(nil)
+
+type EdsFile struct {
+	path string
+	hdr  *Header
+	fl   fileBackend
+}
+
+// OpenEdsFile opens an existing file. File has to be closed after usage.
+func OpenEdsFile(path string) (*EdsFile, error) {
+	f, err := mmap.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := ReadHeader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(WWondertan): Validate header
+	return &EdsFile{
+		path: path,
+		hdr:  h,
+		fl:   f,
+	}, nil
+}
+
+func CreateEdsFile(path string, eds *rsmt2d.ExtendedDataSquare) (*EdsFile, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &Header{
+		shareSize:  uint16(len(eds.GetCell(0, 0))), // TODO: rsmt2d should expose this field
+		squareSize: uint16(eds.Width()),
+		version:    FileV0,
+	}
+
+	if _, err = h.WriteTo(f); err != nil {
+		return nil, err
+	}
+
+	for i := uint(0); i < eds.Width(); i++ {
+		for j := uint(0); j < eds.Width(); j++ {
+			// TODO: Implemented buffered write through io.CopyBuffer
+			shr := eds.GetCell(i, j)
+			if _, err := f.Write(shr); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &EdsFile{
+		path: path,
+		fl:   f,
+		hdr:  h,
+	}, f.Sync()
+}
+
+func (f *EdsFile) Size() int {
+	return f.hdr.SquareSize()
+}
+
+func (f *EdsFile) Close() error {
+	return f.fl.Close()
+}
+
+func (f *EdsFile) Header() *Header {
+	return f.hdr
+}
+
+func (f *EdsFile) AxisHalf(_ context.Context, axisType rsmt2d.Axis, axisIdx int) ([]share.Share, error) {
+	axis, err := f.axis(axisType, axisIdx)
+	if err != nil {
+		return nil, err
+	}
+	return axis[:f.Size()/2], nil
+}
+
+func (f *EdsFile) axis(axisType rsmt2d.Axis, axisIdx int) ([]share.Share, error) {
+	switch axisType {
+	case rsmt2d.Col:
+		return f.readCol(axisIdx)
+	case rsmt2d.Row:
+		return f.readRow(axisIdx)
+	}
+	return nil, fmt.Errorf("unknown axis")
+}
+
+func (f *EdsFile) readRow(idx int) ([]share.Share, error) {
+	shrLn := int(f.hdr.shareSize)
+	odsLn := int(f.hdr.squareSize)
+
+	shrs := make([]share.Share, odsLn)
+
+	pos := idx * odsLn
+	offset := pos*shrLn + HeaderSize
+
+	axsData := make([]byte, odsLn*shrLn)
+	if _, err := f.fl.ReadAt(axsData, int64(offset)); err != nil {
+		return nil, err
+	}
+
+	for i := range shrs {
+		shrs[i] = axsData[i*shrLn : (i+1)*shrLn]
+	}
+	return shrs, nil
+}
+
+func (f *EdsFile) readCol(idx int) ([]share.Share, error) {
+	shrLn := int(f.hdr.shareSize)
+	odsLn := int(f.hdr.squareSize)
+
+	shrs := make([]share.Share, odsLn)
+
+	for i := 0; i < odsLn; i++ {
+		pos := idx + i*odsLn
+		offset := pos*shrLn + HeaderSize
+
+		shr := make(share.Share, shrLn)
+		if _, err := f.fl.ReadAt(shr, int64(offset)); err != nil {
+			return nil, err
+		}
+		shrs[i] = shr
+	}
+	return shrs, nil
+}
+
+func (f *EdsFile) Share(
+	_ context.Context,
+	axisType rsmt2d.Axis,
+	axisIdx, shrIdx int,
+) (share.Share, nmt.Proof, error) {
+	shares, err := f.axis(axisType, axisIdx)
+	if err != nil {
+		return nil, nmt.Proof{}, err
+	}
+
+	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(f.Size()/2), uint(axisIdx))
+	for _, shr := range shares {
+		err := tree.Push(shr)
+		if err != nil {
+			return nil, nmt.Proof{}, err
+		}
+	}
+
+	proof, err := tree.ProveRange(shrIdx, shrIdx+1)
+	if err != nil {
+		return nil, nmt.Proof{}, err
+	}
+
+	return shares[shrIdx], proof, nil
+}
+
+func (f *EdsFile) Data(_ context.Context, namespace share.Namespace, rowIdx int) (share.NamespacedRow, error) {
+	shares, err := f.axis(rsmt2d.Row, rowIdx)
+	if err != nil {
+		return share.NamespacedRow{}, err
+	}
+	return ndDateFromShares(shares, namespace, rowIdx)
+}
+
+func (f *EdsFile) EDS(_ context.Context) (*rsmt2d.ExtendedDataSquare, error) {
+	shrLn := int(f.hdr.shareSize)
+	odsLn := int(f.hdr.squareSize)
+
+	buf := make([]byte, odsLn*odsLn*shrLn)
+	if _, err := f.fl.ReadAt(buf, HeaderSize); err != nil {
+		return nil, err
+	}
+
+	shrs := make([][]byte, odsLn*odsLn)
+	for i := 0; i < odsLn; i++ {
+		for j := 0; j < odsLn; j++ {
+			pos := i*odsLn + j
+			shrs[pos] = buf[pos*shrLn : (pos+1)*shrLn]
+		}
+	}
+
+	treeFn := wrapper.NewConstructor(uint64(f.hdr.squareSize / 2))
+	return rsmt2d.ImportExtendedDataSquare(shrs, share.DefaultRSMT2DCodec(), treeFn)
 }

--- a/share/store/eds_file_test.go
+++ b/share/store/eds_file_test.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+)
+
+func TestCreateEdsFile(t *testing.T) {
+	path := t.TempDir() + "/testfile"
+	edsIn := edstest.RandEDS(t, 8)
+
+	_, err := CreateEdsFile(path, edsIn)
+	require.NoError(t, err)
+
+	f, err := OpenEdsFile(path)
+	require.NoError(t, err)
+	edsOut, err := f.EDS(context.TODO())
+	require.NoError(t, err)
+	assert.True(t, edsIn.Equals(edsOut))
+}
+
+func TestEdsFile(t *testing.T) {
+	size := 32
+	createOdsFile := func(eds *rsmt2d.ExtendedDataSquare) File {
+		path := t.TempDir() + "/testfile"
+		fl, err := CreateEdsFile(path, eds)
+		require.NoError(t, err)
+		return fl
+	}
+
+	t.Run("Share", func(t *testing.T) {
+		testFileShare(t, createOdsFile, size)
+	})
+
+	t.Run("AxisHalf", func(t *testing.T) {
+		testFileAxisHalf(t, createOdsFile, size)
+	})
+
+	t.Run("Data", func(t *testing.T) {
+		testFileDate(t, createOdsFile, size)
+	})
+
+	t.Run("EDS", func(t *testing.T) {
+		testFileEds(t, createOdsFile, size)
+	})
+}
+
+// BenchmarkAxisFromEdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	  288624	      3758 ns/op
+// BenchmarkAxisFromEdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	  313893	      3729 ns/op
+// BenchmarkAxisFromEdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   29406	     41051 ns/op
+// BenchmarkAxisFromEdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	   29145	     41047 ns/op
+// BenchmarkAxisFromEdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	  186302	      6532 ns/op
+// BenchmarkAxisFromEdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	  186172	      6383 ns/op
+// BenchmarkAxisFromEdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	   14451	     82114 ns/op
+// BenchmarkAxisFromEdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	   14572	     82047 ns/op
+// BenchmarkAxisFromEdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	   94576	     11349 ns/op
+// BenchmarkAxisFromEdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	  103954	     11276 ns/op
+// BenchmarkAxisFromEdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	    7072	    165301 ns/op
+// BenchmarkAxisFromEdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	    6805	    165173 ns/op
+func BenchmarkAxisFromEdsFile(b *testing.B) {
+	minSize, maxSize := 32, 128
+	dir := b.TempDir()
+	newFile := func(size int) File {
+		eds := edstest.RandEDS(b, size)
+		path := dir + "/testfile"
+		f, err := CreateEdsFile(path, eds)
+		require.NoError(b, err)
+		return f
+	}
+	benchGetAxisFromFile(b, newFile, minSize, maxSize)
+}
+
+// BenchmarkShareFromEdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	   17850	     66716 ns/op
+// BenchmarkShareFromEdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	   18517	     64462 ns/op
+// BenchmarkShareFromEdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   10000	    104241 ns/op
+// BenchmarkShareFromEdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	   10000	    101964 ns/op
+// BenchmarkShareFromEdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	    8641	    129674 ns/op
+// BenchmarkShareFromEdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    9022	    124899 ns/op
+// BenchmarkShareFromEdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	    5625	    204934 ns/op
+// BenchmarkShareFromEdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    5785	    200634 ns/op
+// BenchmarkShareFromEdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	    4424	    262753 ns/op
+// BenchmarkShareFromEdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	    4690	    252676 ns/op
+// BenchmarkShareFromEdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	    2834	    415072 ns/op
+// BenchmarkShareFromEdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	    2934	    426160 ns/op
+func BenchmarkShareFromEdsFile(b *testing.B) {
+	minSize, maxSize := 32, 128
+	dir := b.TempDir()
+	newFile := func(size int) File {
+		eds := edstest.RandEDS(b, size)
+		path := dir + "/testfile"
+		f, err := CreateEdsFile(path, eds)
+		require.NoError(b, err)
+		return f
+	}
+	benchGetShareFromFile(b, newFile, minSize, maxSize)
+}

--- a/share/store/file.go
+++ b/share/store/file.go
@@ -1,0 +1,25 @@
+package store
+
+import (
+	"context"
+	"io"
+
+	"github.com/celestiaorg/nmt"
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share"
+)
+
+type File interface {
+	io.Closer
+	// Size returns square size of the file.
+	Size() int
+	// Share returns share and corresponding proof for the given axis and share index in this axis.
+	Share(ctx context.Context, axisType rsmt2d.Axis, axisIdx, shrIdx int) (share.Share, nmt.Proof, error)
+	// AxisHalf returns shares for the first half of the axis of the given type and index.
+	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) ([]share.Share, error)
+	// Data returns data for the given namespace and row index.
+	Data(ctx context.Context, namespace share.Namespace, rowIdx int) (share.NamespacedRow, error)
+	// EDS returns extended data square stored in the file.
+	EDS(ctx context.Context) (*rsmt2d.ExtendedDataSquare, error)
+}

--- a/share/store/file_header.go
+++ b/share/store/file_header.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+const HeaderSize = 32
+
+type Header struct {
+	version FileVersion
+
+	// Taken directly from EDS
+	shareSize  uint16
+	squareSize uint16
+}
+
+type FileVersion uint8
+
+const (
+	FileV0 FileVersion = iota
+)
+
+func (h *Header) Version() FileVersion {
+	return h.version
+}
+
+func (h *Header) ShareSize() int {
+	return int(h.shareSize)
+}
+
+func (h *Header) SquareSize() int {
+	return int(h.squareSize)
+}
+
+func (h *Header) WriteTo(w io.Writer) (int64, error) {
+	buf := make([]byte, HeaderSize)
+	buf[0] = byte(h.version)
+	binary.LittleEndian.PutUint16(buf[1:3], h.shareSize)
+	binary.LittleEndian.PutUint16(buf[3:5], h.squareSize)
+	// TODO: Extensions
+	n, err := w.Write(buf)
+	return int64(n), err
+}
+
+func (h *Header) ReadFrom(r io.Reader) (int64, error) {
+	buf := make([]byte, HeaderSize)
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return int64(n), err
+	}
+
+	h.version = FileVersion(buf[0])
+	h.shareSize = binary.LittleEndian.Uint16(buf[1:3])
+	h.squareSize = binary.LittleEndian.Uint16(buf[3:5])
+
+	// TODO: Extensions
+	return int64(n), err
+}
+
+func ReadHeader(r io.ReaderAt) (*Header, error) {
+	h := &Header{}
+	buf := make([]byte, HeaderSize)
+	_, err := r.ReadAt(buf, 0)
+	if err != nil {
+		return h, err
+	}
+
+	h.version = FileVersion(buf[0])
+	h.shareSize = binary.LittleEndian.Uint16(buf[1:3])
+	h.squareSize = binary.LittleEndian.Uint16(buf[3:5])
+	return h, nil
+}

--- a/share/store/file_test.go
+++ b/share/store/file_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	mrand "math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	"github.com/celestiaorg/celestia-node/share/sharetest"
+)
+
+type createFile func(eds *rsmt2d.ExtendedDataSquare) File
+
+func testFileShare(t *testing.T, createFile createFile, size int) {
+	eds := edstest.RandEDS(t, size)
+	fl := createFile(eds)
+
+	root, err := share.NewRoot(eds)
+	require.NoError(t, err)
+
+	width := int(eds.Width())
+	for _, axisType := range []rsmt2d.Axis{rsmt2d.Col, rsmt2d.Row} {
+		for i := 0; i < width*width; i++ {
+			axisIdx, shrIdx := i/width, i%width
+			if axisType == rsmt2d.Col {
+				axisIdx, shrIdx = shrIdx, axisIdx
+			}
+
+			shr, prf, err := fl.Share(context.TODO(), axisType, axisIdx, shrIdx)
+			require.NoError(t, err)
+
+			namespace := share.ParitySharesNamespace
+			if axisIdx < width/2 && shrIdx < width/2 {
+				namespace = share.GetNamespace(shr)
+			}
+
+			axishash := root.RowRoots[axisIdx]
+			if axisType == rsmt2d.Col {
+				axishash = root.ColumnRoots[axisIdx]
+			}
+
+			ok := prf.VerifyInclusion(sha256.New(), namespace.ToNMT(), [][]byte{shr}, axishash)
+			require.True(t, ok)
+		}
+	}
+}
+
+func testFileDate(t *testing.T, createFile createFile, size int) {
+	// generate EDS with random data and some shares with the same namespace
+	namespace := sharetest.RandV0Namespace()
+	amount := mrand.Intn(size*size-1) + 1
+	eds, dah := edstest.RandEDSWithNamespace(t, namespace, amount, size)
+
+	f := createFile(eds)
+
+	for i, root := range dah.RowRoots {
+		if !namespace.IsOutsideRange(root, root) {
+			nd, err := f.Data(context.Background(), namespace, i)
+			require.NoError(t, err)
+			ok := nd.Verify(root, namespace)
+			require.True(t, ok)
+		}
+	}
+}
+
+func testFileAxisHalf(t *testing.T, createFile createFile, size int) {
+	eds := edstest.RandEDS(t, size)
+	fl := createFile(eds)
+
+	for _, axisType := range []rsmt2d.Axis{rsmt2d.Col, rsmt2d.Row} {
+		for i := 0; i < size; i++ {
+			half, err := fl.AxisHalf(context.Background(), axisType, i)
+			require.NoError(t, err)
+			require.Equal(t, getAxis(eds, axisType, i)[:size], half)
+		}
+	}
+}
+
+func testFileEds(t *testing.T, createFile createFile, size int) {
+	eds := edstest.RandEDS(t, size)
+	fl := createFile(eds)
+
+	eds2, err := fl.EDS(context.Background())
+	require.NoError(t, err)
+	require.True(t, eds.Equals(eds2))
+}

--- a/share/store/mem_file.go
+++ b/share/store/mem_file.go
@@ -11,7 +11,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share/ipld"
 )
 
-var _ EdsFile = (*MemFile)(nil)
+var _ File = (*MemFile)(nil)
 
 type MemFile struct {
 	Eds *rsmt2d.ExtendedDataSquare
@@ -53,6 +53,18 @@ func (f *MemFile) AxisHalf(_ context.Context, axisType rsmt2d.Axis, axisIdx int)
 
 func (f *MemFile) Data(_ context.Context, namespace share.Namespace, rowIdx int) (share.NamespacedRow, error) {
 	shares := f.axis(rsmt2d.Row, rowIdx)
+	return ndDateFromShares(shares, namespace, rowIdx)
+}
+
+func (f *MemFile) EDS(_ context.Context) (*rsmt2d.ExtendedDataSquare, error) {
+	return f.Eds, nil
+}
+
+func (f *MemFile) axis(axisType rsmt2d.Axis, axisIdx int) []share.Share {
+	return getAxis(f.Eds, axisType, axisIdx)
+}
+
+func ndDateFromShares(shares []share.Share, namespace share.Namespace, rowIdx int) (share.NamespacedRow, error) {
 	bserv := ipld.NewMemBlockservice()
 	batchAdder := ipld.NewNmtNodeAdder(context.TODO(), bserv, ipld.MaxSizeBatchOption(len(shares)))
 	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(len(shares)/2), uint(rowIdx),
@@ -85,16 +97,12 @@ func (f *MemFile) Data(_ context.Context, namespace share.Namespace, rowIdx int)
 	}, nil
 }
 
-func (f *MemFile) EDS(_ context.Context) (*rsmt2d.ExtendedDataSquare, error) {
-	return f.Eds, nil
-}
-
-func (f *MemFile) axis(axisType rsmt2d.Axis, axisIdx int) []share.Share {
+func getAxis(eds *rsmt2d.ExtendedDataSquare, axisType rsmt2d.Axis, axisIdx int) []share.Share {
 	switch axisType {
 	case rsmt2d.Row:
-		return f.Eds.Row(uint(axisIdx))
+		return eds.Row(uint(axisIdx))
 	case rsmt2d.Col:
-		return f.Eds.Col(uint(axisIdx))
+		return eds.Col(uint(axisIdx))
 	default:
 		panic("unknown axis")
 	}

--- a/share/store/ods_file.go
+++ b/share/store/ods_file.go
@@ -223,11 +223,11 @@ func computeAxisHalf(
 				return err
 			}
 
-			axis, err := extendShares(original)
+			parity, err := rsmt2d.NewLeoRSCodec().Encode(original)
 			if err != nil {
 				return err
 			}
-			shares[i] = axis[axisIdx]
+			shares[i] = parity[axisIdx-f.Size()/2]
 			return nil
 		})
 	}

--- a/share/store/ods_file.go
+++ b/share/store/ods_file.go
@@ -1,0 +1,265 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/exp/mmap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/celestiaorg/celestia-app/pkg/wrapper"
+	"github.com/celestiaorg/nmt"
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share"
+)
+
+var _ File = (*OdsFile)(nil)
+
+type OdsFile struct {
+	path string
+	hdr  *Header
+	fl   fileBackend
+}
+
+type fileBackend interface {
+	io.ReaderAt
+	io.Closer
+}
+
+// OpenOdsFile opens an existing file. File has to be closed after usage.
+func OpenOdsFile(path string) (*OdsFile, error) {
+	f, err := mmap.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := ReadHeader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(WWondertan): Validate header
+	return &OdsFile{
+		path: path,
+		hdr:  h,
+		fl:   f,
+	}, nil
+}
+
+func CreateOdsFile(path string, eds *rsmt2d.ExtendedDataSquare) (*OdsFile, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &Header{
+		shareSize:  uint16(len(eds.GetCell(0, 0))), // TODO: rsmt2d should expose this field
+		squareSize: uint16(eds.Width()),
+		version:    FileV0,
+	}
+
+	if _, err = h.WriteTo(f); err != nil {
+		return nil, err
+	}
+
+	for i := uint(0); i < eds.Width()/2; i++ {
+		for j := uint(0); j < eds.Width()/2; j++ {
+			// TODO: Implemented buffered write through io.CopyBuffer
+			shr := eds.GetCell(i, j)
+			if _, err := f.Write(shr); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &OdsFile{
+		path: path,
+		fl:   f,
+		hdr:  h,
+	}, f.Sync()
+}
+
+func (f *OdsFile) Size() int {
+	return f.hdr.SquareSize()
+}
+
+func (f *OdsFile) Close() error {
+	return f.fl.Close()
+}
+
+func (f *OdsFile) Header() *Header {
+	return f.hdr
+}
+
+func (f *OdsFile) AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) ([]share.Share, error) {
+	// read axis from file if axis is in the first quadrant
+	if axisIdx < f.Size()/2 {
+		return f.odsAxisHalf(axisType, axisIdx)
+	}
+
+	// compute axis if axis is outside the first quadrant
+	return computeAxisHalf(ctx, f, axisType, axisIdx)
+}
+
+func (f *OdsFile) odsAxisHalf(axisType rsmt2d.Axis, axisIdx int) ([]share.Share, error) {
+	switch axisType {
+	case rsmt2d.Col:
+		return f.readCol(axisIdx)
+	case rsmt2d.Row:
+		return f.readRow(axisIdx)
+	}
+	return nil, fmt.Errorf("unknown axis")
+}
+
+func (f *OdsFile) readRow(idx int) ([]share.Share, error) {
+	shrLn := int(f.hdr.shareSize)
+	odsLn := int(f.hdr.squareSize) / 2
+
+	shrs := make([]share.Share, odsLn)
+
+	pos := idx * odsLn
+	offset := pos*shrLn + HeaderSize
+
+	axsData := make([]byte, odsLn*shrLn)
+	if _, err := f.fl.ReadAt(axsData, int64(offset)); err != nil {
+		return nil, err
+	}
+
+	for i := range shrs {
+		shrs[i] = axsData[i*shrLn : (i+1)*shrLn]
+	}
+	return shrs, nil
+}
+
+func (f *OdsFile) readCol(idx int) ([]share.Share, error) {
+	shrLn := int(f.hdr.shareSize)
+	odsLn := int(f.hdr.squareSize) / 2
+
+	shrs := make([]share.Share, odsLn)
+
+	for i := 0; i < odsLn; i++ {
+		pos := idx + i*odsLn
+		offset := pos*shrLn + HeaderSize
+
+		shr := make(share.Share, shrLn)
+		if _, err := f.fl.ReadAt(shr, int64(offset)); err != nil {
+			return nil, err
+		}
+		shrs[i] = shr
+	}
+	return shrs, nil
+}
+
+func computeAxisHalf(
+	ctx context.Context,
+	f *OdsFile,
+	axisType rsmt2d.Axis,
+	axisIdx int,
+) ([]share.Share, error) {
+	shares := make([]share.Share, f.Size()/2)
+
+	// extend opposite half of the square while collecting shares for the first half of required axis
+	g, ctx := errgroup.WithContext(ctx)
+	opposite := oppositeAxis(axisType)
+	for i := 0; i < f.Size()/2; i++ {
+		i := i
+		g.Go(func() error {
+			ax, err := f.axis(ctx, opposite, i)
+			if err != nil {
+				return err
+			}
+			shares[i] = ax[axisIdx]
+			return nil
+		})
+	}
+
+	err := g.Wait()
+	return shares, err
+}
+
+func (f *OdsFile) axis(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) ([]share.Share, error) {
+	original, err := f.AxisHalf(ctx, axisType, axisIdx)
+	if err != nil {
+		return nil, err
+	}
+
+	return extendShares(original)
+}
+
+func extendShares(original []share.Share) ([]share.Share, error) {
+	parity, err := rsmt2d.NewLeoRSCodec().Encode(original)
+	if err != nil {
+		return nil, err
+	}
+
+	shares := make([]share.Share, 0, len(original)+len(parity))
+	shares = append(shares, original...)
+	shares = append(shares, parity...)
+
+	return shares, nil
+}
+
+func (f *OdsFile) Share(
+	ctx context.Context,
+	axisType rsmt2d.Axis,
+	axisIdx, shrIdx int,
+) (share.Share, nmt.Proof, error) {
+	shares, err := f.axis(ctx, axisType, axisIdx)
+	if err != nil {
+		return nil, nmt.Proof{}, err
+	}
+
+	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(f.Size()/2), uint(axisIdx))
+	for _, shr := range shares {
+		err := tree.Push(shr)
+		if err != nil {
+			return nil, nmt.Proof{}, err
+		}
+	}
+
+	proof, err := tree.ProveRange(shrIdx, shrIdx+1)
+	if err != nil {
+		return nil, nmt.Proof{}, err
+	}
+
+	return shares[shrIdx], proof, nil
+}
+
+func (f *OdsFile) Data(ctx context.Context, namespace share.Namespace, rowIdx int) (share.NamespacedRow, error) {
+	shares, err := f.axis(ctx, rsmt2d.Row, rowIdx)
+	if err != nil {
+		return share.NamespacedRow{}, err
+	}
+	return ndDateFromShares(shares, namespace, rowIdx)
+}
+
+func (f *OdsFile) EDS(_ context.Context) (*rsmt2d.ExtendedDataSquare, error) {
+	shrLn := int(f.hdr.shareSize)
+	odsLn := int(f.hdr.squareSize) / 2
+
+	buf := make([]byte, odsLn*odsLn*shrLn)
+	if _, err := f.fl.ReadAt(buf, HeaderSize); err != nil {
+		return nil, err
+	}
+
+	shrs := make([][]byte, odsLn*odsLn)
+	for i := 0; i < odsLn; i++ {
+		for j := 0; j < odsLn; j++ {
+			pos := i*odsLn + j
+			shrs[pos] = buf[pos*shrLn : (pos+1)*shrLn]
+		}
+	}
+
+	treeFn := wrapper.NewConstructor(uint64(f.hdr.squareSize / 2))
+	return rsmt2d.ComputeExtendedDataSquare(shrs, share.DefaultRSMT2DCodec(), treeFn)
+}
+
+func oppositeAxis(axis rsmt2d.Axis) rsmt2d.Axis {
+	if axis == rsmt2d.Col {
+		return rsmt2d.Row
+	}
+	return rsmt2d.Col
+}

--- a/share/store/ods_file_test.go
+++ b/share/store/ods_file_test.go
@@ -16,8 +16,7 @@ import (
 func TestCreateOdsFile(t *testing.T) {
 	path := t.TempDir() + "/testfile"
 	edsIn := edstest.RandEDS(t, 8)
-	codec := rsmt2d.NewLeoRSCodec()
-	mem := newMemPool(codec, int(edsIn.Width()))
+	mem := newMemPools(rsmt2d.NewLeoRSCodec())
 	_, err := CreateOdsFile(path, edsIn, mem)
 	require.NoError(t, err)
 
@@ -30,8 +29,7 @@ func TestCreateOdsFile(t *testing.T) {
 
 func TestOdsFile(t *testing.T) {
 	size := 32
-	codec := rsmt2d.NewLeoRSCodec()
-	mem := newMemPool(codec, size)
+	mem := newMemPools(rsmt2d.NewLeoRSCodec())
 	createOdsFile := func(eds *rsmt2d.ExtendedDataSquare) File {
 		path := t.TempDir() + "/testfile"
 		fl, err := CreateOdsFile(path, eds, mem)
@@ -71,16 +69,12 @@ func TestOdsFile(t *testing.T) {
 func BenchmarkAxisFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()
-	codec := rsmt2d.NewLeoRSCodec()
-	mem := make(map[int]memPool)
-	for i := minSize; i <= maxSize; i *= 2 {
-		mem[i] = newMemPool(codec, i)
-	}
+	mem := newMemPools(rsmt2d.NewLeoRSCodec())
 
 	newFile := func(size int) File {
 		eds := edstest.RandEDS(b, size)
 		path := dir + "/testfile"
-		f, err := CreateOdsFile(path, eds, mem[size])
+		f, err := CreateOdsFile(path, eds, mem)
 		require.NoError(b, err)
 		return f
 	}
@@ -102,16 +96,12 @@ func BenchmarkAxisFromOdsFile(b *testing.B) {
 func BenchmarkShareFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()
-	codec := rsmt2d.NewLeoRSCodec()
-	mem := make(map[int]memPool)
-	for i := minSize; i <= maxSize; i *= 2 {
-		mem[i] = newMemPool(codec, i)
-	}
+	mem := newMemPools(rsmt2d.NewLeoRSCodec())
 
 	newFile := func(size int) File {
 		eds := edstest.RandEDS(b, size)
 		path := dir + "/testfile"
-		f, err := CreateOdsFile(path, eds, mem[size])
+		f, err := CreateOdsFile(path, eds, mem)
 		require.NoError(b, err)
 		return f
 	}

--- a/share/store/ods_file_test.go
+++ b/share/store/ods_file_test.go
@@ -1,0 +1,162 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+)
+
+func TestCreateOdsFile(t *testing.T) {
+	path := t.TempDir() + "/testfile"
+	edsIn := edstest.RandEDS(t, 8)
+
+	_, err := CreateOdsFile(path, edsIn)
+	require.NoError(t, err)
+
+	f, err := OpenOdsFile(path)
+	require.NoError(t, err)
+	edsOut, err := f.EDS(context.TODO())
+	require.NoError(t, err)
+	assert.True(t, edsIn.Equals(edsOut))
+}
+
+func TestOdsFile(t *testing.T) {
+	size := 32
+	createOdsFile := func(eds *rsmt2d.ExtendedDataSquare) File {
+		path := t.TempDir() + "/testfile"
+		fl, err := CreateOdsFile(path, eds)
+		require.NoError(t, err)
+		return fl
+	}
+
+	t.Run("Share", func(t *testing.T) {
+		testFileShare(t, createOdsFile, size)
+	})
+
+	t.Run("AxisHalf", func(t *testing.T) {
+		testFileAxisHalf(t, createOdsFile, size)
+	})
+
+	t.Run("Data", func(t *testing.T) {
+		testFileDate(t, createOdsFile, size)
+	})
+
+	t.Run("EDS", func(t *testing.T) {
+		testFileEds(t, createOdsFile, size)
+	})
+}
+
+// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	  435496	      2488 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	     814	   1279260 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   57886	     21029 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    2365	    493366 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	  272930	      3932 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	     235	   4881303 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	   28566	     41591 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	     758	   1605038 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	  145546	      7922 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	      64	  17827662 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	   14073	     84737 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     127	  11064373 ns/op
+func BenchmarkAxisFromOdsFile(b *testing.B) {
+	minSize, maxSize := 32, 128
+	dir := b.TempDir()
+	newFile := func(size int) File {
+		eds := edstest.RandEDS(b, size)
+		path := dir + "/testfile"
+		f, err := CreateOdsFile(path, eds)
+		require.NoError(b, err)
+		return f
+	}
+	benchGetAxisFromFile(b, newFile, minSize, maxSize)
+}
+
+// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	   10316	    111701 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	     778	   1352715 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	    8174	    130810 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    1890	    646434 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	    4935	    214392 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	     235	   5023812 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	    4323	    252924 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	     567	   1870541 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	    2424	    452331 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	      66	  21867956 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	    2100	    542252 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     100	  14112671 ns/op
+func BenchmarkShareFromOdsFile(b *testing.B) {
+	minSize, maxSize := 32, 128
+	dir := b.TempDir()
+	newFile := func(size int) File {
+		eds := edstest.RandEDS(b, size)
+		path := dir + "/testfile"
+		f, err := CreateOdsFile(path, eds)
+		require.NoError(b, err)
+		return f
+	}
+
+	benchGetShareFromFile(b, newFile, minSize, maxSize)
+}
+
+type squareHalf int
+
+func (q squareHalf) String() string {
+	switch q {
+	case 0:
+		return "first(original)"
+	case 1:
+		return "second(extended)"
+	}
+	return "unknown"
+}
+
+func benchGetAxisFromFile(b *testing.B, newFile func(size int) File, minSize, maxSize int) {
+	for size := minSize; size <= maxSize; size *= 2 {
+		f := newFile(size)
+
+		// loop over all possible axis types and quadrants
+		for _, axisType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
+			for _, squareHalf := range []squareHalf{0, 1} {
+				name := fmt.Sprintf("Size:%v/Axis:%s/squareHalf:%s", size, axisType, squareHalf)
+				b.Run(name, func(b *testing.B) {
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						_, err := f.AxisHalf(context.TODO(), axisType, f.Size()/2*int(squareHalf))
+						require.NoError(b, err)
+					}
+				})
+			}
+		}
+	}
+}
+
+func benchGetShareFromFile(b *testing.B, newFile func(size int) File, minSize, maxSize int) {
+	for size := minSize; size <= maxSize; size *= 2 {
+		f := newFile(size)
+
+		// loop over all possible axis types and quadrants
+		for _, axisType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
+			for _, squareHalf := range []squareHalf{0, 1} {
+				name := fmt.Sprintf("Size:%v/Axis:%s/squareHalf:%s", size, axisType, squareHalf)
+				b.Run(name, func(b *testing.B) {
+					idx := f.Size() - 1
+					// warm up cache
+					_, _, err := f.Share(context.TODO(), axisType, f.Size()/2*int(squareHalf), idx)
+					require.NoError(b, err)
+
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						_, _, err = f.Share(context.TODO(), axisType, f.Size()/2*int(squareHalf), idx)
+						require.NoError(b, err)
+					}
+				})
+			}
+		}
+	}
+}

--- a/share/store/ods_file_test.go
+++ b/share/store/ods_file_test.go
@@ -16,7 +16,7 @@ import (
 func TestCreateOdsFile(t *testing.T) {
 	path := t.TempDir() + "/testfile"
 	edsIn := edstest.RandEDS(t, 8)
-	mem := newMemPools(rsmt2d.NewLeoRSCodec())
+	mem := newMemPools(NewCodec())
 	_, err := CreateOdsFile(path, edsIn, mem)
 	require.NoError(t, err)
 
@@ -29,7 +29,7 @@ func TestCreateOdsFile(t *testing.T) {
 
 func TestOdsFile(t *testing.T) {
 	size := 32
-	mem := newMemPools(rsmt2d.NewLeoRSCodec())
+	mem := newMemPools(NewCodec())
 	createOdsFile := func(eds *rsmt2d.ExtendedDataSquare) File {
 		path := t.TempDir() + "/testfile"
 		fl, err := CreateOdsFile(path, eds, mem)
@@ -56,14 +56,14 @@ func TestOdsFile(t *testing.T) {
 
 func TestReadOdsFile(t *testing.T) {
 	eds := edstest.RandEDS(t, 8)
-	mem := newMemPools(rsmt2d.NewLeoRSCodec())
+	mem := newMemPools(NewCodec())
 	path := t.TempDir() + "/testfile"
 	f, err := CreateOdsFile(path, eds, mem)
 	require.NoError(t, err)
 
 	ods, err := f.readOds(rsmt2d.Row)
 	require.NoError(t, err)
-	for i, row := range ods.shares {
+	for i, row := range ods.square {
 		original, err := f.readRow(i)
 		require.NoError(t, err)
 		require.True(t, len(original) == len(row))
@@ -86,7 +86,7 @@ func TestReadOdsFile(t *testing.T) {
 func BenchmarkAxisFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()
-	mem := newMemPools(rsmt2d.NewLeoRSCodec())
+	mem := newMemPools(NewCodec())
 
 	newFile := func(size int) File {
 		eds := edstest.RandEDS(b, size)
@@ -113,7 +113,7 @@ func BenchmarkAxisFromOdsFile(b *testing.B) {
 func BenchmarkShareFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()
-	mem := newMemPools(rsmt2d.NewLeoRSCodec())
+	mem := newMemPools(NewCodec())
 
 	newFile := func(size int) File {
 		eds := edstest.RandEDS(b, size)

--- a/share/store/ods_file_test.go
+++ b/share/store/ods_file_test.go
@@ -54,18 +54,35 @@ func TestOdsFile(t *testing.T) {
 	})
 }
 
-// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	  429498	      2464 ns/op
-// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    5889	    192904 ns/op
-// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   56209	     20926 ns/op
-// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    5480	    193249 ns/op
-// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	  287070	      4003 ns/op
-// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    2212	    506601 ns/op
-// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	   28990	     41353 ns/op
-// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    2358	    511020 ns/op
-// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	  186265	      6309 ns/op
-// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     610	   1814819 ns/op
-// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	   14460	     82613 ns/op
-// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     640	   1819996 ns/op
+func TestReadOdsFile(t *testing.T) {
+	eds := edstest.RandEDS(t, 8)
+	mem := newMemPools(rsmt2d.NewLeoRSCodec())
+	path := t.TempDir() + "/testfile"
+	f, err := CreateOdsFile(path, eds, mem)
+	require.NoError(t, err)
+
+	ods, err := f.readOds(rsmt2d.Row)
+	require.NoError(t, err)
+	for i, row := range ods.shares {
+		original, err := f.readRow(i)
+		require.NoError(t, err)
+		require.True(t, len(original) == len(row))
+		require.Equal(t, original, row)
+	}
+}
+
+// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	  418206	      2545 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    4968	    227265 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   57007	     20707 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    5016	    214184 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	  308559	      3786 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    1624	    713999 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	   28724	     41421 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    1686	    629314 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	  183322	      6360 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     428	   2616150 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	   14338	     83598 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     488	   2213146 ns/op
 func BenchmarkAxisFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()
@@ -81,18 +98,18 @@ func BenchmarkAxisFromOdsFile(b *testing.B) {
 	benchGetAxisFromFile(b, newFile, minSize, maxSize)
 }
 
-// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	   10333	    113351 ns/op
-// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    3794	    319437 ns/op
-// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	    7201	    139066 ns/op
-// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    3612	    317520 ns/op
-// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	    5462	    220543 ns/op
-// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    1586	    775291 ns/op
-// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	    4611	    257328 ns/op
-// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    1534	    788619 ns/op
-// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	    2413	    448675 ns/op
-// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     517	   2427473 ns/op
-// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	    2200	    528681 ns/op
-// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     464	   2385446 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	   10339	    111328 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    3392	    359180 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	    8925	    131352 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    3447	    346218 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	    5503	    215833 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    1231	   1001053 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	    4711	    250001 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    1315	    910079 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	    2364	    435748 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     358	   3330620 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	    2114	    514642 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     373	   3068104 ns/op
 func BenchmarkShareFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()

--- a/share/store/ods_file_test.go
+++ b/share/store/ods_file_test.go
@@ -71,6 +71,7 @@ func TestReadOdsFile(t *testing.T) {
 	}
 }
 
+// Leopard full encode
 // BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	  418206	      2545 ns/op
 // BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    4968	    227265 ns/op
 // BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   57007	     20707 ns/op
@@ -83,6 +84,20 @@ func TestReadOdsFile(t *testing.T) {
 // BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     428	   2616150 ns/op
 // BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	   14338	     83598 ns/op
 // BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     488	   2213146 ns/op
+
+// ReconstructSome, default codec
+// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	  455848	      2588 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    9015	    203950 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   52734	     21178 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    8830	    127452 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	  303834	      4763 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    2940	    426246 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	   27758	     42842 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    3385	    353868 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	  172086	      6455 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     672	   1550386 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	   14202	     84316 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     978	   1230980 ns/op
 func BenchmarkAxisFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()

--- a/share/store/ods_file_test.go
+++ b/share/store/ods_file_test.go
@@ -16,8 +16,9 @@ import (
 func TestCreateOdsFile(t *testing.T) {
 	path := t.TempDir() + "/testfile"
 	edsIn := edstest.RandEDS(t, 8)
-
-	_, err := CreateOdsFile(path, edsIn)
+	codec := rsmt2d.NewLeoRSCodec()
+	mem := newMemPool(codec, int(edsIn.Width()))
+	_, err := CreateOdsFile(path, edsIn, mem)
 	require.NoError(t, err)
 
 	f, err := OpenOdsFile(path)
@@ -29,9 +30,11 @@ func TestCreateOdsFile(t *testing.T) {
 
 func TestOdsFile(t *testing.T) {
 	size := 32
+	codec := rsmt2d.NewLeoRSCodec()
+	mem := newMemPool(codec, size)
 	createOdsFile := func(eds *rsmt2d.ExtendedDataSquare) File {
 		path := t.TempDir() + "/testfile"
-		fl, err := CreateOdsFile(path, eds)
+		fl, err := CreateOdsFile(path, eds, mem)
 		require.NoError(t, err)
 		return fl
 	}
@@ -53,50 +56,62 @@ func TestOdsFile(t *testing.T) {
 	})
 }
 
-// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	  435496	      2488 ns/op
-// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	     814	   1279260 ns/op
-// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   57886	     21029 ns/op
-// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    2365	    493366 ns/op
-// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	  272930	      3932 ns/op
-// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	     235	   4881303 ns/op
-// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	   28566	     41591 ns/op
-// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	     758	   1605038 ns/op
-// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	  145546	      7922 ns/op
-// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	      64	  17827662 ns/op
-// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	   14073	     84737 ns/op
-// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     127	  11064373 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	  429498	      2464 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    5889	    192904 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	   56209	     20926 ns/op
+// BenchmarkAxisFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    5480	    193249 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	  287070	      4003 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    2212	    506601 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	   28990	     41353 ns/op
+// BenchmarkAxisFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    2358	    511020 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	  186265	      6309 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     610	   1814819 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	   14460	     82613 ns/op
+// BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     640	   1819996 ns/op
 func BenchmarkAxisFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()
+	codec := rsmt2d.NewLeoRSCodec()
+	mem := make(map[int]memPool)
+	for i := minSize; i <= maxSize; i *= 2 {
+		mem[i] = newMemPool(codec, i)
+	}
+
 	newFile := func(size int) File {
 		eds := edstest.RandEDS(b, size)
 		path := dir + "/testfile"
-		f, err := CreateOdsFile(path, eds)
+		f, err := CreateOdsFile(path, eds, mem[size])
 		require.NoError(b, err)
 		return f
 	}
 	benchGetAxisFromFile(b, newFile, minSize, maxSize)
 }
 
-// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	   10316	    111701 ns/op
-// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	     778	   1352715 ns/op
-// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	    8174	    130810 ns/op
-// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    1890	    646434 ns/op
-// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	    4935	    214392 ns/op
-// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	     235	   5023812 ns/op
-// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	    4323	    252924 ns/op
-// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	     567	   1870541 ns/op
-// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	    2424	    452331 ns/op
-// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	      66	  21867956 ns/op
-// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	    2100	    542252 ns/op
-// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     100	  14112671 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:first(original)-10         	   10333	    113351 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    3794	    319437 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:first(original)-10         	    7201	    139066 ns/op
+// BenchmarkShareFromOdsFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    3612	    317520 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:first(original)-10         	    5462	    220543 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    1586	    775291 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:first(original)-10         	    4611	    257328 ns/op
+// BenchmarkShareFromOdsFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    1534	    788619 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-10        	    2413	    448675 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     517	   2427473 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-10        	    2200	    528681 ns/op
+// BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     464	   2385446 ns/op
 func BenchmarkShareFromOdsFile(b *testing.B) {
 	minSize, maxSize := 32, 128
 	dir := b.TempDir()
+	codec := rsmt2d.NewLeoRSCodec()
+	mem := make(map[int]memPool)
+	for i := minSize; i <= maxSize; i *= 2 {
+		mem[i] = newMemPool(codec, i)
+	}
+
 	newFile := func(size int) File {
 		eds := edstest.RandEDS(b, size)
 		path := dir + "/testfile"
-		f, err := CreateOdsFile(path, eds)
+		f, err := CreateOdsFile(path, eds, mem[size])
 		require.NoError(b, err)
 		return f
 	}


### PR DESCRIPTION
Benchmarks results from amd64 16vCPU (dedicated) instance:

There are 2 types of benchmarks:
 - calculate full axis (row/column). Requires only extending 
 - build share + proof. Includes. first one, but also builds merkle tree and collects proofs for share.
 
### EDS file
Stores full EDS file on disk. Reads rows sequentially and columns using random read. 

Axis. Just reads 1 axis from file:
```
BenchmarkAxisFromEdsFile/Size:128/Axis:row/squareHalf:first(original)-16        	   43564	     27772 ns/op
BenchmarkAxisFromEdsFile/Size:128/Axis:row/squareHalf:second(extended)-16       	   42438	     27602 ns/op
BenchmarkAxisFromEdsFile/Size:128/Axis:col/squareHalf:first(original)-16        	    6159	    174715 ns/op
BenchmarkAxisFromEdsFile/Size:128/Axis:col/squareHalf:second(extended)-16       	    5996	    167945 ns/op
```

Share+proofs. Reads 1 axis + builds proofs. 
```
BenchmarkShareFromEdsFile/Size:128/Axis:row/squareHalf:first(original)-16       	    1819	    663927 ns/op
BenchmarkShareFromEdsFile/Size:128/Axis:row/squareHalf:second(extended)-16      	    1818	    639403 ns/op
BenchmarkShareFromEdsFile/Size:128/Axis:col/squareHalf:first(original)-16       	    1400	    836648 ns/op
BenchmarkShareFromEdsFile/Size:128/Axis:col/squareHalf:second(extended)-16      	    1525	    816302 ns/op
```

### In memory EDS file
Acts same as eds file, but reads rows / columns from RAM instead of disk. This one is interesting as it doesn't get I/O involved and depends only on CPU.

Axis. Surprisingly reading rows from disk is faster is faster than from inmemory file. Probably, because of extra allocation for converting axis -> halfAxis.
```
BenchmarkAxisFromMemFile/Size:128/Axis:row/squareHalf:first(original)-16        	   32307	     38273 ns/op
BenchmarkAxisFromMemFile/Size:128/Axis:row/squareHalf:second(extended)-16       	   30530	     38071 ns/op
BenchmarkAxisFromMemFile/Size:128/Axis:col/squareHalf:first(original)-16        	   30776	     38006 ns/op
BenchmarkAxisFromMemFile/Size:128/Axis:col/squareHalf:second(extended)-16       	   29511	     39497 ns/op
```

Share+proofs
```
BenchmarkShareFromMemFile/Size:128/Axis:row/squareHalf:first(original)-16       	    2776	    497677 ns/op
BenchmarkShareFromMemFile/Size:128/Axis:row/squareHalf:second(extended)-16      	    2281	    482510 ns/op
BenchmarkShareFromMemFile/Size:128/Axis:col/squareHalf:first(original)-16       	    2426	    506595 ns/op
BenchmarkShareFromMemFile/Size:128/Axis:col/squareHalf:second(extended)-16      	    2221	    489927 ns/op
```

### ODS file

For rows from top half of square and columns from left side reads+extends. For everything else reads full ods in 1 read, extends half of the square + requested axis. 
```
BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-16        	   79461	     15251 ns/op
BenchmarkAxisFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-16       	      43	  25867157 ns/op
BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-16        	   13600	     88913 ns/op
BenchmarkAxisFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-16       	      40	  25499225 ns/op
```

Share + proof. 
```
BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:first(original)-16       	     776	   1343266 ns/op
BenchmarkShareFromOdsFile/Size:128/Axis:row/squareHalf:second(extended)-16      	      43	  25610133 ns/op
BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:first(original)-16       	     771	   1408687 ns/op
BenchmarkShareFromOdsFile/Size:128/Axis:col/squareHalf:second(extended)-16      	      45	  25726272 ns/op
```

Extending 1 row + build proof takes 1343266 ns (1,3ms). I/O is insignificant here - 15251 ns. Looking at in-memory eds benchmarks, calculating proofs should takes around 0.6ms, which indicates, that it takes about 0.6ms for extending single row. 