### PR TITLE
ci(unit tests): YOINK unit tests with race detector temporarily

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -105,21 +105,27 @@ jobs:
           file: ./coverage.txt
           name: coverage-${{ matrix.os }}
 
-  unit_test_race:
-    needs: [lint, go_mod_tidy_check]
-    name: Unit Tests with Race Detector (ubuntu-latest)
-    runs-on: ubuntu-latest
+  # @ramin - Temporarily removed while we figure out getting
+  # these unit tests consistently running on ubuntu-latest
+  # and then enabled for macos-latest. We aren't requiring
+  # unit_race_test to pass for PRs so lets remove and reintroduce
+  # once green
+  #
+  # unit_test_race:
+  #   needs: [lint, go_mod_tidy_check]
+  #   name: Unit Tests with Race Detector (ubuntu-latest)
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: set up go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ inputs.go-version }}
+  #     - name: set up go
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version: ${{ inputs.go-version }}
 
-      - name: execute test run
-        run: make test-unit-race ENABLE_VERBOSE=${{ needs.setup.outputs.debug }}
+  #     - name: execute test run
+  #       run: make test-unit-race ENABLE_VERBOSE=${{ needs.setup.outputs.debug }}
 
   integration_test:
     name: Integration Tests


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

suggesting we YEET the `unit test with race` temporarily as the job intermittently fails across a handful of tests pretty regularly and we don't require this job to pass for a PR merge anyway.

Lets remove, i'll get it working and also enable for `macos-latest` which fails ALWAYS on github then we can / replace the normal unit tests with unit tests with race after we get it all running and keep CI green vs just ignoring a red x most of the time
