### PR TITLE
fix(nodebuilder/blob): allow blob submit args to be pre-encoded

### DIFF
--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -148,7 +149,7 @@ var submitCmd = &cobra.Command{
 			return fmt.Errorf("error parsing a namespace:%v", err)
 		}
 
-		parsedBlob, err := blob.NewBlobV0(namespace, []byte(args[1]))
+		parsedBlob, err := blob.NewBlobV0(namespace, decodeBlobDataFromArg(args[1]))
 		if err != nil {
 			return fmt.Errorf("error creating a blob:%v", err)
 		}
@@ -230,4 +231,15 @@ func formatData(data interface{}) interface{} {
 		ShareVersion: b.ShareVersion,
 		Commitment:   b.Commitment,
 	}
+}
+
+func decodeBlobDataFromArg(arg string) []byte {
+	// check if arg is a hex string
+	if decoded, err := hex.DecodeString(arg); err == nil {
+		return decoded
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(arg); err == nil {
+		return decoded
+	}
+	return []byte(arg)
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

Closes #3082 

When using the blobData arg from the `celestia blob submit` command, it now checks if the argument is a valid hex string or base64 string. If so, the canonical byte representation of these encodings is used for the blob. Otherwise, the previous behavior (encoding the ascii characters as bytes) is used.
