### PR TITLE
fix(core): Use `Verify` from go-header pkg in `CoreExchange`

### DIFF
--- a/core/exchange.go
+++ b/core/exchange.go
@@ -78,7 +78,7 @@ func (ce *Exchange) GetRangeByHeight(
 	ce.metrics.requestDurationPerHeader(ctx, time.Since(start), amount)
 
 	for _, h := range headers {
-		err := from.Verify(h)
+		err := libhead.Verify[*header.ExtendedHeader](from, h, libhead.DefaultHeightThreshold)
 		if err != nil {
 			return nil, fmt.Errorf("verifying next header against last verified height: %d: %w",
 				from.Height(), err)


### PR DESCRIPTION
We should have been using the high-level `Verify` check from go-header inside of the `CoreExchange` instead of the `ExtendedHeader`-based implementation of Verify.