### PR TITLE
feat(rpc): rpc.disable-auth flag

### DIFF
--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -20,16 +20,17 @@ import (
 var log = logging.Logger("rpc")
 
 type Server struct {
-	srv      *http.Server
-	rpc      *jsonrpc.RPCServer
-	listener net.Listener
+	srv          *http.Server
+	rpc          *jsonrpc.RPCServer
+	listener     net.Listener
+	authDisabled bool
 
 	started atomic.Bool
 
 	auth jwt.Signer
 }
 
-func NewServer(address, port string, secret jwt.Signer) *Server {
+func NewServer(address, port string, authDisabled bool, secret jwt.Signer) *Server {
 	rpc := jsonrpc.NewServer()
 	srv := &Server{
 		rpc: rpc,
@@ -38,7 +39,8 @@ func NewServer(address, port string, secret jwt.Signer) *Server {
 			// the amount of time allowed to read request headers. set to the default 2 seconds
 			ReadHeaderTimeout: 2 * time.Second,
 		},
-		auth: secret,
+		auth:         secret,
+		authDisabled: authDisabled,
 	}
 	srv.srv.Handler = &auth.Handler{
 		Verify: srv.verifyAuth,
@@ -51,6 +53,9 @@ func NewServer(address, port string, secret jwt.Signer) *Server {
 // reached if a token is provided in the header of the request, otherwise only
 // methods with `read` permissions are accessible.
 func (s *Server) verifyAuth(_ context.Context, token string) ([]auth.Permission, error) {
+	if s.authDisabled {
+		return perms.AllPerms, nil
+	}
 	return authtoken.ExtractSignedPermissions(s.auth, token)
 }
 

--- a/nodebuilder/rpc/config.go
+++ b/nodebuilder/rpc/config.go
@@ -8,15 +8,17 @@ import (
 )
 
 type Config struct {
-	Address string
-	Port    string
+	Address      string
+	Port         string
+	AuthDisabled bool
 }
 
 func DefaultConfig() Config {
 	return Config{
 		Address: defaultBindAddress,
 		// do NOT expose the same port as celestia-core by default so that both can run on the same machine
-		Port: defaultPort,
+		Port:         defaultPort,
+		AuthDisabled: false,
 	}
 }
 

--- a/nodebuilder/rpc/constructors.go
+++ b/nodebuilder/rpc/constructors.go
@@ -37,5 +37,5 @@ func registerEndpoints(
 }
 
 func server(cfg *Config, auth jwt.Signer) *rpc.Server {
-	return rpc.NewServer(cfg.Address, cfg.Port, auth)
+	return rpc.NewServer(cfg.Address, cfg.Port, cfg.AuthDisabled, auth)
 }

--- a/nodebuilder/rpc/flags.go
+++ b/nodebuilder/rpc/flags.go
@@ -10,6 +10,7 @@ import (
 var (
 	addrFlag = "rpc.addr"
 	portFlag = "rpc.port"
+	authFlag = "rpc.disable-auth"
 )
 
 // Flags gives a set of hardcoded node/rpc package flags.
@@ -26,6 +27,11 @@ func Flags() *flag.FlagSet {
 		"",
 		fmt.Sprintf("Set a custom RPC port (default: %s)", defaultPort),
 	)
+	flags.Bool(
+		authFlag,
+		false,
+		"Disable authentication for RPC requests",
+	)
 
 	return flags
 }
@@ -39,5 +45,12 @@ func ParseFlags(cmd *cobra.Command, cfg *Config) {
 	port := cmd.Flag(portFlag).Value.String()
 	if port != "" {
 		cfg.Port = port
+	}
+	ok, err := cmd.Flags().GetBool(authFlag)
+	if err != nil {
+		panic(err)
+	}
+	if ok {
+		cfg.AuthDisabled = true
 	}
 }


### PR DESCRIPTION
In many setups, nodes are running in trusted environments and setting the jwt token is not necessary and very cumbersome.

This PR enables a quick fix by providing a flag/config option to the RPC to disable auth.

Breaking config.

New flag: `--rpc.disable-auth`. 

New default config:
```toml
[RPC]
  Address = "localhost"
  Port = "26658"
  AuthDisabled = false
 ```


_______________
Comes from a discussion with @joroshiba at Astria.