### PR TITLE
chore(ci): split da into own tag, and skip a consistently failing test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,6 @@ jobs:
       - name: run blob tests
         run: make test-integration TAGS=blob
 
-
   da_tests:
     name: Da Tests Sync
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,6 +39,22 @@ jobs:
       - name: run blob tests
         run: make test-integration TAGS=blob
 
+
+  da_tests:
+    name: Da Tests Sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: run da tests
+        run: make test-integration SHORT=true TAGS=da
+
   fraud_tests:
     name: Integration Tests Fraud
     runs-on: ubuntu-latest

--- a/nodebuilder/tests/da_test.go
+++ b/nodebuilder/tests/da_test.go
@@ -1,4 +1,4 @@
-//go:build blob || integration
+//go:build da || integration
 
 package tests
 
@@ -101,6 +101,7 @@ func TestDaModule(t *testing.T) {
 		{
 			name: "GetIDs",
 			doFn: func(t *testing.T) {
+				t.Skip()
 				height, _ := da.SplitID(ids[0])
 				ids2, err := fullClient.DA.GetIDs(ctx, height, namespace)
 				require.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

- split the new flakey DA tests into own tag and call so we don't think blob has started failing suddenly
- Total shutdown of DA integration test `GetIDs` until we can figure out what is going on
