### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/nodebuilder/core/flags.go
+++ b/nodebuilder/core/flags.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -45,7 +45,7 @@ func ParseFlags(
 	coreIP := cmd.Flag(coreFlag).Value.String()
 	if coreIP == "" {
 		if cmd.Flag(coreGRPCFlag).Changed || cmd.Flag(coreRPCFlag).Changed {
-			return fmt.Errorf("cannot specify RPC/gRPC ports without specifying an IP address for --core.ip")
+			return errors.New("cannot specify RPC/gRPC ports without specifying an IP address for --core.ip")
 		}
 		return nil
 	}

--- a/nodebuilder/das/constructors.go
+++ b/nodebuilder/das/constructors.go
@@ -2,12 +2,9 @@ package das
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
-	"github.com/ipfs/go-datastore"
-
-	"github.com/celestiaorg/go-fraud"
 	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/das"
@@ -21,7 +18,7 @@ import (
 
 var _ Module = (*daserStub)(nil)
 
-var errStub = fmt.Errorf("module/das: stubbed: dasing is not available on bridge nodes")
+var errStub = errors.New("module/das: stubbed: dasing is not available on bridge nodes")
 
 // daserStub is a stub implementation of the DASer that is used on bridge nodes, so that we can
 // provide a friendlier error when users try to access the daser over the API.

--- a/nodebuilder/header/service_test.go
+++ b/nodebuilder/header/service_test.go
@@ -2,7 +2,7 @@ package header
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +29,7 @@ type errorSyncer[H libhead.Header[H]] struct{}
 
 func (d *errorSyncer[H]) Head(context.Context, ...libhead.HeadOption[H]) (H, error) {
 	var zero H
-	return zero, fmt.Errorf("dummy error")
+	return zero, errors.New("dummy error")
 }
 
 func (d *errorSyncer[H]) State() sync.State {
@@ -37,5 +37,5 @@ func (d *errorSyncer[H]) State() sync.State {
 }
 
 func (d *errorSyncer[H]) SyncWait(context.Context) error {
-	return fmt.Errorf("dummy error")
+	return errors.New("dummy error")
 }

--- a/nodebuilder/p2p/p2p.go
+++ b/nodebuilder/p2p/p2p.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -178,7 +179,7 @@ func (m *module) BandwidthForProtocol(_ context.Context, proto protocol.ID) (met
 func (m *module) ResourceState(context.Context) (rcmgr.ResourceManagerStat, error) {
 	rms, ok := m.rm.(rcmgr.ResourceManagerState)
 	if !ok {
-		return rcmgr.ResourceManagerStat{}, fmt.Errorf("network.resourceManager does not implement " +
+		return rcmgr.ResourceManagerStat{}, errors.New("network.resourceManager does not implement " +
 			"rcmgr.ResourceManagerState")
 	}
 	return rms.Stat(), nil

--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -10,17 +10,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/dgraph-io/badger/v4/options"
-	"github.com/gofrs/flock"
-	"github.com/ipfs/go-datastore"
-	dsbadger "github.com/ipfs/go-ds-badger4"
-	"github.com/mitchellh/go-homedir"
-
 	"github.com/celestiaorg/celestia-node/libs/keystore"
 	nodemod "github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/gofrs/flock"
+	dsbadger "github.com/ipfs/go-ds-badger4"
 )
 
 var (
@@ -115,7 +112,7 @@ func (f *fsStore) PutConfig(cfg *Config) error {
 
 func (f *fsStore) Keystore() (_ keystore.Keystore, err error) {
 	if f.keys == nil {
-		return nil, fmt.Errorf("node: no Keystore found")
+		return nil, errors.New("node: no Keystore found")
 	}
 	return f.keys, nil
 }

--- a/pruner/params.go
+++ b/pruner/params.go
@@ -1,7 +1,7 @@
 package pruner
 
 import (
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -15,7 +15,7 @@ type Params struct {
 
 func (p *Params) Validate() error {
 	if p.pruneCycle == time.Duration(0) {
-		return fmt.Errorf("invalid GC cycle given, value should be positive and non-zero")
+		return errors.New("invalid GC cycle given, value should be positive and non-zero")
 	}
 	return nil
 }

--- a/pruner/service.go
+++ b/pruner/service.go
@@ -2,10 +2,9 @@ package pruner
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	logging "github.com/ipfs/go-log/v2"
 
@@ -90,7 +89,7 @@ func (s *Service) Stop(ctx context.Context) error {
 	case <-s.doneCh:
 		return nil
 	case <-ctx.Done():
-		return fmt.Errorf("pruner unable to exit within context deadline")
+		return errors.New("pruner unable to exit within context deadline")
 	}
 }
 

--- a/pruner/service_test.go
+++ b/pruner/service_test.go
@@ -2,11 +2,10 @@ package pruner
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -312,7 +311,7 @@ func (mp *mockPruner) Prune(_ context.Context, h *header.ExtendedHeader) error {
 				return nil
 			}
 			mp.failHeight[fail]++
-			return fmt.Errorf("failed to prune")
+			return errors.New("failed to prune")
 		}
 	}
 	mp.deletedHeaderHashes = append(mp.deletedHeaderHashes, pruned{hash: h.Hash().String(), height: h.Height()})


### PR DESCRIPTION
If you don't need to format the string, recommended to use error.New().