### PR TITLE
Add logging on startup to stderr

### DIFF
--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -123,10 +123,11 @@ func (n *Node) Start(ctx context.Context) error {
 		log.Errorw("Retrieving multiaddress information", "err", err)
 		return err
 	}
-	fmt.Println("The p2p host is listening on:")
+	log.Infow("The p2p host is listening on:")
 	for _, addr := range addrs {
-		fmt.Println("* ", addr.String())
+		log.Infow("* " + addr.String())
 	}
+	
 	fmt.Println()
 	return nil
 }


### PR DESCRIPTION
fixes https://github.com/celestiaorg/celestia-node/issues/3109 (fixes #3109)
kind:refactor

Replaced `Println` method with `Infow` from the go-log package for structured logging. P2P host information is now logged to `stderr`.