### PR TITLE
feat(state): Integrate new Signer for concurrent tx submission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
 	github.com/benbjohnson/clock v1.3.5
-	github.com/celestiaorg/celestia-app v1.7.0
+	github.com/celestiaorg/celestia-app v1.8.0-rc0
 	github.com/celestiaorg/go-fraud v0.2.0
 	github.com/celestiaorg/go-header v0.6.0
 	github.com/celestiaorg/go-libp2p-messenger v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-app v1.7.0 h1:pFIgQzeMD036ulJ2ShUR/3bDGG6kwNAWaLEE0MXHmgg=
-github.com/celestiaorg/celestia-app v1.7.0/go.mod h1:z2H47Gs9gYd3GdQ22d5sbcL8/aBMRcVDtUWT64goMaY=
+github.com/celestiaorg/celestia-app v1.8.0-rc0 h1:rjEwN0Im1+2QChr8uPfbdomhGL3lEmGlt0cPUodc5JU=
+github.com/celestiaorg/celestia-app v1.8.0-rc0/go.mod h1:z2H47Gs9gYd3GdQ22d5sbcL8/aBMRcVDtUWT64goMaY=
 github.com/celestiaorg/celestia-core v1.35.0-tm-v0.34.29 h1:sXERzNXgyHyqTKNQx4S29C/NMDzgav62DaQDNF49HUQ=
 github.com/celestiaorg/celestia-core v1.35.0-tm-v0.34.29/go.mod h1:weZR4wYx1Vcw3g1Jc5G8VipG4M+KUDSqeIzyyWszmsQ=
 github.com/celestiaorg/cosmos-sdk v1.20.1-sdk-v0.46.16 h1:9U9UthIJSOyVjabD5PkD6aczvqlWOyAFTOXw0duPT5k=

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -28,14 +28,11 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 	if err != nil {
 		return fx.Error(err)
 	}
-	keyring, keyname, err := state.Keyring(cfg.State, ks)
-	if err != nil {
-		return fx.Error(err)
-	}
 
 	baseComponents := fx.Options(
 		fx.Supply(tp),
 		fx.Supply(network),
+		fx.Supply(ks),
 		fx.Provide(p2p.BootstrappersFor),
 		fx.Provide(func(lc fx.Lifecycle) context.Context {
 			return fxutil.WithLifecycle(context.Background(), lc)
@@ -45,8 +42,6 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		fx.Provide(store.Datastore),
 		fx.Provide(store.Keystore),
 		fx.Supply(node.StorePath(store.Path())),
-		fx.Supply(keyring),
-		fx.Supply(keyname),
 		// modules provided by the node
 		p2p.ConstructModule(tp, &cfg.P2P),
 		state.ConstructModule(tp, &cfg.State, &cfg.Core),

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -28,7 +28,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 	if err != nil {
 		return fx.Error(err)
 	}
-	signer, err := state.KeyringSigner(cfg.State, ks, network)
+	keyring, keyname, err := state.Keyring(cfg.State, ks)
 	if err != nil {
 		return fx.Error(err)
 	}
@@ -45,7 +45,8 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		fx.Provide(store.Datastore),
 		fx.Provide(store.Keystore),
 		fx.Supply(node.StorePath(store.Path())),
-		fx.Supply(signer),
+		fx.Supply(keyring),
+		fx.Supply(keyname),
 		// modules provided by the node
 		p2p.ConstructModule(tp, &cfg.P2P),
 		state.ConstructModule(tp, &cfg.State, &cfg.Core),

--- a/nodebuilder/state/core.go
+++ b/nodebuilder/state/core.go
@@ -22,12 +22,21 @@ func coreAccessor(
 	sync *sync.Syncer[*header.ExtendedHeader],
 	fraudServ libfraud.Service[*header.ExtendedHeader],
 	opts []state.Option,
-) (*state.CoreAccessor, Module, *modfraud.ServiceBreaker[*state.CoreAccessor, *header.ExtendedHeader]) {
-	ca := state.NewCoreAccessor(keyring, keyname, sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort, opts...)
+) (
+	*state.CoreAccessor,
+	Module,
+	*modfraud.ServiceBreaker[*state.CoreAccessor, *header.ExtendedHeader],
+	error,
+) {
+	ca, err := state.NewCoreAccessor(keyring, keyname, sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort, opts...)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	sBreaker := &modfraud.ServiceBreaker[*state.CoreAccessor, *header.ExtendedHeader]{
 		Service:   ca,
 		FraudType: byzantine.BadEncoding,
 		FraudServ: fraudServ,
 	}
-	return ca, ca, sBreaker
+	return ca, ca, sBreaker, nil
 }

--- a/nodebuilder/state/core.go
+++ b/nodebuilder/state/core.go
@@ -18,7 +18,7 @@ import (
 func coreAccessor(
 	corecfg core.Config,
 	keyring keyring.Keyring,
-	keyname string,
+	keyname AccName,
 	sync *sync.Syncer[*header.ExtendedHeader],
 	fraudServ libfraud.Service[*header.ExtendedHeader],
 	opts []state.Option,
@@ -28,7 +28,8 @@ func coreAccessor(
 	*modfraud.ServiceBreaker[*state.CoreAccessor, *header.ExtendedHeader],
 	error,
 ) {
-	ca, err := state.NewCoreAccessor(keyring, keyname, sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort, opts...)
+	ca, err := state.NewCoreAccessor(keyring, string(keyname), sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort,
+		opts...)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/nodebuilder/state/core.go
+++ b/nodebuilder/state/core.go
@@ -18,7 +18,7 @@ import (
 func coreAccessor(
 	corecfg core.Config,
 	keyring keyring.Keyring,
-	keyname AccName,
+	keyname AccountName,
 	sync *sync.Syncer[*header.ExtendedHeader],
 	fraudServ libfraud.Service[*header.ExtendedHeader],
 	opts []state.Option,

--- a/nodebuilder/state/core.go
+++ b/nodebuilder/state/core.go
@@ -30,14 +30,12 @@ func coreAccessor(
 ) {
 	ca, err := state.NewCoreAccessor(keyring, string(keyname), sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort,
 		opts...)
-	if err != nil {
-		return nil, nil, nil, err
-	}
 
 	sBreaker := &modfraud.ServiceBreaker[*state.CoreAccessor, *header.ExtendedHeader]{
 		Service:   ca,
 		FraudType: byzantine.BadEncoding,
 		FraudServ: fraudServ,
 	}
-	return ca, ca, sBreaker, nil
+
+	return ca, ca, sBreaker, err
 }

--- a/nodebuilder/state/core.go
+++ b/nodebuilder/state/core.go
@@ -1,7 +1,8 @@
 package state
 
 import (
-	apptypes "github.com/celestiaorg/celestia-app/x/blob/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+
 	libfraud "github.com/celestiaorg/go-fraud"
 	"github.com/celestiaorg/go-header/sync"
 
@@ -16,12 +17,13 @@ import (
 // a celestia-core connection.
 func coreAccessor(
 	corecfg core.Config,
-	signer *apptypes.KeyringSigner,
+	keyring keyring.Keyring,
+	keyname string,
 	sync *sync.Syncer[*header.ExtendedHeader],
 	fraudServ libfraud.Service[*header.ExtendedHeader],
 	opts []state.Option,
 ) (*state.CoreAccessor, Module, *modfraud.ServiceBreaker[*state.CoreAccessor, *header.ExtendedHeader]) {
-	ca := state.NewCoreAccessor(signer, sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort, opts...)
+	ca := state.NewCoreAccessor(keyring, keyname, sync, corecfg.IP, corecfg.RPCPort, corecfg.GRPCPort, opts...)
 	sBreaker := &modfraud.ServiceBreaker[*state.CoreAccessor, *header.ExtendedHeader]{
 		Service:   ca,
 		FraudType: byzantine.BadEncoding,

--- a/nodebuilder/state/keyring.go
+++ b/nodebuilder/state/keyring.go
@@ -13,9 +13,6 @@ const DefaultAccountName = "my_celes_key"
 // as having keyring-backend set to `file` prompts user for password.
 func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, string, error) {
 	ring := ks.Keyring()
-	if ring == nil {
-		panic("keyring is nil")
-	}
 	var info *kr.Record
 	// if custom keyringAccName provided, find key for that name
 	if cfg.KeyringAccName != "" {

--- a/nodebuilder/state/keyring.go
+++ b/nodebuilder/state/keyring.go
@@ -3,26 +3,26 @@ package state
 import (
 	kr "github.com/cosmos/cosmos-sdk/crypto/keyring"
 
-	apptypes "github.com/celestiaorg/celestia-app/x/blob/types"
-
 	"github.com/celestiaorg/celestia-node/libs/keystore"
-	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 const DefaultAccountName = "my_celes_key"
 
-// KeyringSigner constructs a new keyring signer.
-// NOTE: we construct keyring signer before constructing node for easier UX
+// Keyring constructs a new keyring.
+// NOTE: we construct keyring before constructing node for easier UX
 // as having keyring-backend set to `file` prompts user for password.
-func KeyringSigner(cfg Config, ks keystore.Keystore, net p2p.Network) (*apptypes.KeyringSigner, error) {
+func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, string, error) {
 	ring := ks.Keyring()
+	if ring == nil {
+		panic("keyring is nil")
+	}
 	var info *kr.Record
 	// if custom keyringAccName provided, find key for that name
 	if cfg.KeyringAccName != "" {
 		keyInfo, err := ring.Key(cfg.KeyringAccName)
 		if err != nil {
 			log.Errorw("failed to find key by given name", "keyring.accname", cfg.KeyringAccName)
-			return nil, err
+			return nil, "", err
 		}
 		info = keyInfo
 	} else {
@@ -30,15 +30,10 @@ func KeyringSigner(cfg Config, ks keystore.Keystore, net p2p.Network) (*apptypes
 		keyInfo, err := ring.Key(DefaultAccountName)
 		if err != nil {
 			log.Errorw("could not access key in keyring", "name", DefaultAccountName)
-			return nil, err
+			return nil, "", err
 		}
 		info = keyInfo
 	}
-	// construct signer using the default key found / generated above
-	signer := apptypes.NewKeyringSigner(ring, info.Name, string(net))
-	signerInfo := signer.GetSignerInfo()
-	log.Infow("constructed keyring signer", "backend", cfg.KeyringBackend, "path", ks.Path(),
-		"key name", signerInfo.Name, "chain-id", string(net))
 
-	return signer, nil
+	return ring, info.Name, nil
 }

--- a/nodebuilder/state/keyring.go
+++ b/nodebuilder/state/keyring.go
@@ -8,12 +8,12 @@ import (
 
 const DefaultAccountName = "my_celes_key"
 
-type AccName string
+type AccountName string
 
 // Keyring constructs a new keyring.
 // NOTE: we construct keyring before constructing node for easier UX
 // as having keyring-backend set to `file` prompts user for password.
-func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, AccName, error) {
+func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, AccountName, error) {
 	ring := ks.Keyring()
 	var info *kr.Record
 	// if custom keyringAccName provided, find key for that name
@@ -34,5 +34,5 @@ func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, AccName, error) {
 		info = keyInfo
 	}
 
-	return ring, AccName(info.Name), nil
+	return ring, AccountName(info.Name), nil
 }

--- a/nodebuilder/state/keyring.go
+++ b/nodebuilder/state/keyring.go
@@ -8,10 +8,12 @@ import (
 
 const DefaultAccountName = "my_celes_key"
 
+type AccName string
+
 // Keyring constructs a new keyring.
 // NOTE: we construct keyring before constructing node for easier UX
 // as having keyring-backend set to `file` prompts user for password.
-func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, string, error) {
+func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, AccName, error) {
 	ring := ks.Keyring()
 	var info *kr.Record
 	// if custom keyringAccName provided, find key for that name
@@ -32,5 +34,5 @@ func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, string, error) {
 		info = keyInfo
 	}
 
-	return ring, info.Name, nil
+	return ring, AccName(info.Name), nil
 }

--- a/nodebuilder/state/module.go
+++ b/nodebuilder/state/module.go
@@ -31,7 +31,7 @@ func ConstructModule(tp node.Type, cfg *Config, coreCfg *core.Config) fx.Option 
 		fx.Supply(*cfg),
 		fx.Error(cfgErr),
 		fx.Supply(opts),
-		fx.Provide(func(ks keystore.Keystore) (keyring.Keyring, AccName, error) {
+		fx.Provide(func(ks keystore.Keystore) (keyring.Keyring, AccountName, error) {
 			return Keyring(*cfg, ks)
 		}),
 		fxutil.ProvideIf(coreCfg.IsEndpointConfigured(), fx.Annotate(

--- a/nodebuilder/state/module.go
+++ b/nodebuilder/state/module.go
@@ -3,11 +3,13 @@ package state
 import (
 	"context"
 
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
+	"github.com/celestiaorg/celestia-node/libs/keystore"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
 	modfraud "github.com/celestiaorg/celestia-node/nodebuilder/fraud"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -29,6 +31,9 @@ func ConstructModule(tp node.Type, cfg *Config, coreCfg *core.Config) fx.Option 
 		fx.Supply(*cfg),
 		fx.Error(cfgErr),
 		fx.Supply(opts),
+		fx.Provide(func(ks keystore.Keystore) (keyring.Keyring, AccName, error) {
+			return Keyring(*cfg, ks)
+		}),
 		fxutil.ProvideIf(coreCfg.IsEndpointConfigured(), fx.Annotate(
 			coreAccessor,
 			fx.OnStart(func(ctx context.Context,

--- a/nodebuilder/state/opts.go
+++ b/nodebuilder/state/opts.go
@@ -1,13 +1,16 @@
 package state
 
 import (
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"go.uber.org/fx"
-
-	"github.com/celestiaorg/celestia-app/x/blob/types"
 )
 
 // WithKeyringSigner overrides the default keyring signer constructed
 // by the node.
-func WithKeyringSigner(signer *types.KeyringSigner) fx.Option {
-	return fx.Replace(signer)
+func WithKeyring(keyring keyring.Keyring) fx.Option {
+	return fx.Replace(keyring)
+}
+
+func WithKeyName(name string) fx.Option {
+	return fx.Replace(name)
 }

--- a/nodebuilder/state/opts.go
+++ b/nodebuilder/state/opts.go
@@ -1,16 +1,18 @@
 package state
 
 import (
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	kr "github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"go.uber.org/fx"
+
+	"github.com/celestiaorg/celestia-node/libs/fxutil"
 )
 
-// WithKeyringSigner overrides the default keyring signer constructed
+// WithKeyring overrides the default keyring constructed
 // by the node.
-func WithKeyring(keyring keyring.Keyring) fx.Option {
-	return fx.Replace(keyring)
+func WithKeyring(keyring kr.Keyring) fx.Option {
+	return fxutil.ReplaceAs(keyring, new(kr.Keyring))
 }
 
-func WithKeyName(name string) fx.Option {
+func WithKeyName(name AccName) fx.Option {
 	return fx.Replace(name)
 }

--- a/nodebuilder/state/opts.go
+++ b/nodebuilder/state/opts.go
@@ -13,6 +13,7 @@ func WithKeyring(keyring kr.Keyring) fx.Option {
 	return fxutil.ReplaceAs(keyring, new(kr.Keyring))
 }
 
+// WithKeyName configures the signer to use the given key.
 func WithKeyName(name AccName) fx.Option {
 	return fx.Replace(name)
 }

--- a/nodebuilder/state/opts.go
+++ b/nodebuilder/state/opts.go
@@ -14,6 +14,6 @@ func WithKeyring(keyring kr.Keyring) fx.Option {
 }
 
 // WithKeyName configures the signer to use the given key.
-func WithKeyName(name AccName) fx.Option {
+func WithKeyName(name AccountName) fx.Option {
 	return fx.Replace(name)
 }

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	apptypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/core"
@@ -17,8 +16,9 @@ import (
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
-	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
+
+const TestKeyringName = "test_celes"
 
 // MockStore provides mock in memory Store for testing purposes.
 func MockStore(t *testing.T, cfg *Config) Store {
@@ -48,10 +48,13 @@ func TestNodeWithConfig(t *testing.T, tp node.Type, cfg *Config, opts ...fx.Opti
 	store := MockStore(t, cfg)
 	ks, err := store.Keystore()
 	require.NoError(t, err)
+	kr := ks.Keyring()
+	// create a key in the keystore to be used by the core accessor
+	_, _, err = kr.NewMnemonic(TestKeyringName, keyring.English, "", "", hd.Secp256k1)
+	require.NoError(t, err)
+	cfg.State.KeyringAccName = TestKeyringName
 
 	opts = append(opts,
-		// avoid writing keyring on disk
-		state.WithKeyringSigner(TestKeyringSigner(t, ks.Keyring())),
 		// temp dir for the eds store FIXME: Should be in mem
 		fx.Replace(node.StorePath(t.TempDir())),
 		// avoid requesting trustedPeer during initialization
@@ -70,12 +73,4 @@ func TestNodeWithConfig(t *testing.T, tp node.Type, cfg *Config, opts ...fx.Opti
 	nd, err := New(tp, p2p.Private, store, opts...)
 	require.NoError(t, err)
 	return nd
-}
-
-func TestKeyringSigner(t *testing.T, ring keyring.Keyring) *apptypes.KeyringSigner {
-	signer := apptypes.NewKeyringSigner(ring, "", string(p2p.Private))
-	_, _, err := signer.NewMnemonic("my_celes_key", keyring.English, "",
-		"", hd.Secp256k1)
-	require.NoError(t, err)
-	return signer
 }

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -37,10 +37,8 @@ func TestBlobModule(t *testing.T) {
 		blobs = append(blobs, blob)
 	}
 
-	require.NoError(t, err)
 	bridge := sw.NewBridgeNode()
 	require.NoError(t, bridge.Start(ctx))
-
 	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
 	require.NoError(t, err)
 

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -259,7 +259,7 @@ func (s *Swamp) NewNodeWithStore(
 ) *nodebuilder.Node {
 	options = append(options,
 		state.WithKeyring(s.ClientContext.Keyring),
-		state.WithKeyName(state.AccName(s.Accounts[0])),
+		state.WithKeyName(state.AccountName(s.Accounts[0])),
 	)
 
 	switch tp {

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
-	apptypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/core"
@@ -258,9 +257,9 @@ func (s *Swamp) NewNodeWithStore(
 	store nodebuilder.Store,
 	options ...fx.Option,
 ) *nodebuilder.Node {
-	signer := apptypes.NewKeyringSigner(s.ClientContext.Keyring, s.Accounts[0], s.ClientContext.ChainID)
 	options = append(options,
-		state.WithKeyringSigner(signer),
+		state.WithKeyring(s.ClientContext.Keyring),
+		state.WithKeyName(s.Accounts[0]),
 	)
 
 	switch tp {

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -259,7 +259,7 @@ func (s *Swamp) NewNodeWithStore(
 ) *nodebuilder.Node {
 	options = append(options,
 		state.WithKeyring(s.ClientContext.Keyring),
-		state.WithKeyName(s.Accounts[0]),
+		state.WithKeyName(state.AccName(s.Accounts[0])),
 	)
 
 	switch tp {

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -674,6 +674,9 @@ func (ca *CoreAccessor) queryMinimumGasPrice(
 	return coins.AmountOf(app.BondDenom).MustFloat64(), nil
 }
 
+// getSigner returns the signer if it has already been constructed, otherwise
+// it will attempt to set it up. The signer can only be constructed if the account
+// exists / is funded.
 func (ca *CoreAccessor) getSigner(ctx context.Context) (*user.Signer, error) {
 	ca.signerMu.Lock()
 	defer ca.signerMu.Unlock()

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -593,10 +593,7 @@ func (ca *CoreAccessor) GrantFee(
 		return nil, err
 	}
 
-	granter, err := signer.GetSignerInfo().GetAddress()
-	if err != nil {
-		return nil, err
-	}
+	granter := signer.Address()
 
 	allowance := &feegrant.BasicAllowance{}
 	if !amount.IsZero() {
@@ -623,10 +620,7 @@ func (ca *CoreAccessor) RevokeGrantFee(
 		return nil, err
 	}
 
-	granter, err := signer.GetSignerInfo().GetAddress()
-	if err != nil {
-		return nil, err
-	}
+	granter := signer.Address()
 
 	msg := feegrant.NewMsgRevokeAllowance(granter, grantee)
 	return signer.SubmitTx(ctx, []sdktypes.Msg{&msg}, user.SetGasLimit(gasLim), withFee(fee))

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -36,9 +36,11 @@ func TestSubmitPayForBlob(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ca := NewCoreAccessor(cctx.Keyring, accounts[0], nil, "127.0.0.1", extractPort(rpcAddr), extractPort(grpcAddr))
+	ca, err := NewCoreAccessor(cctx.Keyring, accounts[0], nil, "127.0.0.1", extractPort(rpcAddr),
+		extractPort(grpcAddr))
+	require.NoError(t, err)
 	// start the accessor
-	err := ca.Start(ctx)
+	err = ca.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = ca.Stop(ctx)

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -36,8 +36,7 @@ func TestSubmitPayForBlob(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	signer := blobtypes.NewKeyringSigner(cctx.Keyring, accounts[0], cctx.ChainID)
-	ca := NewCoreAccessor(signer, nil, "127.0.0.1", extractPort(rpcAddr), extractPort(grpcAddr))
+	ca := NewCoreAccessor(cctx.Keyring, accounts[0], nil, "127.0.0.1", extractPort(rpcAddr), extractPort(grpcAddr))
 	// start the accessor
 	err := ca.Start(ctx)
 	require.NoError(t, err)

--- a/state/integration_test.go
+++ b/state/integration_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
-	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/core"
@@ -49,8 +48,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.cctx = core.StartTestNodeWithConfig(s.T(), cfg)
 	s.accounts = cfg.Accounts
 
-	signer := blobtypes.NewKeyringSigner(s.cctx.Keyring, s.accounts[0], s.cctx.ChainID)
-	accessor := NewCoreAccessor(signer, localHeader{s.cctx.Client}, "", "", "")
+	accessor := NewCoreAccessor(s.cctx.Keyring, s.accounts[0], localHeader{s.cctx.Client}, "", "", "")
 	setClients(accessor, s.cctx.GRPCClient, s.cctx.Client)
 	s.accessor = accessor
 

--- a/state/integration_test.go
+++ b/state/integration_test.go
@@ -48,12 +48,13 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.cctx = core.StartTestNodeWithConfig(s.T(), cfg)
 	s.accounts = cfg.Accounts
 
-	accessor := NewCoreAccessor(s.cctx.Keyring, s.accounts[0], localHeader{s.cctx.Client}, "", "", "")
+	accessor, err := NewCoreAccessor(s.cctx.Keyring, s.accounts[0], localHeader{s.cctx.Client}, "", "", "")
+	require.NoError(s.T(), err)
 	setClients(accessor, s.cctx.GRPCClient, s.cctx.Client)
 	s.accessor = accessor
 
 	// required to ensure the Head request is non-nil
-	_, err := s.cctx.WaitForHeight(3)
+	_, err = s.cctx.WaitForHeight(3)
 	require.NoError(s.T(), err)
 }
 


### PR DESCRIPTION
Closes: #3296

This adds the [`Signer`](https://github.com/celestiaorg/celestia-app/blob/bcab06582c9802f1d49a2bee86820792258bb587/pkg/user/signer.go#L31) struct from celestia-app's user package. 

Signer keeps track of both the network and local sequence number allowing for multiple messages to be signed within a single block.

This also uses the `EstimateGas` function of the signer to estimate the gas, when the user provides 0 as the `gasLim`

TODO: we should probably introduce some gas multiplier (default: 1.1) to the `EstimateGas` as it seems to underestimate the value (cc @vgonkivs)


