### PR TITLE
fix(header): Return error from `Validate()` after `MakeExtendedHeader`

### DIFF
--- a/header/header.go
+++ b/header/header.go
@@ -67,7 +67,7 @@ func MakeExtendedHeader(
 		Commit:       comm,
 		ValidatorSet: vals,
 	}
-	return eh, nil
+	return eh, eh.Validate()
 }
 
 func (eh *ExtendedHeader) New() *ExtendedHeader {

--- a/libs/utils/resetctx.go
+++ b/libs/utils/resetctx.go
@@ -1,6 +1,8 @@
 package utils
 
-import "context"
+import (
+	"context"
+)
 
 // ResetContextOnError returns a fresh context if the given context has an error.
 func ResetContextOnError(ctx context.Context) context.Context {


### PR DESCRIPTION
This PR re-introduces checking the error from `eh.Validate()` after constructing the ExtendedHeader. I'm not sure why it was removed in https://github.com/celestiaorg/celestia-node/pull/2619/files#diff-c7b74c4c56b9e973cda0ea769f215f89232c4b3a66d3cfdc5c42867b364b2745L98 but I think it makes sense to leave it as a basic sanity check as there doesn't seem to be a clear reason for why it was removed.


This change was found when debugging an issue with headers being propagated from `mocha-4` into mainnet.