### PR TITLE
fix(core): Unsubscribe from new block event on Stop in listener

### DIFF
--- a/core/listener.go
+++ b/core/listener.go
@@ -109,7 +109,12 @@ func (cl *Listener) Start(context.Context) error {
 }
 
 // Stop stops the listener loop.
-func (cl *Listener) Stop(context.Context) error {
+func (cl *Listener) Stop(ctx context.Context) error {
+	err := cl.fetcher.UnsubscribeNewBlockEvent(ctx)
+	if err != nil {
+		log.Warnw("listener: unsubscribing from new block event", "err", err)
+	}
+
 	cl.cancel()
 	cl.cancel = nil
 	return cl.metrics.Close()


### PR DESCRIPTION
Subscription was never cancelled on Stop, found while working on swamp tests for #3188 