### PR TITLE
ci(lint): upgrade golangci-lint to 1.56 and fix revive errors that emerged

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci/ramin/lint
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ci/ramin/lint
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: golangci/golangci-lint-action@v4.0.0
         with:
           args: --timeout 10m
-          version: v1.55
+          version: v1.56
           skip-pkg-cache: true
           skip-build-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,7 @@ issues:
     - path: _test\.go
       linters:
         - gosec
+        - revive
     - linters:
         - lll
       source: "https://"

--- a/api/docgen/openrpc.go
+++ b/api/docgen/openrpc.go
@@ -1,5 +1,7 @@
 // Package docgen generates an OpenRPC spec for the Celestia Node. It has been inspired by and
 // adapted from Filecoin's Lotus API implementation.
+
+//nolint:revive
 package docgen
 
 import (
@@ -95,7 +97,7 @@ func NewOpenRPCDocument(comments Comments, permissions Comments) *go_openrpc_ref
 
 	d.WithMeta(&go_openrpc_reflect.MetaT{
 		GetServersFn: func() func(listeners []net.Listener) (*meta_schema.Servers, error) {
-			return func(listeners []net.Listener) (*meta_schema.Servers, error) {
+			return func(_ []net.Listener) (*meta_schema.Servers, error) {
 				return nil, nil
 			}
 		},

--- a/cmd/cel-shed/eds_store_stress.go
+++ b/cmd/cel-shed/eds_store_stress.go
@@ -69,7 +69,7 @@ var edsStoreStress = &cobra.Command{
 	Use:          "stress",
 	Short:        `Runs eds.Store stress test over default node.Store Datastore backend (e.g. Badger).`,
 	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	RunE: func(cmd *cobra.Command, _ []string) (err error) {
 		// expose expvar vars over http
 		go http.ListenAndServe(":9999", http.DefaultServeMux) //nolint:errcheck,gosec
 

--- a/cmd/cel-shed/p2p.go
+++ b/cmd/cel-shed/p2p.go
@@ -22,7 +22,7 @@ var p2pCmd = &cobra.Command{
 var p2pNewKeyCmd = &cobra.Command{
 	Use:   "new-key",
 	Short: "Generate and print new Ed25519 private key for p2p networking",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error { //nolint:revive
 		privkey, _, err := crypto.GenerateEd25519Key(rand.Reader)
 		if err != nil {
 			return err
@@ -42,7 +42,7 @@ var p2pNewKeyCmd = &cobra.Command{
 var p2pPeerIDCmd = &cobra.Command{
 	Use:   "peer-id",
 	Short: "Get peer-id out of public or private Ed25519 key",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive
 		decKey, err := hex.DecodeString(args[0])
 		if err != nil {
 			return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,7 +12,7 @@ func RemoveConfigCmd(fsets ...*flag.FlagSet) *cobra.Command {
 		Use:   "config-remove",
 		Short: "Deletes the node's config",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			return nodebuilder.RemoveConfig(StorePath(ctx))
 		},
@@ -31,7 +31,7 @@ func UpdateConfigCmd(fsets ...*flag.FlagSet) *cobra.Command {
 		Long: "Updates the node's outdated config with default values from newly-added fields. Check the config " +
 			" afterwards to ensure all old custom values were preserved.",
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			return nodebuilder.UpdateConfig(NodeType(ctx), StorePath(ctx))
 		},

--- a/cmd/docgen/openrpc.go
+++ b/cmd/docgen/openrpc.go
@@ -14,7 +14,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "docgen [packages]",
 	Short: "docgen generates the openrpc documentation for Celestia Node packages",
-	RunE: func(cmd *cobra.Command, moduleNames []string) error {
+	RunE: func(_ *cobra.Command, moduleNames []string) error {
 		// 1. Open the respective nodebuilder/X/service.go files for AST parsing
 		nodeComments, permComments := docgen.ParseCommentsFromNodebuilderModules(moduleNames...)
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -13,7 +13,7 @@ func Init(fsets ...*flag.FlagSet) *cobra.Command {
 		Use:   "init",
 		Short: "Initialization for Celestia Node. Passed flags have persisted effect.",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 
 			return nodebuilder.Init(NodeConfig(ctx), StorePath(ctx), NodeType(ctx))

--- a/cmd/reset_store.go
+++ b/cmd/reset_store.go
@@ -13,7 +13,7 @@ func ResetStore(fsets ...*flag.FlagSet) *cobra.Command {
 		Use:   "unsafe-reset-store",
 		Short: "Resets the node's store to a new state. Leaves the keystore and config intact.",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 
 			return nodebuilder.Reset(StorePath(ctx), NodeType(ctx))

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -25,7 +25,7 @@ Options passed on start override configuration options only on start and are not
 		Aliases:      []string{"run", "daemon"},
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			ctx := cmd.Context()
 
 			// override config with all modifiers passed on start

--- a/nodebuilder/core/module.go
+++ b/nodebuilder/core/module.go
@@ -74,10 +74,10 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			)),
 			fx.Provide(fx.Annotate(
 				remote,
-				fx.OnStart(func(ctx context.Context, client core.Client) error {
+				fx.OnStart(func(_ context.Context, client core.Client) error {
 					return client.Start()
 				}),
-				fx.OnStop(func(ctx context.Context, client core.Client) error {
+				fx.OnStop(func(_ context.Context, client core.Client) error {
 					return client.Stop()
 				}),
 			)),

--- a/nodebuilder/das/cmd/das.go
+++ b/nodebuilder/das/cmd/das.go
@@ -21,7 +21,7 @@ var samplingStatsCmd = &cobra.Command{
 	Use:   "sampling-stats",
 	Short: "Returns the current statistics over the DA sampling process",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err

--- a/nodebuilder/header/cmd/header.go
+++ b/nodebuilder/header/cmd/header.go
@@ -31,7 +31,7 @@ var localHeadCmd = &cobra.Command{
 	Use:   "local-head",
 	Short: "Returns the ExtendedHeader from the chain head.",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err
@@ -47,7 +47,7 @@ var networkHeadCmd = &cobra.Command{
 	Use:   "network-head",
 	Short: "Provides the Syncer's view of the current network head.",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err
@@ -104,7 +104,7 @@ var syncStateCmd = &cobra.Command{
 	Use:   "sync-state",
 	Short: "Returns the current state of the header Syncer.",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err

--- a/nodebuilder/node/cmd/node.go
+++ b/nodebuilder/node/cmd/node.go
@@ -25,7 +25,7 @@ var nodeInfoCmd = &cobra.Command{
 	Use:   "info",
 	Args:  cobra.NoArgs,
 	Short: "Returns administrative information about the node.",
-	RunE: func(c *cobra.Command, args []string) error {
+	RunE: func(c *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(c.Context())
 		if err != nil {
 			return err

--- a/nodebuilder/node/metrics.go
+++ b/nodebuilder/node/metrics.go
@@ -42,7 +42,7 @@ func WithMetrics() error {
 		return err
 	}
 
-	callback := func(ctx context.Context, observer metric.Observer) error {
+	callback := func(_ context.Context, observer metric.Observer) error {
 		if !nodeStarted {
 			// Observe node start timestamp
 			timeStarted = time.Now()

--- a/nodebuilder/p2p/bitswap.go
+++ b/nodebuilder/p2p/bitswap.go
@@ -53,7 +53,7 @@ func dataExchange(params bitSwapParams) exchange.Interface {
 	net.Start(srvr, clnt) // starting with hook does not work
 
 	params.Lifecycle.Append(fx.Hook{
-		OnStop: func(ctx context.Context) (err error) {
+		OnStop: func(_ context.Context) (err error) {
 			err = errors.Join(err, clnt.Close())
 			err = errors.Join(err, srvr.Close())
 			net.Stop()

--- a/nodebuilder/p2p/cmd/p2p.go
+++ b/nodebuilder/p2p/cmd/p2p.go
@@ -48,7 +48,7 @@ var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Gets the node's peer info (peer id and multiaddresses)",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err
@@ -77,7 +77,7 @@ var peersCmd = &cobra.Command{
 	Use:   "peers",
 	Short: "Lists the peers we are connected to",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err
@@ -226,7 +226,7 @@ var natStatusCmd = &cobra.Command{
 	Use:   "nat-status",
 	Short: "Gets the current NAT status",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err
@@ -328,7 +328,7 @@ var blockedPeersCmd = &cobra.Command{
 	Use:   "blocked-peers",
 	Short: "Lists the node's blocked peers",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err
@@ -466,7 +466,7 @@ var bandwidthStatsCmd = &cobra.Command{
 	Long: "Get stats struct with bandwidth metrics for all data sent/" +
 		"received by the local peer, regardless of protocol or remote peer IDs",
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err

--- a/nodebuilder/p2p/metrics.go
+++ b/nodebuilder/p2p/metrics.go
@@ -41,7 +41,7 @@ func prometheusMetrics(lifecycle fx.Lifecycle, registerer prometheus.Registerer)
 	}
 
 	lifecycle.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(_ context.Context) error {
 			go func() {
 				if err := promHTTPServer.ListenAndServe(); err != nil {
 					log.Errorf("Error starting Prometheus metrics exporter http server: %s", err)

--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -100,7 +100,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 
 func discoveryComponents(cfg *Config) fx.Option {
 	return fx.Options(
-		fx.Invoke(func(disc *disc.Discovery) {}),
+		fx.Invoke(func(_ *disc.Discovery) {}),
 		fx.Provide(fx.Annotate(
 			newDiscovery(cfg.Discovery),
 			fx.OnStart(func(ctx context.Context, d *disc.Discovery) error {
@@ -189,7 +189,7 @@ func shrexGetterComponents(cfg *Config) fx.Option {
 
 func shrexServerComponents(cfg *Config) fx.Option {
 	return fx.Options(
-		fx.Invoke(func(edsSrv *shrexeds.Server, ndSrc *shrexnd.Server) {}),
+		fx.Invoke(func(_ *shrexeds.Server, _ *shrexnd.Server) {}),
 		fx.Provide(fx.Annotate(
 			func(host host.Host, store *eds.Store, network modp2p.Network) (*shrexeds.Server, error) {
 				cfg.ShrExEDSParams.WithNetworkID(network.String())

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -40,7 +40,7 @@ var accountAddressCmd = &cobra.Command{
 	Use:   "account-address",
 	Short: "Retrieves the address of the node's account/signer.",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err
@@ -57,7 +57,7 @@ var balanceCmd = &cobra.Command{
 	Short: "Retrieves the Celestia coin balance for the node's account/signer and verifies it against " +
 		"the corresponding block's AppHash.",
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
 			return err

--- a/share/eds/cache/metrics.go
+++ b/share/eds/cache/metrics.go
@@ -39,7 +39,7 @@ func newMetrics(bc *AccessorCache) (*metrics, error) {
 		return nil, err
 	}
 
-	callback := func(ctx context.Context, observer metric.Observer) error {
+	callback := func(_ context.Context, observer metric.Observer) error {
 		observer.ObserveInt64(cacheSize, int64(bc.cache.Len()))
 		return nil
 	}

--- a/share/eds/metrics.go
+++ b/share/eds/metrics.go
@@ -128,7 +128,7 @@ func (s *Store) WithMetrics() error {
 		return err
 	}
 
-	callback := func(ctx context.Context, observer metric.Observer) error {
+	callback := func(_ context.Context, observer metric.Observer) error {
 		stats := s.dgstr.Stats()
 		for status, amount := range stats {
 			observer.ObserveInt64(dagStoreShards, int64(amount),

--- a/share/p2p/discovery/metrics.go
+++ b/share/p2p/discovery/metrics.go
@@ -102,7 +102,7 @@ func initMetrics(d *Discovery) (*metrics, error) {
 		peerRemoved:      peerRemoved,
 	}
 
-	callback := func(ctx context.Context, observer metric.Observer) error {
+	callback := func(_ context.Context, observer metric.Observer) error {
 		observer.ObserveInt64(peersAmount, int64(d.set.Size()))
 		observer.ObserveInt64(backOffSize, int64(d.connector.Size()))
 		return nil

--- a/share/p2p/peers/metrics.go
+++ b/share/p2p/peers/metrics.go
@@ -130,7 +130,7 @@ func initMetrics(manager *Manager) (*metrics, error) {
 		blacklistedPeers:         blacklisted,
 	}
 
-	callback := func(ctx context.Context, observer metric.Observer) error {
+	callback := func(_ context.Context, observer metric.Observer) error {
 		for poolStatus, count := range manager.shrexPools() {
 			observer.ObserveInt64(shrexPools, count,
 				metric.WithAttributes(

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -19,7 +19,7 @@ func WithMetrics(ca *CoreAccessor) {
 		metric.WithDescription("Timestamp of the last submitted PayForBlob transaction"),
 	)
 
-	callback := func(ctx context.Context, observer metric.Observer) error {
+	callback := func(_ context.Context, observer metric.Observer) error {
 		observer.ObserveInt64(pfbCounter, ca.PayForBlobCount())
 		observer.ObserveInt64(lastPfbTimestamp, ca.LastPayForBlob())
 		return nil


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

with our `1.22` upgrade i got inadvertently upgraded to `golangci-lint` 1.56 locally and experiencing different results to what was in CI so figured, why not upgrade, i believe this upgrade makes 'revive' active and a replacement to golint, which introduced some better/stricter checks

- upgrades `golangci-lint` to 1.56
- fixes or marks `//nolint:revive` a few new unused variable errors that were triggering
- configures revive to ignore `_test` files
- CI passes with new checks