### PR TITLE
fix(cmd): explicitly set a string representation of the error

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -24,7 +24,7 @@ import (
 func PrintOutput(data interface{}, err error, formatData func(interface{}) interface{}) error {
 	switch {
 	case err != nil:
-		data = err
+		data = err.Error()
 	case formatData != nil:
 		data = formatData(data)
 	}


### PR DESCRIPTION
json.MarshalIndent cut the result in case of error is received in `PrintOutput`, so the string representation was empty. 

`celestia state balance-for-address celestia1kanc76z0xet2kgq5fl3pj59axy56htk367trer --url=https://full.consensus.mocha-4.celestia-mocha.com --node.store=~/.celestia-light-mocha-4`
`{
  "result": "RPC client error: sendRequest failed: Post \"https://full.consensus.mocha-4.celestia-mocha.com\": dial tcp 151.115.12.131:443: connect: connection refused"
}`