### PR TITLE
improve: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -3,6 +3,7 @@ package docgen
 import (
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -66,7 +67,7 @@ var ExampleValues = map[reflect.Type]interface{}{
 			Shares: []*byzantine.ShareWithProof{},
 		},
 	),
-	reflect.TypeOf((*error)(nil)).Elem(): fmt.Errorf("error"),
+	reflect.TypeOf((*error)(nil)).Elem(): errors.New("error"),
 }
 
 func init() {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -27,7 +27,7 @@ func AuthCmd(fsets ...*flag.FlagSet) *cobra.Command {
 			"the node has already been initialized and started.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return fmt.Errorf("must specify permissions")
+				return errors.New("must specify permissions")
 			}
 			permissions, err := convertToPerms(args[0])
 			if err != nil {

--- a/cmd/cel-shed/header.go
+++ b/cmd/cel-shed/header.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -30,12 +31,12 @@ Custom store path is not supported yet.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 3 {
-			return fmt.Errorf("not enough arguments")
+			return errors.New("not enough arguments")
 		}
 
 		tp := node.ParseType(args[0])
 		if !tp.IsValid() {
-			return fmt.Errorf("invalid node-type")
+			return errors.New("invalid node-type")
 		}
 
 		network := args[1]

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -49,7 +49,7 @@ func InitClient(cmd *cobra.Command, _ []string) error {
 	if authTokenFlag == "" {
 		storePath := ""
 		if !cmd.Flag(nodeStoreFlag).Changed {
-			return fmt.Errorf("cant get the access to the auth token: token/node-store flag was not specified")
+			return errors.New("cant get the access to the auth token: token/node-store flag was not specified")
 		}
 		storePath = cmd.Flag(nodeStoreFlag).Value.String()
 		token, err := getToken(storePath)

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -127,7 +128,7 @@ func (f *BlockFetcher) ValidatorSet(ctx context.Context, height *int64) (*types.
 func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (<-chan types.EventDataSignedBlock, error) {
 	// start the client if not started yet
 	if !f.client.IsRunning() {
-		return nil, fmt.Errorf("client not running")
+		return nil, errors.New("client not running")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/core/listener.go
+++ b/core/listener.go
@@ -91,7 +91,7 @@ func NewListener(
 // Start kicks off the Listener listener loop.
 func (cl *Listener) Start(context.Context) error {
 	if cl.cancel != nil {
-		return fmt.Errorf("listener: already started")
+		return errors.New("listener: already started")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/das/daser.go
+++ b/das/daser.go
@@ -79,7 +79,7 @@ func NewDASer(
 // Start initiates subscription for new ExtendedHeaders and spawns a sampling routine.
 func (d *DASer) Start(ctx context.Context) error {
 	if !atomic.CompareAndSwapInt32(&d.running, 0, 1) {
-		return fmt.Errorf("da: DASer already started")
+		return errors.New("da: DASer already started")
 	}
 
 	sub, err := d.hsub.Subscribe()

--- a/das/options.go
+++ b/das/options.go
@@ -1,6 +1,7 @@
 package das
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -8,7 +9,7 @@ import (
 // ErrInvalidOption is an error that is returned by Parameters.Validate
 // when supplied with invalid values.
 // This error will also be returned by NewDASer if supplied with an invalid option
-var ErrInvalidOption = fmt.Errorf("das: invalid option")
+var ErrInvalidOption = errors.New("das: invalid option")
 
 // errInvalidOptionValue is a utility function to dedup code for error-returning
 // when dealing with invalid parameter values

--- a/share/eds/inverted_index.go
+++ b/share/eds/inverted_index.go
@@ -17,7 +17,7 @@ import (
 const invertedIndexPath = "/inverted_index/"
 
 // ErrNotFoundInIndex is returned instead of ErrNotFound if the multihash doesn't exist in the index
-var ErrNotFoundInIndex = fmt.Errorf("does not exist in index")
+var ErrNotFoundInIndex = errors.New("does not exist in index")
 
 // simpleInvertedIndex is an inverted index that only stores a single shard key per multihash. Its
 // implementation is modified from the default upstream implementation in dagstore/index.

--- a/share/eds/store_options.go
+++ b/share/eds/store_options.go
@@ -1,7 +1,7 @@
 package eds
 
 import (
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -29,15 +29,15 @@ func DefaultParameters() *Parameters {
 
 func (p *Parameters) Validate() error {
 	if p.GCInterval < 0 {
-		return fmt.Errorf("eds: GC interval cannot be negative")
+		return errors.New("eds: GC interval cannot be negative")
 	}
 
 	if p.RecentBlocksCacheSize < 1 {
-		return fmt.Errorf("eds: recent blocks cache size must be positive")
+		return errors.New("eds: recent blocks cache size must be positive")
 	}
 
 	if p.BlockstoreCacheSize < 1 {
-		return fmt.Errorf("eds: blockstore cache size must be positive")
+		return errors.New("eds: blockstore cache size must be positive")
 	}
 	return nil
 }


### PR DESCRIPTION
Some parameterless errors should be using errors.New instead of fmt.Errorf