### PR TITLE
feat: add example value for blob.GasPrice

### DIFF
--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -51,6 +51,7 @@ var ExampleValues = map[reflect.Type]interface{}{
 	reflect.TypeOf(42):                       42,
 	reflect.TypeOf(byte(7)):                  byte(7),
 	reflect.TypeOf(float64(42)):              float64(42),
+	reflect.TypeOf(blob.GasPrice(0)):         blob.GasPrice(0.002),
 	reflect.TypeOf(true):                     true,
 	reflect.TypeOf([]byte{}):                 []byte("byte array"),
 	reflect.TypeOf(node.Full):                node.Full,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->
# Summary

Open RPC spec generation errors, due to a missing sample value for blob.GasPrice.

# Problem

Missing sample value in `api/docgen/examples.go`.

Logs from running on v0.13.0:

```json
--> Generating OpenRPC spec
failed to retrieve example value for type: blob.GasPrice on parent 'blob.GasPrice')
{
    "openrpc": "1.2.6",
    "info": {
        "title": "Celestia Node API",
        "description": "The Celestia Node API is the collection of RPC methods that can be used to interact with the services provided by Celestia Data Availability Nodes.",
        "version": "v0.11.0"
    },
```

Output from logs running on v0.11.0, as another check to see that this worked before:

```json
--> Generating OpenRPC spec
{
    "openrpc": "1.2.6",
    "info": {
        "title": "Celestia Node API",
        "description": "The Celestia Node API is the collection of RPC methods that can be used to interact with the services provided by Celestia Data Availability Nodes.",
        "version": "v0.11.0"
    },
```

# Solution

Add sample value.

[Output after testing](https://gist.github.com/jcstein/02c459fb781889405d7ebc802484509a)

## Other issues found while testing

API version is still v0.11.0, which is the same as last few releases, i just ran make openrpc-gen on v0.11.0 and the API version is the same there. This is already, addressed in https://github.com/celestiaorg/celestia-node/issues/2549, and I am highlighting to bring it out from stale state.

### Proposed solutions for other issues found

To avoid this in the future, i would like to see if we can work this [feature request to add openrpc.json on main](https://github.com/celestiaorg/celestia-node/issues/2611) into celestia-node, so that there is validation before publishing specs, and a history of past versions of the openrpc.json, stored on main with releases. otherwise we JTMB the person updating node-rpc-docs [on almost 10000 lines of spec code](https://github.com/celestiaorg/node-rpc-docs/pull/35/files)

> Note, this output must not contain the output which precedes the json:
> `--> Generating OpenRPC spec`