### PR TITLE
chore(logs): lower bitswap-server verbosity

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -27,6 +27,7 @@ func SetAllLoggers(level logging.LogLevel) {
 	_ = logging.SetLogLevel("dagstore", "WARN")
 	_ = logging.SetLogLevel("dagstore/upgrader", "WARN")
 	_ = logging.SetLogLevel("fx", "FATAL")
+	_ = logging.SetLogLevel("bitswap-server", "WARN")
 }
 
 func SetDebugLogging() {


### PR DESCRIPTION
```
May 24 04:10:51 celestia[1806932]: 2024-05-24T04:10:51.439Z        INFO        bitswap-server        server/server.go:547        Bitswap Client ReceiveError: Application error 0x0 (local)
May 24 04:10:51 celestia[1806932]: 2024-05-24T04:10:51.440Z        INFO        bitswap-server        server/server.go:547        Bitswap Client ReceiveError: stream reset
May 24 04:10:51 celestia[1806932]: 2024-05-24T04:10:51.443Z        INFO        bitswap-server        server/server.go:547        Bitswap Client ReceiveError: Application error 0x0 (local)
May 24 04:10:51 celestia[1806932]: 2024-05-24T04:10:51.443Z        INFO        bitswap-server        server/server.go:547        Bitswap Client ReceiveError: Application error 0x0 (local)
May 24 04:10:51 celestia[1806932]: 2024-05-24T04:10:51.443Z        INFO        bitswap-server        server/server.go:547        Bitswap Client ReceiveError: Application error 0x0 (local)
May 24 04:10:51 celestia[1806932]: 2024-05-24T04:10:51.443Z        INFO        bitswap-server        server/server.go:547        Bitswap Client ReceiveError: Application error 0x0 (local)
May 24 04:10:51 celestia[1806932]: 2024-05-24T04:10:51.443Z        INFO        bitswap-server        server/server.go:547        Bitswap Client ReceiveError: Application error 0x0 (local)

```
These logs are pretty annoying, and this PR jams them.

However, the amount of those logs coming from stream resets is a bit concerning, and a quick look through the code path does not give me an idea of what could go wrong. I propose to shut them for now and observe if something goes wrong because currently, things are running well 

Fixes https://github.com/celestiaorg/celestia-node/issues/3426