### PR TITLE
chore:Fix spelling error: change "submited" to "submitted".

### DIFF
--- a/nodebuilder/tests/api_test.go
+++ b/nodebuilder/tests/api_test.go
@@ -89,7 +89,7 @@ func TestGetByHeight(t *testing.T) {
 	require.ErrorContains(t, err, "given height is from the future")
 }
 
-// TestBlobRPC ensures that blobs can be submited via rpc
+// TestBlobRPC ensures that blobs can be submitted via rpc
 func TestBlobRPC(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)


### PR DESCRIPTION
This PR addresses a minor spelling mistake in test_file to enhance readability and maintain accuracy.



**Changes made:**
- Corrected the spelling of "submited" to "submitted".
