### PR TITLE
fix: improve rpc.skip-auth

### DIFF
--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -61,15 +61,14 @@ func (s *Server) verifyAuth(_ context.Context, token string) ([]auth.Permission,
 
 // RegisterService registers a service onto the RPC server. All methods on the service will then be
 // exposed over the RPC.
-func (s *Server) RegisterService(namespace string, service interface{}) {
-	s.rpc.Register(namespace, service)
-}
+func (s *Server) RegisterService(namespace string, service interface{}, out interface{}) {
+	if s.authDisabled {
+		s.rpc.Register(namespace, service)
+		return
+	}
 
-// RegisterAuthedService registers a service onto the RPC server. All methods on the service will
-// then be exposed over the RPC.
-func (s *Server) RegisterAuthedService(namespace string, service interface{}, out interface{}) {
 	auth.PermissionedProxy(perms.AllPerms, perms.DefaultPerms, service, getInternalStruct(out))
-	s.RegisterService(namespace, out)
+	s.rpc.Register(namespace, out)
 }
 
 func getInternalStruct(api interface{}) interface{} {

--- a/api/rpc_test.go
+++ b/api/rpc_test.go
@@ -306,15 +306,15 @@ func setupNodeWithAuthedRPC(t *testing.T, auth jwt.Signer) (*nodebuilder.Node, *
 	// given the behavior of fx.Invoke, this invoke will be called last as it is added at the root
 	// level module. For further information, check the documentation on fx.Invoke.
 	invokeRPC := fx.Invoke(func(srv *rpc.Server) {
-		srv.RegisterAuthedService("state", mockAPI.State, &statemod.API{})
-		srv.RegisterAuthedService("share", mockAPI.Share, &share.API{})
-		srv.RegisterAuthedService("fraud", mockAPI.Fraud, &fraud.API{})
-		srv.RegisterAuthedService("header", mockAPI.Header, &header.API{})
-		srv.RegisterAuthedService("das", mockAPI.Das, &das.API{})
-		srv.RegisterAuthedService("p2p", mockAPI.P2P, &p2p.API{})
-		srv.RegisterAuthedService("node", mockAPI.Node, &node.API{})
-		srv.RegisterAuthedService("blob", mockAPI.Blob, &blob.API{})
-		srv.RegisterAuthedService("da", mockAPI.DA, &da.API{})
+		srv.RegisterService("fraud", mockAPI.Fraud, &fraud.API{})
+		srv.RegisterService("das", mockAPI.Das, &das.API{})
+		srv.RegisterService("header", mockAPI.Header, &header.API{})
+		srv.RegisterService("state", mockAPI.State, &statemod.API{})
+		srv.RegisterService("share", mockAPI.Share, &share.API{})
+		srv.RegisterService("p2p", mockAPI.P2P, &p2p.API{})
+		srv.RegisterService("node", mockAPI.Node, &node.API{})
+		srv.RegisterService("blob", mockAPI.Blob, &blob.API{})
+		srv.RegisterService("da", mockAPI.DA, &da.API{})
 	})
 	// fx.Replace does not work here, but fx.Decorate does
 	nd := nodebuilder.TestNode(t, node.Full, invokeRPC, fx.Decorate(func() (jwt.Signer, error) {

--- a/nodebuilder/rpc/constructors.go
+++ b/nodebuilder/rpc/constructors.go
@@ -28,15 +28,15 @@ func registerEndpoints(
 	daMod da.Module,
 	serv *rpc.Server,
 ) {
-	serv.RegisterAuthedService("fraud", fraudMod, &fraud.API{})
-	serv.RegisterAuthedService("das", daserMod, &das.API{})
-	serv.RegisterAuthedService("header", headerMod, &header.API{})
-	serv.RegisterAuthedService("state", stateMod, &state.API{})
-	serv.RegisterAuthedService("share", shareMod, &share.API{})
-	serv.RegisterAuthedService("p2p", p2pMod, &p2p.API{})
-	serv.RegisterAuthedService("node", nodeMod, &node.API{})
-	serv.RegisterAuthedService("blob", blobMod, &blob.API{})
-	serv.RegisterAuthedService("da", daMod, &da.API{})
+	serv.RegisterService("fraud", fraudMod, &fraud.API{})
+	serv.RegisterService("das", daserMod, &das.API{})
+	serv.RegisterService("header", headerMod, &header.API{})
+	serv.RegisterService("state", stateMod, &state.API{})
+	serv.RegisterService("share", shareMod, &share.API{})
+	serv.RegisterService("p2p", p2pMod, &p2p.API{})
+	serv.RegisterService("node", nodeMod, &node.API{})
+	serv.RegisterService("blob", blobMod, &blob.API{})
+	serv.RegisterService("da", daMod, &da.API{})
 }
 
 func server(cfg *Config, auth jwt.Signer) *rpc.Server {


### PR DESCRIPTION
In the current skip-auth implementation, there was an issue: Authentication could be skipped, but it still required the `Authentication` header to be set (it just wouldn't check it).

This PR improves the devex by removing this requirement. I missed it the first time because I tested by using the CLI, which always sets the header regardless of what you pass. This came up while implementing https://github.com/eigerco/lumina/pull/210, since the wasm client cannot set headers.

I also think the solution is cleaner than the original.