### PR TITLE
docs: adjust golang version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Continue reading [here](https://blog.celestia.org/celestia-mvp-release-data-avai
 
 | Requirement | Notes          |
 | ----------- |----------------|
-| Go version  | 1.21 or higher |
+| Go version  | 1.21.X         |
 
 ## System Requirements
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

When using go version 1.22 I received this error on building v0.13.0
```
make build
--> Building Celestia
...
# github.com/pyroscope-io/godeltaprof/internal/pprof
../go/pkg/mod/github.com/pyroscope-io/godeltaprof@v0.1.2/internal/pprof/delta_mutex.go:25:20: undefined: runtime_cyclesPerSecond
../go/pkg/mod/github.com/pyroscope-io/godeltaprof@v0.1.2/internal/pprof/proto.go:400:8: undefined: runtime_expandFinalInlineFrame
make: *** [Makefile:38: build] Error 1
```

Reverting to go v1.21.7 builds fine. 

Propose restricting the go version in the readme to v1.21.X until v1.22 is tested and verified. 
