### PR TITLE
refactor(state/gateway)!: remove SubmitTx endpoint from RPC and Gateway

### DIFF
--- a/api/gateway/bindings.go
+++ b/api/gateway/bindings.go
@@ -14,12 +14,6 @@ func (h *Handler) RegisterEndpoints(rpc *Server) {
 	)
 
 	rpc.RegisterHandlerFunc(
-		submitTxEndpoint,
-		h.handleSubmitTx,
-		http.MethodPost,
-	)
-
-	rpc.RegisterHandlerFunc(
 		healthEndpoint,
 		h.handleHealthRequest,
 		http.MethodGet,

--- a/api/gateway/bindings_test.go
+++ b/api/gateway/bindings_test.go
@@ -28,12 +28,6 @@ func TestRegisterEndpoints(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "Submit transaction endpoint",
-			path:     submitTxEndpoint,
-			method:   http.MethodPost,
-			expected: true,
-		},
-		{
 			name:     "Get namespaced shares by height endpoint",
 			path:     fmt.Sprintf("%s/{%s}/height/{%s}", namespacedSharesEndpoint, namespaceKey, heightKey),
 			method:   http.MethodGet,

--- a/api/gateway/state.go
+++ b/api/gateway/state.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -13,8 +12,7 @@ import (
 )
 
 const (
-	balanceEndpoint  = "/balance"
-	submitTxEndpoint = "/submit_tx"
+	balanceEndpoint = "/balance"
 )
 
 const addrKey = "address"
@@ -23,11 +21,6 @@ var (
 	ErrInvalidAddressFormat = errors.New("address must be a valid account or validator address")
 	ErrMissingAddress       = errors.New("address not specified")
 )
-
-// submitTxRequest represents a request to submit a raw transaction
-type submitTxRequest struct {
-	Tx string `json:"tx"`
-}
 
 func (h *Handler) handleBalanceRequest(w http.ResponseWriter, r *http.Request) {
 	var (
@@ -68,35 +61,5 @@ func (h *Handler) handleBalanceRequest(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write(resp)
 	if err != nil {
 		log.Errorw("writing response", "endpoint", balanceEndpoint, "err", err)
-	}
-}
-
-func (h *Handler) handleSubmitTx(w http.ResponseWriter, r *http.Request) {
-	// decode request
-	var req submitTxRequest
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, submitTxEndpoint, err)
-		return
-	}
-	rawTx, err := hex.DecodeString(req.Tx)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, submitTxEndpoint, err)
-		return
-	}
-	// perform request
-	txResp, err := h.state.SubmitTx(r.Context(), rawTx)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, submitTxEndpoint, err)
-		return
-	}
-	resp, err := json.Marshal(txResp)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, submitTxEndpoint, err)
-		return
-	}
-	_, err = w.Write(resp)
-	if err != nil {
-		log.Errorw("writing response", "endpoint", submitTxEndpoint, "err", err)
 	}
 }

--- a/nodebuilder/state/mocks/api.go
+++ b/nodebuilder/state/mocks/api.go
@@ -14,7 +14,6 @@ import (
 	types0 "github.com/cosmos/cosmos-sdk/x/staking/types"
 	gomock "github.com/golang/mock/gomock"
 	types1 "github.com/tendermint/tendermint/proto/tendermint/types"
-	types2 "github.com/tendermint/tendermint/types"
 )
 
 // MockModule is a mock of Module interface.
@@ -218,21 +217,6 @@ func (m *MockModule) SubmitPayForBlob(arg0 context.Context, arg1 []*types1.Blob,
 func (mr *MockModuleMockRecorder) SubmitPayForBlob(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitPayForBlob", reflect.TypeOf((*MockModule)(nil).SubmitPayForBlob), arg0, arg1, arg2)
-}
-
-// SubmitTx mocks base method.
-func (m *MockModule) SubmitTx(arg0 context.Context, arg1 types2.Tx) (*types.TxResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitTx", arg0, arg1)
-	ret0, _ := ret[0].(*types.TxResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SubmitTx indicates an expected call of SubmitTx.
-func (mr *MockModuleMockRecorder) SubmitTx(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTx", reflect.TypeOf((*MockModule)(nil).SubmitTx), arg0, arg1)
 }
 
 // Transfer mocks base method.

--- a/nodebuilder/state/state.go
+++ b/nodebuilder/state/state.go
@@ -29,16 +29,11 @@ type Module interface {
 	// the node's current head (head-1). This is due to the fact that for block N, the block's
 	// `AppHash` is the result of applying the previous block's transaction list.
 	BalanceForAddress(ctx context.Context, addr state.Address) (*state.Balance, error)
-
 	// Transfer sends the given amount of coins from default wallet of the node to the given account
 	// address.
 	Transfer(
 		ctx context.Context, to state.AccAddress, amount state.Int, config *state.TxConfig,
 	) (*state.TxResponse, error)
-	// SubmitTx submits the given transaction/message to the
-	// Celestia network and blocks until the tx is included in
-	// a block.
-	SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, error)
 	// SubmitPayForBlob builds, signs and submits a PayForBlob transaction.
 	SubmitPayForBlob(
 		ctx context.Context,
@@ -116,7 +111,6 @@ type API struct {
 			amount state.Int,
 			config *state.TxConfig,
 		) (*state.TxResponse, error) `perm:"write"`
-		SubmitTx         func(ctx context.Context, tx state.Tx) (*state.TxResponse, error) `perm:"read"`
 		SubmitPayForBlob func(
 			ctx context.Context,
 			blobs []*state.Blob,
@@ -189,10 +183,6 @@ func (api *API) Transfer(
 	config *state.TxConfig,
 ) (*state.TxResponse, error) {
 	return api.Internal.Transfer(ctx, to, amount, config)
-}
-
-func (api *API) SubmitTx(ctx context.Context, tx state.Tx) (*state.TxResponse, error) {
-	return api.Internal.SubmitTx(ctx, tx)
 }
 
 func (api *API) SubmitPayForBlob(

--- a/nodebuilder/state/stub.go
+++ b/nodebuilder/state/stub.go
@@ -40,10 +40,6 @@ func (s stubbedStateModule) Transfer(
 	return nil, ErrNoStateAccess
 }
 
-func (s stubbedStateModule) SubmitTx(context.Context, state.Tx) (*state.TxResponse, error) {
-	return nil, ErrNoStateAccess
-}
-
 func (s stubbedStateModule) SubmitPayForBlob(
 	context.Context,
 	[]*state.Blob,

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/feegrant"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -28,7 +27,6 @@ import (
 	"github.com/celestiaorg/celestia-app/app/encoding"
 	apperrors "github.com/celestiaorg/celestia-app/app/errors"
 	"github.com/celestiaorg/celestia-app/pkg/user"
-	apptypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/header"
@@ -359,26 +357,6 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 		Denom:  app.BondDenom,
 		Amount: coin,
 	}, nil
-}
-
-func (ca *CoreAccessor) SubmitTx(ctx context.Context, tx Tx) (*TxResponse, error) {
-	txResp, err := apptypes.BroadcastTx(ctx, ca.coreConn, sdktx.BroadcastMode_BROADCAST_MODE_BLOCK, tx)
-	if err != nil {
-		return nil, err
-	}
-	return unsetTx(txResp.TxResponse), nil
-}
-
-func (ca *CoreAccessor) SubmitTxWithBroadcastMode(
-	ctx context.Context,
-	tx Tx,
-	mode sdktx.BroadcastMode,
-) (*TxResponse, error) {
-	txResp, err := apptypes.BroadcastTx(ctx, ca.coreConn, mode, tx)
-	if err != nil {
-		return nil, err
-	}
-	return unsetTx(txResp.TxResponse), nil
 }
 
 func (ca *CoreAccessor) Transfer(


### PR DESCRIPTION
This PR removes the `state.SubmitTx` endpoint from the RPC, and the `submit_tx` endpoint from the gateway. 

Related: #3348 
## Rationale
This endpoint was never fully documented, and no usage examples exist. 
When creating usage examples after a discussion in #3345 , we realized the endpoint is not very useful at all. In order to use it, you need to construct a transaction, importing app, tendermint... all to then proxy it to an app instance via node anyways. Here is a snippet from @jcstein in the docs tutorial for submitting data.

The example for `celestia-openrpc`/`celestia-node` would essentially be exactly the same, except we build a rpc connection to node instead of a grpc to app. I think it is clear from this example why SubmitTx is too much of a hassle to use, and if users do need this functionality for their use-case, it is likely a sign that they should be interacting with app directly instead anyways.

To verify this, @Bidon15 reached out to teams to get feedback on this decision. All teams confirmed that the endpoint is not being used and not needed.

We support enough transaction types in the state module. If users need more functionality, we should either add the granularity to the current methods or add specific methods for specific transaction types/use cases. Dropping down a level to SubmitTx should never be needed if our API is good enough.

### Example (using app conn)
```go
import (
    "context"
    "fmt"

    "github.com/celestiaorg/celestia-app/app"
    "github.com/celestiaorg/celestia-app/app/encoding"
    "github.com/celestiaorg/celestia-app/pkg/appconsts"
    "github.com/celestiaorg/celestia-app/pkg/namespace"
    "github.com/celestiaorg/celestia-app/pkg/user"
    blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
    "github.com/cosmos/cosmos-sdk/crypto/keyring"
    tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
    "google.golang.org/grpc"
    "google.golang.org/grpc/credentials/insecure"
)

// SubmitData is a demo function that shows how to use the signer to submit data
// to the blockchain directly via a celestia node. We can manage this keyring
// using the `celestia-appd keys` or `celestia keys` sub commands and load this
// keyring from a file and use it to programmatically sign transactions.
func DemoSubmitData(grpcAddr string, kr keyring.Keyring) error {
    // create an encoding config that can decode and encode all celestia-app
    // data structures.
    ecfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)

    // create a connection to the grpc server on the consensus node.
    conn, err := grpc.Dial(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
    if err != nil {
        return err
    }
    defer conn.Close()

    // get the address of the account we want to use to sign transactions.
    rec, err := kr.Key("accountName")
    if err != nil {
        return err
    }

    addr, err := rec.GetAddress()
    if err != nil {
        return err
    }

    // Setup the signer. This function will automatically query the relevant
    // account information such as sequence (nonce) and account number.
    signer, err := user.SetupSigner(context.TODO(), kr, conn, addr, ecfg)
    if err != nil {
        return err
    }

    ns := namespace.MustNewV0([]byte("1234567890"))

    fmt.Println("namespace", len(ns.Bytes()))

    blob, err := blobtypes.NewBlob(ns, []byte("some data"), appconsts.ShareVersionZero)
    if err != nil {
        return err
    }

    gasLimit := blobtypes.DefaultEstimateGas([]uint32{uint32(len(blob.Data))})

    options := []user.TxOption{
        // here we're setting estimating the gas limit from the above estimated
        // function, and then setting the gas price to 0.1utia per unit of gas.
        user.SetGasLimitAndFee(gasLimit, 0.1),
    }

    // this function will submit the transaction and block until a timeout is
    // reached or the transaction is committed.
    resp, err := signer.SubmitPayForBlob(context.TODO(), []*tmproto.Blob{blob}, options...)
    if err != nil {
        return err
    }

    // check the response code to see if the transaction was successful.
    if resp.Code != 0 {
        // handle code
        fmt.Println(resp.Code, resp.Codespace, resp.RawLog)
    }

    // if we don't want to wait for the transaction to be confirmed, we can
    // manually sign and submit the transaction using the same package.
    blobTx, err := signer.CreatePayForBlob([]*tmproto.Blob{blob}, options...)
    if err != nil {
        return err
    }

    resp, err = signer.BroadcastTx(context.TODO(), blobTx)
    if err != nil {
        return err
    }

    // check the response code to see if the transaction was successful. Note
    // that this time we're not waiting for the transaction to be committed.
    // Therefore the code here is only from the consensus node's mempool.
    if resp.Code != 0 {
        // handle code
        fmt.Println(resp.Code, resp.Codespace, resp.RawLog)
    }

    return err
}
``` 


