### PR TITLE
feat!(state/core_access): add TxConfig

### DIFF
--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -178,14 +178,14 @@ func init() {
 	}
 	addToExampleValues(libhead.Hash(hash))
 
-	txOptions := state.NewTxOptions(
+	txConfig := state.NewTxConfig(
 		state.WithGasPrice(0.002),
 		state.WithGas(142225),
 		state.WithKeyName("my_celes_key"),
 		state.WithSignerAddress("celestia1pjcmwj8w6hyr2c4wehakc5g8cfs36aysgucx66"),
 		state.WithFeeGranterAddress("celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"),
 	)
-	addToExampleValues(txOptions)
+	addToExampleValues(txConfig)
 }
 
 func addToExampleValues(v interface{}) {

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -61,7 +61,6 @@ var ExampleValues = map[reflect.Type]interface{}{
 	reflect.TypeOf(42):                       42,
 	reflect.TypeOf(byte(7)):                  byte(7),
 	reflect.TypeOf(float64(42)):              float64(42),
-	reflect.TypeOf(blob.GasPrice(0)):         blob.GasPrice(0.002),
 	reflect.TypeOf(true):                     true,
 	reflect.TypeOf([]byte{}):                 []byte("byte array"),
 	reflect.TypeOf(node.Full):                node.Full,
@@ -187,7 +186,7 @@ func init() {
 	txOptions := options.DefaultTxOptions()
 	txOptions.AccountKey = "my_celes_key"
 	txOptions.Gas = 142225
-	txOptions.SetFeeAmount(2_000)
+	txOptions.SetGasPrice(0.002)
 	txOptions.FeeGranterAddress = "celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"
 	addToExampleValues(txOptions)
 }

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -188,7 +188,7 @@ func init() {
 	txOptions.Account = "my_celes_key"
 	txOptions.Gas = 142225
 	txOptions.SetFeeAmount(2_000)
-	txOptions.Granter = "celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"
+	txOptions.FeeGranterAddress = "celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"
 	addToExampleValues(txOptions)
 }
 

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -185,7 +185,7 @@ func init() {
 	addToExampleValues(blobProof)
 
 	txOptions := options.DefaultTxOptions()
-	txOptions.Account = "my_celes_key"
+	txOptions.AccountKey = "my_celes_key"
 	txOptions.Gas = 142225
 	txOptions.SetFeeAmount(2_000)
 	txOptions.FeeGranterAddress = "celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -181,7 +181,8 @@ func init() {
 	txOptions := state.NewTxOptions(
 		state.WithGasPrice(0.002),
 		state.WithGas(142225),
-		state.WithAccountKey("my_celes_key"),
+		state.WithKeyName("my_celes_key"),
+		state.WithSignerAddress("celestia1pjcmwj8w6hyr2c4wehakc5g8cfs36aysgucx66"),
 		state.WithFeeGranterAddress("celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"),
 	)
 	addToExampleValues(txOptions)

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -31,7 +31,6 @@ import (
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
 	"github.com/celestiaorg/celestia-node/state"
-	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 //go:embed "exampledata/extendedHeader.json"
@@ -183,11 +182,12 @@ func init() {
 	blobProof = &blob.Proof{&proof}
 	addToExampleValues(blobProof)
 
-	txOptions := options.DefaultTxOptions()
-	txOptions.AccountKey = "my_celes_key"
-	txOptions.Gas = 142225
-	txOptions.SetGasPrice(0.002)
-	txOptions.FeeGranterAddress = "celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"
+	txOptions := state.NewTxOptions(
+		state.WithGasPrice(0.002),
+		state.WithGas(142225),
+		state.WithAccountKey("my_celes_key"),
+		state.WithFeeGranterAddress("celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"),
+	)
 	addToExampleValues(txOptions)
 }
 

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -186,7 +186,7 @@ func init() {
 
 	txOptions := options.DefaultTxOptions()
 	txOptions.Account = "my_celes_key"
-	txOptions.GasLimit = 142225
+	txOptions.Gas = 142225
 	txOptions.SetFeeAmount(2_000)
 	txOptions.Granter = "celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"
 	addToExampleValues(txOptions)

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -31,6 +31,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
 	"github.com/celestiaorg/celestia-node/state"
+	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 //go:embed "exampledata/extendedHeader.json"
@@ -177,8 +178,18 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-
 	addToExampleValues(libhead.Hash(hash))
+
+	proof := nmt.NewInclusionProof(0, 4, [][]byte{[]byte("test")}, true)
+	blobProof = &blob.Proof{&proof}
+	addToExampleValues(blobProof)
+
+	txOptions := options.DefaultTxOptions()
+	txOptions.Account = "celestia1fcw3wrlhzk4pf5y68m4009pzyg97p2ftaezl6y"
+	txOptions.GasLimit = 142225
+	txOptions.SetFeeAmount(2_000)
+	txOptions.Granter = "celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"
+	addToExampleValues(txOptions)
 }
 
 func addToExampleValues(v interface{}) {

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -178,10 +178,6 @@ func init() {
 	}
 	addToExampleValues(libhead.Hash(hash))
 
-	proof := nmt.NewInclusionProof(0, 4, [][]byte{[]byte("test")}, true)
-	blobProof = &blob.Proof{&proof}
-	addToExampleValues(blobProof)
-
 	txOptions := state.NewTxOptions(
 		state.WithGasPrice(0.002),
 		state.WithGas(142225),

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -185,7 +185,7 @@ func init() {
 	addToExampleValues(blobProof)
 
 	txOptions := options.DefaultTxOptions()
-	txOptions.Account = "celestia1fcw3wrlhzk4pf5y68m4009pzyg97p2ftaezl6y"
+	txOptions.Account = "my_celes_key"
 	txOptions.GasLimit = 142225
 	txOptions.SetFeeAmount(2_000)
 	txOptions.Granter = "celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"

--- a/api/rpc_test.go
+++ b/api/rpc_test.go
@@ -202,12 +202,12 @@ func TestAuthedRPC(t *testing.T) {
 				server.State.EXPECT().Delegate(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any()).Return(expectedResp, nil)
 				txResp, err := rpcClient.State.Delegate(ctx,
-					state.ValAddress{}, state.Int{}, state.NewTxOptions())
+					state.ValAddress{}, state.Int{}, state.NewTxConfig())
 				require.NoError(t, err)
 				require.Equal(t, expectedResp, txResp)
 			} else {
 				_, err := rpcClient.State.Delegate(ctx,
-					state.ValAddress{}, state.Int{}, state.NewTxOptions())
+					state.ValAddress{}, state.Int{}, state.NewTxConfig())
 				require.Error(t, err)
 				require.ErrorContains(t, err, "missing permission")
 			}

--- a/api/rpc_test.go
+++ b/api/rpc_test.go
@@ -39,6 +39,7 @@ import (
 	statemod "github.com/celestiaorg/celestia-node/nodebuilder/state"
 	stateMock "github.com/celestiaorg/celestia-node/nodebuilder/state/mocks"
 	"github.com/celestiaorg/celestia-node/state"
+	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 func TestRPCCallsUnderlyingNode(t *testing.T) {
@@ -200,14 +201,14 @@ func TestAuthedRPC(t *testing.T) {
 			expectedResp := &state.TxResponse{}
 			if tt.perm > 2 {
 				server.State.EXPECT().Delegate(gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedResp, nil)
+					gomock.Any(), gomock.Any()).Return(expectedResp, nil)
 				txResp, err := rpcClient.State.Delegate(ctx,
-					state.ValAddress{}, state.Int{}, state.Int{}, 0)
+					state.ValAddress{}, state.Int{}, options.DefaultTxOptions())
 				require.NoError(t, err)
 				require.Equal(t, expectedResp, txResp)
 			} else {
 				_, err := rpcClient.State.Delegate(ctx,
-					state.ValAddress{}, state.Int{}, state.Int{}, 0)
+					state.ValAddress{}, state.Int{}, options.DefaultTxOptions())
 				require.Error(t, err)
 				require.ErrorContains(t, err, "missing permission")
 			}

--- a/api/rpc_test.go
+++ b/api/rpc_test.go
@@ -39,7 +39,6 @@ import (
 	statemod "github.com/celestiaorg/celestia-node/nodebuilder/state"
 	stateMock "github.com/celestiaorg/celestia-node/nodebuilder/state/mocks"
 	"github.com/celestiaorg/celestia-node/state"
-	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 func TestRPCCallsUnderlyingNode(t *testing.T) {
@@ -203,12 +202,12 @@ func TestAuthedRPC(t *testing.T) {
 				server.State.EXPECT().Delegate(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any()).Return(expectedResp, nil)
 				txResp, err := rpcClient.State.Delegate(ctx,
-					state.ValAddress{}, state.Int{}, options.DefaultTxOptions())
+					state.ValAddress{}, state.Int{}, state.NewTxOptions())
 				require.NoError(t, err)
 				require.Equal(t, expectedResp, txResp)
 			} else {
 				_, err := rpcClient.State.Delegate(ctx,
-					state.ValAddress{}, state.Int{}, options.DefaultTxOptions())
+					state.ValAddress{}, state.Int{}, state.NewTxOptions())
 				require.Error(t, err)
 				require.ErrorContains(t, err, "missing permission")
 			}

--- a/blob/helper.go
+++ b/blob/helper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 
 	"github.com/celestiaorg/celestia-app/pkg/shares"
+	apptypes "github.com/celestiaorg/celestia-app/x/blob/types"
 
 	"github.com/celestiaorg/celestia-node/share"
 )
@@ -34,6 +35,15 @@ func BlobsToShares(blobs ...*Blob) ([]share.Share, error) {
 		return nil, err
 	}
 	return shares.ToBytes(rawShares), nil
+}
+
+// ToAppBlobs convertc node's blobs to the app blobs.
+func ToAppBlobs(blobs ...*Blob) []*apptypes.Blob {
+	appBlobs := make([]*apptypes.Blob, 0, len(blobs))
+	for i := range blobs {
+		appBlobs[i] = &blobs[i].Blob
+	}
+	return appBlobs
 }
 
 // toAppShares converts node's raw shares to the app shares, skipping padding

--- a/blob/helper.go
+++ b/blob/helper.go
@@ -37,7 +37,7 @@ func BlobsToShares(blobs ...*Blob) ([]share.Share, error) {
 	return shares.ToBytes(rawShares), nil
 }
 
-// ToAppBlobs convertc node's blobs to the app blobs.
+// ToAppBlobs converts node's blob type to the blob type from celestia-app.
 func ToAppBlobs(blobs ...*Blob) []*apptypes.Blob {
 	appBlobs := make([]*apptypes.Blob, 0, len(blobs))
 	for i := range blobs {

--- a/blob/service.go
+++ b/blob/service.go
@@ -68,21 +68,6 @@ func NewService(
 	}
 }
 
-// SubmitOptions contains the information about fee and gasLimit price in order to configure the
-// Submit request.
-type SubmitOptions struct {
-	Fee      int64
-	GasLimit uint64
-}
-
-// DefaultSubmitOptions creates a default fee and gas price values.
-func DefaultSubmitOptions() *SubmitOptions {
-	return &SubmitOptions{
-		Fee:      -1,
-		GasLimit: 0,
-	}
-}
-
 // Submit sends PFB transaction and reports the height at which it was included.
 // Allows sending multiple Blobs atomically synchronously.
 // Uses default wallet registered on the Node.

--- a/blob/service.go
+++ b/blob/service.go
@@ -31,7 +31,7 @@ var (
 )
 
 // GasPrice represents the amount to be paid per gas unit. Fee is set by
-// multiplying GasPrice by GasLimit, which is determined by the blob sizes.
+// multiplying GasPrice by Gas, which is determined by the blob sizes.
 type GasPrice float64
 
 // DefaultGasPrice returns the default gas price, letting node automatically

--- a/blob/service.go
+++ b/blob/service.go
@@ -34,7 +34,7 @@ var (
 // avoid a circular dependency between the blob and the state package, since the state package needs
 // the blob.Blob type for this signature.
 type Submitter interface {
-	SubmitPayForBlob(context.Context, []*state.Blob, state.Options) (*types.TxResponse, error)
+	SubmitPayForBlob(context.Context, []*state.Blob, *state.TxOptions) (*types.TxResponse, error)
 }
 
 type Service struct {
@@ -62,7 +62,7 @@ func NewService(
 // Allows sending multiple Blobs atomically synchronously.
 // Uses default wallet registered on the Node.
 // Handles gas estimation and fee calculation.
-func (s *Service) Submit(ctx context.Context, blobs []*Blob, txOptions state.Options) (uint64, error) {
+func (s *Service) Submit(ctx context.Context, blobs []*Blob, txOptions *state.TxOptions) (uint64, error) {
 	log.Debugw("submitting blobs", "amount", len(blobs))
 
 	appblobs := make([]*state.Blob, len(blobs))

--- a/blob/service.go
+++ b/blob/service.go
@@ -30,6 +30,10 @@ var (
 	tracer = otel.Tracer("blob/service")
 )
 
+// SubmitOptions aliases TxOptions from state package allowing users
+// to specify options for SubmitPFB transaction.
+type SubmitOptions = state.TxConfig
+
 // Submitter is an interface that allows submitting blobs to the celestia-core. It is used to
 // avoid a circular dependency between the blob and the state package, since the state package needs
 // the blob.Blob type for this signature.
@@ -62,7 +66,7 @@ func NewService(
 // Allows sending multiple Blobs atomically synchronously.
 // Uses default wallet registered on the Node.
 // Handles gas estimation and fee calculation.
-func (s *Service) Submit(ctx context.Context, blobs []*Blob, txConfig *state.TxConfig) (uint64, error) {
+func (s *Service) Submit(ctx context.Context, blobs []*Blob, txConfig *SubmitOptions) (uint64, error) {
 	log.Debugw("submitting blobs", "amount", len(blobs))
 
 	appblobs := make([]*state.Blob, len(blobs))

--- a/blob/service.go
+++ b/blob/service.go
@@ -19,7 +19,7 @@ import (
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/libs/utils"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/state/options"
+	"github.com/celestiaorg/celestia-node/state"
 )
 
 var (
@@ -34,7 +34,7 @@ var (
 // avoid a circular dependency between the blob and the state package, since the state package needs
 // the blob.Blob type for this signature.
 type Submitter interface {
-	SubmitPayForBlob(context.Context, []*Blob, *options.TxOptions) (*types.TxResponse, error)
+	SubmitPayForBlob(context.Context, []*state.Blob, state.Options) (*types.TxResponse, error)
 }
 
 type Service struct {
@@ -62,10 +62,18 @@ func NewService(
 // Allows sending multiple Blobs atomically synchronously.
 // Uses default wallet registered on the Node.
 // Handles gas estimation and fee calculation.
-func (s *Service) Submit(ctx context.Context, blobs []*Blob, txOptions *options.TxOptions) (uint64, error) {
+func (s *Service) Submit(ctx context.Context, blobs []*Blob, txOptions state.Options) (uint64, error) {
 	log.Debugw("submitting blobs", "amount", len(blobs))
 
-	resp, err := s.blobSubmitter.SubmitPayForBlob(ctx, blobs, txOptions)
+	appblobs := make([]*state.Blob, len(blobs))
+	for i := range blobs {
+		if err := blobs[i].Namespace().ValidateForBlob(); err != nil {
+			return 0, err
+		}
+		appblobs[i] = &blobs[i].Blob
+	}
+
+	resp, err := s.blobSubmitter.SubmitPayForBlob(ctx, appblobs, txOptions)
 	if err != nil {
 		return 0, err
 	}

--- a/blob/service.go
+++ b/blob/service.go
@@ -30,16 +30,6 @@ var (
 	tracer = otel.Tracer("blob/service")
 )
 
-// GasPrice represents the amount to be paid per gas unit. Fee is set by
-// multiplying GasPrice by Gas, which is determined by the blob sizes.
-type GasPrice float64
-
-// DefaultGasPrice returns the default gas price, letting node automatically
-// determine the Fee based on the passed blob sizes.
-func DefaultGasPrice() GasPrice {
-	return -1.0
-}
-
 // Submitter is an interface that allows submitting blobs to the celestia-core. It is used to
 // avoid a circular dependency between the blob and the state package, since the state package needs
 // the blob.Blob type for this signature.

--- a/blob/service.go
+++ b/blob/service.go
@@ -34,7 +34,7 @@ var (
 // avoid a circular dependency between the blob and the state package, since the state package needs
 // the blob.Blob type for this signature.
 type Submitter interface {
-	SubmitPayForBlob(context.Context, []*state.Blob, *state.TxOptions) (*types.TxResponse, error)
+	SubmitPayForBlob(context.Context, []*state.Blob, *state.TxConfig) (*types.TxResponse, error)
 }
 
 type Service struct {
@@ -62,7 +62,7 @@ func NewService(
 // Allows sending multiple Blobs atomically synchronously.
 // Uses default wallet registered on the Node.
 // Handles gas estimation and fee calculation.
-func (s *Service) Submit(ctx context.Context, blobs []*Blob, txOptions *state.TxOptions) (uint64, error) {
+func (s *Service) Submit(ctx context.Context, blobs []*Blob, txConfig *state.TxConfig) (uint64, error) {
 	log.Debugw("submitting blobs", "amount", len(blobs))
 
 	appblobs := make([]*state.Blob, len(blobs))
@@ -73,7 +73,7 @@ func (s *Service) Submit(ctx context.Context, blobs []*Blob, txOptions *state.Tx
 		appblobs[i] = &blobs[i].Blob
 	}
 
-	resp, err := s.blobSubmitter.SubmitPayForBlob(ctx, appblobs, txOptions)
+	resp, err := s.blobSubmitter.SubmitPayForBlob(ctx, appblobs, txConfig)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -38,7 +38,7 @@ Options passed on start override configuration options only on start and are not
 			// TODO @renaynay: Include option for setting custom `userInput` parameter with
 			//  implementation of https://github.com/celestiaorg/celestia-node/issues/415.
 			encConf := encoding.MakeConfig(app.ModuleEncodingRegisters...)
-			ring, err := keyring.New(app.Name, cfg.State.KeyringBackend, keysPath, os.Stdin, encConf.Codec)
+			ring, err := keyring.New(app.Name, cfg.State.DefaultBackendName, keysPath, os.Stdin, encConf.Codec)
 			if err != nil {
 				return err
 			}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -111,11 +111,7 @@ func PersistentPreRunEnv(cmd *cobra.Command, nodeType node.Type, _ []string) err
 		return err
 	}
 
-	err = state.ParseFlags(cmd, &cfg.State)
-	if err != nil {
-		return err
-	}
-
+	state.ParseFlags(cmd, &cfg.State)
 	rpc_cfg.ParseFlags(cmd, &cfg.RPC)
 	gateway.ParseFlags(cmd, &cfg.Gateway)
 

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -253,7 +253,7 @@ NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
       ctx context.Context, 
       nID namespace.ID, 
       data []byte,
-      options *state.TxOptions,
+      options *state.TxConfig,
     ) (*state.TxResponse, error)
     // Transfer sends the given amount of coins from default wallet of the node 
     // to the given account address.
@@ -261,7 +261,7 @@ NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
       ctx context.Context, 
       to types.Address,
       amount types.Int,
-      options *state.TxOptions,
+      options *state.TxConfig,
     ) (*state.TxResponse, error)
 
     // StateModule also provides StakingModule
@@ -282,7 +282,7 @@ yet.
         ctx context.Context, 
         delAddr state.ValAddress, 
         amount state.Int,
-        options *state.TxOptions,
+        options *state.TxConfig,
     ) (*state.TxResponse, error)
     // BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
     BeginRedelegate(
@@ -290,7 +290,7 @@ yet.
         srcValAddr,
         dstValAddr state.ValAddress,
         amount state.Int,
-        options *state.TxOptions, 
+        options *state.TxConfig, 
     ) (*state.TxResponse, error)
     // Undelegate undelegates a user's delegated tokens, unbonding them from the
     // current validator.
@@ -298,7 +298,7 @@ yet.
         ctx context.Context, 
         delAddr state.ValAddress,
         amount state.Int,
-        options *state.TxOptions,
+        options *state.TxConfig,
     ) (*state.TxResponse, error)
 
     // CancelUnbondingDelegation cancels a user's pending undelegation from a 
@@ -308,7 +308,7 @@ yet.
         valAddr state.ValAddress,
         amount types.Int,
         height types.Int,
-        options *state.TxOptions,
+        options *state.TxConfig,
     ) (*state.TxResponse, error)
 
     // QueryDelegation retrieves the delegation information between a delegator
@@ -399,7 +399,7 @@ type BankModule interface {
   SubmitPayForBlob(
     ctx context.Context,
     blobs []*state.Blob,
-    options *state.TxOptions, 
+    options *state.TxConfig, 
   ) (*state.TxResponse, error)	
   // Transfer sends the given amount of coins from default wallet of the node 
   // to the given account address.
@@ -407,7 +407,7 @@ type BankModule interface {
     ctx context.Context,
     to state.AccAddress, 
     amount state.Int, 
-    options *state.TxOptions,
+    options *state.TxConfig,
   ) (*state.TxResponse, error)
 }
 ```

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -253,8 +253,7 @@ NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
       ctx context.Context, 
       nID namespace.ID, 
       data []byte,
-      fee types.Int,
-      gasLimit uint64,
+	  options *state.TxOptions,
     ) (*state.TxResponse, error)
     // Transfer sends the given amount of coins from default wallet of the node 
     // to the given account address.
@@ -262,8 +261,7 @@ NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
       ctx context.Context, 
       to types.Address,
       amount types.Int,
-      fee types.Int,
-      gasLimit uint64,
+	  options *state.TxOptions,
     ) (*state.TxResponse, error)
 
     // StateModule also provides StakingModule
@@ -284,8 +282,7 @@ yet.
         ctx context.Context, 
         delAddr state.ValAddress, 
         amount state.Int,
-        fee types.Int,
-        gasLim uint64,
+        options *state.TxOptions,
     ) (*state.TxResponse, error)
     // BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
     BeginRedelegate(
@@ -293,8 +290,7 @@ yet.
         srcValAddr,
         dstValAddr state.ValAddress,
         amount state.Int,
-        fee types.Int,
-        gasLim uint64, 
+        options *state.TxOptions, 
     ) (*state.TxResponse, error)
     // Undelegate undelegates a user's delegated tokens, unbonding them from the
     // current validator.
@@ -302,8 +298,7 @@ yet.
         ctx context.Context, 
         delAddr state.ValAddress,
         amount state.Int,
-        fee types.Int,
-        gasLim uint64,
+		options *state.TxOptions,
     ) (*state.TxResponse, error)
 
     // CancelUnbondingDelegation cancels a user's pending undelegation from a 
@@ -313,8 +308,7 @@ yet.
         valAddr state.ValAddress,
         amount types.Int,
         height types.Int,
-        fee types.Int,
-        gasLim uint64,
+        options *state.TxOptions,
     ) (*state.TxResponse, error)
 
     // QueryDelegation retrieves the delegation information between a delegator
@@ -404,17 +398,16 @@ type BankModule interface {
   // SubmitPayForBlob builds, signs and submits a PayForBlob transaction.
   SubmitPayForBlob(
     ctx context.Context,
-    nID namespace.ID,
-    data []byte,
-    gasLimit uint64,
-  ) (*state.TxResponse, error)
+    blobs []*state.Blob,
+    options *state.TxOptions, 
+  ) (*state.TxResponse, error)	
   // Transfer sends the given amount of coins from default wallet of the node 
   // to the given account address.
   Transfer(
     ctx context.Context,
-    to types.Address,
-    amount types.Int,
-    gasLimit uint64,
+    to state.AccAddress, 
+    amount state.Int, 
+    options *state.TxOptions,
   ) (*state.TxResponse, error)
 }
 ```

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -400,13 +400,13 @@ type BankModule interface {
     ctx context.Context,
     blobs []*state.Blob,
     options *state.TxConfig, 
-  ) (*state.TxResponse, error)	
+  ) (*state.TxResponse, error)
   // Transfer sends the given amount of coins from default wallet of the node 
   // to the given account address.
   Transfer(
     ctx context.Context,
-    to state.AccAddress, 
-    amount state.Int, 
+    to state.AccAddress,
+    amount state.Int,
     options *state.TxConfig,
   ) (*state.TxResponse, error)
 }

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -253,7 +253,7 @@ NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
       ctx context.Context, 
       nID namespace.ID, 
       data []byte,
-      options *state.TxConfig,
+      config *state.TxConfig,
     ) (*state.TxResponse, error)
     // Transfer sends the given amount of coins from default wallet of the node 
     // to the given account address.
@@ -261,7 +261,7 @@ NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
       ctx context.Context, 
       to types.Address,
       amount types.Int,
-      options *state.TxConfig,
+      config *state.TxConfig,
     ) (*state.TxResponse, error)
 
     // StateModule also provides StakingModule
@@ -282,7 +282,7 @@ yet.
         ctx context.Context, 
         delAddr state.ValAddress, 
         amount state.Int,
-        options *state.TxConfig,
+        config *state.TxConfig,
     ) (*state.TxResponse, error)
     // BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
     BeginRedelegate(
@@ -290,7 +290,7 @@ yet.
         srcValAddr,
         dstValAddr state.ValAddress,
         amount state.Int,
-        options *state.TxConfig, 
+        config *state.TxConfig, 
     ) (*state.TxResponse, error)
     // Undelegate undelegates a user's delegated tokens, unbonding them from the
     // current validator.
@@ -298,7 +298,7 @@ yet.
         ctx context.Context, 
         delAddr state.ValAddress,
         amount state.Int,
-        options *state.TxConfig,
+        config *state.TxConfig,
     ) (*state.TxResponse, error)
 
     // CancelUnbondingDelegation cancels a user's pending undelegation from a 
@@ -308,7 +308,7 @@ yet.
         valAddr state.ValAddress,
         amount types.Int,
         height types.Int,
-        options *state.TxConfig,
+        config *state.TxConfig,
     ) (*state.TxResponse, error)
 
     // QueryDelegation retrieves the delegation information between a delegator
@@ -399,7 +399,7 @@ type BankModule interface {
   SubmitPayForBlob(
     ctx context.Context,
     blobs []*state.Blob,
-    options *state.TxConfig, 
+    config *state.TxConfig, 
   ) (*state.TxResponse, error)
   // Transfer sends the given amount of coins from default wallet of the node 
   // to the given account address.
@@ -407,7 +407,7 @@ type BankModule interface {
     ctx context.Context,
     to state.AccAddress,
     amount state.Int,
-    options *state.TxConfig,
+    config *state.TxConfig,
   ) (*state.TxResponse, error)
 }
 ```

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -253,7 +253,7 @@ NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
       ctx context.Context, 
       nID namespace.ID, 
       data []byte,
-	  options *state.TxOptions,
+      options *state.TxOptions,
     ) (*state.TxResponse, error)
     // Transfer sends the given amount of coins from default wallet of the node 
     // to the given account address.
@@ -261,7 +261,7 @@ NetworkHead(ctx context.Context) (*header.ExtendedHeader, error)
       ctx context.Context, 
       to types.Address,
       amount types.Int,
-	  options *state.TxOptions,
+      options *state.TxOptions,
     ) (*state.TxResponse, error)
 
     // StateModule also provides StakingModule
@@ -298,7 +298,7 @@ yet.
         ctx context.Context, 
         delAddr state.ValAddress,
         amount state.Int,
-		options *state.TxOptions,
+        options *state.TxOptions,
     ) (*state.TxResponse, error)
 
     // CancelUnbondingDelegation cancels a user's pending undelegation from a 

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -17,7 +17,7 @@ type Module interface {
 	// Submit sends Blobs and reports the height in which they were included.
 	// Allows sending multiple Blobs atomically synchronously.
 	// Uses default wallet registered on the Node.
-	Submit(_ context.Context, _ []*blob.Blob, _ *state.TxOptions) (height uint64, _ error)
+	Submit(_ context.Context, _ []*blob.Blob, _ *state.TxConfig) (height uint64, _ error)
 	// Get retrieves the blob by commitment under the given namespace and height.
 	Get(_ context.Context, height uint64, _ share.Namespace, _ blob.Commitment) (*blob.Blob, error)
 	// GetAll returns all blobs under the given namespaces at the given height.
@@ -39,7 +39,7 @@ type Module interface {
 
 type API struct {
 	Internal struct {
-		Submit   func(context.Context, []*blob.Blob, *state.TxOptions) (uint64, error)                      `perm:"write"`
+		Submit   func(context.Context, []*blob.Blob, *state.TxConfig) (uint64, error)                       `perm:"write"`
 		Get      func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Blob, error)        `perm:"read"`
 		GetAll   func(context.Context, uint64, []share.Namespace) ([]*blob.Blob, error)                     `perm:"read"`
 		GetProof func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Proof, error)       `perm:"read"`
@@ -47,7 +47,7 @@ type API struct {
 	}
 }
 
-func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options *state.TxOptions) (uint64, error) {
+func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options *state.TxConfig) (uint64, error) {
 	return api.Internal.Submit(ctx, blobs, options)
 }
 

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -17,7 +17,7 @@ type Module interface {
 	// Submit sends Blobs and reports the height in which they were included.
 	// Allows sending multiple Blobs atomically synchronously.
 	// Uses default wallet registered on the Node.
-	Submit(_ context.Context, _ []*blob.Blob, _ state.Options) (height uint64, _ error)
+	Submit(_ context.Context, _ []*blob.Blob, _ *state.TxOptions) (height uint64, _ error)
 	// Get retrieves the blob by commitment under the given namespace and height.
 	Get(_ context.Context, height uint64, _ share.Namespace, _ blob.Commitment) (*blob.Blob, error)
 	// GetAll returns all blobs under the given namespaces at the given height.
@@ -39,7 +39,7 @@ type Module interface {
 
 type API struct {
 	Internal struct {
-		Submit   func(context.Context, []*blob.Blob, state.Options) (uint64, error)                         `perm:"write"`
+		Submit   func(context.Context, []*blob.Blob, *state.TxOptions) (uint64, error)                      `perm:"write"`
 		Get      func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Blob, error)        `perm:"read"`
 		GetAll   func(context.Context, uint64, []share.Namespace) ([]*blob.Blob, error)                     `perm:"read"`
 		GetProof func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Proof, error)       `perm:"read"`
@@ -47,7 +47,7 @@ type API struct {
 	}
 }
 
-func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options state.Options) (uint64, error) {
+func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options *state.TxOptions) (uint64, error) {
 	return api.Internal.Submit(ctx, blobs, options)
 }
 

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/state/options"
+	"github.com/celestiaorg/celestia-node/state"
 )
 
 var _ Module = (*API)(nil)
@@ -17,7 +17,7 @@ type Module interface {
 	// Submit sends Blobs and reports the height in which they were included.
 	// Allows sending multiple Blobs atomically synchronously.
 	// Uses default wallet registered on the Node.
-	Submit(_ context.Context, _ []*blob.Blob, _ *options.TxOptions) (height uint64, _ error)
+	Submit(_ context.Context, _ []*blob.Blob, _ state.Options) (height uint64, _ error)
 	// Get retrieves the blob by commitment under the given namespace and height.
 	Get(_ context.Context, height uint64, _ share.Namespace, _ blob.Commitment) (*blob.Blob, error)
 	// GetAll returns all blobs under the given namespaces at the given height.
@@ -39,7 +39,7 @@ type Module interface {
 
 type API struct {
 	Internal struct {
-		Submit   func(context.Context, []*blob.Blob, *options.TxOptions) (uint64, error)                    `perm:"write"`
+		Submit   func(context.Context, []*blob.Blob, state.Options) (uint64, error)                         `perm:"write"`
 		Get      func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Blob, error)        `perm:"read"`
 		GetAll   func(context.Context, uint64, []share.Namespace) ([]*blob.Blob, error)                     `perm:"read"`
 		GetProof func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Proof, error)       `perm:"read"`
@@ -47,7 +47,7 @@ type API struct {
 	}
 }
 
-func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options *options.TxOptions) (uint64, error) {
+func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options state.Options) (uint64, error) {
 	return api.Internal.Submit(ctx, blobs, options)
 }
 

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 var _ Module = (*API)(nil)
@@ -16,7 +17,7 @@ type Module interface {
 	// Submit sends Blobs and reports the height in which they were included.
 	// Allows sending multiple Blobs atomically synchronously.
 	// Uses default wallet registered on the Node.
-	Submit(_ context.Context, _ []*blob.Blob, _ blob.GasPrice) (height uint64, _ error)
+	Submit(_ context.Context, _ []*blob.Blob, _ *options.TxOptions) (height uint64, _ error)
 	// Get retrieves the blob by commitment under the given namespace and height.
 	Get(_ context.Context, height uint64, _ share.Namespace, _ blob.Commitment) (*blob.Blob, error)
 	// GetAll returns all blobs under the given namespaces at the given height.
@@ -38,7 +39,7 @@ type Module interface {
 
 type API struct {
 	Internal struct {
-		Submit   func(context.Context, []*blob.Blob, blob.GasPrice) (uint64, error)                         `perm:"write"`
+		Submit   func(context.Context, []*blob.Blob, *options.TxOptions) (uint64, error)                    `perm:"write"`
 		Get      func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Blob, error)        `perm:"read"`
 		GetAll   func(context.Context, uint64, []share.Namespace) ([]*blob.Blob, error)                     `perm:"read"`
 		GetProof func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Proof, error)       `perm:"read"`
@@ -46,8 +47,8 @@ type API struct {
 	}
 }
 
-func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, gasPrice blob.GasPrice) (uint64, error) {
-	return api.Internal.Submit(ctx, blobs, gasPrice)
+func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options *options.TxOptions) (uint64, error) {
+	return api.Internal.Submit(ctx, blobs, options)
 }
 
 func (api *API) Get(

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/state"
 )
 
 var _ Module = (*API)(nil)
@@ -17,7 +16,7 @@ type Module interface {
 	// Submit sends Blobs and reports the height in which they were included.
 	// Allows sending multiple Blobs atomically synchronously.
 	// Uses default wallet registered on the Node.
-	Submit(_ context.Context, _ []*blob.Blob, _ *state.TxConfig) (height uint64, _ error)
+	Submit(_ context.Context, _ []*blob.Blob, _ *blob.SubmitOptions) (height uint64, _ error)
 	// Get retrieves the blob by commitment under the given namespace and height.
 	Get(_ context.Context, height uint64, _ share.Namespace, _ blob.Commitment) (*blob.Blob, error)
 	// GetAll returns all blobs under the given namespaces at the given height.
@@ -39,7 +38,7 @@ type Module interface {
 
 type API struct {
 	Internal struct {
-		Submit   func(context.Context, []*blob.Blob, *state.TxConfig) (uint64, error)                       `perm:"write"`
+		Submit   func(context.Context, []*blob.Blob, *blob.SubmitOptions) (uint64, error)                   `perm:"write"`
 		Get      func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Blob, error)        `perm:"read"`
 		GetAll   func(context.Context, uint64, []share.Namespace) ([]*blob.Blob, error)                     `perm:"read"`
 		GetProof func(context.Context, uint64, share.Namespace, blob.Commitment) (*blob.Proof, error)       `perm:"read"`
@@ -47,7 +46,7 @@ type API struct {
 	}
 }
 
-func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options *state.TxConfig) (uint64, error) {
+func (api *API) Submit(ctx context.Context, blobs []*blob.Blob, options *blob.SubmitOptions) (uint64, error) {
 	return api.Internal.Submit(ctx, blobs, options)
 }
 

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -13,20 +13,13 @@ import (
 
 	"github.com/celestiaorg/celestia-node/blob"
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
+	state "github.com/celestiaorg/celestia-node/nodebuilder/state/cmd"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 var (
 	base64Flag bool
-
-	fee int64
-
-	gasLimit uint64
-
-	account string
-
-	granter string
 
 	// flagFileInput allows the user to provide file path to the json file
 	// for submitting multiple blobs.
@@ -50,40 +43,7 @@ func init() {
 		"Printed blob's data and namespace as base64 strings",
 	)
 
-	submitCmd.PersistentFlags().Int64Var(
-		&fee,
-		"fee",
-		-1,
-		"Specifies fee(in utia) for blob submission.\n"+
-			"Fee will be set to default(-1) if no value is passed.",
-	)
-
-	submitCmd.PersistentFlags().Uint64Var(
-		&gasLimit,
-		"gas.limit",
-		0,
-		"Specifies gas limit (in utia) for blob submission.\n"+
-			"Gas Limit will be set to default(0) if no value is passed",
-	)
-
-	submitCmd.PersistentFlags().String(
-		account,
-		"",
-		"Specifies the signer address.\n"+
-			"Account address will be set to an empty string in case no value is passed.\n"+
-			"Note: Address should be passed as Bench32 address.\n"+
-			"Example: celestiaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-	)
-
-	submitCmd.PersistentFlags().String(
-		granter,
-		"",
-		"Specifies the address that can pay fees on behalf of the signer."+
-			"If no value is passed, the granter address will be set to an empty string."+
-			"The granter must submit the transaction to pay for the grantee's (signer's) transactions."+
-			"By default, this will be set to an empty string, meaning the signer will pay the fees."+
-			"Note: The granter should be provided as a Bech32 address.",
-	)
+	state.ApplyFlags(submitCmd)
 
 	submitCmd.PersistentFlags().String(flagFileInput, "", "Specifies the file input")
 }
@@ -246,10 +206,10 @@ var submitCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(fee)
-		opts.GasLimit = gasLimit
-		opts.Account = account
-		opts.Granter = granter
+		opts.SetFeeAmount(state.Fee)
+		opts.GasLimit = state.GasLimit
+		opts.Account = state.Account
+		opts.Granter = state.Granter
 		height, err := client.Blob.Submit(
 			cmd.Context(),
 			resultBlobs,

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -209,7 +209,7 @@ var submitCmd = &cobra.Command{
 		opts.SetFeeAmount(state.Fee)
 		opts.Gas = state.Gas
 		opts.Account = state.Account
-		opts.Granter = state.Granter
+		opts.FeeGranterAddress = state.FeeGranterAddress
 		height, err := client.Blob.Submit(
 			cmd.Context(),
 			resultBlobs,

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -14,12 +14,19 @@ import (
 	"github.com/celestiaorg/celestia-node/blob"
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 var (
 	base64Flag bool
 
-	gasPrice float64
+	fee int64
+
+	gasLimit uint64
+
+	account string
+
+	granter string
 
 	// flagFileInput allows the user to provide file path to the json file
 	// for submitting multiple blobs.
@@ -33,25 +40,52 @@ func init() {
 		&base64Flag,
 		"base64",
 		false,
-		"printed blob's data and namespace as base64 strings",
+		"Printed blob's data and namespace as base64 strings",
 	)
 
 	getAllCmd.PersistentFlags().BoolVar(
 		&base64Flag,
 		"base64",
 		false,
-		"printed blob's data and namespace as base64 strings",
+		"Printed blob's data and namespace as base64 strings",
 	)
 
-	submitCmd.PersistentFlags().Float64Var(
-		&gasPrice,
-		"gas.price",
-		float64(blob.DefaultGasPrice()),
-		"specifies gas price (in utia) for blob submission.\n"+
-			"Gas price will be set to default (0.002) if no value is passed",
+	submitCmd.PersistentFlags().Int64Var(
+		&fee,
+		"fee",
+		-1,
+		"Specifies fee(in utia) for blob submission.\n"+
+			"Fee will be set to default(-1) if no value is passed.",
 	)
 
-	submitCmd.PersistentFlags().String(flagFileInput, "", "Specify the file input")
+	submitCmd.PersistentFlags().Uint64Var(
+		&gasLimit,
+		"gas.limit",
+		0,
+		"Specifies gas limit (in utia) for blob submission.\n"+
+			"Gas Limit will be set to default(0) if no value is passed",
+	)
+
+	submitCmd.PersistentFlags().String(
+		account,
+		"",
+		"Specifies the signer address.\n"+
+			"Account address will be set to an empty string in case no value is passed.\n"+
+			"Note: Address should be passed as Bench32 address.\n"+
+			"Example: celestiaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	)
+
+	submitCmd.PersistentFlags().String(
+		granter,
+		"",
+		"Specifies the address that can pay fees on behalf of the signer."+
+			"If no value is passed, the granter address will be set to an empty string."+
+			"The granter must submit the transaction to pay for the grantee's (signer's) transactions."+
+			"By default, this will be set to an empty string, meaning the signer will pay the fees."+
+			"Note: The granter should be provided as a Bech32 address.",
+	)
+
+	submitCmd.PersistentFlags().String(flagFileInput, "", "Specifies the file input")
 }
 
 var Cmd = &cobra.Command{
@@ -200,21 +234,26 @@ var submitCmd = &cobra.Command{
 			jsonBlobs = append(jsonBlobs, blobJSON{Namespace: args[0], BlobData: args[1]})
 		}
 
-		var blobs []*blob.Blob
+		var resultBlobs []*blob.Blob
 		var commitments []blob.Commitment
 		for _, jsonBlob := range jsonBlobs {
 			blob, err := getBlobFromArguments(jsonBlob.Namespace, jsonBlob.BlobData)
 			if err != nil {
 				return err
 			}
-			blobs = append(blobs, blob)
+			resultBlobs = append(resultBlobs, blob)
 			commitments = append(commitments, blob.Commitment)
 		}
 
+		opts := options.DefaultTxOptions()
+		opts.SetFeeAmount(fee)
+		opts.GasLimit = gasLimit
+		opts.Account = account
+		opts.Granter = granter
 		height, err := client.Blob.Submit(
 			cmd.Context(),
-			blobs,
-			blob.GasPrice(gasPrice),
+			resultBlobs,
+			opts,
 		)
 
 		response := struct {

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -206,7 +206,7 @@ var submitCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(state.Fee)
+		opts.SetGasPrice(state.GasPrice)
 		opts.Gas = state.Gas
 		opts.AccountKey = state.AccountKey
 		opts.FeeGranterAddress = state.FeeGranterAddress

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -15,7 +15,6 @@ import (
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	state "github.com/celestiaorg/celestia-node/nodebuilder/state/cmd"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 var (
@@ -205,15 +204,10 @@ var submitCmd = &cobra.Command{
 			commitments = append(commitments, blob.Commitment)
 		}
 
-		opts := options.DefaultTxOptions()
-		opts.SetGasPrice(state.GasPrice)
-		opts.Gas = state.Gas
-		opts.AccountKey = state.AccountKey
-		opts.FeeGranterAddress = state.FeeGranterAddress
 		height, err := client.Blob.Submit(
 			cmd.Context(),
 			resultBlobs,
-			opts,
+			state.GetTxOptions(),
 		)
 
 		response := struct {

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -208,7 +208,7 @@ var submitCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(state.Fee)
 		opts.Gas = state.Gas
-		opts.Account = state.Account
+		opts.AccountKey = state.AccountKey
 		opts.FeeGranterAddress = state.FeeGranterAddress
 		height, err := client.Blob.Submit(
 			cmd.Context(),

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -207,7 +207,7 @@ var submitCmd = &cobra.Command{
 		height, err := client.Blob.Submit(
 			cmd.Context(),
 			resultBlobs,
-			state.GetTxOptions(),
+			state.GetTxConfig(),
 		)
 
 		response := struct {

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -207,7 +207,7 @@ var submitCmd = &cobra.Command{
 
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(state.Fee)
-		opts.GasLimit = state.GasLimit
+		opts.Gas = state.Gas
 		opts.Account = state.Account
 		opts.Granter = state.Granter
 		height, err := client.Blob.Submit(

--- a/nodebuilder/blob/mocks/api.go
+++ b/nodebuilder/blob/mocks/api.go
@@ -10,7 +10,7 @@ import (
 
 	blob "github.com/celestiaorg/celestia-node/blob"
 	share "github.com/celestiaorg/celestia-node/share"
-	options "github.com/celestiaorg/celestia-node/state/options"
+	state "github.com/celestiaorg/celestia-node/state"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -98,7 +98,7 @@ func (mr *MockModuleMockRecorder) Included(arg0, arg1, arg2, arg3, arg4 interfac
 }
 
 // Submit mocks base method.
-func (m *MockModule) Submit(arg0 context.Context, arg1 []*blob.Blob, arg2 *options.TxOptions) (uint64, error) {
+func (m *MockModule) Submit(arg0 context.Context, arg1 []*blob.Blob, arg2 state.Options) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Submit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(uint64)

--- a/nodebuilder/blob/mocks/api.go
+++ b/nodebuilder/blob/mocks/api.go
@@ -10,6 +10,7 @@ import (
 
 	blob "github.com/celestiaorg/celestia-node/blob"
 	share "github.com/celestiaorg/celestia-node/share"
+	options "github.com/celestiaorg/celestia-node/state/options"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -97,7 +98,7 @@ func (mr *MockModuleMockRecorder) Included(arg0, arg1, arg2, arg3, arg4 interfac
 }
 
 // Submit mocks base method.
-func (m *MockModule) Submit(arg0 context.Context, arg1 []*blob.Blob, arg2 blob.GasPrice) (uint64, error) {
+func (m *MockModule) Submit(arg0 context.Context, arg1 []*blob.Blob, arg2 *options.TxOptions) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Submit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(uint64)

--- a/nodebuilder/blob/mocks/api.go
+++ b/nodebuilder/blob/mocks/api.go
@@ -98,7 +98,7 @@ func (mr *MockModuleMockRecorder) Included(arg0, arg1, arg2, arg3, arg4 interfac
 }
 
 // Submit mocks base method.
-func (m *MockModule) Submit(arg0 context.Context, arg1 []*blob.Blob, arg2 state.Options) (uint64, error) {
+func (m *MockModule) Submit(arg0 context.Context, arg1 []*blob.Blob, arg2 *state.TxOptions) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Submit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(uint64)

--- a/nodebuilder/blob/mocks/api.go
+++ b/nodebuilder/blob/mocks/api.go
@@ -98,7 +98,7 @@ func (mr *MockModuleMockRecorder) Included(arg0, arg1, arg2, arg3, arg4 interfac
 }
 
 // Submit mocks base method.
-func (m *MockModule) Submit(arg0 context.Context, arg1 []*blob.Blob, arg2 *state.TxOptions) (uint64, error) {
+func (m *MockModule) Submit(arg0 context.Context, arg1 []*blob.Blob, arg2 *state.TxConfig) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Submit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(uint64)

--- a/nodebuilder/config_test.go
+++ b/nodebuilder/config_test.go
@@ -52,7 +52,7 @@ func TestUpdateConfig(t *testing.T) {
 	// ensure this config field is now set after updating the config
 	require.Equal(t, newCfg.Share.PeerManagerParams, cfg.Share.PeerManagerParams)
 	// ensure old custom values were not changed
-	require.Equal(t, []string{"thisshouldnthavechanged"}, cfg.State.KeyringKeyNames)
+	require.Equal(t, "thisshouldnthavechanged", cfg.State.KeyringAccName)
 	require.Equal(t, "7979", cfg.RPC.Port)
 	require.True(t, cfg.Gateway.Enabled)
 }
@@ -65,7 +65,7 @@ var outdatedConfig = `
   GRPCPort = "0"
 
 [State]
-  KeyringKeyNames = ["thisshouldnthavechanged"]
+  KeyringAccName = "thisshouldnthavechanged"
   KeyringBackend = "test"
 
 [P2P]

--- a/nodebuilder/config_test.go
+++ b/nodebuilder/config_test.go
@@ -52,7 +52,7 @@ func TestUpdateConfig(t *testing.T) {
 	// ensure this config field is now set after updating the config
 	require.Equal(t, newCfg.Share.PeerManagerParams, cfg.Share.PeerManagerParams)
 	// ensure old custom values were not changed
-	require.Equal(t, "thisshouldnthavechanged", cfg.State.KeyringAccName)
+	require.Equal(t, []string{"thisshouldnthavechanged"}, cfg.State.KeyringKeyNames)
 	require.Equal(t, "7979", cfg.RPC.Port)
 	require.True(t, cfg.Gateway.Enabled)
 }
@@ -65,7 +65,7 @@ var outdatedConfig = `
   GRPCPort = "0"
 
 [State]
-  KeyringAccName = "thisshouldnthavechanged"
+  KeyringKeyNames = ["thisshouldnthavechanged"]
   KeyringBackend = "test"
 
 [P2P]

--- a/nodebuilder/config_test.go
+++ b/nodebuilder/config_test.go
@@ -52,7 +52,7 @@ func TestUpdateConfig(t *testing.T) {
 	// ensure this config field is now set after updating the config
 	require.Equal(t, newCfg.Share.PeerManagerParams, cfg.Share.PeerManagerParams)
 	// ensure old custom values were not changed
-	require.Equal(t, "thisshouldnthavechanged", cfg.State.KeyringAccName)
+	require.Equal(t, "thisshouldnthavechanged", cfg.State.KeyringKeyName)
 	require.Equal(t, "7979", cfg.RPC.Port)
 	require.True(t, cfg.Gateway.Enabled)
 }
@@ -65,7 +65,7 @@ var outdatedConfig = `
   GRPCPort = "0"
 
 [State]
-  KeyringAccName = "thisshouldnthavechanged"
+  KeyringKeyName = "thisshouldnthavechanged"
   KeyringBackend = "test"
 
 [P2P]

--- a/nodebuilder/config_test.go
+++ b/nodebuilder/config_test.go
@@ -52,7 +52,7 @@ func TestUpdateConfig(t *testing.T) {
 	// ensure this config field is now set after updating the config
 	require.Equal(t, newCfg.Share.PeerManagerParams, cfg.Share.PeerManagerParams)
 	// ensure old custom values were not changed
-	require.Equal(t, "thisshouldnthavechanged", cfg.State.KeyringKeyName)
+	require.Equal(t, "thisshouldnthavechanged", cfg.State.DefaultKeyName)
 	require.Equal(t, "7979", cfg.RPC.Port)
 	require.True(t, cfg.Gateway.Enabled)
 }
@@ -65,8 +65,8 @@ var outdatedConfig = `
   GRPCPort = "0"
 
 [State]
-  KeyringKeyName = "thisshouldnthavechanged"
-  KeyringBackend = "test"
+  DefaultKeyName = "thisshouldnthavechanged"
+  DefaultBackendName = "test"
 
 [P2P]
   ListenAddresses = ["/ip4/0.0.0.0/udp/2121/quic-v1", "/ip6/::/udp/2121/quic-v1", "/ip4/0.0.0.0/tcp/2121",

--- a/nodebuilder/da/service.go
+++ b/nodebuilder/da/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/celestiaorg/celestia-node/blob"
 	nodeblob "github.com/celestiaorg/celestia-node/nodebuilder/blob"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/state/options"
+	"github.com/celestiaorg/celestia-node/state"
 )
 
 var _ da.DA = (*Service)(nil)
@@ -111,8 +111,7 @@ func (s *Service) Submit(
 		return nil, err
 	}
 
-	opts := options.DefaultTxOptions()
-	opts.SetGasPrice(gasPrice)
+	opts := state.NewTxOptions(state.WithGasPrice(gasPrice))
 
 	height, err := s.blobServ.Submit(ctx, blobs, opts)
 	if err != nil {

--- a/nodebuilder/da/service.go
+++ b/nodebuilder/da/service.go
@@ -111,7 +111,7 @@ func (s *Service) Submit(
 		return nil, err
 	}
 
-	opts := state.NewTxOptions(state.WithGasPrice(gasPrice))
+	opts := state.NewTxConfig(state.WithGasPrice(gasPrice))
 
 	height, err := s.blobServ.Submit(ctx, blobs, opts)
 	if err != nil {

--- a/nodebuilder/da/service.go
+++ b/nodebuilder/da/service.go
@@ -112,17 +112,7 @@ func (s *Service) Submit(
 	}
 
 	opts := options.DefaultTxOptions()
-	if blob.DefaultGasPrice() == blob.GasPrice(gasPrice) {
-		blobSizes := make([]uint32, len(blobs))
-		for i, blob := range blobs {
-			blobSizes[i] = uint32(len(blob.Data))
-		}
-		opts.EstimateGasForBlobs(blobSizes)
-		err = opts.CalculateFee(gasPrice)
-		if err != nil {
-			return nil, err
-		}
-	}
+	opts.SetGasPrice(gasPrice)
 
 	height, err := s.blobServ.Submit(ctx, blobs, opts)
 	if err != nil {

--- a/nodebuilder/init.go
+++ b/nodebuilder/init.go
@@ -192,11 +192,11 @@ func initDir(path string) error {
 func generateKeys(cfg Config, ksPath string) error {
 	encConf := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 
-	if cfg.State.KeyringBackend == keyring.BackendTest {
+	if cfg.State.DefaultBackendName == keyring.BackendTest {
 		log.Warn("Detected plaintext keyring backend. For elevated security properties, consider using" +
 			" the `file` keyring backend.")
 	}
-	ring, err := keyring.New(app.Name, cfg.State.KeyringBackend, ksPath, os.Stdin, encConf.Codec)
+	ring, err := keyring.New(app.Name, cfg.State.DefaultBackendName, ksPath, os.Stdin, encConf.Codec)
 	if err != nil {
 		return err
 	}
@@ -228,6 +228,6 @@ func generateKeys(cfg Config, ksPath string) error {
 // generateNewKey generates and returns a new key on the given keyring called
 // "my_celes_key".
 func generateNewKey(ring keyring.Keyring) (*keyring.Record, string, error) {
-	return ring.NewMnemonic(state.DefaultAccountName, keyring.English, sdk.GetConfig().GetFullBIP44Path(),
+	return ring.NewMnemonic(state.DefaultKeyName, keyring.English, sdk.GetConfig().GetFullBIP44Path(),
 		keyring.DefaultBIP39Passphrase, hd.Secp256k1)
 }

--- a/nodebuilder/init_test.go
+++ b/nodebuilder/init_test.go
@@ -76,7 +76,7 @@ func TestInit_generateNewKey(t *testing.T) {
 	cfg := DefaultConfig(node.Bridge)
 
 	encConf := encoding.MakeConfig(app.ModuleEncodingRegisters...)
-	ring, err := keyring.New(app.Name, cfg.State.KeyringBackend, t.TempDir(), os.Stdin, encConf.Codec)
+	ring, err := keyring.New(app.Name, cfg.State.DefaultBackendName, t.TempDir(), os.Stdin, encConf.Codec)
 	require.NoError(t, err)
 
 	originalKey, mn, err := generateNewKey(ring)
@@ -93,7 +93,7 @@ func TestInit_generateNewKey(t *testing.T) {
 	assert.Contains(t, addr.String(), "celestia")
 
 	// ensure account is recoverable from mnemonic
-	ring2, err := keyring.New(app.Name, cfg.State.KeyringBackend, t.TempDir(), os.Stdin, encConf.Codec)
+	ring2, err := keyring.New(app.Name, cfg.State.DefaultBackendName, t.TempDir(), os.Stdin, encConf.Codec)
 	require.NoError(t, err)
 	duplicateKey, err := ring2.NewAccount("test", mn, keyring.DefaultBIP39Passphrase, sdk.GetConfig().GetFullBIP44Path(),
 		hd.Secp256k1)

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -19,7 +19,7 @@ var (
 
 	Gas uint64
 
-	Account string
+	AccountKey string
 
 	FeeGranterAddress string
 )
@@ -146,7 +146,7 @@ var transferCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
-		opts.Account = Account
+		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.Transfer(
@@ -188,7 +188,7 @@ var cancelUnbondingDelegationCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
-		opts.Account = Account
+		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.CancelUnbondingDelegation(
@@ -231,7 +231,7 @@ var beginRedelegateCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
-		opts.Account = Account
+		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.BeginRedelegate(
@@ -269,7 +269,7 @@ var undelegateCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
-		opts.Account = Account
+		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.Undelegate(
@@ -306,7 +306,7 @@ var delegateCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
-		opts.Account = Account
+		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.Delegate(
@@ -411,7 +411,7 @@ var grantFeeCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
-		opts.Account = Account
+		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.GrantFee(
@@ -442,7 +442,7 @@ var revokeGrantFeeCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
-		opts.Account = Account
+		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.RevokeGrantFee(
@@ -481,8 +481,8 @@ func ApplyFlags(cmds ...*cobra.Command) {
 		)
 
 		cmd.PersistentFlags().StringVar(
-			&Account,
-			"account",
+			&AccountKey,
+			"account.key",
 			"",
 			"Specifies the signer name from the keystore.",
 		)

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -8,15 +8,17 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
+	stateBuilder "github.com/celestiaorg/celestia-node/nodebuilder/state"
 	"github.com/celestiaorg/celestia-node/state"
 )
 
 var (
-	accountKey        string
-	feeGranterAddress string
-	amount            uint64
+	signer            string
+	keyName           string
 	gas               uint64
 	gasPrice          float64
+	feeGranterAddress string
+	amount            uint64
 )
 
 func init() {
@@ -418,6 +420,22 @@ func parseAddressFromString(addrStr string) (state.Address, error) {
 
 func ApplyFlags(cmds ...*cobra.Command) {
 	for _, cmd := range cmds {
+		cmd.PersistentFlags().StringVar(
+			&signer,
+			"signer",
+			"",
+			"Specifies the signer address from the keystore.\n"+
+				"If both the address and the key are specified, the address field will take priority.\n"+
+				"Note: The account address should be provided as a Bech32 address.",
+		)
+
+		cmd.PersistentFlags().StringVar(
+			&keyName,
+			"key.name",
+			stateBuilder.DefaultAccountName,
+			"Specifies the signer name from the keystore.",
+		)
+
 		cmd.PersistentFlags().Float64Var(
 			&gasPrice,
 			"gas.price",
@@ -431,13 +449,6 @@ func ApplyFlags(cmds ...*cobra.Command) {
 			0,
 			"Specifies gas limit (in utia) for tx submission. "+
 				"(default 0)",
-		)
-
-		cmd.PersistentFlags().StringVar(
-			&accountKey,
-			"account.key",
-			"",
-			"Specifies the signer name from the keystore.",
 		)
 
 		cmd.PersistentFlags().StringVar(
@@ -457,7 +468,8 @@ func GetTxOptions() *state.TxOptions {
 	return state.NewTxOptions(
 		state.WithGasPrice(gasPrice),
 		state.WithGas(gas),
-		state.WithAccountKey(accountKey),
+		state.WithKeyName(keyName),
+		state.WithSignerAddress(signer),
 		state.WithFeeGranterAddress(feeGranterAddress),
 	)
 }

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -457,7 +457,7 @@ func ApplyFlags(cmds ...*cobra.Command) {
 	}
 }
 
-func GetTxOptions() state.Options {
+func GetTxOptions() *state.TxOptions {
 	return state.NewTxOptions(
 		state.WithGasPrice(gasPrice),
 		state.WithGas(gas),

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -21,7 +21,7 @@ var (
 
 	Account string
 
-	Granter string
+	FeeGranterAddress string
 )
 
 func init() {
@@ -147,7 +147,7 @@ var transferCmd = &cobra.Command{
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
 		opts.Account = Account
-		opts.Granter = Granter
+		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.Transfer(
 			cmd.Context(),
@@ -189,7 +189,7 @@ var cancelUnbondingDelegationCmd = &cobra.Command{
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
 		opts.Account = Account
-		opts.Granter = Granter
+		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.CancelUnbondingDelegation(
 			cmd.Context(),
@@ -232,7 +232,7 @@ var beginRedelegateCmd = &cobra.Command{
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
 		opts.Account = Account
-		opts.Granter = Granter
+		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.BeginRedelegate(
 			cmd.Context(),
@@ -270,7 +270,7 @@ var undelegateCmd = &cobra.Command{
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
 		opts.Account = Account
-		opts.Granter = Granter
+		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.Undelegate(
 			cmd.Context(),
@@ -307,7 +307,7 @@ var delegateCmd = &cobra.Command{
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
 		opts.Account = Account
-		opts.Granter = Granter
+		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.Delegate(
 			cmd.Context(),
@@ -412,7 +412,7 @@ var grantFeeCmd = &cobra.Command{
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
 		opts.Account = Account
-		opts.Granter = Granter
+		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.GrantFee(
 			cmd.Context(),
@@ -443,7 +443,7 @@ var revokeGrantFeeCmd = &cobra.Command{
 		opts.SetFeeAmount(Fee)
 		opts.Gas = Gas
 		opts.Account = Account
-		opts.Granter = Granter
+		opts.FeeGranterAddress = FeeGranterAddress
 
 		txResponse, err := client.State.RevokeGrantFee(
 			cmd.Context(),
@@ -488,8 +488,8 @@ func ApplyFlags(cmds ...*cobra.Command) {
 		)
 
 		cmd.PersistentFlags().StringVar(
-			&Granter,
-			"granter",
+			&FeeGranterAddress,
+			"granter.address",
 			"",
 			"Specifies the address that can pay fees on behalf of the signer.\n"+
 				"The granter must submit the transaction to pay for the grantee's (signer's) transactions.\n"+

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -17,7 +17,7 @@ var (
 
 	Fee int64
 
-	GasLimit uint64
+	Gas uint64
 
 	Account string
 
@@ -145,7 +145,7 @@ var transferCmd = &cobra.Command{
 
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
-		opts.GasLimit = GasLimit
+		opts.Gas = Gas
 		opts.Account = Account
 		opts.Granter = Granter
 
@@ -187,7 +187,7 @@ var cancelUnbondingDelegationCmd = &cobra.Command{
 
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
-		opts.GasLimit = GasLimit
+		opts.Gas = Gas
 		opts.Account = Account
 		opts.Granter = Granter
 
@@ -230,7 +230,7 @@ var beginRedelegateCmd = &cobra.Command{
 
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
-		opts.GasLimit = GasLimit
+		opts.Gas = Gas
 		opts.Account = Account
 		opts.Granter = Granter
 
@@ -245,7 +245,6 @@ var beginRedelegateCmd = &cobra.Command{
 	},
 }
 
-//nolint:dupl
 var undelegateCmd = &cobra.Command{
 	Use:   "undelegate [valAddress] [amount]",
 	Short: "Undelegates a user's delegated tokens, unbonding them from the current validator.",
@@ -267,19 +266,9 @@ var undelegateCmd = &cobra.Command{
 			return fmt.Errorf("error parsing an amount: %w", err)
 		}
 
-		fee, err := strconv.ParseInt(args[2], 10, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing a fee: %w", err)
-		}
-
-		gasLimit, err := strconv.ParseUint(args[3], 10, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing a gas limit: %w", err)
-		}
-
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(fee)
-		opts.GasLimit = gasLimit
+		opts.SetFeeAmount(Fee)
+		opts.Gas = Gas
 		opts.Account = Account
 		opts.Granter = Granter
 
@@ -293,7 +282,6 @@ var undelegateCmd = &cobra.Command{
 	},
 }
 
-//nolint:dupl
 var delegateCmd = &cobra.Command{
 	Use:   "delegate [valAddress] [amount]",
 	Short: "Sends a user's liquid tokens to a validator for delegation.",
@@ -315,19 +303,9 @@ var delegateCmd = &cobra.Command{
 			return fmt.Errorf("error parsing an amount: %w", err)
 		}
 
-		fee, err := strconv.ParseInt(args[2], 10, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing a fee: %w", err)
-		}
-
-		gasLimit, err := strconv.ParseUint(args[3], 10, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing a gas limit: %w", err)
-		}
-
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(fee)
-		opts.GasLimit = gasLimit
+		opts.SetFeeAmount(Fee)
+		opts.Gas = Gas
 		opts.Account = Account
 		opts.Granter = Granter
 
@@ -432,7 +410,7 @@ var grantFeeCmd = &cobra.Command{
 
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
-		opts.GasLimit = GasLimit
+		opts.Gas = Gas
 		opts.Account = Account
 		opts.Granter = Granter
 
@@ -463,7 +441,7 @@ var revokeGrantFeeCmd = &cobra.Command{
 
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(Fee)
-		opts.GasLimit = GasLimit
+		opts.Gas = Gas
 		opts.Account = Account
 		opts.Granter = Granter
 
@@ -495,8 +473,8 @@ func ApplyFlags(cmds ...*cobra.Command) {
 		)
 
 		cmd.PersistentFlags().Uint64Var(
-			&GasLimit,
-			"gas.limit",
+			&Gas,
+			"gas",
 			0,
 			"Specifies gas limit (in utia) for tx submission. "+
 				"(default 0)",

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -15,13 +15,13 @@ import (
 var (
 	amount uint64
 
-	fee int64
+	Fee int64
 
-	gasLimit uint64
+	GasLimit uint64
 
-	account string
+	Account string
 
-	granter string
+	Granter string
 )
 
 func init() {
@@ -50,7 +50,7 @@ func init() {
 	)
 
 	// apply option flags for all txs that require `TxOptions`.
-	applyFlags(
+	ApplyFlags(
 		transferCmd,
 		cancelUnbondingDelegationCmd,
 		beginRedelegateCmd,
@@ -144,8 +144,10 @@ var transferCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(fee)
-		opts.GasLimit = gasLimit
+		opts.SetFeeAmount(Fee)
+		opts.GasLimit = GasLimit
+		opts.Account = Account
+		opts.Granter = Granter
 
 		txResponse, err := client.State.Transfer(
 			cmd.Context(),
@@ -184,8 +186,10 @@ var cancelUnbondingDelegationCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(fee)
-		opts.GasLimit = gasLimit
+		opts.SetFeeAmount(Fee)
+		opts.GasLimit = GasLimit
+		opts.Account = Account
+		opts.Granter = Granter
 
 		txResponse, err := client.State.CancelUnbondingDelegation(
 			cmd.Context(),
@@ -225,8 +229,10 @@ var beginRedelegateCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(fee)
-		opts.GasLimit = gasLimit
+		opts.SetFeeAmount(Fee)
+		opts.GasLimit = GasLimit
+		opts.Account = Account
+		opts.Granter = Granter
 
 		txResponse, err := client.State.BeginRedelegate(
 			cmd.Context(),
@@ -274,6 +280,8 @@ var undelegateCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(fee)
 		opts.GasLimit = gasLimit
+		opts.Account = Account
+		opts.Granter = Granter
 
 		txResponse, err := client.State.Undelegate(
 			cmd.Context(),
@@ -320,6 +328,8 @@ var delegateCmd = &cobra.Command{
 		opts := options.DefaultTxOptions()
 		opts.SetFeeAmount(fee)
 		opts.GasLimit = gasLimit
+		opts.Account = Account
+		opts.Granter = Granter
 
 		txResponse, err := client.State.Delegate(
 			cmd.Context(),
@@ -421,8 +431,10 @@ var grantFeeCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(fee)
-		opts.GasLimit = gasLimit
+		opts.SetFeeAmount(Fee)
+		opts.GasLimit = GasLimit
+		opts.Account = Account
+		opts.Granter = Granter
 
 		txResponse, err := client.State.GrantFee(
 			cmd.Context(),
@@ -450,8 +462,10 @@ var revokeGrantFeeCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(fee)
-		opts.GasLimit = gasLimit
+		opts.SetFeeAmount(Fee)
+		opts.GasLimit = GasLimit
+		opts.Account = Account
+		opts.Granter = Granter
 
 		txResponse, err := client.State.RevokeGrantFee(
 			cmd.Context(),
@@ -471,38 +485,35 @@ func parseAddressFromString(addrStr string) (state.Address, error) {
 	return address, nil
 }
 
-func applyFlags(cmds ...*cobra.Command) {
+func ApplyFlags(cmds ...*cobra.Command) {
 	for _, cmd := range cmds {
 		cmd.PersistentFlags().Int64Var(
-			&fee,
+			&Fee,
 			"fee",
 			-1,
-			"Specifies fee(in utia) for tx submission.\n"+
-				"Fee will be set to default(-1) if no value is passed.",
+			"Specifies fee(in utia) for tx submission.",
 		)
 
 		cmd.PersistentFlags().Uint64Var(
-			&gasLimit,
+			&GasLimit,
 			"gas.limit",
 			0,
-			"Specifies gas limit (in utia) for tx submission.\n"+
-				"Gas Limit will be set to default(0) if no value is passed",
+			"Specifies gas limit (in utia) for tx submission. "+
+				"(default 0)",
 		)
 
-		cmd.PersistentFlags().String(
-			account,
+		cmd.PersistentFlags().StringVar(
+			&Account,
+			"account",
 			"",
-			"Specifies the signer address.\n"+
-				"Account address will be set to an empty string in case no value is passed.\n"+
-				"Note: Address should be passed as Bench32 address.\n"+
-				"Example: celestiaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			"Specifies the signer name from the keystore.",
 		)
 
-		cmd.PersistentFlags().String(
-			granter,
+		cmd.PersistentFlags().StringVar(
+			&Granter,
+			"granter",
 			"",
 			"Specifies the address that can pay fees on behalf of the signer.\n"+
-				"If no value is passed, the granter address will be set to an empty string.\n"+
 				"The granter must submit the transaction to pay for the grantee's (signer's) transactions.\n"+
 				"By default, this will be set to an empty string, meaning the signer will pay the fees.\n"+
 				"Note: The granter should be provided as a Bech32 address.\n"+

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -439,7 +439,7 @@ func ApplyFlags(cmds ...*cobra.Command) {
 		cmd.PersistentFlags().Float64Var(
 			&gasPrice,
 			"gas.price",
-			state.DefaultPrice,
+			state.DefaultGasPrice,
 			"Specifies gas price for the fee calculation",
 		)
 

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -46,7 +46,7 @@ func init() {
 			"The default value is 0 which means the grantee does not have a spend limit.",
 	)
 
-	// apply option flags for all txs that require `TxOptions`.
+	// apply option flags for all txs that require `TxConfig`.
 	ApplyFlags(
 		transferCmd,
 		cancelUnbondingDelegationCmd,
@@ -144,7 +144,7 @@ var transferCmd = &cobra.Command{
 			cmd.Context(),
 			addr.Address.(state.AccAddress),
 			math.NewInt(amount),
-			GetTxOptions(),
+			GetTxConfig(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -181,7 +181,7 @@ var cancelUnbondingDelegationCmd = &cobra.Command{
 			addr.Address.(state.ValAddress),
 			math.NewInt(amount),
 			math.NewInt(height),
-			GetTxOptions(),
+			GetTxConfig(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -218,7 +218,7 @@ var beginRedelegateCmd = &cobra.Command{
 			srcAddr.Address.(state.ValAddress),
 			dstAddr.Address.(state.ValAddress),
 			math.NewInt(amount),
-			GetTxOptions(),
+			GetTxConfig(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -249,7 +249,7 @@ var undelegateCmd = &cobra.Command{
 			cmd.Context(),
 			addr.Address.(state.ValAddress),
 			math.NewInt(amount),
-			GetTxOptions(),
+			GetTxConfig(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -280,7 +280,7 @@ var delegateCmd = &cobra.Command{
 			cmd.Context(),
 			addr.Address.(state.ValAddress),
 			math.NewInt(amount),
-			GetTxOptions(),
+			GetTxConfig(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -378,7 +378,7 @@ var grantFeeCmd = &cobra.Command{
 		txResponse, err := client.State.GrantFee(
 			cmd.Context(),
 			granteeAddr.Address.(state.AccAddress),
-			math.NewInt(int64(amount)), GetTxOptions(),
+			math.NewInt(int64(amount)), GetTxConfig(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -403,7 +403,7 @@ var revokeGrantFeeCmd = &cobra.Command{
 		txResponse, err := client.State.RevokeGrantFee(
 			cmd.Context(),
 			granteeAddr.Address.(state.AccAddress),
-			GetTxOptions(),
+			GetTxConfig(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -464,8 +464,8 @@ func ApplyFlags(cmds ...*cobra.Command) {
 	}
 }
 
-func GetTxOptions() *state.TxOptions {
-	return state.NewTxOptions(
+func GetTxConfig() *state.TxConfig {
+	return state.NewTxConfig(
 		state.WithGasPrice(gasPrice),
 		state.WithGas(gas),
 		state.WithKeyName(keyName),

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -9,19 +9,18 @@ import (
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
 	"github.com/celestiaorg/celestia-node/state"
-	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 var (
 	amount uint64
 
-	GasPrice float64
+	gasPrice float64
 
-	Gas uint64
+	gas uint64
 
-	AccountKey string
+	accountKey string
 
-	FeeGranterAddress string
+	feeGranterAddress string
 )
 
 func init() {
@@ -143,17 +142,11 @@ var transferCmd = &cobra.Command{
 			return fmt.Errorf("error parsing an amount: %w", err)
 		}
 
-		opts := options.DefaultTxOptions()
-		opts.SetGasPrice(GasPrice)
-		opts.Gas = Gas
-		opts.AccountKey = AccountKey
-		opts.FeeGranterAddress = FeeGranterAddress
-
 		txResponse, err := client.State.Transfer(
 			cmd.Context(),
 			addr.Address.(state.AccAddress),
 			math.NewInt(amount),
-			opts,
+			GetTxOptions(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -185,18 +178,12 @@ var cancelUnbondingDelegationCmd = &cobra.Command{
 			return fmt.Errorf("error parsing height: %w", err)
 		}
 
-		opts := options.DefaultTxOptions()
-		opts.SetGasPrice(GasPrice)
-		opts.Gas = Gas
-		opts.AccountKey = AccountKey
-		opts.FeeGranterAddress = FeeGranterAddress
-
 		txResponse, err := client.State.CancelUnbondingDelegation(
 			cmd.Context(),
 			addr.Address.(state.ValAddress),
 			math.NewInt(amount),
 			math.NewInt(height),
-			opts,
+			GetTxOptions(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -228,18 +215,12 @@ var beginRedelegateCmd = &cobra.Command{
 			return fmt.Errorf("error parsing an amount: %w", err)
 		}
 
-		opts := options.DefaultTxOptions()
-		opts.SetGasPrice(GasPrice)
-		opts.Gas = Gas
-		opts.AccountKey = AccountKey
-		opts.FeeGranterAddress = FeeGranterAddress
-
 		txResponse, err := client.State.BeginRedelegate(
 			cmd.Context(),
 			srcAddr.Address.(state.ValAddress),
 			dstAddr.Address.(state.ValAddress),
 			math.NewInt(amount),
-			opts,
+			GetTxOptions(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -266,17 +247,11 @@ var undelegateCmd = &cobra.Command{
 			return fmt.Errorf("error parsing an amount: %w", err)
 		}
 
-		opts := options.DefaultTxOptions()
-		opts.SetGasPrice(GasPrice)
-		opts.Gas = Gas
-		opts.AccountKey = AccountKey
-		opts.FeeGranterAddress = FeeGranterAddress
-
 		txResponse, err := client.State.Undelegate(
 			cmd.Context(),
 			addr.Address.(state.ValAddress),
 			math.NewInt(amount),
-			opts,
+			GetTxOptions(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -303,17 +278,11 @@ var delegateCmd = &cobra.Command{
 			return fmt.Errorf("error parsing an amount: %w", err)
 		}
 
-		opts := options.DefaultTxOptions()
-		opts.SetGasPrice(GasPrice)
-		opts.Gas = Gas
-		opts.AccountKey = AccountKey
-		opts.FeeGranterAddress = FeeGranterAddress
-
 		txResponse, err := client.State.Delegate(
 			cmd.Context(),
 			addr.Address.(state.ValAddress),
 			math.NewInt(amount),
-			opts,
+			GetTxOptions(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -408,16 +377,10 @@ var grantFeeCmd = &cobra.Command{
 			return fmt.Errorf("error parsing an address: %w", err)
 		}
 
-		opts := options.DefaultTxOptions()
-		opts.SetGasPrice(GasPrice)
-		opts.Gas = Gas
-		opts.AccountKey = AccountKey
-		opts.FeeGranterAddress = FeeGranterAddress
-
 		txResponse, err := client.State.GrantFee(
 			cmd.Context(),
 			granteeAddr.Address.(state.AccAddress),
-			math.NewInt(int64(amount)), opts,
+			math.NewInt(int64(amount)), GetTxOptions(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -439,16 +402,10 @@ var revokeGrantFeeCmd = &cobra.Command{
 			return fmt.Errorf("error parsing an address: %w", err)
 		}
 
-		opts := options.DefaultTxOptions()
-		opts.SetGasPrice(GasPrice)
-		opts.Gas = Gas
-		opts.AccountKey = AccountKey
-		opts.FeeGranterAddress = FeeGranterAddress
-
 		txResponse, err := client.State.RevokeGrantFee(
 			cmd.Context(),
 			granteeAddr.Address.(state.AccAddress),
-			opts,
+			GetTxOptions(),
 		)
 		return cmdnode.PrintOutput(txResponse, err, nil)
 	},
@@ -466,14 +423,14 @@ func parseAddressFromString(addrStr string) (state.Address, error) {
 func ApplyFlags(cmds ...*cobra.Command) {
 	for _, cmd := range cmds {
 		cmd.PersistentFlags().Float64Var(
-			&GasPrice,
-			"gas-price",
+			&gasPrice,
+			"gas.price",
 			-1,
 			"Specifies gas price for the fee calculation",
 		)
 
 		cmd.PersistentFlags().Uint64Var(
-			&Gas,
+			&gas,
 			"gas",
 			0,
 			"Specifies gas limit (in utia) for tx submission. "+
@@ -481,15 +438,15 @@ func ApplyFlags(cmds ...*cobra.Command) {
 		)
 
 		cmd.PersistentFlags().StringVar(
-			&AccountKey,
-			"account-key",
+			&accountKey,
+			"account.key",
 			"",
 			"Specifies the signer name from the keystore.",
 		)
 
 		cmd.PersistentFlags().StringVar(
-			&FeeGranterAddress,
-			"granter-address",
+			&feeGranterAddress,
+			"granter.address",
 			"",
 			"Specifies the address that can pay fees on behalf of the signer.\n"+
 				"The granter must submit the transaction to pay for the grantee's (signer's) transactions.\n"+
@@ -498,4 +455,13 @@ func ApplyFlags(cmds ...*cobra.Command) {
 				"Example: celestiaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		)
 	}
+}
+
+func GetTxOptions() state.Options {
+	return state.NewTxOptions(
+		state.WithGasPrice(gasPrice),
+		state.WithGas(gas),
+		state.WithAccountKey(accountKey),
+		state.WithFeeGranterAddress(feeGranterAddress),
+	)
 }

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -467,7 +467,7 @@ func ApplyFlags(cmds ...*cobra.Command) {
 	for _, cmd := range cmds {
 		cmd.PersistentFlags().Float64Var(
 			&GasPrice,
-			"gas.price",
+			"gas-price",
 			-1,
 			"Specifies gas price for the fee calculation",
 		)
@@ -482,14 +482,14 @@ func ApplyFlags(cmds ...*cobra.Command) {
 
 		cmd.PersistentFlags().StringVar(
 			&AccountKey,
-			"account.key",
+			"account-key",
 			"",
 			"Specifies the signer name from the keystore.",
 		)
 
 		cmd.PersistentFlags().StringVar(
 			&FeeGranterAddress,
-			"granter.address",
+			"granter-address",
 			"",
 			"Specifies the address that can pay fees on behalf of the signer.\n"+
 				"The granter must submit the transaction to pay for the grantee's (signer's) transactions.\n"+

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -15,7 +15,7 @@ import (
 var (
 	amount uint64
 
-	Fee int64
+	GasPrice float64
 
 	Gas uint64
 
@@ -144,7 +144,7 @@ var transferCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(Fee)
+		opts.SetGasPrice(GasPrice)
 		opts.Gas = Gas
 		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
@@ -182,11 +182,11 @@ var cancelUnbondingDelegationCmd = &cobra.Command{
 
 		height, err := strconv.ParseInt(args[2], 10, 64)
 		if err != nil {
-			return fmt.Errorf("error parsing a fee: %w", err)
+			return fmt.Errorf("error parsing height: %w", err)
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(Fee)
+		opts.SetGasPrice(GasPrice)
 		opts.Gas = Gas
 		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
@@ -229,7 +229,7 @@ var beginRedelegateCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(Fee)
+		opts.SetGasPrice(GasPrice)
 		opts.Gas = Gas
 		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
@@ -267,7 +267,7 @@ var undelegateCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(Fee)
+		opts.SetGasPrice(GasPrice)
 		opts.Gas = Gas
 		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
@@ -304,7 +304,7 @@ var delegateCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(Fee)
+		opts.SetGasPrice(GasPrice)
 		opts.Gas = Gas
 		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
@@ -409,7 +409,7 @@ var grantFeeCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(Fee)
+		opts.SetGasPrice(GasPrice)
 		opts.Gas = Gas
 		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
@@ -440,7 +440,7 @@ var revokeGrantFeeCmd = &cobra.Command{
 		}
 
 		opts := options.DefaultTxOptions()
-		opts.SetFeeAmount(Fee)
+		opts.SetGasPrice(GasPrice)
 		opts.Gas = Gas
 		opts.AccountKey = AccountKey
 		opts.FeeGranterAddress = FeeGranterAddress
@@ -465,11 +465,11 @@ func parseAddressFromString(addrStr string) (state.Address, error) {
 
 func ApplyFlags(cmds ...*cobra.Command) {
 	for _, cmd := range cmds {
-		cmd.PersistentFlags().Int64Var(
-			&Fee,
-			"fee",
+		cmd.PersistentFlags().Float64Var(
+			&GasPrice,
+			"gas.price",
 			-1,
-			"Specifies fee(in utia) for tx submission.",
+			"Specifies gas price for the fee calculation",
 		)
 
 		cmd.PersistentFlags().Uint64Var(

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
-	stateBuilder "github.com/celestiaorg/celestia-node/nodebuilder/state"
 	"github.com/celestiaorg/celestia-node/state"
 )
 
@@ -432,7 +431,7 @@ func ApplyFlags(cmds ...*cobra.Command) {
 		cmd.PersistentFlags().StringVar(
 			&keyName,
 			"key.name",
-			stateBuilder.DefaultAccountName,
+			"",
 			"Specifies the signer name from the keystore.",
 		)
 

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -12,15 +12,11 @@ import (
 )
 
 var (
-	amount uint64
-
-	gasPrice float64
-
-	gas uint64
-
-	accountKey string
-
+	accountKey        string
 	feeGranterAddress string
+	amount            uint64
+	gas               uint64
+	gasPrice          float64
 )
 
 func init() {
@@ -425,7 +421,7 @@ func ApplyFlags(cmds ...*cobra.Command) {
 		cmd.PersistentFlags().Float64Var(
 			&gasPrice,
 			"gas.price",
-			-1,
+			state.DefaultPrice,
 			"Specifies gas price for the fee calculation",
 		)
 

--- a/nodebuilder/state/config.go
+++ b/nodebuilder/state/config.go
@@ -9,14 +9,14 @@ var defaultKeyringBackend = keyring.BackendTest
 // Config contains configuration parameters for constructing
 // the node's keyring signer.
 type Config struct {
-	KeyringKeyNames []string
-	KeyringBackend  string
+	KeyringAccName string
+	KeyringBackend string
 }
 
 func DefaultConfig() Config {
 	return Config{
-		KeyringKeyNames: []string{},
-		KeyringBackend:  defaultKeyringBackend,
+		KeyringAccName: DefaultAccountName,
+		KeyringBackend: defaultKeyringBackend,
 	}
 }
 

--- a/nodebuilder/state/config.go
+++ b/nodebuilder/state/config.go
@@ -9,13 +9,13 @@ var defaultKeyringBackend = keyring.BackendTest
 // Config contains configuration parameters for constructing
 // the node's keyring signer.
 type Config struct {
-	KeyringAccName string
+	KeyringKeyName string
 	KeyringBackend string
 }
 
 func DefaultConfig() Config {
 	return Config{
-		KeyringAccName: DefaultAccountName,
+		KeyringKeyName: DefaultAccountName,
 		KeyringBackend: defaultKeyringBackend,
 	}
 }

--- a/nodebuilder/state/config.go
+++ b/nodebuilder/state/config.go
@@ -2,8 +2,6 @@ package state
 
 import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-
-	"github.com/celestiaorg/celestia-node/state"
 )
 
 var defaultKeyringBackend = keyring.BackendTest
@@ -11,16 +9,14 @@ var defaultKeyringBackend = keyring.BackendTest
 // Config contains configuration parameters for constructing
 // the node's keyring signer.
 type Config struct {
-	KeyringAccName string
-	KeyringBackend string
-	GranterAddress state.AccAddress
+	KeyringKeyNames []string
+	KeyringBackend  string
 }
 
 func DefaultConfig() Config {
 	return Config{
-		KeyringAccName: "",
-		KeyringBackend: defaultKeyringBackend,
-		GranterAddress: state.AccAddress{},
+		KeyringKeyNames: []string{},
+		KeyringBackend:  defaultKeyringBackend,
 	}
 }
 

--- a/nodebuilder/state/config.go
+++ b/nodebuilder/state/config.go
@@ -4,19 +4,19 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 )
 
-var defaultKeyringBackend = keyring.BackendTest
+var defaultBackendName = keyring.BackendTest
 
 // Config contains configuration parameters for constructing
 // the node's keyring signer.
 type Config struct {
-	KeyringKeyName string
-	KeyringBackend string
+	DefaultKeyName     string
+	DefaultBackendName string
 }
 
 func DefaultConfig() Config {
 	return Config{
-		KeyringKeyName: DefaultAccountName,
-		KeyringBackend: defaultKeyringBackend,
+		DefaultKeyName:     DefaultKeyName,
+		DefaultBackendName: defaultBackendName,
 	}
 }
 

--- a/nodebuilder/state/flags.go
+++ b/nodebuilder/state/flags.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	keyringKeyNameFlag = "keyring.keyname"
+	keyringAccNameFlag = "keyring.accname"
 	keyringBackendFlag = "keyring.backend"
 )
 
@@ -16,22 +16,18 @@ var (
 func Flags() *flag.FlagSet {
 	flags := &flag.FlagSet{}
 
-	flags.StringSlice(keyringKeyNameFlag, []string{}, "Directs node's keyring signer to use the key by the "+
-		"given name. The first key in the list will be the default key that will be used to sign the transactions. "+
-		"All other keys can be used to sign transactions, given that the user specifies it in the transaction options.")
+	flags.String(keyringAccNameFlag, "", "Directs node's keyring signer to use the key prefixed with the "+
+		"given string.")
 	flags.String(keyringBackendFlag, defaultKeyringBackend, fmt.Sprintf("Directs node's keyring signer to use the given "+
 		"backend. Default is %s.", defaultKeyringBackend))
 	return flags
 }
 
 // ParseFlags parses State flags from the given cmd and saves them to the passed config.
-func ParseFlags(cmd *cobra.Command, cfg *Config) error {
-	keyringKeyNames, err := cmd.Flags().GetStringSlice(keyringKeyNameFlag)
-	if err != nil {
-		return err
+func ParseFlags(cmd *cobra.Command, cfg *Config) {
+	keyringAccName := cmd.Flag(keyringAccNameFlag).Value.String()
+	if keyringAccName != "" {
+		cfg.KeyringAccName = keyringAccName
 	}
-	cfg.KeyringKeyNames = keyringKeyNames
-
 	cfg.KeyringBackend = cmd.Flag(keyringBackendFlag).Value.String()
-	return err
 }

--- a/nodebuilder/state/flags.go
+++ b/nodebuilder/state/flags.go
@@ -16,17 +16,17 @@ var (
 func Flags() *flag.FlagSet {
 	flags := &flag.FlagSet{}
 
-	flags.String(keyringKeyNameFlag, DefaultAccountName,
+	flags.String(keyringKeyNameFlag, DefaultKeyName,
 		fmt.Sprintf("Directs node's keyring signer to use the key prefixed with the "+
-			"given string. Default is %s", DefaultAccountName))
-	flags.String(keyringBackendFlag, defaultKeyringBackend,
+			"given string. Default is %s", DefaultKeyName))
+	flags.String(keyringBackendFlag, defaultBackendName,
 		fmt.Sprintf("Directs node's keyring signer to use the given "+
-			"backend. Default is %s.", defaultKeyringBackend))
+			"backend. Default is %s.", defaultBackendName))
 	return flags
 }
 
 // ParseFlags parses State flags from the given cmd and saves them to the passed config.
 func ParseFlags(cmd *cobra.Command, cfg *Config) {
-	cfg.KeyringKeyName = cmd.Flag(keyringKeyNameFlag).Value.String()
-	cfg.KeyringBackend = cmd.Flag(keyringBackendFlag).Value.String()
+	cfg.DefaultKeyName = cmd.Flag(keyringKeyNameFlag).Value.String()
+	cfg.DefaultBackendName = cmd.Flag(keyringBackendFlag).Value.String()
 }

--- a/nodebuilder/state/flags.go
+++ b/nodebuilder/state/flags.go
@@ -3,46 +3,35 @@ package state
 import (
 	"fmt"
 
-	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 )
 
 var (
-	keyringAccNameFlag = "keyring.accname"
+	keyringKeyNameFlag = "keyring.keyname"
 	keyringBackendFlag = "keyring.backend"
-
-	granterAddressFlag = "granter.address"
 )
 
 // Flags gives a set of hardcoded State flags.
 func Flags() *flag.FlagSet {
 	flags := &flag.FlagSet{}
 
-	flags.String(keyringAccNameFlag, "", "Directs node's keyring signer to use the key prefixed with the "+
-		"given string.")
+	flags.StringSlice(keyringKeyNameFlag, []string{}, "Directs node's keyring signer to use the key by the "+
+		"given name. The first key in the list will be the default key that will be used to sign the transactions. "+
+		"All other keys can be used to sign transactions, given that the user specifies it in the transaction options.")
 	flags.String(keyringBackendFlag, defaultKeyringBackend, fmt.Sprintf("Directs node's keyring signer to use the given "+
 		"backend. Default is %s.", defaultKeyringBackend))
-
-	flags.String(granterAddressFlag, "", "Account address that will pay for all transactions submitted from the node.")
 	return flags
 }
 
 // ParseFlags parses State flags from the given cmd and saves them to the passed config.
 func ParseFlags(cmd *cobra.Command, cfg *Config) error {
-	keyringAccName := cmd.Flag(keyringAccNameFlag).Value.String()
-	if keyringAccName != "" {
-		cfg.KeyringAccName = keyringAccName
+	keyringKeyNames, err := cmd.Flags().GetStringSlice(keyringKeyNameFlag)
+	if err != nil {
+		return err
 	}
+	cfg.KeyringKeyNames = keyringKeyNames
 
 	cfg.KeyringBackend = cmd.Flag(keyringBackendFlag).Value.String()
-
-	addr := cmd.Flag(granterAddressFlag).Value.String()
-	if addr == "" {
-		return nil
-	}
-
-	sdkAddress, err := sdktypes.AccAddressFromBech32(addr)
-	cfg.GranterAddress = sdkAddress
 	return err
 }

--- a/nodebuilder/state/flags.go
+++ b/nodebuilder/state/flags.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	keyringAccNameFlag = "keyring.accname"
+	keyringKeyNameFlag = "keyring.keyname"
 	keyringBackendFlag = "keyring.backend"
 )
 
@@ -16,18 +16,17 @@ var (
 func Flags() *flag.FlagSet {
 	flags := &flag.FlagSet{}
 
-	flags.String(keyringAccNameFlag, "", "Directs node's keyring signer to use the key prefixed with the "+
-		"given string.")
-	flags.String(keyringBackendFlag, defaultKeyringBackend, fmt.Sprintf("Directs node's keyring signer to use the given "+
-		"backend. Default is %s.", defaultKeyringBackend))
+	flags.String(keyringKeyNameFlag, DefaultAccountName,
+		fmt.Sprintf("Directs node's keyring signer to use the key prefixed with the "+
+			"given string. Default is %s", DefaultAccountName))
+	flags.String(keyringBackendFlag, defaultKeyringBackend,
+		fmt.Sprintf("Directs node's keyring signer to use the given "+
+			"backend. Default is %s.", defaultKeyringBackend))
 	return flags
 }
 
 // ParseFlags parses State flags from the given cmd and saves them to the passed config.
 func ParseFlags(cmd *cobra.Command, cfg *Config) {
-	keyringAccName := cmd.Flag(keyringAccNameFlag).Value.String()
-	if keyringAccName != "" {
-		cfg.KeyringAccName = keyringAccName
-	}
+	cfg.KeyringKeyName = cmd.Flag(keyringKeyNameFlag).Value.String()
 	cfg.KeyringBackend = cmd.Flag(keyringBackendFlag).Value.String()
 }

--- a/nodebuilder/state/keyring.go
+++ b/nodebuilder/state/keyring.go
@@ -15,9 +15,9 @@ type AccountName string
 // as having keyring-backend set to `file` prompts user for password.
 func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, AccountName, error) {
 	ring := ks.Keyring()
-	keyInfo, err := ring.Key(cfg.KeyringAccName)
+	keyInfo, err := ring.Key(cfg.KeyringKeyName)
 	if err != nil {
-		log.Errorw("could not access key in keyring", "keyring.accname", cfg.KeyringAccName)
+		log.Errorw("could not access key in keyring", "keyring.keyname", cfg.KeyringKeyName)
 		return nil, "", err
 	}
 	return ring, AccountName(keyInfo.Name), nil

--- a/nodebuilder/state/keyring.go
+++ b/nodebuilder/state/keyring.go
@@ -1,8 +1,6 @@
 package state
 
 import (
-	"fmt"
-
 	kr "github.com/cosmos/cosmos-sdk/crypto/keyring"
 
 	"github.com/celestiaorg/celestia-node/libs/keystore"
@@ -17,29 +15,10 @@ type AccountName string
 // as having keyring-backend set to `file` prompts user for password.
 func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, AccountName, error) {
 	ring := ks.Keyring()
-	var info *kr.Record
-
-	// go through all keys in the config and check their availability in the KeyStore.
-	for _, accName := range cfg.KeyringKeyNames {
-		keyInfo, err := ring.Key(accName)
-		if err != nil {
-			err = fmt.Errorf("key not found in keystore: %s", accName)
-			return nil, "", err
-		}
-		if info == nil {
-			info = keyInfo
-		}
+	keyInfo, err := ring.Key(cfg.KeyringAccName)
+	if err != nil {
+		log.Errorw("could not access key in keyring", "keyring.accname", cfg.KeyringAccName)
+		return nil, "", err
 	}
-	// set the default key in case config does not provide any keys.
-	if info == nil {
-		// use default key
-		keyInfo, err := ring.Key(DefaultAccountName)
-		if err != nil {
-			log.Errorw("could not access key in keyring", "name", DefaultAccountName)
-			return nil, "", err
-		}
-		info = keyInfo
-	}
-
-	return ring, AccountName(info.Name), nil
+	return ring, AccountName(keyInfo.Name), nil
 }

--- a/nodebuilder/state/keyring.go
+++ b/nodebuilder/state/keyring.go
@@ -1,12 +1,14 @@
 package state
 
 import (
+	"fmt"
+
 	kr "github.com/cosmos/cosmos-sdk/crypto/keyring"
 
 	"github.com/celestiaorg/celestia-node/libs/keystore"
 )
 
-const DefaultAccountName = "my_celes_key"
+const DefaultKeyName = "my_celes_key"
 
 type AccountName string
 
@@ -15,9 +17,10 @@ type AccountName string
 // as having keyring-backend set to `file` prompts user for password.
 func Keyring(cfg Config, ks keystore.Keystore) (kr.Keyring, AccountName, error) {
 	ring := ks.Keyring()
-	keyInfo, err := ring.Key(cfg.KeyringKeyName)
+	keyInfo, err := ring.Key(cfg.DefaultKeyName)
 	if err != nil {
-		log.Errorw("could not access key in keyring", "keyring.keyname", cfg.KeyringKeyName)
+		err = fmt.Errorf("can't get key: `%s` from the keystore: %w", cfg.DefaultKeyName, err)
+		log.Error(err)
 		return nil, "", err
 	}
 	return ring, AccountName(keyInfo.Name), nil

--- a/nodebuilder/state/mocks/api.go
+++ b/nodebuilder/state/mocks/api.go
@@ -86,7 +86,7 @@ func (mr *MockModuleMockRecorder) BalanceForAddress(arg0, arg1 interface{}) *gom
 }
 
 // BeginRedelegate mocks base method.
-func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3 math.Int, arg4 state.Options) (*types.TxResponse, error) {
+func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3 math.Int, arg4 *state.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeginRedelegate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -101,7 +101,7 @@ func (mr *MockModuleMockRecorder) BeginRedelegate(arg0, arg1, arg2, arg3, arg4 i
 }
 
 // CancelUnbondingDelegation mocks base method.
-func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 state.Options) (*types.TxResponse, error) {
+func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 *state.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelUnbondingDelegation", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -116,7 +116,7 @@ func (mr *MockModuleMockRecorder) CancelUnbondingDelegation(arg0, arg1, arg2, ar
 }
 
 // Delegate mocks base method.
-func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 state.Options) (*types.TxResponse, error) {
+func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *state.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delegate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -131,7 +131,7 @@ func (mr *MockModuleMockRecorder) Delegate(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // GrantFee mocks base method.
-func (m *MockModule) GrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 state.Options) (*types.TxResponse, error) {
+func (m *MockModule) GrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *state.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GrantFee", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -191,7 +191,7 @@ func (mr *MockModuleMockRecorder) QueryUnbonding(arg0, arg1 interface{}) *gomock
 }
 
 // RevokeGrantFee mocks base method.
-func (m *MockModule) RevokeGrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 state.Options) (*types.TxResponse, error) {
+func (m *MockModule) RevokeGrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 *state.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeGrantFee", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -206,7 +206,7 @@ func (mr *MockModuleMockRecorder) RevokeGrantFee(arg0, arg1, arg2 interface{}) *
 }
 
 // SubmitPayForBlob mocks base method.
-func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 []*types1.Blob, arg2 state.Options) (*types.TxResponse, error) {
+func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 []*types1.Blob, arg2 *state.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitPayForBlob", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -236,7 +236,7 @@ func (mr *MockModuleMockRecorder) SubmitTx(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // Transfer mocks base method.
-func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 state.Options) (*types.TxResponse, error) {
+func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *state.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transfer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -251,7 +251,7 @@ func (mr *MockModuleMockRecorder) Transfer(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // Undelegate mocks base method.
-func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 state.Options) (*types.TxResponse, error) {
+func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *state.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Undelegate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)

--- a/nodebuilder/state/mocks/api.go
+++ b/nodebuilder/state/mocks/api.go
@@ -86,7 +86,7 @@ func (mr *MockModuleMockRecorder) BalanceForAddress(arg0, arg1 interface{}) *gom
 }
 
 // BeginRedelegate mocks base method.
-func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3 math.Int, arg4 *state.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3 math.Int, arg4 *state.TxConfig) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeginRedelegate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -101,7 +101,7 @@ func (mr *MockModuleMockRecorder) BeginRedelegate(arg0, arg1, arg2, arg3, arg4 i
 }
 
 // CancelUnbondingDelegation mocks base method.
-func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 *state.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 *state.TxConfig) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelUnbondingDelegation", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -116,7 +116,7 @@ func (mr *MockModuleMockRecorder) CancelUnbondingDelegation(arg0, arg1, arg2, ar
 }
 
 // Delegate mocks base method.
-func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *state.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *state.TxConfig) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delegate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -131,7 +131,7 @@ func (mr *MockModuleMockRecorder) Delegate(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // GrantFee mocks base method.
-func (m *MockModule) GrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *state.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) GrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *state.TxConfig) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GrantFee", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -191,7 +191,7 @@ func (mr *MockModuleMockRecorder) QueryUnbonding(arg0, arg1 interface{}) *gomock
 }
 
 // RevokeGrantFee mocks base method.
-func (m *MockModule) RevokeGrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 *state.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) RevokeGrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 *state.TxConfig) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeGrantFee", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -206,7 +206,7 @@ func (mr *MockModuleMockRecorder) RevokeGrantFee(arg0, arg1, arg2 interface{}) *
 }
 
 // SubmitPayForBlob mocks base method.
-func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 []*types1.Blob, arg2 *state.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 []*types1.Blob, arg2 *state.TxConfig) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitPayForBlob", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -236,7 +236,7 @@ func (mr *MockModuleMockRecorder) SubmitTx(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // Transfer mocks base method.
-func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *state.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *state.TxConfig) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transfer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -251,7 +251,7 @@ func (mr *MockModuleMockRecorder) Transfer(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // Undelegate mocks base method.
-func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *state.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *state.TxConfig) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Undelegate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)

--- a/nodebuilder/state/mocks/api.go
+++ b/nodebuilder/state/mocks/api.go
@@ -5,19 +5,16 @@
 package mocks
 
 import (
-	"context"
-	"reflect"
+	context "context"
+	reflect "reflect"
 
-	"cosmossdk.io/math"
-
-	"github.com/celestiaorg/celestia-node/blob"
-	"github.com/celestiaorg/celestia-node/state"
-	"github.com/celestiaorg/celestia-node/state/options"
-
-	"github.com/cosmos/cosmos-sdk/types"
+	math "cosmossdk.io/math"
+	state "github.com/celestiaorg/celestia-node/state"
+	types "github.com/cosmos/cosmos-sdk/types"
 	types0 "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/golang/mock/gomock"
-	types1 "github.com/tendermint/tendermint/types"
+	gomock "github.com/golang/mock/gomock"
+	types1 "github.com/tendermint/tendermint/proto/tendermint/types"
+	types2 "github.com/tendermint/tendermint/types"
 )
 
 // MockModule is a mock of Module interface.
@@ -89,7 +86,7 @@ func (mr *MockModuleMockRecorder) BalanceForAddress(arg0, arg1 interface{}) *gom
 }
 
 // BeginRedelegate mocks base method.
-func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3 math.Int, arg4 *options.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3 math.Int, arg4 state.Options) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeginRedelegate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -104,7 +101,7 @@ func (mr *MockModuleMockRecorder) BeginRedelegate(arg0, arg1, arg2, arg3, arg4 i
 }
 
 // CancelUnbondingDelegation mocks base method.
-func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 *options.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 state.Options) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelUnbondingDelegation", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -119,7 +116,7 @@ func (mr *MockModuleMockRecorder) CancelUnbondingDelegation(arg0, arg1, arg2, ar
 }
 
 // Delegate mocks base method.
-func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *options.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 state.Options) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delegate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -134,7 +131,7 @@ func (mr *MockModuleMockRecorder) Delegate(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // GrantFee mocks base method.
-func (m *MockModule) GrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *options.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) GrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 state.Options) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GrantFee", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -194,7 +191,7 @@ func (mr *MockModuleMockRecorder) QueryUnbonding(arg0, arg1 interface{}) *gomock
 }
 
 // RevokeGrantFee mocks base method.
-func (m *MockModule) RevokeGrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 *options.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) RevokeGrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 state.Options) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeGrantFee", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -209,7 +206,7 @@ func (mr *MockModuleMockRecorder) RevokeGrantFee(arg0, arg1, arg2 interface{}) *
 }
 
 // SubmitPayForBlob mocks base method.
-func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 []*blob.Blob, arg2 *options.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 []*types1.Blob, arg2 state.Options) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitPayForBlob", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -224,7 +221,7 @@ func (mr *MockModuleMockRecorder) SubmitPayForBlob(arg0, arg1, arg2 interface{})
 }
 
 // SubmitTx mocks base method.
-func (m *MockModule) SubmitTx(arg0 context.Context, arg1 types1.Tx) (*types.TxResponse, error) {
+func (m *MockModule) SubmitTx(arg0 context.Context, arg1 types2.Tx) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitTx", arg0, arg1)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -239,7 +236,7 @@ func (mr *MockModuleMockRecorder) SubmitTx(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // Transfer mocks base method.
-func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *options.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 state.Options) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transfer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
@@ -254,7 +251,7 @@ func (mr *MockModuleMockRecorder) Transfer(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // Undelegate mocks base method.
-func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *options.TxOptions) (*types.TxResponse, error) {
+func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 state.Options) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Undelegate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)

--- a/nodebuilder/state/mocks/api.go
+++ b/nodebuilder/state/mocks/api.go
@@ -5,15 +5,18 @@
 package mocks
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
-	math "cosmossdk.io/math"
-	blob "github.com/celestiaorg/celestia-node/blob"
-	state "github.com/celestiaorg/celestia-node/state"
-	types "github.com/cosmos/cosmos-sdk/types"
+	"cosmossdk.io/math"
+
+	"github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/state"
+	"github.com/celestiaorg/celestia-node/state/options"
+
+	"github.com/cosmos/cosmos-sdk/types"
 	types0 "github.com/cosmos/cosmos-sdk/x/staking/types"
-	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/mock/gomock"
 	types1 "github.com/tendermint/tendermint/types"
 )
 
@@ -86,63 +89,63 @@ func (mr *MockModuleMockRecorder) BalanceForAddress(arg0, arg1 interface{}) *gom
 }
 
 // BeginRedelegate mocks base method.
-func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3, arg4 math.Int, arg5 uint64) (*types.TxResponse, error) {
+func (m *MockModule) BeginRedelegate(arg0 context.Context, arg1, arg2 types.ValAddress, arg3 math.Int, arg4 *options.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BeginRedelegate", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "BeginRedelegate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BeginRedelegate indicates an expected call of BeginRedelegate.
-func (mr *MockModuleMockRecorder) BeginRedelegate(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) BeginRedelegate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginRedelegate", reflect.TypeOf((*MockModule)(nil).BeginRedelegate), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginRedelegate", reflect.TypeOf((*MockModule)(nil).BeginRedelegate), arg0, arg1, arg2, arg3, arg4)
 }
 
 // CancelUnbondingDelegation mocks base method.
-func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3, arg4 math.Int, arg5 uint64) (*types.TxResponse, error) {
+func (m *MockModule) CancelUnbondingDelegation(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 *options.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelUnbondingDelegation", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CancelUnbondingDelegation", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CancelUnbondingDelegation indicates an expected call of CancelUnbondingDelegation.
-func (mr *MockModuleMockRecorder) CancelUnbondingDelegation(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) CancelUnbondingDelegation(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUnbondingDelegation", reflect.TypeOf((*MockModule)(nil).CancelUnbondingDelegation), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUnbondingDelegation", reflect.TypeOf((*MockModule)(nil).CancelUnbondingDelegation), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Delegate mocks base method.
-func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
+func (m *MockModule) Delegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *options.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delegate", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Delegate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Delegate indicates an expected call of Delegate.
-func (mr *MockModuleMockRecorder) Delegate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) Delegate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delegate", reflect.TypeOf((*MockModule)(nil).Delegate), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delegate", reflect.TypeOf((*MockModule)(nil).Delegate), arg0, arg1, arg2, arg3)
 }
 
 // GrantFee mocks base method.
-func (m *MockModule) GrantFee(arg0 context.Context, arg1 types.AccAddress, arg2, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
+func (m *MockModule) GrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *options.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GrantFee", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "GrantFee", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GrantFee indicates an expected call of GrantFee.
-func (mr *MockModuleMockRecorder) GrantFee(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) GrantFee(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantFee", reflect.TypeOf((*MockModule)(nil).GrantFee), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantFee", reflect.TypeOf((*MockModule)(nil).GrantFee), arg0, arg1, arg2, arg3)
 }
 
 // QueryDelegation mocks base method.
@@ -191,33 +194,33 @@ func (mr *MockModuleMockRecorder) QueryUnbonding(arg0, arg1 interface{}) *gomock
 }
 
 // RevokeGrantFee mocks base method.
-func (m *MockModule) RevokeGrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 uint64) (*types.TxResponse, error) {
+func (m *MockModule) RevokeGrantFee(arg0 context.Context, arg1 types.AccAddress, arg2 *options.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RevokeGrantFee", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "RevokeGrantFee", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RevokeGrantFee indicates an expected call of RevokeGrantFee.
-func (mr *MockModuleMockRecorder) RevokeGrantFee(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) RevokeGrantFee(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeGrantFee", reflect.TypeOf((*MockModule)(nil).RevokeGrantFee), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeGrantFee", reflect.TypeOf((*MockModule)(nil).RevokeGrantFee), arg0, arg1, arg2)
 }
 
 // SubmitPayForBlob mocks base method.
-func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 math.Int, arg2 uint64, arg3 []*blob.Blob) (*types.TxResponse, error) {
+func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 []*blob.Blob, arg2 *options.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitPayForBlob", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SubmitPayForBlob", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SubmitPayForBlob indicates an expected call of SubmitPayForBlob.
-func (mr *MockModuleMockRecorder) SubmitPayForBlob(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) SubmitPayForBlob(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitPayForBlob", reflect.TypeOf((*MockModule)(nil).SubmitPayForBlob), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitPayForBlob", reflect.TypeOf((*MockModule)(nil).SubmitPayForBlob), arg0, arg1, arg2)
 }
 
 // SubmitTx mocks base method.
@@ -236,31 +239,31 @@ func (mr *MockModuleMockRecorder) SubmitTx(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // Transfer mocks base method.
-func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
+func (m *MockModule) Transfer(arg0 context.Context, arg1 types.AccAddress, arg2 math.Int, arg3 *options.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Transfer", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Transfer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Transfer indicates an expected call of Transfer.
-func (mr *MockModuleMockRecorder) Transfer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) Transfer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transfer", reflect.TypeOf((*MockModule)(nil).Transfer), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transfer", reflect.TypeOf((*MockModule)(nil).Transfer), arg0, arg1, arg2, arg3)
 }
 
 // Undelegate mocks base method.
-func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2, arg3 math.Int, arg4 uint64) (*types.TxResponse, error) {
+func (m *MockModule) Undelegate(arg0 context.Context, arg1 types.ValAddress, arg2 math.Int, arg3 *options.TxOptions) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Undelegate", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Undelegate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.TxResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Undelegate indicates an expected call of Undelegate.
-func (mr *MockModuleMockRecorder) Undelegate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) Undelegate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Undelegate", reflect.TypeOf((*MockModule)(nil).Undelegate), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Undelegate", reflect.TypeOf((*MockModule)(nil).Undelegate), arg0, arg1, arg2, arg3)
 }

--- a/nodebuilder/state/module.go
+++ b/nodebuilder/state/module.go
@@ -24,9 +24,6 @@ func ConstructModule(tp node.Type, cfg *Config, coreCfg *core.Config) fx.Option 
 	// sanitize config values before constructing module
 	cfgErr := cfg.Validate()
 	opts := make([]state.Option, 0)
-	if !cfg.GranterAddress.Empty() {
-		opts = append(opts, state.WithGranter(cfg.GranterAddress))
-	}
 	baseComponents := fx.Options(
 		fx.Supply(*cfg),
 		fx.Error(cfgErr),

--- a/nodebuilder/state/state.go
+++ b/nodebuilder/state/state.go
@@ -33,7 +33,7 @@ type Module interface {
 	// Transfer sends the given amount of coins from default wallet of the node to the given account
 	// address.
 	Transfer(
-		ctx context.Context, to state.AccAddress, amount state.Int, options state.Options,
+		ctx context.Context, to state.AccAddress, amount state.Int, options *state.TxOptions,
 	) (*state.TxResponse, error)
 	// SubmitTx submits the given transaction/message to the
 	// Celestia network and blocks until the tx is included in
@@ -43,7 +43,7 @@ type Module interface {
 	SubmitPayForBlob(
 		ctx context.Context,
 		blobs []*state.Blob,
-		options state.Options,
+		options *state.TxOptions,
 	) (*state.TxResponse, error)
 	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
 	CancelUnbondingDelegation(
@@ -51,7 +51,7 @@ type Module interface {
 		valAddr state.ValAddress,
 		amount,
 		height state.Int,
-		options state.Options,
+		options *state.TxOptions,
 	) (*state.TxResponse, error)
 	// BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
 	BeginRedelegate(
@@ -59,21 +59,21 @@ type Module interface {
 		srcValAddr,
 		dstValAddr state.ValAddress,
 		amount state.Int,
-		options state.Options,
+		options *state.TxOptions,
 	) (*state.TxResponse, error)
 	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.
 	Undelegate(
 		ctx context.Context,
 		delAddr state.ValAddress,
 		amount state.Int,
-		options state.Options,
+		options *state.TxOptions,
 	) (*state.TxResponse, error)
 	// Delegate sends a user's liquid tokens to a validator for delegation.
 	Delegate(
 		ctx context.Context,
 		delAddr state.ValAddress,
 		amount state.Int,
-		options state.Options,
+		options *state.TxOptions,
 	) (*state.TxResponse, error)
 
 	// QueryDelegation retrieves the delegation information between a delegator and a validator.
@@ -91,13 +91,13 @@ type Module interface {
 		ctx context.Context,
 		grantee state.AccAddress,
 		amount state.Int,
-		options state.Options,
+		options *state.TxOptions,
 	) (*state.TxResponse, error)
 
 	RevokeGrantFee(
 		ctx context.Context,
 		grantee state.AccAddress,
-		options state.Options,
+		options *state.TxOptions,
 	) (*state.TxResponse, error)
 }
 
@@ -114,38 +114,38 @@ type API struct {
 			ctx context.Context,
 			to state.AccAddress,
 			amount state.Int,
-			options state.Options,
+			options *state.TxOptions,
 		) (*state.TxResponse, error) `perm:"write"`
 		SubmitTx         func(ctx context.Context, tx state.Tx) (*state.TxResponse, error) `perm:"read"`
 		SubmitPayForBlob func(
 			ctx context.Context,
 			blobs []*state.Blob,
-			options state.Options,
+			options *state.TxOptions,
 		) (*state.TxResponse, error) `perm:"write"`
 		CancelUnbondingDelegation func(
 			ctx context.Context,
 			valAddr state.ValAddress,
 			amount, height state.Int,
-			options state.Options,
+			options *state.TxOptions,
 		) (*state.TxResponse, error) `perm:"write"`
 		BeginRedelegate func(
 			ctx context.Context,
 			srcValAddr,
 			dstValAddr state.ValAddress,
 			amount state.Int,
-			options state.Options,
+			options *state.TxOptions,
 		) (*state.TxResponse, error) `perm:"write"`
 		Undelegate func(
 			ctx context.Context,
 			delAddr state.ValAddress,
 			amount state.Int,
-			options state.Options,
+			options *state.TxOptions,
 		) (*state.TxResponse, error) `perm:"write"`
 		Delegate func(
 			ctx context.Context,
 			delAddr state.ValAddress,
 			amount state.Int,
-			options state.Options,
+			options *state.TxOptions,
 		) (*state.TxResponse, error) `perm:"write"`
 		QueryDelegation func(
 			ctx context.Context,
@@ -164,12 +164,12 @@ type API struct {
 			ctx context.Context,
 			grantee state.AccAddress,
 			amount state.Int,
-			options state.Options,
+			options *state.TxOptions,
 		) (*state.TxResponse, error) `perm:"write"`
 		RevokeGrantFee func(
 			ctx context.Context,
 			grantee state.AccAddress,
-			options state.Options,
+			options *state.TxOptions,
 		) (*state.TxResponse, error) `perm:"write"`
 	}
 }
@@ -186,7 +186,7 @@ func (api *API) Transfer(
 	ctx context.Context,
 	to state.AccAddress,
 	amount state.Int,
-	options state.Options,
+	options *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return api.Internal.Transfer(ctx, to, amount, options)
 }
@@ -198,7 +198,7 @@ func (api *API) SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, e
 func (api *API) SubmitPayForBlob(
 	ctx context.Context,
 	blobs []*state.Blob,
-	options state.Options,
+	options *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return api.Internal.SubmitPayForBlob(ctx, blobs, options)
 }
@@ -207,7 +207,7 @@ func (api *API) CancelUnbondingDelegation(
 	ctx context.Context,
 	valAddr state.ValAddress,
 	amount, height state.Int,
-	options state.Options,
+	options *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return api.Internal.CancelUnbondingDelegation(ctx, valAddr, amount, height, options)
 }
@@ -216,7 +216,7 @@ func (api *API) BeginRedelegate(
 	ctx context.Context,
 	srcValAddr, dstValAddr state.ValAddress,
 	amount state.Int,
-	options state.Options,
+	options *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return api.Internal.BeginRedelegate(ctx, srcValAddr, dstValAddr, amount, options)
 }
@@ -225,7 +225,7 @@ func (api *API) Undelegate(
 	ctx context.Context,
 	delAddr state.ValAddress,
 	amount state.Int,
-	options state.Options,
+	options *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return api.Internal.Undelegate(ctx, delAddr, amount, options)
 }
@@ -234,7 +234,7 @@ func (api *API) Delegate(
 	ctx context.Context,
 	delAddr state.ValAddress,
 	amount state.Int,
-	options state.Options,
+	options *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return api.Internal.Delegate(ctx, delAddr, amount, options)
 }
@@ -265,7 +265,7 @@ func (api *API) GrantFee(
 	ctx context.Context,
 	grantee state.AccAddress,
 	amount state.Int,
-	options state.Options,
+	options *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return api.Internal.GrantFee(ctx, grantee, amount, options)
 }
@@ -273,7 +273,7 @@ func (api *API) GrantFee(
 func (api *API) RevokeGrantFee(
 	ctx context.Context,
 	grantee state.AccAddress,
-	options state.Options,
+	options *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return api.Internal.RevokeGrantFee(ctx, grantee, options)
 }

--- a/nodebuilder/state/state.go
+++ b/nodebuilder/state/state.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/state"
-	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 var _ Module = (*API)(nil)
@@ -35,7 +33,7 @@ type Module interface {
 	// Transfer sends the given amount of coins from default wallet of the node to the given account
 	// address.
 	Transfer(
-		ctx context.Context, to state.AccAddress, amount state.Int, options *options.TxOptions,
+		ctx context.Context, to state.AccAddress, amount state.Int, options state.Options,
 	) (*state.TxResponse, error)
 	// SubmitTx submits the given transaction/message to the
 	// Celestia network and blocks until the tx is included in
@@ -44,8 +42,8 @@ type Module interface {
 	// SubmitPayForBlob builds, signs and submits a PayForBlob transaction.
 	SubmitPayForBlob(
 		ctx context.Context,
-		blobs []*blob.Blob,
-		options *options.TxOptions,
+		blobs []*state.Blob,
+		options state.Options,
 	) (*state.TxResponse, error)
 	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
 	CancelUnbondingDelegation(
@@ -53,7 +51,7 @@ type Module interface {
 		valAddr state.ValAddress,
 		amount,
 		height state.Int,
-		options *options.TxOptions,
+		options state.Options,
 	) (*state.TxResponse, error)
 	// BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
 	BeginRedelegate(
@@ -61,21 +59,21 @@ type Module interface {
 		srcValAddr,
 		dstValAddr state.ValAddress,
 		amount state.Int,
-		options *options.TxOptions,
+		options state.Options,
 	) (*state.TxResponse, error)
 	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.
 	Undelegate(
 		ctx context.Context,
 		delAddr state.ValAddress,
 		amount state.Int,
-		options *options.TxOptions,
+		options state.Options,
 	) (*state.TxResponse, error)
 	// Delegate sends a user's liquid tokens to a validator for delegation.
 	Delegate(
 		ctx context.Context,
 		delAddr state.ValAddress,
 		amount state.Int,
-		options *options.TxOptions,
+		options state.Options,
 	) (*state.TxResponse, error)
 
 	// QueryDelegation retrieves the delegation information between a delegator and a validator.
@@ -93,13 +91,13 @@ type Module interface {
 		ctx context.Context,
 		grantee state.AccAddress,
 		amount state.Int,
-		options *options.TxOptions,
+		options state.Options,
 	) (*state.TxResponse, error)
 
 	RevokeGrantFee(
 		ctx context.Context,
 		grantee state.AccAddress,
-		options *options.TxOptions,
+		options state.Options,
 	) (*state.TxResponse, error)
 }
 
@@ -116,38 +114,38 @@ type API struct {
 			ctx context.Context,
 			to state.AccAddress,
 			amount state.Int,
-			options *options.TxOptions,
+			options state.Options,
 		) (*state.TxResponse, error) `perm:"write"`
 		SubmitTx         func(ctx context.Context, tx state.Tx) (*state.TxResponse, error) `perm:"read"`
 		SubmitPayForBlob func(
 			ctx context.Context,
-			blobs []*blob.Blob,
-			options *options.TxOptions,
+			blobs []*state.Blob,
+			options state.Options,
 		) (*state.TxResponse, error) `perm:"write"`
 		CancelUnbondingDelegation func(
 			ctx context.Context,
 			valAddr state.ValAddress,
 			amount, height state.Int,
-			options *options.TxOptions,
+			options state.Options,
 		) (*state.TxResponse, error) `perm:"write"`
 		BeginRedelegate func(
 			ctx context.Context,
 			srcValAddr,
 			dstValAddr state.ValAddress,
 			amount state.Int,
-			options *options.TxOptions,
+			options state.Options,
 		) (*state.TxResponse, error) `perm:"write"`
 		Undelegate func(
 			ctx context.Context,
 			delAddr state.ValAddress,
 			amount state.Int,
-			options *options.TxOptions,
+			options state.Options,
 		) (*state.TxResponse, error) `perm:"write"`
 		Delegate func(
 			ctx context.Context,
 			delAddr state.ValAddress,
 			amount state.Int,
-			options *options.TxOptions,
+			options state.Options,
 		) (*state.TxResponse, error) `perm:"write"`
 		QueryDelegation func(
 			ctx context.Context,
@@ -166,12 +164,12 @@ type API struct {
 			ctx context.Context,
 			grantee state.AccAddress,
 			amount state.Int,
-			options *options.TxOptions,
+			options state.Options,
 		) (*state.TxResponse, error) `perm:"write"`
 		RevokeGrantFee func(
 			ctx context.Context,
 			grantee state.AccAddress,
-			options *options.TxOptions,
+			options state.Options,
 		) (*state.TxResponse, error) `perm:"write"`
 	}
 }
@@ -188,7 +186,7 @@ func (api *API) Transfer(
 	ctx context.Context,
 	to state.AccAddress,
 	amount state.Int,
-	options *options.TxOptions,
+	options state.Options,
 ) (*state.TxResponse, error) {
 	return api.Internal.Transfer(ctx, to, amount, options)
 }
@@ -199,8 +197,8 @@ func (api *API) SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, e
 
 func (api *API) SubmitPayForBlob(
 	ctx context.Context,
-	blobs []*blob.Blob,
-	options *options.TxOptions,
+	blobs []*state.Blob,
+	options state.Options,
 ) (*state.TxResponse, error) {
 	return api.Internal.SubmitPayForBlob(ctx, blobs, options)
 }
@@ -209,7 +207,7 @@ func (api *API) CancelUnbondingDelegation(
 	ctx context.Context,
 	valAddr state.ValAddress,
 	amount, height state.Int,
-	options *options.TxOptions,
+	options state.Options,
 ) (*state.TxResponse, error) {
 	return api.Internal.CancelUnbondingDelegation(ctx, valAddr, amount, height, options)
 }
@@ -218,7 +216,7 @@ func (api *API) BeginRedelegate(
 	ctx context.Context,
 	srcValAddr, dstValAddr state.ValAddress,
 	amount state.Int,
-	options *options.TxOptions,
+	options state.Options,
 ) (*state.TxResponse, error) {
 	return api.Internal.BeginRedelegate(ctx, srcValAddr, dstValAddr, amount, options)
 }
@@ -227,7 +225,7 @@ func (api *API) Undelegate(
 	ctx context.Context,
 	delAddr state.ValAddress,
 	amount state.Int,
-	options *options.TxOptions,
+	options state.Options,
 ) (*state.TxResponse, error) {
 	return api.Internal.Undelegate(ctx, delAddr, amount, options)
 }
@@ -236,7 +234,7 @@ func (api *API) Delegate(
 	ctx context.Context,
 	delAddr state.ValAddress,
 	amount state.Int,
-	options *options.TxOptions,
+	options state.Options,
 ) (*state.TxResponse, error) {
 	return api.Internal.Delegate(ctx, delAddr, amount, options)
 }
@@ -267,7 +265,7 @@ func (api *API) GrantFee(
 	ctx context.Context,
 	grantee state.AccAddress,
 	amount state.Int,
-	options *options.TxOptions,
+	options state.Options,
 ) (*state.TxResponse, error) {
 	return api.Internal.GrantFee(ctx, grantee, amount, options)
 }
@@ -275,7 +273,7 @@ func (api *API) GrantFee(
 func (api *API) RevokeGrantFee(
 	ctx context.Context,
 	grantee state.AccAddress,
-	options *options.TxOptions,
+	options state.Options,
 ) (*state.TxResponse, error) {
 	return api.Internal.RevokeGrantFee(ctx, grantee, options)
 }

--- a/nodebuilder/state/state.go
+++ b/nodebuilder/state/state.go
@@ -33,7 +33,7 @@ type Module interface {
 	// Transfer sends the given amount of coins from default wallet of the node to the given account
 	// address.
 	Transfer(
-		ctx context.Context, to state.AccAddress, amount state.Int, options *state.TxConfig,
+		ctx context.Context, to state.AccAddress, amount state.Int, config *state.TxConfig,
 	) (*state.TxResponse, error)
 	// SubmitTx submits the given transaction/message to the
 	// Celestia network and blocks until the tx is included in
@@ -43,7 +43,7 @@ type Module interface {
 	SubmitPayForBlob(
 		ctx context.Context,
 		blobs []*state.Blob,
-		options *state.TxConfig,
+		config *state.TxConfig,
 	) (*state.TxResponse, error)
 	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
 	CancelUnbondingDelegation(
@@ -51,7 +51,7 @@ type Module interface {
 		valAddr state.ValAddress,
 		amount,
 		height state.Int,
-		options *state.TxConfig,
+		config *state.TxConfig,
 	) (*state.TxResponse, error)
 	// BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
 	BeginRedelegate(
@@ -59,21 +59,21 @@ type Module interface {
 		srcValAddr,
 		dstValAddr state.ValAddress,
 		amount state.Int,
-		options *state.TxConfig,
+		config *state.TxConfig,
 	) (*state.TxResponse, error)
 	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.
 	Undelegate(
 		ctx context.Context,
 		delAddr state.ValAddress,
 		amount state.Int,
-		options *state.TxConfig,
+		config *state.TxConfig,
 	) (*state.TxResponse, error)
 	// Delegate sends a user's liquid tokens to a validator for delegation.
 	Delegate(
 		ctx context.Context,
 		delAddr state.ValAddress,
 		amount state.Int,
-		options *state.TxConfig,
+		config *state.TxConfig,
 	) (*state.TxResponse, error)
 
 	// QueryDelegation retrieves the delegation information between a delegator and a validator.
@@ -91,13 +91,13 @@ type Module interface {
 		ctx context.Context,
 		grantee state.AccAddress,
 		amount state.Int,
-		options *state.TxConfig,
+		config *state.TxConfig,
 	) (*state.TxResponse, error)
 
 	RevokeGrantFee(
 		ctx context.Context,
 		grantee state.AccAddress,
-		options *state.TxConfig,
+		config *state.TxConfig,
 	) (*state.TxResponse, error)
 }
 
@@ -114,38 +114,38 @@ type API struct {
 			ctx context.Context,
 			to state.AccAddress,
 			amount state.Int,
-			options *state.TxConfig,
+			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		SubmitTx         func(ctx context.Context, tx state.Tx) (*state.TxResponse, error) `perm:"read"`
 		SubmitPayForBlob func(
 			ctx context.Context,
 			blobs []*state.Blob,
-			options *state.TxConfig,
+			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		CancelUnbondingDelegation func(
 			ctx context.Context,
 			valAddr state.ValAddress,
 			amount, height state.Int,
-			options *state.TxConfig,
+			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		BeginRedelegate func(
 			ctx context.Context,
 			srcValAddr,
 			dstValAddr state.ValAddress,
 			amount state.Int,
-			options *state.TxConfig,
+			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		Undelegate func(
 			ctx context.Context,
 			delAddr state.ValAddress,
 			amount state.Int,
-			options *state.TxConfig,
+			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		Delegate func(
 			ctx context.Context,
 			delAddr state.ValAddress,
 			amount state.Int,
-			options *state.TxConfig,
+			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		QueryDelegation func(
 			ctx context.Context,
@@ -164,12 +164,12 @@ type API struct {
 			ctx context.Context,
 			grantee state.AccAddress,
 			amount state.Int,
-			options *state.TxConfig,
+			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		RevokeGrantFee func(
 			ctx context.Context,
 			grantee state.AccAddress,
-			options *state.TxConfig,
+			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 	}
 }
@@ -186,9 +186,9 @@ func (api *API) Transfer(
 	ctx context.Context,
 	to state.AccAddress,
 	amount state.Int,
-	options *state.TxConfig,
+	config *state.TxConfig,
 ) (*state.TxResponse, error) {
-	return api.Internal.Transfer(ctx, to, amount, options)
+	return api.Internal.Transfer(ctx, to, amount, config)
 }
 
 func (api *API) SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, error) {
@@ -198,45 +198,45 @@ func (api *API) SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, e
 func (api *API) SubmitPayForBlob(
 	ctx context.Context,
 	blobs []*state.Blob,
-	options *state.TxConfig,
+	config *state.TxConfig,
 ) (*state.TxResponse, error) {
-	return api.Internal.SubmitPayForBlob(ctx, blobs, options)
+	return api.Internal.SubmitPayForBlob(ctx, blobs, config)
 }
 
 func (api *API) CancelUnbondingDelegation(
 	ctx context.Context,
 	valAddr state.ValAddress,
 	amount, height state.Int,
-	options *state.TxConfig,
+	config *state.TxConfig,
 ) (*state.TxResponse, error) {
-	return api.Internal.CancelUnbondingDelegation(ctx, valAddr, amount, height, options)
+	return api.Internal.CancelUnbondingDelegation(ctx, valAddr, amount, height, config)
 }
 
 func (api *API) BeginRedelegate(
 	ctx context.Context,
 	srcValAddr, dstValAddr state.ValAddress,
 	amount state.Int,
-	options *state.TxConfig,
+	config *state.TxConfig,
 ) (*state.TxResponse, error) {
-	return api.Internal.BeginRedelegate(ctx, srcValAddr, dstValAddr, amount, options)
+	return api.Internal.BeginRedelegate(ctx, srcValAddr, dstValAddr, amount, config)
 }
 
 func (api *API) Undelegate(
 	ctx context.Context,
 	delAddr state.ValAddress,
 	amount state.Int,
-	options *state.TxConfig,
+	config *state.TxConfig,
 ) (*state.TxResponse, error) {
-	return api.Internal.Undelegate(ctx, delAddr, amount, options)
+	return api.Internal.Undelegate(ctx, delAddr, amount, config)
 }
 
 func (api *API) Delegate(
 	ctx context.Context,
 	delAddr state.ValAddress,
 	amount state.Int,
-	options *state.TxConfig,
+	config *state.TxConfig,
 ) (*state.TxResponse, error) {
-	return api.Internal.Delegate(ctx, delAddr, amount, options)
+	return api.Internal.Delegate(ctx, delAddr, amount, config)
 }
 
 func (api *API) QueryDelegation(ctx context.Context, valAddr state.ValAddress) (*types.QueryDelegationResponse, error) {
@@ -265,15 +265,15 @@ func (api *API) GrantFee(
 	ctx context.Context,
 	grantee state.AccAddress,
 	amount state.Int,
-	options *state.TxConfig,
+	config *state.TxConfig,
 ) (*state.TxResponse, error) {
-	return api.Internal.GrantFee(ctx, grantee, amount, options)
+	return api.Internal.GrantFee(ctx, grantee, amount, config)
 }
 
 func (api *API) RevokeGrantFee(
 	ctx context.Context,
 	grantee state.AccAddress,
-	options *state.TxConfig,
+	config *state.TxConfig,
 ) (*state.TxResponse, error) {
-	return api.Internal.RevokeGrantFee(ctx, grantee, options)
+	return api.Internal.RevokeGrantFee(ctx, grantee, config)
 }

--- a/nodebuilder/state/state.go
+++ b/nodebuilder/state/state.go
@@ -33,7 +33,7 @@ type Module interface {
 	// Transfer sends the given amount of coins from default wallet of the node to the given account
 	// address.
 	Transfer(
-		ctx context.Context, to state.AccAddress, amount state.Int, options *state.TxOptions,
+		ctx context.Context, to state.AccAddress, amount state.Int, options *state.TxConfig,
 	) (*state.TxResponse, error)
 	// SubmitTx submits the given transaction/message to the
 	// Celestia network and blocks until the tx is included in
@@ -43,7 +43,7 @@ type Module interface {
 	SubmitPayForBlob(
 		ctx context.Context,
 		blobs []*state.Blob,
-		options *state.TxOptions,
+		options *state.TxConfig,
 	) (*state.TxResponse, error)
 	// CancelUnbondingDelegation cancels a user's pending undelegation from a validator.
 	CancelUnbondingDelegation(
@@ -51,7 +51,7 @@ type Module interface {
 		valAddr state.ValAddress,
 		amount,
 		height state.Int,
-		options *state.TxOptions,
+		options *state.TxConfig,
 	) (*state.TxResponse, error)
 	// BeginRedelegate sends a user's delegated tokens to a new validator for redelegation.
 	BeginRedelegate(
@@ -59,21 +59,21 @@ type Module interface {
 		srcValAddr,
 		dstValAddr state.ValAddress,
 		amount state.Int,
-		options *state.TxOptions,
+		options *state.TxConfig,
 	) (*state.TxResponse, error)
 	// Undelegate undelegates a user's delegated tokens, unbonding them from the current validator.
 	Undelegate(
 		ctx context.Context,
 		delAddr state.ValAddress,
 		amount state.Int,
-		options *state.TxOptions,
+		options *state.TxConfig,
 	) (*state.TxResponse, error)
 	// Delegate sends a user's liquid tokens to a validator for delegation.
 	Delegate(
 		ctx context.Context,
 		delAddr state.ValAddress,
 		amount state.Int,
-		options *state.TxOptions,
+		options *state.TxConfig,
 	) (*state.TxResponse, error)
 
 	// QueryDelegation retrieves the delegation information between a delegator and a validator.
@@ -91,13 +91,13 @@ type Module interface {
 		ctx context.Context,
 		grantee state.AccAddress,
 		amount state.Int,
-		options *state.TxOptions,
+		options *state.TxConfig,
 	) (*state.TxResponse, error)
 
 	RevokeGrantFee(
 		ctx context.Context,
 		grantee state.AccAddress,
-		options *state.TxOptions,
+		options *state.TxConfig,
 	) (*state.TxResponse, error)
 }
 
@@ -114,38 +114,38 @@ type API struct {
 			ctx context.Context,
 			to state.AccAddress,
 			amount state.Int,
-			options *state.TxOptions,
+			options *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		SubmitTx         func(ctx context.Context, tx state.Tx) (*state.TxResponse, error) `perm:"read"`
 		SubmitPayForBlob func(
 			ctx context.Context,
 			blobs []*state.Blob,
-			options *state.TxOptions,
+			options *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		CancelUnbondingDelegation func(
 			ctx context.Context,
 			valAddr state.ValAddress,
 			amount, height state.Int,
-			options *state.TxOptions,
+			options *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		BeginRedelegate func(
 			ctx context.Context,
 			srcValAddr,
 			dstValAddr state.ValAddress,
 			amount state.Int,
-			options *state.TxOptions,
+			options *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		Undelegate func(
 			ctx context.Context,
 			delAddr state.ValAddress,
 			amount state.Int,
-			options *state.TxOptions,
+			options *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		Delegate func(
 			ctx context.Context,
 			delAddr state.ValAddress,
 			amount state.Int,
-			options *state.TxOptions,
+			options *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		QueryDelegation func(
 			ctx context.Context,
@@ -164,12 +164,12 @@ type API struct {
 			ctx context.Context,
 			grantee state.AccAddress,
 			amount state.Int,
-			options *state.TxOptions,
+			options *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 		RevokeGrantFee func(
 			ctx context.Context,
 			grantee state.AccAddress,
-			options *state.TxOptions,
+			options *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
 	}
 }
@@ -186,7 +186,7 @@ func (api *API) Transfer(
 	ctx context.Context,
 	to state.AccAddress,
 	amount state.Int,
-	options *state.TxOptions,
+	options *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.Transfer(ctx, to, amount, options)
 }
@@ -198,7 +198,7 @@ func (api *API) SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, e
 func (api *API) SubmitPayForBlob(
 	ctx context.Context,
 	blobs []*state.Blob,
-	options *state.TxOptions,
+	options *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.SubmitPayForBlob(ctx, blobs, options)
 }
@@ -207,7 +207,7 @@ func (api *API) CancelUnbondingDelegation(
 	ctx context.Context,
 	valAddr state.ValAddress,
 	amount, height state.Int,
-	options *state.TxOptions,
+	options *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.CancelUnbondingDelegation(ctx, valAddr, amount, height, options)
 }
@@ -216,7 +216,7 @@ func (api *API) BeginRedelegate(
 	ctx context.Context,
 	srcValAddr, dstValAddr state.ValAddress,
 	amount state.Int,
-	options *state.TxOptions,
+	options *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.BeginRedelegate(ctx, srcValAddr, dstValAddr, amount, options)
 }
@@ -225,7 +225,7 @@ func (api *API) Undelegate(
 	ctx context.Context,
 	delAddr state.ValAddress,
 	amount state.Int,
-	options *state.TxOptions,
+	options *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.Undelegate(ctx, delAddr, amount, options)
 }
@@ -234,7 +234,7 @@ func (api *API) Delegate(
 	ctx context.Context,
 	delAddr state.ValAddress,
 	amount state.Int,
-	options *state.TxOptions,
+	options *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.Delegate(ctx, delAddr, amount, options)
 }
@@ -265,7 +265,7 @@ func (api *API) GrantFee(
 	ctx context.Context,
 	grantee state.AccAddress,
 	amount state.Int,
-	options *state.TxOptions,
+	options *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.GrantFee(ctx, grantee, amount, options)
 }
@@ -273,7 +273,7 @@ func (api *API) GrantFee(
 func (api *API) RevokeGrantFee(
 	ctx context.Context,
 	grantee state.AccAddress,
-	options *state.TxOptions,
+	options *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.RevokeGrantFee(ctx, grantee, options)
 }

--- a/nodebuilder/state/stub.go
+++ b/nodebuilder/state/stub.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/state"
+	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 var ErrNoStateAccess = errors.New("node is running without state access. run with --core.ip <CORE NODE IP> to resolve")
@@ -35,8 +36,8 @@ func (s stubbedStateModule) BalanceForAddress(
 func (s stubbedStateModule) Transfer(
 	_ context.Context,
 	_ state.AccAddress,
-	_, _ state.Int,
-	_ uint64,
+	_ state.Int,
+	_ *options.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -47,9 +48,8 @@ func (s stubbedStateModule) SubmitTx(context.Context, state.Tx) (*state.TxRespon
 
 func (s stubbedStateModule) SubmitPayForBlob(
 	context.Context,
-	state.Int,
-	uint64,
 	[]*blob.Blob,
+	*options.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -57,8 +57,8 @@ func (s stubbedStateModule) SubmitPayForBlob(
 func (s stubbedStateModule) CancelUnbondingDelegation(
 	_ context.Context,
 	_ state.ValAddress,
-	_, _, _ state.Int,
-	_ uint64,
+	_, _ state.Int,
+	_ *options.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -66,8 +66,8 @@ func (s stubbedStateModule) CancelUnbondingDelegation(
 func (s stubbedStateModule) BeginRedelegate(
 	_ context.Context,
 	_, _ state.ValAddress,
-	_, _ state.Int,
-	_ uint64,
+	_ state.Int,
+	_ *options.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -75,8 +75,8 @@ func (s stubbedStateModule) BeginRedelegate(
 func (s stubbedStateModule) Undelegate(
 	_ context.Context,
 	_ state.ValAddress,
-	_, _ state.Int,
-	_ uint64,
+	_ state.Int,
+	_ *options.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -84,8 +84,8 @@ func (s stubbedStateModule) Undelegate(
 func (s stubbedStateModule) Delegate(
 	_ context.Context,
 	_ state.ValAddress,
-	_, _ state.Int,
-	_ uint64,
+	_ state.Int,
+	_ *options.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -114,9 +114,8 @@ func (s stubbedStateModule) QueryRedelegations(
 func (s stubbedStateModule) GrantFee(
 	_ context.Context,
 	_ state.AccAddress,
-	_,
 	_ state.Int,
-	_ uint64,
+	_ *options.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -124,8 +123,7 @@ func (s stubbedStateModule) GrantFee(
 func (s stubbedStateModule) RevokeGrantFee(
 	_ context.Context,
 	_ state.AccAddress,
-	_ state.Int,
-	_ uint64,
+	_ *options.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }

--- a/nodebuilder/state/stub.go
+++ b/nodebuilder/state/stub.go
@@ -35,7 +35,7 @@ func (s stubbedStateModule) Transfer(
 	_ context.Context,
 	_ state.AccAddress,
 	_ state.Int,
-	_ state.Options,
+	_ *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -47,7 +47,7 @@ func (s stubbedStateModule) SubmitTx(context.Context, state.Tx) (*state.TxRespon
 func (s stubbedStateModule) SubmitPayForBlob(
 	context.Context,
 	[]*state.Blob,
-	state.Options,
+	*state.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -56,7 +56,7 @@ func (s stubbedStateModule) CancelUnbondingDelegation(
 	_ context.Context,
 	_ state.ValAddress,
 	_, _ state.Int,
-	_ state.Options,
+	_ *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -65,7 +65,7 @@ func (s stubbedStateModule) BeginRedelegate(
 	_ context.Context,
 	_, _ state.ValAddress,
 	_ state.Int,
-	_ state.Options,
+	_ *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -74,7 +74,7 @@ func (s stubbedStateModule) Undelegate(
 	_ context.Context,
 	_ state.ValAddress,
 	_ state.Int,
-	_ state.Options,
+	_ *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -83,7 +83,7 @@ func (s stubbedStateModule) Delegate(
 	_ context.Context,
 	_ state.ValAddress,
 	_ state.Int,
-	_ state.Options,
+	_ *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -113,7 +113,7 @@ func (s stubbedStateModule) GrantFee(
 	_ context.Context,
 	_ state.AccAddress,
 	_ state.Int,
-	_ state.Options,
+	_ *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -121,7 +121,7 @@ func (s stubbedStateModule) GrantFee(
 func (s stubbedStateModule) RevokeGrantFee(
 	_ context.Context,
 	_ state.AccAddress,
-	_ state.Options,
+	_ *state.TxOptions,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }

--- a/nodebuilder/state/stub.go
+++ b/nodebuilder/state/stub.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/state"
-	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 var ErrNoStateAccess = errors.New("node is running without state access. run with --core.ip <CORE NODE IP> to resolve")
@@ -37,7 +35,7 @@ func (s stubbedStateModule) Transfer(
 	_ context.Context,
 	_ state.AccAddress,
 	_ state.Int,
-	_ *options.TxOptions,
+	_ state.Options,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -48,8 +46,8 @@ func (s stubbedStateModule) SubmitTx(context.Context, state.Tx) (*state.TxRespon
 
 func (s stubbedStateModule) SubmitPayForBlob(
 	context.Context,
-	[]*blob.Blob,
-	*options.TxOptions,
+	[]*state.Blob,
+	state.Options,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -58,7 +56,7 @@ func (s stubbedStateModule) CancelUnbondingDelegation(
 	_ context.Context,
 	_ state.ValAddress,
 	_, _ state.Int,
-	_ *options.TxOptions,
+	_ state.Options,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -67,7 +65,7 @@ func (s stubbedStateModule) BeginRedelegate(
 	_ context.Context,
 	_, _ state.ValAddress,
 	_ state.Int,
-	_ *options.TxOptions,
+	_ state.Options,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -76,7 +74,7 @@ func (s stubbedStateModule) Undelegate(
 	_ context.Context,
 	_ state.ValAddress,
 	_ state.Int,
-	_ *options.TxOptions,
+	_ state.Options,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -85,7 +83,7 @@ func (s stubbedStateModule) Delegate(
 	_ context.Context,
 	_ state.ValAddress,
 	_ state.Int,
-	_ *options.TxOptions,
+	_ state.Options,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -115,7 +113,7 @@ func (s stubbedStateModule) GrantFee(
 	_ context.Context,
 	_ state.AccAddress,
 	_ state.Int,
-	_ *options.TxOptions,
+	_ state.Options,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -123,7 +121,7 @@ func (s stubbedStateModule) GrantFee(
 func (s stubbedStateModule) RevokeGrantFee(
 	_ context.Context,
 	_ state.AccAddress,
-	_ *options.TxOptions,
+	_ state.Options,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }

--- a/nodebuilder/state/stub.go
+++ b/nodebuilder/state/stub.go
@@ -35,7 +35,7 @@ func (s stubbedStateModule) Transfer(
 	_ context.Context,
 	_ state.AccAddress,
 	_ state.Int,
-	_ *state.TxOptions,
+	_ *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -47,7 +47,7 @@ func (s stubbedStateModule) SubmitTx(context.Context, state.Tx) (*state.TxRespon
 func (s stubbedStateModule) SubmitPayForBlob(
 	context.Context,
 	[]*state.Blob,
-	*state.TxOptions,
+	*state.TxConfig,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -56,7 +56,7 @@ func (s stubbedStateModule) CancelUnbondingDelegation(
 	_ context.Context,
 	_ state.ValAddress,
 	_, _ state.Int,
-	_ *state.TxOptions,
+	_ *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -65,7 +65,7 @@ func (s stubbedStateModule) BeginRedelegate(
 	_ context.Context,
 	_, _ state.ValAddress,
 	_ state.Int,
-	_ *state.TxOptions,
+	_ *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -74,7 +74,7 @@ func (s stubbedStateModule) Undelegate(
 	_ context.Context,
 	_ state.ValAddress,
 	_ state.Int,
-	_ *state.TxOptions,
+	_ *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -83,7 +83,7 @@ func (s stubbedStateModule) Delegate(
 	_ context.Context,
 	_ state.ValAddress,
 	_ state.Int,
-	_ *state.TxOptions,
+	_ *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -113,7 +113,7 @@ func (s stubbedStateModule) GrantFee(
 	_ context.Context,
 	_ state.AccAddress,
 	_ state.Int,
-	_ *state.TxOptions,
+	_ *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }
@@ -121,7 +121,7 @@ func (s stubbedStateModule) GrantFee(
 func (s stubbedStateModule) RevokeGrantFee(
 	_ context.Context,
 	_ state.AccAddress,
-	_ *state.TxOptions,
+	_ *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return nil, ErrNoStateAccess
 }

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -57,7 +57,7 @@ func TestNodeWithConfig(t *testing.T, tp node.Type, cfg *Config, opts ...fx.Opti
 	// create a key in the keystore to be used by the core accessor
 	_, _, err = kr.NewMnemonic(TestKeyringName, keyring.English, "", "", hd.Secp256k1)
 	require.NoError(t, err)
-	cfg.State.KeyringAccName = TestKeyringName
+	cfg.State.KeyringKeyName = TestKeyringName
 	_, accName, err := state.Keyring(cfg.State, ks)
 	require.NoError(t, err)
 	require.Equal(t, TestKeyringName, string(accName))

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -57,9 +57,7 @@ func TestNodeWithConfig(t *testing.T, tp node.Type, cfg *Config, opts ...fx.Opti
 	// create a key in the keystore to be used by the core accessor
 	_, _, err = kr.NewMnemonic(TestKeyringName, keyring.English, "", "", hd.Secp256k1)
 	require.NoError(t, err)
-	_, _, err = kr.NewMnemonic(TestKeyringName1, keyring.English, "", "", hd.Secp256k1)
-	require.NoError(t, err)
-	cfg.State.KeyringKeyNames = []string{TestKeyringName, TestKeyringName1}
+	cfg.State.KeyringAccName = TestKeyringName
 	_, accName, err := state.Keyring(cfg.State, ks)
 	require.NoError(t, err)
 	require.Equal(t, TestKeyringName, string(accName))

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -16,9 +16,13 @@ import (
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
 
-const TestKeyringName = "test_celes"
+const (
+	TestKeyringName  = "test_celes"
+	TestKeyringName1 = "test_celes1"
+)
 
 // MockStore provides mock in memory Store for testing purposes.
 func MockStore(t *testing.T, cfg *Config) Store {
@@ -49,10 +53,16 @@ func TestNodeWithConfig(t *testing.T, tp node.Type, cfg *Config, opts ...fx.Opti
 	ks, err := store.Keystore()
 	require.NoError(t, err)
 	kr := ks.Keyring()
+
 	// create a key in the keystore to be used by the core accessor
 	_, _, err = kr.NewMnemonic(TestKeyringName, keyring.English, "", "", hd.Secp256k1)
 	require.NoError(t, err)
-	cfg.State.KeyringAccName = TestKeyringName
+	_, _, err = kr.NewMnemonic(TestKeyringName1, keyring.English, "", "", hd.Secp256k1)
+	require.NoError(t, err)
+	cfg.State.KeyringKeyNames = []string{TestKeyringName, TestKeyringName1}
+	_, accName, err := state.Keyring(cfg.State, ks)
+	require.NoError(t, err)
+	require.Equal(t, TestKeyringName, string(accName))
 
 	opts = append(opts,
 		// temp dir for the eds store FIXME: Should be in mem

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -57,7 +57,7 @@ func TestNodeWithConfig(t *testing.T, tp node.Type, cfg *Config, opts ...fx.Opti
 	// create a key in the keystore to be used by the core accessor
 	_, _, err = kr.NewMnemonic(TestKeyringName, keyring.English, "", "", hd.Secp256k1)
 	require.NoError(t, err)
-	cfg.State.KeyringKeyName = TestKeyringName
+	cfg.State.DefaultKeyName = TestKeyringName
 	_, accName, err := state.Keyring(cfg.State, ks)
 	require.NoError(t, err)
 	require.Equal(t, TestKeyringName, string(accName))

--- a/nodebuilder/tests/api_test.go
+++ b/nodebuilder/tests/api_test.go
@@ -117,7 +117,7 @@ func TestBlobRPC(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	height, err := rpcClient.Blob.Submit(ctx, []*blob.Blob{newBlob}, state.NewTxOptions())
+	height, err := rpcClient.Blob.Submit(ctx, []*blob.Blob{newBlob}, state.NewTxConfig())
 	require.NoError(t, err)
 	require.True(t, height != 0)
 }

--- a/nodebuilder/tests/api_test.go
+++ b/nodebuilder/tests/api_test.go
@@ -116,7 +116,7 @@ func TestBlobRPC(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	height, err := rpcClient.Blob.Submit(ctx, []*blob.Blob{newBlob}, blob.DefaultGasPrice())
+	height, err := rpcClient.Blob.Submit(ctx, []*blob.Blob{newBlob}, options.DefaultTxOptions())
 	require.NoError(t, err)
 	require.True(t, height != 0)
 }

--- a/nodebuilder/tests/api_test.go
+++ b/nodebuilder/tests/api_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
-	"github.com/celestiaorg/celestia-node/state/options"
+	"github.com/celestiaorg/celestia-node/state"
 )
 
 const (
@@ -117,7 +117,7 @@ func TestBlobRPC(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	height, err := rpcClient.Blob.Submit(ctx, []*blob.Blob{newBlob}, options.DefaultTxOptions())
+	height, err := rpcClient.Blob.Submit(ctx, []*blob.Blob{newBlob}, state.NewTxOptions())
 	require.NoError(t, err)
 	require.True(t, height != 0)
 }

--- a/nodebuilder/tests/api_test.go
+++ b/nodebuilder/tests/api_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
+	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 const (

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 func TestBlobModule(t *testing.T) {
@@ -58,7 +59,7 @@ func TestBlobModule(t *testing.T) {
 	fullClient := getAdminClient(ctx, fullNode, t)
 	lightClient := getAdminClient(ctx, lightNode, t)
 
-	height, err := fullClient.Blob.Submit(ctx, blobs, blob.DefaultGasPrice())
+	height, err := fullClient.Blob.Submit(ctx, blobs, options.DefaultTxOptions())
 	require.NoError(t, err)
 
 	_, err = fullClient.Header.WaitForHeight(ctx, height)
@@ -145,7 +146,7 @@ func TestBlobModule(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				height, err := fullClient.Blob.Submit(ctx, []*blob.Blob{b, b}, blob.DefaultGasPrice())
+				height, err := fullClient.Blob.Submit(ctx, []*blob.Blob{b, b}, options.DefaultTxOptions())
 				require.NoError(t, err)
 
 				_, err = fullClient.Header.WaitForHeight(ctx, height)
@@ -174,7 +175,7 @@ func TestBlobModule(t *testing.T) {
 			// different pfbs.
 			name: "Submit the same blob in different pfb",
 			doFn: func(t *testing.T) {
-				h, err := fullClient.Blob.Submit(ctx, []*blob.Blob{blobs[0]}, blob.DefaultGasPrice())
+				h, err := fullClient.Blob.Submit(ctx, []*blob.Blob{blobs[0]}, options.DefaultTxOptions())
 				require.NoError(t, err)
 
 				_, err = fullClient.Header.WaitForHeight(ctx, h)

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/state/options"
+	"github.com/celestiaorg/celestia-node/state"
 )
 
 func TestBlobModule(t *testing.T) {
@@ -59,7 +59,7 @@ func TestBlobModule(t *testing.T) {
 	fullClient := getAdminClient(ctx, fullNode, t)
 	lightClient := getAdminClient(ctx, lightNode, t)
 
-	height, err := fullClient.Blob.Submit(ctx, blobs, options.DefaultTxOptions())
+	height, err := fullClient.Blob.Submit(ctx, blobs, state.NewTxOptions())
 	require.NoError(t, err)
 
 	_, err = fullClient.Header.WaitForHeight(ctx, height)
@@ -146,7 +146,7 @@ func TestBlobModule(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				height, err := fullClient.Blob.Submit(ctx, []*blob.Blob{b, b}, options.DefaultTxOptions())
+				height, err := fullClient.Blob.Submit(ctx, []*blob.Blob{b, b}, state.NewTxOptions())
 				require.NoError(t, err)
 
 				_, err = fullClient.Header.WaitForHeight(ctx, height)
@@ -175,7 +175,7 @@ func TestBlobModule(t *testing.T) {
 			// different pfbs.
 			name: "Submit the same blob in different pfb",
 			doFn: func(t *testing.T) {
-				h, err := fullClient.Blob.Submit(ctx, []*blob.Blob{blobs[0]}, options.DefaultTxOptions())
+				h, err := fullClient.Blob.Submit(ctx, []*blob.Blob{blobs[0]}, state.NewTxOptions())
 				require.NoError(t, err)
 
 				_, err = fullClient.Header.WaitForHeight(ctx, h)

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -59,7 +59,7 @@ func TestBlobModule(t *testing.T) {
 	fullClient := getAdminClient(ctx, fullNode, t)
 	lightClient := getAdminClient(ctx, lightNode, t)
 
-	height, err := fullClient.Blob.Submit(ctx, blobs, state.NewTxOptions())
+	height, err := fullClient.Blob.Submit(ctx, blobs, state.NewTxConfig())
 	require.NoError(t, err)
 
 	_, err = fullClient.Header.WaitForHeight(ctx, height)
@@ -146,7 +146,7 @@ func TestBlobModule(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				height, err := fullClient.Blob.Submit(ctx, []*blob.Blob{b, b}, state.NewTxOptions())
+				height, err := fullClient.Blob.Submit(ctx, []*blob.Blob{b, b}, state.NewTxConfig())
 				require.NoError(t, err)
 
 				_, err = fullClient.Header.WaitForHeight(ctx, height)
@@ -175,7 +175,7 @@ func TestBlobModule(t *testing.T) {
 			// different pfbs.
 			name: "Submit the same blob in different pfb",
 			doFn: func(t *testing.T) {
-				h, err := fullClient.Blob.Submit(ctx, []*blob.Blob{blobs[0]}, state.NewTxOptions())
+				h, err := fullClient.Blob.Submit(ctx, []*blob.Blob{blobs[0]}, state.NewTxConfig())
 				require.NoError(t, err)
 
 				_, err = fullClient.Header.WaitForHeight(ctx, h)

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -207,8 +207,8 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 
 	var feeGrant user.TxOption
 	// set granter and update gas in case node run in a grantee mode
-	if options.Granter != "" {
-		granter, err := options.GetGranter()
+	if options.FeeGranterAddress != "" {
+		granter, err := options.GetFeeGranterAddress()
 		if err != nil {
 			return nil, err
 		}
@@ -660,8 +660,8 @@ func (ca *CoreAccessor) submitMsg(
 
 	txOptions = append(txOptions, user.SetGasLimitAndFee(options.Gas, float64(options.GetFee())))
 
-	if options.Granter != "" {
-		granter, err := options.GetGranter()
+	if options.FeeGranterAddress != "" {
+		granter, err := options.GetFeeGranterAddress()
 		if err != nil {
 			return nil, fmt.Errorf("getting granter: %w", err)
 		}

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -221,8 +221,6 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 		gasPrice = ca.getMinGasPrice()
 	}
 
-	fee := calculateFee(gas, gasPrice)
-
 	signer, err := ca.getSigner(cfg)
 	if err != nil {
 		return nil, err
@@ -239,7 +237,7 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 
 	var lastErr error
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		opts := []user.TxOption{user.SetGasLimitAndFee(gas, float64(fee))}
+		opts := []user.TxOption{user.SetGasLimitAndFee(gas, gasPrice)}
 		if feeGrant != nil {
 			opts = append(opts, feeGrant)
 		}
@@ -266,8 +264,6 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 
 			ca.setMinGasPrice(gasPrice)
 			lastErr = err
-			// explicitly recalculate fee based on the recent minGasPrice
-			fee = calculateFee(gas, gasPrice)
 			continue
 		}
 
@@ -646,8 +642,7 @@ func (ca *CoreAccessor) submitMsg(
 		gasPrice = ca.minGasPrice
 	}
 
-	fee := calculateFee(gas, gasPrice)
-	txConfig = append(txConfig, user.SetGasLimitAndFee(gas, float64(fee)))
+	txConfig = append(txConfig, user.SetGasLimitAndFee(gas, gasPrice))
 
 	if cfg.FeeGranterAddress() != "" {
 		granter, err := parseAccAddressFromString(cfg.FeeGranterAddress())

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -232,8 +232,8 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 	}
 
 	acc := ca.keyname
-	if options.Account != "" {
-		acc = options.Account
+	if options.AccountKey != "" {
+		acc = options.AccountKey
 	}
 
 	var lastErr error
@@ -398,7 +398,7 @@ func (ca *CoreAccessor) Transfer(
 
 	signer := ca.client.DefaultAddress()
 	var err error
-	if options.Account != "" {
+	if options.AccountKey != "" {
 		signer, err = options.GetSigner(ca.keyring)
 		if err != nil {
 			return nil, err
@@ -423,7 +423,7 @@ func (ca *CoreAccessor) CancelUnbondingDelegation(
 
 	signer := ca.client.DefaultAddress()
 	var err error
-	if options.Account != "" {
+	if options.AccountKey != "" {
 		signer, err = options.GetSigner(ca.keyring)
 		if err != nil {
 			return nil, err
@@ -448,7 +448,7 @@ func (ca *CoreAccessor) BeginRedelegate(
 
 	signer := ca.client.DefaultAddress()
 	var err error
-	if options.Account != "" {
+	if options.AccountKey != "" {
 		signer, err = options.GetSigner(ca.keyring)
 		if err != nil {
 			return nil, err
@@ -472,7 +472,7 @@ func (ca *CoreAccessor) Undelegate(
 
 	signer := ca.client.DefaultAddress()
 	var err error
-	if options.Account != "" {
+	if options.AccountKey != "" {
 		signer, err = options.GetSigner(ca.keyring)
 		if err != nil {
 			return nil, err
@@ -496,7 +496,7 @@ func (ca *CoreAccessor) Delegate(
 
 	signer := ca.client.DefaultAddress()
 	var err error
-	if options.Account != "" {
+	if options.AccountKey != "" {
 		signer, err = options.GetSigner(ca.keyring)
 		if err != nil {
 			return nil, err
@@ -551,7 +551,7 @@ func (ca *CoreAccessor) GrantFee(
 ) (*TxResponse, error) {
 	granter := ca.client.DefaultAddress()
 	var err error
-	if options.Account != "" {
+	if options.AccountKey != "" {
 		granter, err = options.GetSigner(ca.keyring)
 		if err != nil {
 			return nil, err
@@ -577,7 +577,7 @@ func (ca *CoreAccessor) RevokeGrantFee(
 ) (*TxResponse, error) {
 	granter := ca.client.DefaultAddress()
 	var err error
-	if options.Account != "" {
+	if options.AccountKey != "" {
 		granter, err = options.GetSigner(ca.keyring)
 		if err != nil {
 			return nil, err

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -206,7 +206,7 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 	}
 
 	var feeGrant user.TxOption
-	// set granter and update gasLimit in case node run in a grantee mode
+	// set granter and update gas in case node run in a grantee mode
 	if options.Granter != "" {
 		granter, err := options.GetGranter()
 		if err != nil {
@@ -238,7 +238,7 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 
 	var lastErr error
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		opts := []user.TxOption{user.SetGasLimit(options.GasLimit), user.SetFee(options.GetFee())}
+		opts := []user.TxOption{user.SetGasLimitAndFee(options.Gas, float64(options.GetFee()))}
 		if feeGrant != nil {
 			opts = append(opts, feeGrant)
 		}
@@ -258,7 +258,7 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 		// update our version accordingly
 		if apperrors.IsInsufficientMinGasPrice(err) && !estimatedFee {
 			// The error message contains enough information to parse the new min gas price
-			minGasPrice, err = apperrors.ParseInsufficientMinGasPrice(err, minGasPrice, options.GasLimit)
+			minGasPrice, err = apperrors.ParseInsufficientMinGasPrice(err, minGasPrice, options.Gas)
 			if err != nil {
 				return nil, fmt.Errorf("parsing insufficient min gas price error: %w", err)
 			}
@@ -658,7 +658,7 @@ func (ca *CoreAccessor) submitMsg(
 		}
 	}
 
-	txOptions = append(txOptions, user.SetGasLimit(options.GasLimit), user.SetFee(options.GetFee()))
+	txOptions = append(txOptions, user.SetGasLimitAndFee(options.Gas, float64(options.GetFee())))
 
 	if options.Granter != "" {
 		granter, err := options.GetGranter()

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -217,7 +217,7 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 	}
 
 	gasPrice := cfg.GasPrice()
-	if cfg.GasPrice() == DefaultPrice {
+	if cfg.GasPrice() == DefaultGasPrice {
 		gasPrice = ca.getMinGasPrice()
 	}
 
@@ -642,7 +642,7 @@ func (ca *CoreAccessor) submitMsg(
 	}
 
 	gasPrice := cfg.GasPrice()
-	if gasPrice == DefaultPrice {
+	if gasPrice == DefaultGasPrice {
 		gasPrice = ca.minGasPrice
 	}
 

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -189,7 +189,7 @@ func (ca *CoreAccessor) cancelCtx() {
 func (ca *CoreAccessor) SubmitPayForBlob(
 	ctx context.Context,
 	appblobs []*Blob,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	if len(appblobs) == 0 {
 		return nil, errors.New("state: no blobs provided")
@@ -214,7 +214,7 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 	}
 
 	gasPrice := options.GasPrice()
-	if options.GasPrice() < 0 {
+	if options.GasPrice() == DefaultPrice {
 		gasPrice = ca.getMinGasPrice()
 	}
 
@@ -377,7 +377,7 @@ func (ca *CoreAccessor) Transfer(
 	ctx context.Context,
 	addr AccAddress,
 	amount Int,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	if amount.IsNil() || amount.Int64() <= 0 {
 		return nil, ErrInvalidAmount
@@ -402,7 +402,7 @@ func (ca *CoreAccessor) CancelUnbondingDelegation(
 	valAddr ValAddress,
 	amount,
 	height Int,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	if amount.IsNil() || amount.Int64() <= 0 {
 		return nil, ErrInvalidAmount
@@ -427,7 +427,7 @@ func (ca *CoreAccessor) BeginRedelegate(
 	srcValAddr,
 	dstValAddr ValAddress,
 	amount Int,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	if amount.IsNil() || amount.Int64() <= 0 {
 		return nil, ErrInvalidAmount
@@ -451,7 +451,7 @@ func (ca *CoreAccessor) Undelegate(
 	ctx context.Context,
 	delAddr ValAddress,
 	amount Int,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	if amount.IsNil() || amount.Int64() <= 0 {
 		return nil, ErrInvalidAmount
@@ -475,7 +475,7 @@ func (ca *CoreAccessor) Delegate(
 	ctx context.Context,
 	delAddr ValAddress,
 	amount Int,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	if amount.IsNil() || amount.Int64() <= 0 {
 		return nil, ErrInvalidAmount
@@ -534,7 +534,7 @@ func (ca *CoreAccessor) GrantFee(
 	ctx context.Context,
 	grantee AccAddress,
 	amount Int,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	var (
 		granter = ca.client.DefaultAddress()
@@ -564,7 +564,7 @@ func (ca *CoreAccessor) GrantFee(
 func (ca *CoreAccessor) RevokeGrantFee(
 	ctx context.Context,
 	grantee AccAddress,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	var (
 		granter = ca.client.DefaultAddress()
@@ -649,7 +649,7 @@ func (ca *CoreAccessor) setupTxClient(ctx context.Context, keyName string) (*use
 func (ca *CoreAccessor) submitMsg(
 	ctx context.Context,
 	msg sdktypes.Msg,
-	options Options,
+	options *TxOptions,
 ) (*TxResponse, error) {
 	txOptions := make([]user.TxOption, 0)
 	var (
@@ -664,7 +664,7 @@ func (ca *CoreAccessor) submitMsg(
 	}
 
 	gasPrice := options.GasPrice()
-	if gasPrice < 0 {
+	if gasPrice == DefaultPrice {
 		gasPrice = ca.minGasPrice
 	}
 

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -50,7 +50,7 @@ func TestSubmitPayForBlob(t *testing.T) {
 		{
 			name:     "empty blobs",
 			blobs:    []*apptypes.Blob{},
-			gasPrice: DefaultPrice,
+			gasPrice: DefaultGasPrice,
 			gasLim:   0,
 			expErr:   errors.New("state: no blobs provided"),
 		},
@@ -115,7 +115,7 @@ func TestTransfer(t *testing.T) {
 	}{
 		{
 			name:     "transfer without options",
-			gasPrice: DefaultPrice,
+			gasPrice: DefaultGasPrice,
 			gasLim:   0,
 			account:  "",
 			expErr:   nil,
@@ -177,7 +177,7 @@ func TestDelegate(t *testing.T) {
 	}{
 		{
 			name:     "delegate/undelegate without options",
-			gasPrice: DefaultPrice,
+			gasPrice: DefaultGasPrice,
 			gasLim:   0,
 			account:  "",
 		},

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"cosmossdk.io/math"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
@@ -44,25 +43,25 @@ func TestSubmitPayForBlob(t *testing.T) {
 	require.Equal(t, appconsts.DefaultMinGasPrice, minGas)
 
 	testcases := []struct {
-		name   string
-		blobs  []*blob.Blob
-		fee    math.Int
-		gasLim uint64
-		expErr error
+		name     string
+		blobs    []*blob.Blob
+		gasPrice float64
+		gasLim   uint64
+		expErr   error
 	}{
 		{
-			name:   "empty blobs",
-			blobs:  []*blob.Blob{},
-			fee:    sdktypes.ZeroInt(),
-			gasLim: 0,
-			expErr: errors.New("state: no blobs provided"),
+			name:     "empty blobs",
+			blobs:    []*blob.Blob{},
+			gasPrice: options.DefaultPrice,
+			gasLim:   0,
+			expErr:   errors.New("state: no blobs provided"),
 		},
 		{
-			name:   "good blob with user provided gas and fees",
-			blobs:  []*blob.Blob{blobbyTheBlob},
-			fee:    sdktypes.NewInt(10_000), // roughly 0.12 utia per gas (should be good)
-			gasLim: blobtypes.DefaultEstimateGas([]uint32{uint32(len(blobbyTheBlob.Data))}),
-			expErr: nil,
+			name:     "good blob with user provided gas and fees",
+			blobs:    []*blob.Blob{blobbyTheBlob},
+			gasPrice: 0.005,
+			gasLim:   blobtypes.DefaultEstimateGas([]uint32{uint32(len(blobbyTheBlob.Data))}),
+			expErr:   nil,
 		},
 		// TODO: add more test cases. The problem right now is that the celestia-app doesn't
 		// correctly construct the node (doesn't pass the min gas price) hence the price on
@@ -83,7 +82,7 @@ func TestSubmitPayForBlob(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := options.DefaultTxOptions()
 			opts.Gas = tc.gasLim
-			opts.SetFeeAmount(tc.fee.Int64())
+			opts.SetGasPrice(tc.gasPrice)
 			opts.AccountKey = accounts[2]
 			resp, err := ca.SubmitPayForBlob(ctx, tc.blobs, opts)
 			require.Equal(t, tc.expErr, err)
@@ -109,32 +108,32 @@ func TestTransfer(t *testing.T) {
 	require.Equal(t, appconsts.DefaultMinGasPrice, minGas)
 
 	testcases := []struct {
-		name    string
-		fee     int64
-		gasLim  uint64
-		account string
-		expErr  error
+		name     string
+		gasPrice float64
+		gasLim   uint64
+		account  string
+		expErr   error
 	}{
 		{
-			name:    "transfer without options",
-			fee:     -1,
-			gasLim:  0,
-			account: "",
-			expErr:  nil,
+			name:     "transfer without options",
+			gasPrice: options.DefaultPrice,
+			gasLim:   0,
+			account:  "",
+			expErr:   nil,
 		},
 		{
-			name:    "transfer with options",
-			fee:     2_000,
-			gasLim:  0,
-			account: accounts[2],
-			expErr:  nil,
+			name:     "transfer with options",
+			gasPrice: 0.005,
+			gasLim:   0,
+			account:  accounts[2],
+			expErr:   nil,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := options.DefaultTxOptions()
-			opts.SetFeeAmount(tc.fee)
+			opts.SetGasPrice(tc.gasPrice)
 			opts.Gas = tc.gasLim
 			if tc.account != "" {
 				opts.AccountKey = tc.account
@@ -174,29 +173,29 @@ func TestDelegate(t *testing.T) {
 	require.NoError(t, err)
 
 	testcases := []struct {
-		name    string
-		fee     int64
-		gasLim  uint64
-		account string
+		name     string
+		gasPrice float64
+		gasLim   uint64
+		account  string
 	}{
 		{
-			name:    "delegate/undelegate without options",
-			fee:     -1,
-			gasLim:  0,
-			account: "",
+			name:     "delegate/undelegate without options",
+			gasPrice: options.DefaultPrice,
+			gasLim:   0,
+			account:  "",
 		},
 		{
-			name:    "delegate/undelegate with options",
-			fee:     2_000,
-			gasLim:  0,
-			account: accounts[2],
+			name:     "delegate/undelegate with options",
+			gasPrice: 0.005,
+			gasLim:   0,
+			account:  accounts[2],
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := options.DefaultTxOptions()
-			opts.SetFeeAmount(tc.fee)
+			opts.SetGasPrice(tc.gasPrice)
 			opts.Gas = tc.gasLim
 			if tc.account != "" {
 				opts.AccountKey = tc.account
@@ -208,7 +207,7 @@ func TestDelegate(t *testing.T) {
 
 			// reset for empty case
 			opts = options.DefaultTxOptions()
-			opts.SetFeeAmount(tc.fee)
+			opts.SetGasPrice(tc.gasPrice)
 			opts.Gas = tc.gasLim
 			if tc.account != "" {
 				opts.AccountKey = tc.account

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -81,7 +81,7 @@ func TestSubmitPayForBlob(t *testing.T) {
 			opts := NewTxOptions(
 				WithGas(tc.gasLim),
 				WithGasPrice(tc.gasPrice),
-				WithAccountKey(accounts[2]),
+				WithKeyName(accounts[2]),
 			)
 			resp, err := ca.SubmitPayForBlob(ctx, tc.blobs, opts)
 			require.Equal(t, tc.expErr, err)
@@ -134,7 +134,7 @@ func TestTransfer(t *testing.T) {
 			opts := NewTxOptions(
 				WithGas(tc.gasLim),
 				WithGasPrice(tc.gasPrice),
-				WithAccountKey(accounts[2]),
+				WithKeyName(accounts[2]),
 			)
 			key, err := ca.keyring.Key(accounts[1])
 			require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestDelegate(t *testing.T) {
 			opts := NewTxOptions(
 				WithGas(tc.gasLim),
 				WithGasPrice(tc.gasPrice),
-				WithAccountKey(accounts[2]),
+				WithKeyName(accounts[2]),
 			)
 			resp, err := ca.Delegate(ctx, ValAddress(valAddr), sdktypes.NewInt(100_000), opts)
 			require.NoError(t, err)

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -84,7 +84,7 @@ func TestSubmitPayForBlob(t *testing.T) {
 			opts := options.DefaultTxOptions()
 			opts.Gas = tc.gasLim
 			opts.SetFeeAmount(tc.fee.Int64())
-			opts.Account = accounts[2]
+			opts.AccountKey = accounts[2]
 			resp, err := ca.SubmitPayForBlob(ctx, tc.blobs, opts)
 			require.Equal(t, tc.expErr, err)
 			if err == nil {
@@ -137,7 +137,7 @@ func TestTransfer(t *testing.T) {
 			opts.SetFeeAmount(tc.fee)
 			opts.Gas = tc.gasLim
 			if tc.account != "" {
-				opts.Account = tc.account
+				opts.AccountKey = tc.account
 			}
 
 			key, err := ca.keyring.Key(accounts[1])
@@ -199,7 +199,7 @@ func TestDelegate(t *testing.T) {
 			opts.SetFeeAmount(tc.fee)
 			opts.Gas = tc.gasLim
 			if tc.account != "" {
-				opts.Account = tc.account
+				opts.AccountKey = tc.account
 			}
 
 			resp, err := ca.Delegate(ctx, ValAddress(valAddr), sdktypes.NewInt(100_000), opts)
@@ -211,7 +211,7 @@ func TestDelegate(t *testing.T) {
 			opts.SetFeeAmount(tc.fee)
 			opts.Gas = tc.gasLim
 			if tc.account != "" {
-				opts.Account = tc.account
+				opts.AccountKey = tc.account
 			}
 			resp, err = ca.Undelegate(ctx, ValAddress(valAddr), sdktypes.NewInt(100_000), opts)
 			require.NoError(t, err)

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -82,7 +82,7 @@ func TestSubmitPayForBlob(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := options.DefaultTxOptions()
-			opts.GasLimit = tc.gasLim
+			opts.Gas = tc.gasLim
 			opts.SetFeeAmount(tc.fee.Int64())
 			opts.Account = accounts[2]
 			resp, err := ca.SubmitPayForBlob(ctx, tc.blobs, opts)
@@ -135,7 +135,7 @@ func TestTransfer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := options.DefaultTxOptions()
 			opts.SetFeeAmount(tc.fee)
-			opts.GasLimit = tc.gasLim
+			opts.Gas = tc.gasLim
 			if tc.account != "" {
 				opts.Account = tc.account
 			}
@@ -197,7 +197,7 @@ func TestDelegate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := options.DefaultTxOptions()
 			opts.SetFeeAmount(tc.fee)
-			opts.GasLimit = tc.gasLim
+			opts.Gas = tc.gasLim
 			if tc.account != "" {
 				opts.Account = tc.account
 			}
@@ -209,7 +209,7 @@ func TestDelegate(t *testing.T) {
 			// reset for empty case
 			opts = options.DefaultTxOptions()
 			opts.SetFeeAmount(tc.fee)
-			opts.GasLimit = tc.gasLim
+			opts.Gas = tc.gasLim
 			if tc.account != "" {
 				opts.Account = tc.account
 			}

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -137,12 +137,7 @@ func TestTransfer(t *testing.T) {
 			opts.SetFeeAmount(tc.fee)
 			opts.GasLimit = tc.gasLim
 			if tc.account != "" {
-				key, err := ca.keyring.Key(accounts[2])
-				require.NoError(t, err)
-				addr, err := key.GetAddress()
-
-				require.NoError(t, err)
-				opts.Account = addr.String()
+				opts.Account = tc.account
 			}
 
 			key, err := ca.keyring.Key(accounts[1])
@@ -204,12 +199,7 @@ func TestDelegate(t *testing.T) {
 			opts.SetFeeAmount(tc.fee)
 			opts.GasLimit = tc.gasLim
 			if tc.account != "" {
-				key, err := ca.keyring.Key(accounts[2])
-				require.NoError(t, err)
-				addr, err := key.GetAddress()
-
-				require.NoError(t, err)
-				opts.Account = addr.String()
+				opts.Account = tc.account
 			}
 
 			resp, err := ca.Delegate(ctx, ValAddress(valAddr), sdktypes.NewInt(100_000), opts)
@@ -221,12 +211,7 @@ func TestDelegate(t *testing.T) {
 			opts.SetFeeAmount(tc.fee)
 			opts.GasLimit = tc.gasLim
 			if tc.account != "" {
-				key, err := ca.keyring.Key(accounts[2])
-				require.NoError(t, err)
-				addr, err := key.GetAddress()
-
-				require.NoError(t, err)
-				opts.Account = addr.String()
+				opts.Account = tc.account
 			}
 			resp, err = ca.Undelegate(ctx, ValAddress(valAddr), sdktypes.NewInt(100_000), opts)
 			require.NoError(t, err)

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -68,7 +68,7 @@ func TestSubmitPayForBlob(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := ca.SubmitPayForBlob(ctx, tc.blobs, NewTxOptions())
+			resp, err := ca.SubmitPayForBlob(ctx, tc.blobs, NewTxConfig())
 			require.Equal(t, tc.expErr, err)
 			if err == nil {
 				require.EqualValues(t, 0, resp.Code)
@@ -78,7 +78,7 @@ func TestSubmitPayForBlob(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			opts := NewTxOptions(
+			opts := NewTxConfig(
 				WithGas(tc.gasLim),
 				WithGasPrice(tc.gasPrice),
 				WithKeyName(accounts[2]),
@@ -131,7 +131,7 @@ func TestTransfer(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			opts := NewTxOptions(
+			opts := NewTxConfig(
 				WithGas(tc.gasLim),
 				WithGasPrice(tc.gasPrice),
 				WithKeyName(accounts[2]),
@@ -191,7 +191,7 @@ func TestDelegate(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			opts := NewTxOptions(
+			opts := NewTxConfig(
 				WithGas(tc.gasLim),
 				WithGasPrice(tc.gasPrice),
 				WithKeyName(accounts[2]),

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -21,25 +21,14 @@ import (
 
 	"github.com/celestiaorg/celestia-node/blob"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/state/options"
 )
 
 func TestSubmitPayForBlob(t *testing.T) {
-	accounts := []string{"jimy", "rob"}
-	tmCfg := testnode.DefaultTendermintConfig()
-	tmCfg.Consensus.TimeoutCommit = time.Millisecond * 1
-	appConf := testnode.DefaultAppConfig()
-	appConf.API.Enable = true
-	appConf.MinGasPrices = fmt.Sprintf("0.002%s", app.BondDenom)
-
-	config := testnode.DefaultConfig().WithTendermintConfig(tmCfg).WithAppConfig(appConf).WithAccounts(accounts)
-	cctx, _, grpcAddr := testnode.NewNetwork(t, config)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ca, err := NewCoreAccessor(cctx.Keyring, accounts[0], nil, "127.0.0.1", extractPort(grpcAddr))
-	require.NoError(t, err)
+	ctx := context.Background()
+	ca, accounts := buildAccessor(t)
 	// start the accessor
-	err = ca.Start(ctx)
+	err := ca.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = ca.Stop(ctx)
@@ -82,7 +71,21 @@ func TestSubmitPayForBlob(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := ca.SubmitPayForBlob(ctx, tc.fee, tc.gasLim, tc.blobs)
+			resp, err := ca.SubmitPayForBlob(ctx, tc.blobs, options.DefaultTxOptions())
+			require.Equal(t, tc.expErr, err)
+			if err == nil {
+				require.EqualValues(t, 0, resp.Code)
+			}
+		})
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := options.DefaultTxOptions()
+			opts.GasLimit = tc.gasLim
+			opts.SetFeeAmount(tc.fee.Int64())
+			opts.Account = accounts[2]
+			resp, err := ca.SubmitPayForBlob(ctx, tc.blobs, opts)
 			require.Equal(t, tc.expErr, err)
 			if err == nil {
 				require.EqualValues(t, 0, resp.Code)
@@ -91,7 +94,166 @@ func TestSubmitPayForBlob(t *testing.T) {
 	}
 }
 
+func TestTransfer(t *testing.T) {
+	ctx := context.Background()
+	ca, accounts := buildAccessor(t)
+	// start the accessor
+	err := ca.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ca.Stop(ctx)
+	})
+
+	minGas, err := ca.queryMinimumGasPrice(ctx)
+	require.NoError(t, err)
+	require.Equal(t, appconsts.DefaultMinGasPrice, minGas)
+
+	testcases := []struct {
+		name    string
+		fee     int64
+		gasLim  uint64
+		account string
+		expErr  error
+	}{
+		{
+			name:    "transfer without options",
+			fee:     -1,
+			gasLim:  0,
+			account: "",
+			expErr:  nil,
+		},
+		{
+			name:    "transfer with options",
+			fee:     2_000,
+			gasLim:  0,
+			account: accounts[2],
+			expErr:  nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := options.DefaultTxOptions()
+			opts.SetFeeAmount(tc.fee)
+			opts.GasLimit = tc.gasLim
+			if tc.account != "" {
+				key, err := ca.keyring.Key(accounts[2])
+				require.NoError(t, err)
+				addr, err := key.GetAddress()
+
+				require.NoError(t, err)
+				opts.Account = addr.String()
+			}
+
+			key, err := ca.keyring.Key(accounts[1])
+			require.NoError(t, err)
+			addr, err := key.GetAddress()
+			require.NoError(t, err)
+
+			resp, err := ca.Transfer(ctx, addr, sdktypes.NewInt(10_000), opts)
+			require.Equal(t, tc.expErr, err)
+			if err == nil {
+				require.EqualValues(t, 0, resp.Code)
+			}
+		})
+	}
+}
+
+func TestDelegate(t *testing.T) {
+	ctx := context.Background()
+	ca, accounts := buildAccessor(t)
+	// start the accessor
+	err := ca.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ca.Stop(ctx)
+	})
+
+	minGas, err := ca.queryMinimumGasPrice(ctx)
+	require.NoError(t, err)
+	require.Equal(t, appconsts.DefaultMinGasPrice, minGas)
+
+	valRec, err := ca.keyring.Key("validator")
+	require.NoError(t, err)
+	valAddr, err := valRec.GetAddress()
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name    string
+		fee     int64
+		gasLim  uint64
+		account string
+	}{
+		{
+			name:    "delegate/undelegate without options",
+			fee:     -1,
+			gasLim:  0,
+			account: "",
+		},
+		{
+			name:    "delegate/undelegate with options",
+			fee:     2_000,
+			gasLim:  0,
+			account: accounts[2],
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := options.DefaultTxOptions()
+			opts.SetFeeAmount(tc.fee)
+			opts.GasLimit = tc.gasLim
+			if tc.account != "" {
+				key, err := ca.keyring.Key(accounts[2])
+				require.NoError(t, err)
+				addr, err := key.GetAddress()
+
+				require.NoError(t, err)
+				opts.Account = addr.String()
+			}
+
+			resp, err := ca.Delegate(ctx, ValAddress(valAddr), sdktypes.NewInt(100_000), opts)
+			require.NoError(t, err)
+			require.EqualValues(t, 0, resp.Code)
+
+			// reset for empty case
+			opts = options.DefaultTxOptions()
+			opts.SetFeeAmount(tc.fee)
+			opts.GasLimit = tc.gasLim
+			if tc.account != "" {
+				key, err := ca.keyring.Key(accounts[2])
+				require.NoError(t, err)
+				addr, err := key.GetAddress()
+
+				require.NoError(t, err)
+				opts.Account = addr.String()
+			}
+			resp, err = ca.Undelegate(ctx, ValAddress(valAddr), sdktypes.NewInt(100_000), opts)
+			require.NoError(t, err)
+			require.EqualValues(t, 0, resp.Code)
+		})
+	}
+}
+
 func extractPort(addr string) string {
 	splitStr := strings.Split(addr, ":")
 	return splitStr[len(splitStr)-1]
+}
+
+func buildAccessor(t *testing.T) (*CoreAccessor, []string) {
+	t.Helper()
+	accounts := []string{"jimmy", "carl", "sheen", "cindy"}
+	tmCfg := testnode.DefaultTendermintConfig()
+	tmCfg.Consensus.TimeoutCommit = time.Millisecond * 1
+
+	appConf := testnode.DefaultAppConfig()
+	appConf.API.Enable = true
+	appConf.MinGasPrices = fmt.Sprintf("0.002%s", app.BondDenom)
+
+	config := testnode.DefaultConfig().WithTendermintConfig(tmCfg).WithAppConfig(appConf).WithAccounts(accounts)
+	cctx, _, grpcAddr := testnode.NewNetwork(t, config)
+
+	ca, err := NewCoreAccessor(cctx.Keyring, accounts[0], nil, "127.0.0.1", extractPort(grpcAddr))
+	require.NoError(t, err)
+	return ca, accounts
 }

--- a/state/options/tx_options.go
+++ b/state/options/tx_options.go
@@ -38,7 +38,7 @@ type TxOptions struct {
 	// Specifies the key from the keystore associated with an account that
 	// will be used to sign transactions.
 	// NOTE: This `Account` must be available in the `Keystore`.
-	Account string
+	AccountKey string
 	// Specifies the account that will pay for the transaction.
 	// Input format Bech32.
 	FeeGranterAddress string
@@ -53,7 +53,7 @@ func DefaultTxOptions() *TxOptions {
 type jsonTxOptions struct {
 	Fee               *Fee   `json:"fee,omitempty"`
 	Gas               uint64 `json:"gas,omitempty"`
-	Account           string `json:"account,omitempty"`
+	AccountKey        string `json:"account,omitempty"`
 	FeeGranterAddress string `json:"granter,omitempty"`
 }
 
@@ -61,7 +61,7 @@ func (options *TxOptions) MarshalJSON() ([]byte, error) {
 	jsonOpts := &jsonTxOptions{
 		Fee:               options.fee,
 		Gas:               options.Gas,
-		Account:           options.Account,
+		AccountKey:        options.AccountKey,
 		FeeGranterAddress: options.FeeGranterAddress,
 	}
 	return json.Marshal(jsonOpts)
@@ -76,7 +76,7 @@ func (options *TxOptions) UnmarshalJSON(data []byte) error {
 
 	options.fee = jsonOpts.Fee
 	options.Gas = jsonOpts.Gas
-	options.Account = jsonOpts.Account
+	options.AccountKey = jsonOpts.AccountKey
 	options.FeeGranterAddress = jsonOpts.FeeGranterAddress
 	return nil
 }
@@ -137,10 +137,10 @@ func (options *TxOptions) EstimateGasForBlobs(blobSizes []uint32) {
 
 // GetSigner retrieves the keystore by the provided account name and returns the account address.
 func (options *TxOptions) GetSigner(kr keyring.Keyring) (sdktypes.AccAddress, error) {
-	if options.Account == "" {
+	if options.AccountKey == "" {
 		return nil, errNoAddressProvided
 	}
-	rec, err := kr.Key(options.Account)
+	rec, err := kr.Key(options.AccountKey)
 	if err != nil {
 		return nil, fmt.Errorf("getting account key: %w", err)
 	}

--- a/state/options/tx_options.go
+++ b/state/options/tx_options.go
@@ -32,6 +32,7 @@ var (
 type TxOptions struct {
 	// fee is private since it has to be set through `SetFeeAmount`
 	fee *Fee
+	// 0 Gas means users want us to calculate it for them.
 	Gas uint64
 
 	// Specifies the key from the keystore associated with an account that
@@ -40,7 +41,7 @@ type TxOptions struct {
 	Account string
 	// Specifies the account that will pay for the transaction.
 	// Input format Bech32.
-	Granter string
+	FeeGranterAddress string
 }
 
 func DefaultTxOptions() *TxOptions {
@@ -50,18 +51,18 @@ func DefaultTxOptions() *TxOptions {
 }
 
 type jsonTxOptions struct {
-	Fee     *Fee   `json:"fee,omitempty"`
-	Gas     uint64 `json:"gas,omitempty"`
-	Account string `json:"account,omitempty"`
-	Granter string `json:"granter,omitempty"`
+	Fee               *Fee   `json:"fee,omitempty"`
+	Gas               uint64 `json:"gas,omitempty"`
+	Account           string `json:"account,omitempty"`
+	FeeGranterAddress string `json:"granter,omitempty"`
 }
 
 func (options *TxOptions) MarshalJSON() ([]byte, error) {
 	jsonOpts := &jsonTxOptions{
-		Fee:     options.fee,
-		Gas:     options.Gas,
-		Account: options.Account,
-		Granter: options.Granter,
+		Fee:               options.fee,
+		Gas:               options.Gas,
+		Account:           options.Account,
+		FeeGranterAddress: options.FeeGranterAddress,
 	}
 	return json.Marshal(jsonOpts)
 }
@@ -76,7 +77,7 @@ func (options *TxOptions) UnmarshalJSON(data []byte) error {
 	options.fee = jsonOpts.Fee
 	options.Gas = jsonOpts.Gas
 	options.Account = jsonOpts.Account
-	options.Granter = jsonOpts.Granter
+	options.FeeGranterAddress = jsonOpts.FeeGranterAddress
 	return nil
 }
 
@@ -146,13 +147,13 @@ func (options *TxOptions) GetSigner(kr keyring.Keyring) (sdktypes.AccAddress, er
 	return rec.GetAddress()
 }
 
-// GetGranter converts provided granter address to the cosmos-sdk `AccAddress`
-func (options *TxOptions) GetGranter() (sdktypes.AccAddress, error) {
-	if options.Granter == "" {
-		return nil, fmt.Errorf("granter %s", errNoAddressProvided.Error())
+// GetFeeGranterAddress converts provided granter address to the cosmos-sdk `AccAddress`
+func (options *TxOptions) GetFeeGranterAddress() (sdktypes.AccAddress, error) {
+	if options.FeeGranterAddress == "" {
+		return nil, fmt.Errorf("granter address %s", errNoAddressProvided.Error())
 	}
 
-	return parseAccAddressFromString(options.Granter)
+	return parseAccAddressFromString(options.FeeGranterAddress)
 }
 
 type Fee struct {

--- a/state/options/tx_options.go
+++ b/state/options/tx_options.go
@@ -31,8 +31,8 @@ var (
 // TxOptions specifies additional options that will be applied to the Tx.
 type TxOptions struct {
 	// fee is private since it has to be set through `SetFeeAmount`
-	fee      *Fee
-	GasLimit uint64
+	fee *Fee
+	Gas uint64
 
 	// Specifies the key from the keystore associated with an account that
 	// will be used to sign transactions.
@@ -50,18 +50,18 @@ func DefaultTxOptions() *TxOptions {
 }
 
 type jsonTxOptions struct {
-	Fee      *Fee   `json:"fee,omitempty"`
-	GasLimit uint64 `json:"gasLimit,omitempty"`
-	Account  string `json:"account,omitempty"`
-	Granter  string `json:"granter,omitempty"`
+	Fee     *Fee   `json:"fee,omitempty"`
+	Gas     uint64 `json:"gas,omitempty"`
+	Account string `json:"account,omitempty"`
+	Granter string `json:"granter,omitempty"`
 }
 
 func (options *TxOptions) MarshalJSON() ([]byte, error) {
 	jsonOpts := &jsonTxOptions{
-		Fee:      options.fee,
-		GasLimit: options.GasLimit,
-		Account:  options.Account,
-		Granter:  options.Granter,
+		Fee:     options.fee,
+		Gas:     options.Gas,
+		Account: options.Account,
+		Granter: options.Granter,
 	}
 	return json.Marshal(jsonOpts)
 }
@@ -74,7 +74,7 @@ func (options *TxOptions) UnmarshalJSON(data []byte) error {
 	}
 
 	options.fee = jsonOpts.Fee
-	options.GasLimit = jsonOpts.GasLimit
+	options.Gas = jsonOpts.Gas
 	options.Account = jsonOpts.Account
 	options.Granter = jsonOpts.Granter
 	return nil
@@ -88,16 +88,16 @@ func (options *TxOptions) SetFeeAmount(amount int64) {
 	}
 }
 
-// CalculateFee calculates fee amount based on the `minGasPrice` and `GasLimit`.
-// NOTE: GasLimit can't be 0.
+// CalculateFee calculates fee amount based on the `minGasPrice` and `Gas`.
+// NOTE: Gas can't be 0.
 func (options *TxOptions) CalculateFee(minGasPrice float64) error {
-	if options.GasLimit == 0 {
+	if options.Gas == 0 {
 		return errNoGasProvided
 	}
 	if minGasPrice < 0 {
 		return errors.New(" gas price can't be negative")
 	}
-	options.fee.Amount = int64(math.Ceil(minGasPrice * float64(options.GasLimit)))
+	options.fee.Amount = int64(math.Ceil(minGasPrice * float64(options.Gas)))
 	options.fee.isSet = true
 	return nil
 }
@@ -113,13 +113,13 @@ func (options *TxOptions) IsFeeSet() bool {
 // EstimateGas estimates gas in case it has not been set.
 // NOTE: final result of the estimation will be multiplied by the `gasMultiplier`(1.1) to cover additional costs.
 func (options *TxOptions) EstimateGas(ctx context.Context, client *user.TxClient, msg sdktypes.Msg) error {
-	if options.GasLimit == 0 {
+	if options.Gas == 0 {
 		// set fee as 1utia helps to simulate the tx more reliably.
-		gasLimit, err := client.EstimateGas(ctx, []sdktypes.Msg{msg}, user.SetFee(1))
+		gas, err := client.EstimateGas(ctx, []sdktypes.Msg{msg}, user.SetFee(1))
 		if err != nil {
 			return fmt.Errorf("estimating gas: %w", err)
 		}
-		options.GasLimit = uint64(float64(gasLimit) * gasMultiplier)
+		options.Gas = uint64(float64(gas) * gasMultiplier)
 	}
 	return nil
 }
@@ -128,9 +128,9 @@ func (options *TxOptions) EstimateGas(ctx context.Context, client *user.TxClient
 // NOTE: final result of the estimation will be multiplied by the `gasMultiplier`(1.1)
 // to cover additional options of the Tx.
 func (options *TxOptions) EstimateGasForBlobs(blobSizes []uint32) {
-	if options.GasLimit == 0 {
-		gasLimit := apptypes.DefaultEstimateGas(blobSizes)
-		options.GasLimit = uint64(float64(gasLimit) * gasMultiplier)
+	if options.Gas == 0 {
+		gas := apptypes.DefaultEstimateGas(blobSizes)
+		options.Gas = uint64(float64(gas) * gasMultiplier)
 	}
 }
 

--- a/state/options/tx_options.go
+++ b/state/options/tx_options.go
@@ -1,0 +1,201 @@
+package options
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/celestiaorg/celestia-app/pkg/user"
+	apptypes "github.com/celestiaorg/celestia-app/x/blob/types"
+)
+
+const (
+	// gasMultiplier is used to increase gas limit in case if tx has additional options.
+	gasMultiplier = 1.1
+
+	//	Since 0 is a valid fee input for the Tx, the default value is -1.
+	defaultFeeAmount = -1
+)
+
+var (
+	errNoGasProvided     = errors.New("gas limit was not set")
+	errNoAddressProvided = errors.New("address was not set")
+)
+
+// TxOptions specifies additional options that will be applied to the Tx.
+type TxOptions struct {
+	// fee is private since it has to be set through `SetFeeAmount`
+	fee      *Fee
+	GasLimit uint64
+
+	// Specifies the key that should be used to sign transactions.
+	//  Should be a Bech32 string
+	// NOTE: This `Account` should be available in the `Keystore`.
+	Account string
+	// Specifies the account that will pay for the transaction.
+	//	//  Should be a Bech32 string
+	Granter string
+}
+
+func DefaultTxOptions() *TxOptions {
+	return &TxOptions{
+		fee:      DefaultFee(),
+		GasLimit: 0,
+		Account:  "",
+	}
+}
+
+type jsonTxOptions struct {
+	Fee      *Fee   `json:"fee,omitempty"`
+	GasLimit uint64 `json:"gasLimit,omitempty"`
+	Account  string `json:"account,omitempty"`
+	Granter  string `json:"granter,omitempty"`
+}
+
+func (options *TxOptions) MarshalJSON() ([]byte, error) {
+	jsonOpts := &jsonTxOptions{
+		Fee:      options.fee,
+		GasLimit: options.GasLimit,
+		Account:  options.Account,
+		Granter:  options.Granter,
+	}
+	return json.Marshal(jsonOpts)
+}
+
+func (options *TxOptions) UnmarshalJSON(data []byte) error {
+	var jsonOpts jsonTxOptions
+	err := json.Unmarshal(data, &jsonOpts)
+	if err != nil {
+		return fmt.Errorf("unmarshalling TxOptions:%w", err)
+	}
+
+	options.fee = jsonOpts.Fee
+	options.GasLimit = jsonOpts.GasLimit
+	options.Account = jsonOpts.Account
+	options.Granter = jsonOpts.Granter
+	return nil
+}
+
+// SetFeeAmount sets fee for the transaction.
+func (options *TxOptions) SetFeeAmount(amount int64) {
+	if amount >= 0 {
+		options.fee.Amount = amount
+		options.fee.isSet = true
+	}
+}
+
+// CalculateFee calculates fee amount as a `user.TxOption` that can be applied to the transactions,
+// based on the `minGasPrice` and `GasLimit`.
+// NOTE: it is very important to ensure that gas limit was set.
+func (options *TxOptions) CalculateFee(minGasPrice float64) error {
+	if options.GasLimit == 0 {
+		return errNoGasProvided
+	}
+	if minGasPrice < 0 {
+		return errors.New("minimum gas price should be equal or greater than zero")
+	}
+	options.fee.Amount = int64(math.Ceil(minGasPrice * float64(options.GasLimit)))
+	options.fee.isSet = true
+	return nil
+}
+
+func (options *TxOptions) GetFee() uint64 {
+	return uint64(options.fee.Amount)
+}
+
+func (options *TxOptions) IsFeeSet() bool {
+	return options.fee.isSet
+}
+
+// EstimateGas returns a gas limit as a `user.TxOption` that can be applied to the transactions.
+// GasLimit will be estimated in case it has not been set.
+// NOTE: final result of the estimation will be multiplied by the `gasMultiplier`(1.1) to cover additional сosts for the
+// options of the Tx, as not all options are counted in the `EstimateGas`
+func (options *TxOptions) EstimateGas(ctx context.Context, client *user.TxClient, msg sdktypes.Msg) error {
+	if options.GasLimit == 0 {
+		// Gas estimation depends on the amount of bytes of the original TX, including all options(Fee, Granter, etc.),
+		// so, it is very important to pass ALL options that will be applied to the tx.
+		// 1utia as fee is ok at this point(as fee may not be calculated yet).
+		gasLimit, err := client.EstimateGas(ctx, []sdktypes.Msg{msg}, user.SetFee(1))
+		if err != nil {
+			return fmt.Errorf("estimating gas: %w", err)
+		}
+		options.GasLimit = uint64(float64(gasLimit) * gasMultiplier)
+	}
+	return nil
+}
+
+// EstimateGasForBlobs returns a gas limit as a `user.TxOption` that can be applied to the `MsgPayForBlob` transactions.
+// NOTE: final result of the estimation will be multiplied by the `gasMultiplier`(1.1)
+// to cover additional options of the Tx.
+func (options *TxOptions) EstimateGasForBlobs(blobSizes []uint32) {
+	if options.GasLimit == 0 {
+		gasLimit := apptypes.DefaultEstimateGas(blobSizes)
+		options.GasLimit = uint64(float64(gasLimit) * gasMultiplier)
+	}
+}
+
+func (options *TxOptions) GetAccount() (sdktypes.AccAddress, error) {
+	if options.Account == "" {
+		return nil, errNoAddressProvided
+	}
+	return parseAccAddressFromString(options.Account)
+}
+
+func (options *TxOptions) GetGranter() (sdktypes.AccAddress, error) {
+	if options.Granter == "" {
+		return nil, fmt.Errorf("granter %s", errNoAddressProvided.Error())
+	}
+
+	return parseAccAddressFromString(options.Granter)
+}
+
+type Fee struct {
+	Amount int64
+	isSet  bool
+}
+
+// DefaultFee creates a Fee struct with the default value of fee amount.
+func DefaultFee() *Fee {
+	return &Fee{
+		Amount: defaultFeeAmount,
+	}
+}
+
+type jsonFee struct {
+	Amount int64 `json:"amount,omitempty"`
+	IsSet  bool  `json:"isSet,omitempty"`
+}
+
+func (f *Fee) MarshalJSON() ([]byte, error) {
+	fee := jsonFee{
+		Amount: f.Amount,
+		IsSet:  f.isSet,
+	}
+	return json.Marshal(fee)
+}
+
+func (f *Fee) UnmarshalJSON(data []byte) error {
+	var fee jsonFee
+	err := json.Unmarshal(data, &fee)
+	if err != nil {
+		return err
+	}
+
+	f.Amount = fee.Amount
+	f.isSet = fee.IsSet
+	if !f.isSet {
+		f.Amount = -1
+	}
+	return nil
+}
+
+func parseAccAddressFromString(addrStr string) (sdktypes.AccAddress, error) {
+	addrString := strings.Trim(addrStr, "\"")
+	return sdktypes.AccAddressFromBech32(addrString)
+}

--- a/state/state.go
+++ b/state/state.go
@@ -7,6 +7,8 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	coretypes "github.com/tendermint/tendermint/types"
+
+	apptypes "github.com/celestiaorg/celestia-app/x/blob/types"
 )
 
 // Balance is an alias to the Coin type from Cosmos-SDK.
@@ -23,6 +25,9 @@ type TxResponse = sdk.TxResponse
 type Address struct {
 	sdk.Address
 }
+
+// Blob is an alias of Blob from celestia-app.
+type Blob = apptypes.Blob
 
 // ValAddress is an alias to the ValAddress type from Cosmos-SDK.
 type ValAddress = sdk.ValAddress

--- a/state/tx_config.go
+++ b/state/tx_config.go
@@ -32,7 +32,6 @@ func NewTxConfig(attributes ...Attribute) *TxConfig {
 }
 
 // TxConfig specifies additional options that will be applied to the Tx.
-// Implements `Option` interface.
 type TxConfig struct {
 	// Specifies the address from the keystore that will sign transactions.
 	// NOTE: Only `signerAddress` or `KeyName` should be passed.

--- a/state/tx_config.go
+++ b/state/tx_config.go
@@ -20,13 +20,13 @@ const (
 	gasMultiplier = 1.1
 )
 
-// NewTxConfig constructs a new TxConfig with the provided attributes.
+// NewTxConfig constructs a new TxConfig with the provided options.
 // It starts with a DefaultGasPrice and then applies any additional
-// attributes provided through the variadic parameter.
-func NewTxConfig(attributes ...Attribute) *TxConfig {
+// options provided through the variadic parameter.
+func NewTxConfig(opts ...ConfigOption) *TxConfig {
 	options := &TxConfig{gasPrice: DefaultGasPrice}
-	for _, attr := range attributes {
-		attr(options)
+	for _, opt := range opts {
+		opt(options)
 	}
 	return options
 }
@@ -118,7 +118,7 @@ func estimateGas(ctx context.Context, client *user.TxClient, msg sdktypes.Msg) (
 	return uint64(float64(gas) * gasMultiplier), nil
 }
 
-// estimateGasForBlobs returns a gas limit as a `user.TxOption` that can be applied to the `MsgPayForBlob` transactions.
+// estimateGasForBlobs returns a gas limit that can be applied to the `MsgPayForBlob` transactions.
 // NOTE: final result of the estimation will be multiplied by the `gasMultiplier`(1.1)
 // to cover additional options of the Tx.
 func estimateGasForBlobs(blobSizes []uint32) uint64 {
@@ -138,14 +138,14 @@ func parseAccAddressFromString(addrStr string) (sdktypes.AccAddress, error) {
 	return sdktypes.AccAddressFromBech32(addrStr)
 }
 
-// Attribute is the functional option that is applied to the TxOption instance
+// ConfigOption is the functional option that is applied to the TxConfig instance
 // to configure parameters.
-type Attribute func(cfg *TxConfig)
+type ConfigOption func(cfg *TxConfig)
 
-// WithGasPrice is an attribute that allows to specify a GasPrice, which is needed
+// WithGasPrice is an option that allows to specify a GasPrice, which is needed
 // to calculate the fee. In case GasPrice is not specified, the global GasPrice fetched from
 // celestia-app will be used.
-func WithGasPrice(gasPrice float64) Attribute {
+func WithGasPrice(gasPrice float64) ConfigOption {
 	return func(cfg *TxConfig) {
 		if gasPrice >= 0 {
 			cfg.gasPrice = gasPrice
@@ -154,33 +154,33 @@ func WithGasPrice(gasPrice float64) Attribute {
 	}
 }
 
-// WithGas is an attribute that allows to specify Gas.
+// WithGas is an option that allows to specify Gas.
 // Gas will be calculated in case it wasn't specified.
-func WithGas(gas uint64) Attribute {
+func WithGas(gas uint64) ConfigOption {
 	return func(cfg *TxConfig) {
 		cfg.gas = gas
 	}
 }
 
-// WithKeyName is an attribute that allows you to specify an KeyName, which is needed to
+// WithKeyName is an option that allows you to specify an KeyName, which is needed to
 // sign the transaction. This key should be associated with the address and stored
 // locally in the key store. Default Account will be used in case it wasn't specified.
-func WithKeyName(key string) Attribute {
+func WithKeyName(key string) ConfigOption {
 	return func(cfg *TxConfig) {
 		cfg.keyName = key
 	}
 }
 
-// WithSignerAddress is an attribute that allows you to specify an address, that will sign the transaction.
+// WithSignerAddress is an option that allows you to specify an address, that will sign the transaction.
 // This address must be stored locally in the key store. Default signerAddress will be used in case it wasn't specified.
-func WithSignerAddress(address string) Attribute {
+func WithSignerAddress(address string) ConfigOption {
 	return func(cfg *TxConfig) {
 		cfg.signerAddress = address
 	}
 }
 
-// WithFeeGranterAddress is an attribute that allows you to specify a GranterAddress to pay the fees.
-func WithFeeGranterAddress(granter string) Attribute {
+// WithFeeGranterAddress is an option that allows you to specify a GranterAddress to pay the fees.
+func WithFeeGranterAddress(granter string) ConfigOption {
 	return func(cfg *TxConfig) {
 		cfg.feeGranterAddress = granter
 	}

--- a/state/tx_config.go
+++ b/state/tx_config.go
@@ -14,6 +14,8 @@ import (
 )
 
 const (
+	// DefaultPrice specifies the default gas price value to be used when the user
+	// wants to use the global minimal gas price, which is fetched from the celestia-app.
 	DefaultPrice float64 = -1.0
 	// gasMultiplier is used to increase gas limit in case if tx has additional cfg.
 	gasMultiplier = 1.1

--- a/state/tx_config.go
+++ b/state/tx_config.go
@@ -14,15 +14,18 @@ import (
 )
 
 const (
-	// DefaultPrice specifies the default gas price value to be used when the user
+	// DefaultGasPrice specifies the default gas price value to be used when the user
 	// wants to use the global minimal gas price, which is fetched from the celestia-app.
-	DefaultPrice float64 = -1.0
+	DefaultGasPrice float64 = -1.0
 	// gasMultiplier is used to increase gas limit in case if tx has additional cfg.
 	gasMultiplier = 1.1
 )
 
+// NewTxConfig constructs a new TxConfig with the provided attributes.
+// It starts with a DefaultGasPrice and then applies any additional
+// attributes provided through the variadic parameter.
 func NewTxConfig(attributes ...Attribute) *TxConfig {
-	options := &TxConfig{gasPrice: DefaultPrice}
+	options := &TxConfig{gasPrice: DefaultGasPrice}
 	for _, attr := range attributes {
 		attr(options)
 	}
@@ -56,7 +59,7 @@ type TxConfig struct {
 
 func (cfg *TxConfig) GasPrice() float64 {
 	if !cfg.isGasPriceSet {
-		return DefaultPrice
+		return DefaultGasPrice
 	}
 	return cfg.gasPrice
 }

--- a/state/tx_config.go
+++ b/state/tx_config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
@@ -107,12 +106,6 @@ func (cfg *TxConfig) UnmarshalJSON(data []byte) error {
 	cfg.gas = jsonOpts.Gas
 	cfg.feeGranterAddress = jsonOpts.FeeGranterAddress
 	return nil
-}
-
-// calculateFee calculates fee amount based on the `minGasPrice` and `Gas`.
-func calculateFee(gas uint64, gasPrice float64) int64 {
-	fee := int64(math.Ceil(gasPrice * float64(gas)))
-	return fee
 }
 
 // estimateGas estimates gas in case it has not been set.

--- a/state/tx_config_test.go
+++ b/state/tx_config_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMarshallingOptions(t *testing.T) {
-	opts := NewTxOptions(
+	opts := NewTxConfig(
 		WithGas(10_000),
 		WithGasPrice(0.002),
 		WithKeyName("test"),
@@ -19,7 +19,7 @@ func TestMarshallingOptions(t *testing.T) {
 	data, err := json.Marshal(opts)
 	require.NoError(t, err)
 
-	newOpts := &TxOptions{}
+	newOpts := &TxConfig{}
 	err = json.Unmarshal(data, newOpts)
 	require.NoError(t, err)
 	require.Equal(t, opts, newOpts)

--- a/state/tx_options.go
+++ b/state/tx_options.go
@@ -47,7 +47,6 @@ type TxOptions struct {
 	isGasPriceSet bool
 	// 0 gas means users want us to calculate it for them.
 	gas uint64
-
 	// Specifies the account that will pay for the transaction.
 	// Input format Bech32.
 	feeGranterAddress string

--- a/state/tx_options.go
+++ b/state/tx_options.go
@@ -43,11 +43,11 @@ func NewTxOptions(attributes ...Attribute) Options {
 // txOptions specifies additional options that will be applied to the Tx.
 // Implements `Option` interface.
 type txOptions struct {
-	// GasPrice represents the amount to be paid per gas unit.
-	// Negative GasPrice means user want us to use a minGasPrice,
-	// stored in node.
+	// gasPrice represents the amount to be paid per gas unit.
+	// Negative gasPrice means user want us to use the minGasPrice
+	// defined in the node.
 	gasPrice float64
-	// 0 Gas means users want us to calculate it for them.
+	// 0 gas means users want us to calculate it for them.
 	gas uint64
 
 	// Specifies the key from the keystore associated with an account that
@@ -88,7 +88,7 @@ func (options *txOptions) UnmarshalJSON(data []byte) error {
 	var jsonOpts jsonTxOptions
 	err := json.Unmarshal(data, &jsonOpts)
 	if err != nil {
-		return fmt.Errorf("unmarshalling TxOptions:%w", err)
+		return fmt.Errorf("unmarshalling TxOptions: %w", err)
 	}
 
 	options.gasPrice = jsonOpts.GasPrice

--- a/state/tx_options.go
+++ b/state/tx_options.go
@@ -136,7 +136,9 @@ func parseAccAddressFromString(addrStr string) (sdktypes.AccAddress, error) {
 // to configure parameters.
 type Attribute func(options *TxOptions)
 
-// WithGasPrice is an attribute that allows to specify a GasPrice
+// WithGasPrice is an attribute that allows to specify a GasPrice, which is needed
+// to calculate the fee. In case GasPrice is not specified, the global GasPrice fetched from
+// celestia-app will be used.
 func WithGasPrice(gasPrice float64) Attribute {
 	return func(options *TxOptions) {
 		if gasPrice >= 0 {
@@ -146,21 +148,24 @@ func WithGasPrice(gasPrice float64) Attribute {
 	}
 }
 
-// WithGas is an attribute that allows to specify a Gas
+// WithGas is an attribute that allows to specify Gas.
+// Gas will be calculated in case it wasn't specified.
 func WithGas(gas uint64) Attribute {
 	return func(options *TxOptions) {
 		options.gas = gas
 	}
 }
 
-// WithAccountKey is an attribute that allows to specify an AccountKey
+// WithAccountKey is an attribute that allows you to specify an AccountKey, which is needed to
+// sign the transaction. This key should be associated with the address and stored
+// locally in the key store. Default Account will be used in case it wasn't specified.
 func WithAccountKey(key string) Attribute {
 	return func(options *TxOptions) {
 		options.accountKey = key
 	}
 }
 
-// WithFeeGranterAddress is an attribute that allows to specify a GranterAddress
+// WithFeeGranterAddress is an attribute that allows you to specify a GranterAddress to pay the fees.
 func WithFeeGranterAddress(granter string) Attribute {
 	return func(options *TxOptions) {
 		options.feeGranterAddress = granter

--- a/state/tx_options.go
+++ b/state/tx_options.go
@@ -31,8 +31,8 @@ func NewTxOptions(attributes ...Attribute) *TxOptions {
 // Implements `Option` interface.
 type TxOptions struct {
 	// Specifies the address from the keystore that will sign transactions.
-	// NOTE: Only `accountAddress` or `KeyName` should be passed.
-	// accountAddress is a primary options. This means If both the address and the key are specified,
+	// NOTE: Only `signerAddress` or `KeyName` should be passed.
+	// signerAddress is a primary options. This means If both the address and the key are specified,
 	// the address field will take priority.
 	signerAddress string
 	// Specifies the key from the keystore associated with an account that

--- a/state/tx_options.go
+++ b/state/tx_options.go
@@ -1,4 +1,4 @@
-package options
+package state
 
 import (
 	"context"

--- a/state/tx_options_test.go
+++ b/state/tx_options_test.go
@@ -11,7 +11,8 @@ func TestMarshallingOptions(t *testing.T) {
 	opts := NewTxOptions(
 		WithGas(10_000),
 		WithGasPrice(0.002),
-		WithAccountKey("test"),
+		WithKeyName("test"),
+		WithSignerAddress("celestia1eucs6ax66ypjcmwj81hak531w6hyr2c4g8cfsgc"),
 		WithFeeGranterAddress("celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"),
 	)
 

--- a/state/tx_options_test.go
+++ b/state/tx_options_test.go
@@ -1,0 +1,25 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshallingOptions(t *testing.T) {
+	opts := NewTxOptions(
+		WithGas(10_000),
+		WithGasPrice(0.002),
+		WithAccountKey("test"),
+		WithFeeGranterAddress("celestia1hakc56ax66ypjcmwj8w6hyr2c4g8cfs3wesguc"),
+	)
+
+	data, err := json.Marshal(opts)
+	require.NoError(t, err)
+
+	newOpts := &TxOptions{}
+	err = json.Unmarshal(data, newOpts)
+	require.NoError(t, err)
+	require.Equal(t, opts, newOpts)
+}


### PR DESCRIPTION
Resolves #3346

What was done:
Implemented a new TxConfig struct
```go
// TxConfig specifies additional options that will be applied to the Tx.
type TxConfig struct {
	// Specifies the address from the keystore that will sign transactions.
	// NOTE: Only `accountAddress` or `KeyName` should be passed.
	// accountAddress is a primary options. This means If both the address and the key are specified,
	// the address field will take priority.
	signerAddress string
	// Specifies the key from the keystore associated with an account that
	// will be used to sign transactions.
	// NOTE: This `Account` must be available in the `Keystore`.
	keyName string
	// gasPrice represents the amount to be paid per gas unit.
	// Negative gasPrice means user want us to use the minGasPrice
	// defined in the node.
	gasPrice float64
	// since gasPrice can be 0, it is necessary to understand that user explicitly set it.
	isGasPriceSet bool
	// 0 gas means users want us to calculate it for them.
	gas uint64

	// Specifies the account that will pay for the transaction.
	// Input format Bech32.
	feeGranterAddress string
}
```

The keyName field allows the user to use a non-default account from the Keystore to pay fees.
The granter field is moved from the state config. The user will need to specify the granter address each time he wants to submit a tx with a granter.  The reason for moving the granter to the options struct is that previously user had to restart the node each time when he wanted to start/stop using `grantee` mode. 
Tested on mocha with several accounts:

``` 
celestia blob submit 0x42690c204d39600fddd3 'gm' --key.name testKey --gas 140000
{
  "result": {
    "height": 1383824,
    "commitments": [
      "IXg+08HV5RsPF3Lle8PH+B2TUGsGUsBiseflxh6wB5E="
    ]
  }
}
```

```
celestia blob submit 0x42690c204d39600fddd3 'gm' --gas.price 0.1 --gas 1400000 --granter.address celestia14s2aeemrzw34crdh79e6wj56kjzpu4ffmvxsyx
{
  "result": {
    "height": 1383809,
    "commitments": [
      "IXg+08HV5RsPF3Lle8PH+B2TUGsGUsBiseflxh6wB5E="
    ]
  }
}
```

```
celestia state transfer celestia14s2aeemrzw34crdh79e6wj56kjzpu4ffmvxsyx 10000 --gas 100000 --gas.price 0.1
{
  "result": {
    "height": 1383817,
    "txhash": "1F38E94AFAE8AA4C4819844100803B8D7C83016DB1C02148F332FBB8E8DBC857",
```

List of breaking changes:
* Added a TxConfig struct that is applied to all *write* transactions(transfer/submitPFB etc);
* Renamed `KeyringAccName` to `DefaultKeyName` and `KeyringBackend`  to `DefaultBackendName` in the config;
* Removed `blob.GasPrice` since `blob.Submit` requires `SubmitOptions` which are type alias of `TxConfig`;
* Reworked flags for tx submission through CLI;
* Added `state.Blob` which is an alias for `app.Blob`(State Module now requires blob type from app)(Was added to avoid circular dependency between node's blob Module and node's state Module);
