### PR TITLE
fix(nodebuilder): return fx error if theres an error getting keystore or constructing signer

### DIFF
--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -26,11 +26,11 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 	log.Infow("Accessing keyring...")
 	ks, err := store.Keystore()
 	if err != nil {
-		fx.Error(err)
+		return fx.Error(err)
 	}
 	signer, err := state.KeyringSigner(cfg.State, ks, network)
 	if err != nil {
-		fx.Error(err)
+		return fx.Error(err)
 	}
 
 	baseComponents := fx.Options(

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -67,7 +67,7 @@ func TestNodeWithConfig(t *testing.T, tp node.Type, cfg *Config, opts ...fx.Opti
 
 func TestKeyringSigner(t *testing.T, ring keyring.Keyring) *apptypes.KeyringSigner {
 	signer := apptypes.NewKeyringSigner(ring, "", string(p2p.Private))
-	_, _, err := signer.NewMnemonic("test_celes", keyring.English, "",
+	_, _, err := signer.NewMnemonic("my_celes_key", keyring.English, "",
 		"", hd.Secp256k1)
 	require.NoError(t, err)
 	return signer

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -24,8 +24,15 @@ import (
 func MockStore(t *testing.T, cfg *Config) Store {
 	t.Helper()
 	store := NewMemStore()
+
 	err := store.PutConfig(cfg)
 	require.NoError(t, err)
+
+	ks, err := store.Keystore()
+	require.NoError(t, err)
+	_, _, err = generateNewKey(ks.Keyring())
+	require.NoError(t, err)
+
 	return store
 }
 


### PR DESCRIPTION
We never did anything with the errors provided to fx, we can just short-circuit and return quickly if either fails.