### PR TITLE
feat: add workdir to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,8 @@ COPY --chown=${USER_NAME}:${USER_NAME} docker/entrypoint.sh /opt/entrypoint.sh
 
 USER ${USER_NAME}
 
+WORKDIR ${CELESTIA_HOME}
+
 EXPOSE 2121
 
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]


### PR DESCRIPTION
This should be a non-breaking change.

This only changes the work directory when the container is started. This means that if you want to execute a command in a running container, it will be automatically in that directory instead of '/'. This improves maintaining and debugging our environments.