### PR TITLE
fix(nodebuilder/share/cmd): Fix parsing of uint for height in `share` rpc CLI commands

### DIFF
--- a/nodebuilder/share/cmd/share.go
+++ b/nodebuilder/share/cmd/share.go
@@ -167,13 +167,15 @@ var getEDS = &cobra.Command{
 }
 
 func getExtendedHeaderFromCmdArg(ctx context.Context, client *rpc.Client, arg string) (*header.ExtendedHeader, error) {
-	hash, err := hex.DecodeString(arg)
-	if err == nil {
-		return client.Header.GetByHash(ctx, hash)
-	}
 	height, err := strconv.ParseUint(arg, 10, 64)
+	if err == nil {
+		return client.Header.GetByHeight(ctx, height)
+	}
+
+	hash, err := hex.DecodeString(arg)
 	if err != nil {
 		return nil, fmt.Errorf("can't parse the height/hash argument: %w", err)
 	}
-	return client.Header.GetByHeight(ctx, height)
+
+	return client.Header.GetByHash(ctx, hash)
 }


### PR DESCRIPTION
This PR resolves https://github.com/celestiaorg/celestia-node/issues/3226

![image](https://github.com/celestiaorg/celestia-node/assets/41963722/6d7f199d-9f42-43c1-b803-8aa4c755bd2a)

Numbers with an even amount of digits are valid hex :) we should try to parse uint first, then attempt to parse hash.