### PR TITLE
chore(das/worker): rename log verb to be clear that not all headers are sampled

### DIFF
--- a/das/worker.go
+++ b/das/worker.go
@@ -86,7 +86,7 @@ func (w *worker) run(ctx context.Context, timeout time.Duration, resultCh chan<-
 
 	if w.state.jobType != recentJob {
 		log.Infow(
-			"finished sampling headers",
+			"finished receiving headers",
 			"type", w.state.jobType,
 			"from", w.state.from,
 			"to", w.state.curr,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

Addresses #3194 by suggesting we change the log message from "sampling" to "receiving". Other option could be "evaluating"?  Somethign else?

