### PR TITLE
refactor(nodebuilder): stick to lock semantics, not file

### DIFF
--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -97,10 +97,10 @@ func RemoveConfig(path string) (err error) {
 	if err != nil {
 		return fmt.Errorf("locking file: %w", err)
 	}
-	defer flk.Close()
 	if !ok {
 		return ErrOpened
 	}
+	defer flk.Unlock() //nolint:errcheck
 
 	return removeConfig(configPath(path))
 }
@@ -124,10 +124,10 @@ func UpdateConfig(tp node.Type, path string) (err error) {
 	if err != nil {
 		return fmt.Errorf("locking file: %w", err)
 	}
-	defer flk.Close()
 	if !ok {
 		return ErrOpened
 	}
+	defer flk.Unlock() //nolint:errcheck
 
 	newCfg := DefaultConfig(tp)
 

--- a/nodebuilder/init.go
+++ b/nodebuilder/init.go
@@ -40,10 +40,10 @@ func Init(cfg Config, path string, tp node.Type) error {
 	if err != nil {
 		return fmt.Errorf("locking file: %w", err)
 	}
-	defer flk.Close()
 	if !ok {
 		return ErrOpened
 	}
+	defer flk.Unlock() //nolint:errcheck
 
 	ksPath := keysPath(path)
 	err = initDir(ksPath)
@@ -88,10 +88,10 @@ func Reset(path string, tp node.Type) error {
 	if err != nil {
 		return fmt.Errorf("locking file: %w", err)
 	}
-	defer flk.Close()
 	if !ok {
 		return ErrOpened
 	}
+	defer flk.Unlock() //nolint:errcheck
 
 	err = resetDir(dataPath(path))
 	if err != nil {

--- a/nodebuilder/init_test.go
+++ b/nodebuilder/init_test.go
@@ -61,7 +61,7 @@ func TestInitErrForLockedDir(t *testing.T) {
 	flk := flock.New(lockPath(dir))
 	_, err := flk.TryLock()
 	require.NoError(t, err)
-	defer flk.Close()
+	defer flk.Unlock() //nolint:errcheck
 	nodes := []node.Type{node.Light, node.Bridge}
 
 	for _, node := range nodes {

--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -68,13 +68,13 @@ func OpenStore(path string, ring keyring.Keyring) (Store, error) {
 	}
 
 	if !IsInit(path) {
-		err := errors.Join(ErrNotInited, flk.Close())
+		err := errors.Join(ErrNotInited, flk.Unlock())
 		return nil, err
 	}
 
 	ks, err := keystore.NewFSKeystore(keysPath(path), ring)
 	if err != nil {
-		err = errors.Join(err, flk.Close())
+		err = errors.Join(err, flk.Unlock())
 		return nil, err
 	}
 


### PR DESCRIPTION
Review discussion that did't get to the PR because of automerge