### PR TITLE
refactor(shwap): Extract eds interface

### DIFF
--- a/share/new_eds/accessor.go
+++ b/share/new_eds/accessor.go
@@ -13,7 +13,7 @@ import (
 // Accessor is an interface for accessing extended data square data.
 type Accessor interface {
 	// Size returns square size of the Accessor.
-	Size() int
+	Size(ctx context.Context) int
 	// Sample returns share and corresponding proof for row and column indices. Implementation can
 	// choose which axis to use for proof. Chosen axis for proof should be indicated in the returned
 	// Sample.
@@ -23,8 +23,8 @@ type Accessor interface {
 	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error)
 	// RowNamespaceData returns data for the given namespace and row index.
 	RowNamespaceData(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)
-	// Flattened returns data shares extracted from the Accessor.
-	Flattened(ctx context.Context) ([]share.Share, error)
+	// Shares returns data shares extracted from the Accessor.
+	Shares(ctx context.Context) ([]share.Share, error)
 }
 
 // AccessorCloser is an interface that groups Accessor and io.Closer interfaces.

--- a/share/new_eds/accessor.go
+++ b/share/new_eds/accessor.go
@@ -10,10 +10,9 @@ import (
 	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
-// EDS is an interface for accessing extended data square data.
-type EDS interface {
-	io.Closer
-	// Size returns square size of the file.
+// Accessor is an interface for accessing extended data square data.
+type Accessor interface {
+	// Size returns square size of the Accessor.
 	Size() int
 	// Sample returns share and corresponding proof for row and column indices. Implementation can
 	// choose which axis to use for proof. Chosen axis for proof should be indicated in the returned
@@ -22,8 +21,14 @@ type EDS interface {
 	// AxisHalf returns half of shares axis of the given type and index. Side is determined by
 	// implementation. Implementations should indicate the side in the returned AxisHalf.
 	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error)
-	// RowData returns data for the given namespace and row index.
-	RowData(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)
-	// EDS returns extended data square stored in the file.
-	EDS(ctx context.Context) (*rsmt2d.ExtendedDataSquare, error)
+	// RowNamespaceData returns data for the given namespace and row index.
+	RowNamespaceData(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)
+	// Flattened returns data shares extracted from the Accessor.
+	Flattened(ctx context.Context) ([]share.Share, error)
+}
+
+// AccessorCloser is an interface that groups Accessor and io.Closer interfaces.
+type AccessorCloser interface {
+	Accessor
+	io.Closer
 }

--- a/share/new_eds/axis_half.go
+++ b/share/new_eds/axis_half.go
@@ -1,4 +1,4 @@
-package file
+package eds
 
 import (
 	"github.com/celestiaorg/celestia-node/share"

--- a/share/new_eds/axis_half.go
+++ b/share/new_eds/axis_half.go
@@ -5,7 +5,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
-// AxisHalf represents a half of a row or column in a shwap.
+// AxisHalf represents a half of data for a row or column in the EDS.
 type AxisHalf struct {
 	Shares []share.Share
 	// IsParity indicates whether the half is parity or data.

--- a/share/new_eds/axis_half.go
+++ b/share/new_eds/axis_half.go
@@ -5,11 +5,14 @@ import (
 	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
+// AxisHalf represents a half of a row or column in a shwap.
 type AxisHalf struct {
-	Shares   []share.Share
+	Shares []share.Share
+	// IsParity indicates whether the half is parity or data.
 	IsParity bool
 }
 
+// ToRow converts the AxisHalf to a shwap.Row.
 func (a AxisHalf) ToRow() shwap.Row {
 	side := shwap.Left
 	if a.IsParity {

--- a/share/new_eds/eds.go
+++ b/share/new_eds/eds.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
+// EDS is an interface for accessing extended data square data.
 type EDS interface {
 	io.Closer
 	// Size returns square size of the file.
@@ -20,6 +21,6 @@ type EDS interface {
 	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error)
 	// Data returns data for the given namespace and row index.
 	Data(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)
-	// InMem returns extended data square stored in the file.
+	// EDS returns extended data square stored in the file.
 	EDS(ctx context.Context) (*rsmt2d.ExtendedDataSquare, error)
 }

--- a/share/new_eds/eds.go
+++ b/share/new_eds/eds.go
@@ -15,9 +15,12 @@ type EDS interface {
 	io.Closer
 	// Size returns square size of the file.
 	Size() int
-	// Sample returns share and corresponding proof for the given axis and share index in this axis.
+	// Sample returns share and corresponding proof for row and column indices. Implementation can choose
+	// which axis to use for proof. Chosen axis for proof should be indicated in the returned Sample.
 	Sample(ctx context.Context, rowIdx, colIdx int) (shwap.Sample, error)
-	// AxisHalf returns Shares for the first half of the axis of the given type and index.
+	// AxisHalf returns half of shares axis of the given type and index. Side is determined by implementation
+	// and is not guaranteed to be the same for all implementations. Implementations should indicate the side
+	// in the returned AxisHalf.
 	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error)
 	// RowData returns data for the given namespace and row index.
 	RowData(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)

--- a/share/new_eds/eds.go
+++ b/share/new_eds/eds.go
@@ -15,12 +15,12 @@ type EDS interface {
 	io.Closer
 	// Size returns square size of the file.
 	Size() int
-	// Share returns share and corresponding proof for the given axis and share index in this axis.
-	Share(ctx context.Context, rowIdx, colIdx int) (*shwap.Sample, error)
+	// Sample returns share and corresponding proof for the given axis and share index in this axis.
+	Sample(ctx context.Context, rowIdx, colIdx int) (shwap.Sample, error)
 	// AxisHalf returns Shares for the first half of the axis of the given type and index.
 	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error)
-	// Data returns data for the given namespace and row index.
-	Data(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)
+	// RowData returns data for the given namespace and row index.
+	RowData(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)
 	// EDS returns extended data square stored in the file.
 	EDS(ctx context.Context) (*rsmt2d.ExtendedDataSquare, error)
 }

--- a/share/new_eds/eds.go
+++ b/share/new_eds/eds.go
@@ -15,12 +15,12 @@ type EDS interface {
 	io.Closer
 	// Size returns square size of the file.
 	Size() int
-	// Sample returns share and corresponding proof for row and column indices. Implementation can choose
-	// which axis to use for proof. Chosen axis for proof should be indicated in the returned Sample.
+	// Sample returns share and corresponding proof for row and column indices. Implementation can
+	// choose which axis to use for proof. Chosen axis for proof should be indicated in the returned
+	// Sample.
 	Sample(ctx context.Context, rowIdx, colIdx int) (shwap.Sample, error)
-	// AxisHalf returns half of shares axis of the given type and index. Side is determined by implementation
-	// and is not guaranteed to be the same for all implementations. Implementations should indicate the side
-	// in the returned AxisHalf.
+	// AxisHalf returns half of shares axis of the given type and index. Side is determined by
+	// implementation. Implementations should indicate the side in the returned AxisHalf.
 	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error)
 	// RowData returns data for the given namespace and row index.
 	RowData(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)

--- a/share/new_eds/eds.go
+++ b/share/new_eds/eds.go
@@ -1,4 +1,4 @@
-package file
+package eds
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
-type EdsFile interface {
+type EDS interface {
 	io.Closer
 	// Size returns square size of the file.
 	Size() int
@@ -20,6 +20,6 @@ type EdsFile interface {
 	AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error)
 	// Data returns data for the given namespace and row index.
 	Data(ctx context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error)
-	// EDS returns extended data square stored in the file.
+	// InMem returns extended data square stored in the file.
 	EDS(ctx context.Context) (*rsmt2d.ExtendedDataSquare, error)
 }

--- a/share/new_eds/in_mem.go
+++ b/share/new_eds/in_mem.go
@@ -18,14 +18,17 @@ type InMem struct {
 	*rsmt2d.ExtendedDataSquare
 }
 
+// Close does nothing.
 func (eds InMem) Close() error {
 	return nil
 }
 
+// Size returns the size of the Extended Data Square.
 func (eds InMem) Size() int {
 	return int(eds.Width())
 }
 
+// Sample returns share and corresponding proof for row and column indices.
 func (eds InMem) Sample(
 	_ context.Context,
 	rowIdx, colIdx int,
@@ -70,6 +73,7 @@ func (eds InMem) SampleForProofAxis(
 	}, nil
 }
 
+// AxisHalf returns Shares for the first half of the axis of the given type and index.
 func (eds InMem) AxisHalf(_ context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error) {
 	return AxisHalf{
 		Shares:   getAxis(eds.ExtendedDataSquare, axisType, axisIdx)[:eds.Size()/2],
@@ -84,6 +88,7 @@ func (eds InMem) HalfRow(idx int, side shwap.RowSide) shwap.Row {
 	return shwap.RowFromShares(shares, side)
 }
 
+// RowData returns data for the given namespace and row index.
 func (eds InMem) RowData(_ context.Context, namespace share.Namespace, rowIdx int) (shwap.RowNamespaceData, error) {
 	shares := eds.Row(uint(rowIdx))
 	return shwap.RowNamespaceDataFromShares(shares, namespace, rowIdx)
@@ -111,6 +116,7 @@ func (eds InMem) NamespacedData(
 	return rows, nil
 }
 
+// EDS returns extended data square stored in the file.
 func (eds InMem) EDS(_ context.Context) (*rsmt2d.ExtendedDataSquare, error) {
 	return eds.ExtendedDataSquare, nil
 }

--- a/share/new_eds/in_mem_test.go
+++ b/share/new_eds/in_mem_test.go
@@ -1,4 +1,4 @@
-package file
+package eds
 
 import (
 	"context"
@@ -16,7 +16,7 @@ func TestMemFileShare(t *testing.T) {
 	eds := edstest.RandEDS(t, 32)
 	root, err := share.NewRoot(eds)
 	require.NoError(t, err)
-	fl := &MemFile{Eds: eds}
+	fl := &InMem{ExtendedDataSquare: eds}
 
 	width := int(eds.Width())
 	for rowIdx := 0; rowIdx < width; rowIdx++ {
@@ -33,12 +33,12 @@ func TestMemFileShare(t *testing.T) {
 func TestMemFileDate(t *testing.T) {
 	size := 32
 
-	// generate EDS with random data and some shares with the same namespace
+	// generate InMem with random data and some shares with the same namespace
 	namespace := sharetest.RandV0Namespace()
 	amount := mrand.Intn(size*size-1) + 1
 	eds, dah := edstest.RandEDSWithNamespace(t, namespace, amount, size)
 
-	file := &MemFile{Eds: eds}
+	file := &InMem{ExtendedDataSquare: eds}
 
 	for i, root := range dah.RowRoots {
 		if !namespace.IsOutsideRange(root, root) {

--- a/share/new_eds/in_mem_test.go
+++ b/share/new_eds/in_mem_test.go
@@ -2,26 +2,25 @@ package eds
 
 import (
 	"context"
-	mrand "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/rsmt2d"
+
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 	"github.com/celestiaorg/celestia-node/share/sharetest"
+	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
-func TestMemFileShare(t *testing.T) {
-	eds := edstest.RandEDS(t, 32)
-	root, err := share.NewRoot(eds)
-	require.NoError(t, err)
-	fl := &InMem{ExtendedDataSquare: eds}
+func TestMemFileSample(t *testing.T) {
+	eds, root := randInMemEDS(t, 8)
 
 	width := int(eds.Width())
 	for rowIdx := 0; rowIdx < width; rowIdx++ {
 		for colIdx := 0; colIdx < width; colIdx++ {
-			shr, err := fl.Share(context.TODO(), rowIdx, colIdx)
+			shr, err := eds.Sample(context.TODO(), rowIdx, colIdx)
 			require.NoError(t, err)
 
 			err = shr.Validate(root, rowIdx, colIdx)
@@ -30,22 +29,65 @@ func TestMemFileShare(t *testing.T) {
 	}
 }
 
-func TestMemFileDate(t *testing.T) {
-	size := 32
+func TestHalfRowFromInMem(t *testing.T) {
+	const odsSize = 8
+	eds, _ := randInMemEDS(t, odsSize)
 
-	// generate InMem with random data and some shares with the same namespace
-	namespace := sharetest.RandV0Namespace()
-	amount := mrand.Intn(size*size-1) + 1
-	eds, dah := edstest.RandEDSWithNamespace(t, namespace, amount, size)
+	for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
+		for _, side := range []shwap.RowSide{shwap.Left, shwap.Right} {
+			row := eds.HalfRow(rowIdx, side)
 
-	file := &InMem{ExtendedDataSquare: eds}
-
-	for i, root := range dah.RowRoots {
-		if !namespace.IsOutsideRange(root, root) {
-			nd, err := file.Data(context.Background(), namespace, i)
+			want := eds.Row(uint(rowIdx))
+			shares, err := row.Shares()
 			require.NoError(t, err)
-			err = nd.Validate(dah, namespace, i)
-			require.NoError(t, err)
+			require.Equal(t, want, shares)
 		}
 	}
+}
+
+func TestInMemNamespacedData(t *testing.T) {
+	const odsSize = 8
+
+	sharesAmount := odsSize * odsSize
+	namespace := sharetest.RandV0Namespace()
+	for amount := 1; amount < sharesAmount; amount++ {
+		eds, root := edstest.RandEDSWithNamespace(t, namespace, amount, odsSize)
+		inMem := InMem{ExtendedDataSquare: eds}
+		nd, err := inMem.NamespacedData(namespace)
+		require.NoError(t, err)
+		require.True(t, len(nd) > 0)
+		require.Len(t, nd.Flatten(), amount)
+
+		err = nd.Validate(root, namespace)
+		require.NoError(t, err)
+	}
+}
+
+func TestInMemSampleForProofAxis(t *testing.T) {
+	const odsSize = 8
+	eds := edstest.RandEDS(t, odsSize)
+	inMem := InMem{ExtendedDataSquare: eds}
+
+	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
+		for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
+			for colIdx := 0; colIdx < odsSize*2; colIdx++ {
+				sample, err := inMem.SampleForProofAxis(rowIdx, colIdx, proofType)
+				require.NoError(t, err)
+
+				want := eds.GetCell(uint(rowIdx), uint(colIdx))
+				require.Equal(t, want, sample.Share)
+				require.Equal(t, proofType, sample.ProofType)
+				require.NotNil(t, sample.Proof)
+				require.Equal(t, sample.Proof.End()-sample.Proof.Start(), 1)
+				require.Len(t, sample.Proof.Nodes(), 4)
+			}
+		}
+	}
+}
+
+func randInMemEDS(t *testing.T, size int) (InMem, *share.Root) {
+	eds := edstest.RandEDS(t, size)
+	root, err := share.NewRoot(eds)
+	require.NoError(t, err)
+	return InMem{ExtendedDataSquare: eds}, root
 }

--- a/share/new_eds/nd.go
+++ b/share/new_eds/nd.go
@@ -9,7 +9,8 @@ import (
 )
 
 // NamespacedData extracts shares for a specific namespace from an EDS, considering
-// each row independently.
+// each row independently. It uses root to determine which rows to extract data from,
+// avoiding the need to recalculate the row roots for each row.
 func NamespacedData(
 	ctx context.Context,
 	root *share.Root,

--- a/share/new_eds/nd.go
+++ b/share/new_eds/nd.go
@@ -1,0 +1,30 @@
+package eds
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+// NamespacedData extracts shares for a specific namespace from an EDS, considering
+// each row independently.
+func NamespacedData(
+	ctx context.Context,
+	root *share.Root,
+	eds Accessor,
+	namespace share.Namespace,
+) (shwap.NamespacedData, error) {
+	rowIdxs := share.RowsWithNamespace(root, namespace)
+	rows := make(shwap.NamespacedData, len(rowIdxs))
+	var err error
+	for i, idx := range rowIdxs {
+		rows[i], err = eds.RowNamespaceData(ctx, namespace, idx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process row %d: %w", idx, err)
+		}
+	}
+
+	return rows, nil
+}

--- a/share/new_eds/nd_test.go
+++ b/share/new_eds/nd_test.go
@@ -1,0 +1,32 @@
+package eds
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	"github.com/celestiaorg/celestia-node/share/sharetest"
+)
+
+func TestNamespacedData(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	const odsSize = 8
+	sharesAmount := odsSize * odsSize
+	namespace := sharetest.RandV0Namespace()
+	for amount := 1; amount < sharesAmount; amount++ {
+		eds, root := edstest.RandEDSWithNamespace(t, namespace, amount, odsSize)
+		rsmt2d := Rsmt2D{ExtendedDataSquare: eds}
+		nd, err := NamespacedData(ctx, root, rsmt2d, namespace)
+		require.NoError(t, err)
+		require.True(t, len(nd) > 0)
+		require.Len(t, nd.Flatten(), amount)
+
+		err = nd.Validate(root, namespace)
+		require.NoError(t, err)
+	}
+}

--- a/share/new_eds/rsmt2d.go
+++ b/share/new_eds/rsmt2d.go
@@ -18,13 +18,8 @@ type Rsmt2D struct {
 	*rsmt2d.ExtendedDataSquare
 }
 
-// Close does nothing.
-func (eds Rsmt2D) Close() error {
-	return nil
-}
-
 // Size returns the size of the Extended Data Square.
-func (eds Rsmt2D) Size() int {
+func (eds Rsmt2D) Size(context.Context) int {
 	return int(eds.Width())
 }
 
@@ -68,7 +63,7 @@ func (eds Rsmt2D) SampleForProofAxis(
 // AxisHalf returns Shares for the first half of the axis of the given type and index.
 func (eds Rsmt2D) AxisHalf(_ context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error) {
 	shares := getAxis(eds.ExtendedDataSquare, axisType, axisIdx)
-	halfShares := shares[:eds.Size()/2]
+	halfShares := shares[:eds.Width()/2]
 	return AxisHalf{
 		Shares:   halfShares,
 		IsParity: false,
@@ -92,9 +87,9 @@ func (eds Rsmt2D) RowNamespaceData(
 	return shwap.RowNamespaceDataFromShares(shares, namespace, rowIdx)
 }
 
-// Flattened returns data shares extracted from the EDS. It returns new copy of the shares each
+// Shares returns data shares extracted from the EDS. It returns new copy of the shares each
 // time.
-func (eds Rsmt2D) Flattened(_ context.Context) ([]share.Share, error) {
+func (eds Rsmt2D) Shares(_ context.Context) ([]share.Share, error) {
 	return eds.ExtendedDataSquare.Flattened(), nil
 }
 

--- a/share/new_eds/rsmt2d_test.go
+++ b/share/new_eds/rsmt2d_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
-func TestMemFileSample(t *testing.T) {
-	eds, root := randInMemEDS(t, 8)
+func TestRsmt2dSample(t *testing.T) {
+	eds, root := randRsmt2dAccsessor(t, 8)
 
 	width := int(eds.Width())
 	for rowIdx := 0; rowIdx < width; rowIdx++ {
@@ -28,9 +28,9 @@ func TestMemFileSample(t *testing.T) {
 	}
 }
 
-func TestHalfRowFromInMem(t *testing.T) {
+func TestRsmt2dHalfRowFrom(t *testing.T) {
 	const odsSize = 8
-	eds, _ := randInMemEDS(t, odsSize)
+	eds, _ := randRsmt2dAccsessor(t, odsSize)
 
 	for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
 		for _, side := range []shwap.RowSide{shwap.Left, shwap.Right} {
@@ -44,15 +44,15 @@ func TestHalfRowFromInMem(t *testing.T) {
 	}
 }
 
-func TestInMemSampleForProofAxis(t *testing.T) {
+func TestRsmt2dSampleForProofAxis(t *testing.T) {
 	const odsSize = 8
 	eds := edstest.RandEDS(t, odsSize)
-	inMem := Rsmt2D{ExtendedDataSquare: eds}
+	accessor := Rsmt2D{ExtendedDataSquare: eds}
 
 	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
 		for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
 			for colIdx := 0; colIdx < odsSize*2; colIdx++ {
-				sample, err := inMem.SampleForProofAxis(rowIdx, colIdx, proofType)
+				sample, err := accessor.SampleForProofAxis(rowIdx, colIdx, proofType)
 				require.NoError(t, err)
 
 				want := eds.GetCell(uint(rowIdx), uint(colIdx))
@@ -66,7 +66,7 @@ func TestInMemSampleForProofAxis(t *testing.T) {
 	}
 }
 
-func randInMemEDS(t *testing.T, size int) (Rsmt2D, *share.Root) {
+func randRsmt2dAccsessor(t *testing.T, size int) (Rsmt2D, *share.Root) {
 	eds := edstest.RandEDS(t, size)
 	root, err := share.NewRoot(eds)
 	require.NoError(t, err)

--- a/share/new_eds/rsmt2d_test.go
+++ b/share/new_eds/rsmt2d_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
-	"github.com/celestiaorg/celestia-node/share/sharetest"
 	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
@@ -45,28 +44,10 @@ func TestHalfRowFromInMem(t *testing.T) {
 	}
 }
 
-func TestInMemNamespacedData(t *testing.T) {
-	const odsSize = 8
-
-	sharesAmount := odsSize * odsSize
-	namespace := sharetest.RandV0Namespace()
-	for amount := 1; amount < sharesAmount; amount++ {
-		eds, root := edstest.RandEDSWithNamespace(t, namespace, amount, odsSize)
-		inMem := InMem{ExtendedDataSquare: eds}
-		nd, err := inMem.NamespacedData(namespace)
-		require.NoError(t, err)
-		require.True(t, len(nd) > 0)
-		require.Len(t, nd.Flatten(), amount)
-
-		err = nd.Validate(root, namespace)
-		require.NoError(t, err)
-	}
-}
-
 func TestInMemSampleForProofAxis(t *testing.T) {
 	const odsSize = 8
 	eds := edstest.RandEDS(t, odsSize)
-	inMem := InMem{ExtendedDataSquare: eds}
+	inMem := Rsmt2D{ExtendedDataSquare: eds}
 
 	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
 		for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
@@ -85,9 +66,9 @@ func TestInMemSampleForProofAxis(t *testing.T) {
 	}
 }
 
-func randInMemEDS(t *testing.T, size int) (InMem, *share.Root) {
+func randInMemEDS(t *testing.T, size int) (Rsmt2D, *share.Root) {
 	eds := edstest.RandEDS(t, size)
 	root, err := share.NewRoot(eds)
 	require.NoError(t, err)
-	return InMem{ExtendedDataSquare: eds}, root
+	return Rsmt2D{ExtendedDataSquare: eds}, root
 }

--- a/share/shwap/namespace_data.go
+++ b/share/shwap/namespace_data.go
@@ -3,38 +3,12 @@ package shwap
 import (
 	"fmt"
 
-	"github.com/celestiaorg/rsmt2d"
-
 	"github.com/celestiaorg/celestia-node/share"
 )
 
 // NamespacedData stores collections of RowNamespaceData, each representing shares and their proofs
 // within a namespace.
 type NamespacedData []RowNamespaceData
-
-// NamespacedDataFromEDS extracts shares for a specific namespace from an EDS, considering
-// each row independently.
-func NamespacedDataFromEDS(
-	square *rsmt2d.ExtendedDataSquare,
-	namespace share.Namespace,
-) (NamespacedData, error) {
-	root, err := share.NewRoot(square)
-	if err != nil {
-		return nil, fmt.Errorf("error computing root: %w", err)
-	}
-
-	rowIdxs := share.RowsWithNamespace(root, namespace)
-	rows := make(NamespacedData, len(rowIdxs))
-	for i, idx := range rowIdxs {
-		shares := square.Row(uint(idx))
-		rows[i], err = RowNamespaceDataFromShares(shares, namespace, idx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to process row %d: %w", idx, err)
-		}
-	}
-
-	return rows, nil
-}
 
 // Flatten combines all shares from all rows within the namespace into a single slice.
 func (ns NamespacedData) Flatten() []share.Share {

--- a/share/shwap/row.go
+++ b/share/shwap/row.go
@@ -92,7 +92,10 @@ func (r Row) Validate(dah *share.Root, idx int) error {
 		return fmt.Errorf("invalid RowSide: %d", r.side)
 	}
 
-	return r.verifyInclusion(dah, idx)
+	if err := r.verifyInclusion(dah, idx); err != nil {
+		return fmt.Errorf("%w: %w", ErrorFailedVerification, err)
+	}
+	return nil
 }
 
 // verifyInclusion verifies the integrity of the row's shares against the provided root hash for the

--- a/share/shwap/row.go
+++ b/share/shwap/row.go
@@ -93,7 +93,7 @@ func (r Row) Validate(dah *share.Root, idx int) error {
 	}
 
 	if err := r.verifyInclusion(dah, idx); err != nil {
-		return fmt.Errorf("%w: %w", ErrorFailedVerification, err)
+		return fmt.Errorf("%w: %w", ErrFailedVerification, err)
 	}
 	return nil
 }

--- a/share/shwap/row.go
+++ b/share/shwap/row.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
-	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/shwap/pb"
@@ -35,14 +34,12 @@ func NewRow(halfShares []share.Share, side RowSide) Row {
 
 // RowFromEDS constructs a new Row from an Extended Data Square based on the specified index and
 // side.
-func RowFromEDS(square *rsmt2d.ExtendedDataSquare, idx int, side RowSide) Row {
-	sqrLn := int(square.Width())
-	shares := square.Row(uint(idx))
+func RowFromShares(shares []share.Share, side RowSide) Row {
 	var halfShares []share.Share
 	if side == Right {
-		halfShares = shares[sqrLn/2:] // Take the right half of the shares.
+		halfShares = shares[len(shares)/2:] // Take the right half of the shares.
 	} else {
-		halfShares = shares[:sqrLn/2] // Take the left half of the shares.
+		halfShares = shares[:len(shares)/2] // Take the left half of the shares.
 	}
 
 	return NewRow(halfShares, side)

--- a/share/shwap/row_namespace_data.go
+++ b/share/shwap/row_namespace_data.go
@@ -6,7 +6,6 @@ import (
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	nmt_pb "github.com/celestiaorg/nmt/pb"
-	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/shwap/pb"
@@ -16,22 +15,6 @@ import (
 type RowNamespaceData struct {
 	Shares []share.Share `json:"shares"` // Shares within the namespace.
 	Proof  *nmt.Proof    `json:"proof"`  // Proof of the shares' inclusion in the namespace.
-}
-
-// RowNamespaceDataFromEDS extracts and constructs a RowNamespaceData from the row of given EDS
-// identified by the index and the namespace.
-func RowNamespaceDataFromEDS(
-	eds *rsmt2d.ExtendedDataSquare,
-	namespace share.Namespace,
-	rowIdx int,
-) (RowNamespaceData, error) {
-	shares := eds.Row(uint(rowIdx))
-	rowData, err := RowNamespaceDataFromShares(shares, namespace, rowIdx)
-	if err != nil {
-		return RowNamespaceData{}, err
-	}
-
-	return rowData, nil
 }
 
 // RowNamespaceDataFromShares extracts and constructs a RowNamespaceData from shares within the

--- a/share/shwap/row_namespace_data.go
+++ b/share/shwap/row_namespace_data.go
@@ -127,7 +127,7 @@ func (rnd RowNamespaceData) Validate(dah *share.Root, namespace share.Namespace,
 	}
 
 	if !rnd.verifyInclusion(rowRoot, namespace) {
-		return fmt.Errorf("inclusion proof failed for row %d", rowIdx)
+		return fmt.Errorf("%w for row: %d", ErrorFailedVerification, rowIdx)
 	}
 	return nil
 }

--- a/share/shwap/row_namespace_data.go
+++ b/share/shwap/row_namespace_data.go
@@ -127,7 +127,7 @@ func (rnd RowNamespaceData) Validate(dah *share.Root, namespace share.Namespace,
 	}
 
 	if !rnd.verifyInclusion(rowRoot, namespace) {
-		return fmt.Errorf("%w for row: %d", ErrorFailedVerification, rowIdx)
+		return fmt.Errorf("%w for row: %d", ErrFailedVerification, rowIdx)
 	}
 	return nil
 }

--- a/share/shwap/row_namespace_data_test.go
+++ b/share/shwap/row_namespace_data_test.go
@@ -2,8 +2,10 @@ package shwap_test
 
 import (
 	"bytes"
+	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -55,13 +57,16 @@ func TestNamespacedRowFromSharesNonIncluded(t *testing.T) {
 }
 
 func TestValidateNamespacedRow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
 	const odsSize = 8
 	sharesAmount := odsSize * odsSize
 	namespace := sharetest.RandV0Namespace()
 	for amount := 1; amount < sharesAmount; amount++ {
 		randEDS, root := edstest.RandEDSWithNamespace(t, namespace, amount, odsSize)
-		eds := eds.InMem{ExtendedDataSquare: randEDS}
-		nd, err := eds.NamespacedData(namespace)
+		rsmt2d := eds.Rsmt2D{ExtendedDataSquare: randEDS}
+		nd, err := eds.NamespacedData(ctx, root, rsmt2d, namespace)
 		require.NoError(t, err)
 		require.True(t, len(nd) > 0)
 
@@ -76,11 +81,14 @@ func TestValidateNamespacedRow(t *testing.T) {
 }
 
 func TestNamespacedRowProtoEncoding(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
 	const odsSize = 8
 	namespace := sharetest.RandV0Namespace()
-	edss, _ := edstest.RandEDSWithNamespace(t, namespace, odsSize, odsSize)
-	eds := eds.InMem{ExtendedDataSquare: edss}
-	nd, err := eds.NamespacedData(namespace)
+	randEDS, root := edstest.RandEDSWithNamespace(t, namespace, odsSize, odsSize)
+	rsmt2d := eds.Rsmt2D{ExtendedDataSquare: randEDS}
+	nd, err := eds.NamespacedData(ctx, root, rsmt2d, namespace)
 	require.NoError(t, err)
 	require.True(t, len(nd) > 0)
 

--- a/share/shwap/sample.go
+++ b/share/shwap/sample.go
@@ -12,9 +12,9 @@ import (
 	"github.com/celestiaorg/celestia-node/share/shwap/pb"
 )
 
-// ErrorFailedVerification is returned when inclusion proof verification fails. It is returned
+// ErrFailedVerification is returned when inclusion proof verification fails. It is returned
 // when the data and the proof do not match trusted data root.
-var ErrorFailedVerification = errors.New("failed to verify inclusion")
+var ErrFailedVerification = errors.New("failed to verify inclusion")
 
 // Sample represents a data share along with its Merkle proof, used to validate the share's
 // inclusion in a data square.
@@ -67,7 +67,7 @@ func (s Sample) Validate(dah *share.Root, rowIdx, colIdx int) error {
 		return fmt.Errorf("invalid SampleProofType: %d", s.ProofType)
 	}
 	if !s.verifyInclusion(dah, rowIdx, colIdx) {
-		return ErrorFailedVerification
+		return ErrFailedVerification
 	}
 	return nil
 }

--- a/share/shwap/sample.go
+++ b/share/shwap/sample.go
@@ -12,6 +12,8 @@ import (
 	"github.com/celestiaorg/celestia-node/share/shwap/pb"
 )
 
+// ErrorFailedVerification is returned when inclusion proof verification fails. It is returned
+// when the data and the proof do not match trusted data root.
 var ErrorFailedVerification = errors.New("failed to verify inclusion")
 
 // Sample represents a data share along with its Merkle proof, used to validate the share's

--- a/share/shwap/sample_test.go
+++ b/share/shwap/sample_test.go
@@ -19,7 +19,7 @@ func TestSampleValidate(t *testing.T) {
 	randEDS := edstest.RandEDS(t, odsSize)
 	root, err := share.NewRoot(randEDS)
 	require.NoError(t, err)
-	inMem := eds.InMem{ExtendedDataSquare: randEDS}
+	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
 
 	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
 		for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
@@ -39,7 +39,7 @@ func TestSampleNegativeVerifyInclusion(t *testing.T) {
 	randEDS := edstest.RandEDS(t, odsSize)
 	root, err := share.NewRoot(randEDS)
 	require.NoError(t, err)
-	inMem := eds.InMem{ExtendedDataSquare: randEDS}
+	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
 
 	sample, err := inMem.Sample(context.TODO(), 0, 0)
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestSampleNegativeVerifyInclusion(t *testing.T) {
 func TestSampleProtoEncoding(t *testing.T) {
 	const odsSize = 8
 	randEDS := edstest.RandEDS(t, odsSize)
-	inMem := eds.InMem{ExtendedDataSquare: randEDS}
+	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
 
 	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
 		for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
@@ -97,7 +97,7 @@ func BenchmarkSampleValidate(b *testing.B) {
 	randEDS := edstest.RandEDS(b, odsSize)
 	root, err := share.NewRoot(randEDS)
 	require.NoError(b, err)
-	inMem := eds.InMem{ExtendedDataSquare: randEDS}
+	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
 	sample, err := inMem.SampleForProofAxis(0, 0, rsmt2d.Row)
 	require.NoError(b, err)
 

--- a/share/shwap/sample_test.go
+++ b/share/shwap/sample_test.go
@@ -1,6 +1,7 @@
-package shwap
+package shwap_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,42 +10,23 @@ import (
 
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	eds "github.com/celestiaorg/celestia-node/share/new_eds"
+	"github.com/celestiaorg/celestia-node/share/shwap"
 )
-
-func TestNewSampleFromEDS(t *testing.T) {
-	const odsSize = 8
-	eds := edstest.RandEDS(t, odsSize)
-
-	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
-		for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
-			for colIdx := 0; colIdx < odsSize*2; colIdx++ {
-				sample, err := SampleFromEDS(eds, proofType, rowIdx, colIdx)
-				require.NoError(t, err)
-
-				want := eds.GetCell(uint(rowIdx), uint(colIdx))
-				require.Equal(t, want, sample.Share)
-				require.Equal(t, proofType, sample.ProofType)
-				require.NotNil(t, sample.Proof)
-				require.Equal(t, sample.Proof.End()-sample.Proof.Start(), 1)
-				require.Len(t, sample.Proof.Nodes(), 4)
-			}
-		}
-	}
-}
 
 func TestSampleValidate(t *testing.T) {
 	const odsSize = 8
-	eds := edstest.RandEDS(t, odsSize)
-	root, err := share.NewRoot(eds)
+	randEDS := edstest.RandEDS(t, odsSize)
+	root, err := share.NewRoot(randEDS)
 	require.NoError(t, err)
+	inMem := eds.InMem{ExtendedDataSquare: randEDS}
 
 	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
 		for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
 			for colIdx := 0; colIdx < odsSize*2; colIdx++ {
-				sample, err := SampleFromEDS(eds, proofType, rowIdx, colIdx)
+				sample, err := inMem.SampleForProofAxis(rowIdx, colIdx, proofType)
 				require.NoError(t, err)
 
-				require.True(t, sample.verifyInclusion(root, rowIdx, colIdx))
 				require.NoError(t, sample.Validate(root, rowIdx, colIdx))
 			}
 		}
@@ -54,55 +36,53 @@ func TestSampleValidate(t *testing.T) {
 // TestSampleNegativeVerifyInclusion checks
 func TestSampleNegativeVerifyInclusion(t *testing.T) {
 	const odsSize = 8
-	eds := edstest.RandEDS(t, odsSize)
-	root, err := share.NewRoot(eds)
+	randEDS := edstest.RandEDS(t, odsSize)
+	root, err := share.NewRoot(randEDS)
 	require.NoError(t, err)
+	inMem := eds.InMem{ExtendedDataSquare: randEDS}
 
-	sample, err := SampleFromEDS(eds, rsmt2d.Row, 0, 0)
+	sample, err := inMem.Sample(context.TODO(), 0, 0)
 	require.NoError(t, err)
-	included := sample.verifyInclusion(root, 0, 0)
-	require.True(t, included)
+	err = sample.Validate(root, 0, 0)
+	require.NoError(t, err)
 
 	// incorrect row index
-	included = sample.verifyInclusion(root, 1, 0)
-	require.False(t, included)
-
-	// incorrect col index is not used in the inclusion proof verification
-	included = sample.verifyInclusion(root, 0, 1)
-	require.True(t, included)
+	err = sample.Validate(root, 1, 0)
+	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
 
 	// Corrupt the share
 	sample.Share[0] ^= 0xFF
-	included = sample.verifyInclusion(root, 0, 0)
-	require.False(t, included)
+	err = sample.Validate(root, 0, 0)
+	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
 
 	// incorrect proofType
-	sample, err = SampleFromEDS(eds, rsmt2d.Row, 0, 0)
+	sample, err = inMem.Sample(context.TODO(), 0, 0)
 	require.NoError(t, err)
 	sample.ProofType = rsmt2d.Col
-	included = sample.verifyInclusion(root, 0, 0)
-	require.False(t, included)
+	err = sample.Validate(root, 0, 0)
+	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
 
 	// Corrupt the last root hash byte
-	sample, err = SampleFromEDS(eds, rsmt2d.Row, 0, 0)
+	sample, err = inMem.Sample(context.TODO(), 0, 0)
 	require.NoError(t, err)
 	root.RowRoots[0][len(root.RowRoots[0])-1] ^= 0xFF
-	included = sample.verifyInclusion(root, 0, 0)
-	require.False(t, included)
+	err = sample.Validate(root, 0, 0)
+	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
 }
 
 func TestSampleProtoEncoding(t *testing.T) {
 	const odsSize = 8
-	eds := edstest.RandEDS(t, odsSize)
+	randEDS := edstest.RandEDS(t, odsSize)
+	inMem := eds.InMem{ExtendedDataSquare: randEDS}
 
 	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
 		for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
 			for colIdx := 0; colIdx < odsSize*2; colIdx++ {
-				sample, err := SampleFromEDS(eds, proofType, rowIdx, colIdx)
+				sample, err := inMem.SampleForProofAxis(rowIdx, colIdx, proofType)
 				require.NoError(t, err)
 
 				pb := sample.ToProto()
-				sampleOut := SampleFromProto(pb)
+				sampleOut := shwap.SampleFromProto(pb)
 				require.NoError(t, err)
 				require.Equal(t, sample, sampleOut)
 			}
@@ -114,10 +94,11 @@ func TestSampleProtoEncoding(t *testing.T) {
 // BenchmarkSampleValidate-10    	  284829	      3935 ns/op
 func BenchmarkSampleValidate(b *testing.B) {
 	const odsSize = 32
-	eds := edstest.RandEDS(b, odsSize)
-	root, err := share.NewRoot(eds)
+	randEDS := edstest.RandEDS(b, odsSize)
+	root, err := share.NewRoot(randEDS)
 	require.NoError(b, err)
-	sample, err := SampleFromEDS(eds, rsmt2d.Row, 0, 0)
+	inMem := eds.InMem{ExtendedDataSquare: randEDS}
+	sample, err := inMem.SampleForProofAxis(0, 0, rsmt2d.Row)
 	require.NoError(b, err)
 
 	b.ResetTimer()

--- a/share/shwap/sample_test.go
+++ b/share/shwap/sample_test.go
@@ -41,7 +41,7 @@ func TestSampleNegativeVerifyInclusion(t *testing.T) {
 	require.NoError(t, err)
 	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
 
-	sample, err := inMem.Sample(context.TODO(), 0, 0)
+	sample, err := inMem.Sample(context.Background(), 0, 0)
 	require.NoError(t, err)
 	err = sample.Validate(root, 0, 0)
 	require.NoError(t, err)
@@ -56,14 +56,14 @@ func TestSampleNegativeVerifyInclusion(t *testing.T) {
 	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
 
 	// incorrect proofType
-	sample, err = inMem.Sample(context.TODO(), 0, 0)
+	sample, err = inMem.Sample(context.Background(), 0, 0)
 	require.NoError(t, err)
 	sample.ProofType = rsmt2d.Col
 	err = sample.Validate(root, 0, 0)
 	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
 
 	// Corrupt the last root hash byte
-	sample, err = inMem.Sample(context.TODO(), 0, 0)
+	sample, err = inMem.Sample(context.Background(), 0, 0)
 	require.NoError(t, err)
 	root.RowRoots[0][len(root.RowRoots[0])-1] ^= 0xFF
 	err = sample.Validate(root, 0, 0)

--- a/share/shwap/sample_test.go
+++ b/share/shwap/sample_test.go
@@ -48,26 +48,26 @@ func TestSampleNegativeVerifyInclusion(t *testing.T) {
 
 	// incorrect row index
 	err = sample.Validate(root, 1, 0)
-	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
+	require.ErrorIs(t, err, shwap.ErrFailedVerification)
 
 	// Corrupt the share
 	sample.Share[0] ^= 0xFF
 	err = sample.Validate(root, 0, 0)
-	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
+	require.ErrorIs(t, err, shwap.ErrFailedVerification)
 
 	// incorrect proofType
 	sample, err = inMem.Sample(context.Background(), 0, 0)
 	require.NoError(t, err)
 	sample.ProofType = rsmt2d.Col
 	err = sample.Validate(root, 0, 0)
-	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
+	require.ErrorIs(t, err, shwap.ErrFailedVerification)
 
 	// Corrupt the last root hash byte
 	sample, err = inMem.Sample(context.Background(), 0, 0)
 	require.NoError(t, err)
 	root.RowRoots[0][len(root.RowRoots[0])-1] ^= 0xFF
 	err = sample.Validate(root, 0, 0)
-	require.ErrorIs(t, err, shwap.ErrorFailedVerification)
+	require.ErrorIs(t, err, shwap.ErrFailedVerification)
 }
 
 func TestSampleProtoEncoding(t *testing.T) {


### PR DESCRIPTION
- Reintroduce file interface as eds interface. Change aims to allow usage of EDS interface outside of storage package and to be high level interface of EDS methods.
- Renames of eds interface methods to align with returned shwap types names
    - Share() -> Sample
    - Data -> Row data
- Extracts New<shwap_type_name>FromEDS functions to eds file methods
    - moves associated tests to eds pkg
    
**Additional refactoring:**
- **Change Interface Name**: Realized that 'EDS' is a terrible name for an interface. Renamed `eds.EDS` to `eds.Accessor` to more accurately reflect its functionality rather than its internal content.

- **Separate Closer**: Extracted `Closer` from `Accessor`. Now it is available in a new composite interface `AccessorCloser`.

- **Rename InMem**: Renamed `InMem` to `rsmt2d` to better align with its usage.

- **Decouple NamespacedData**: Separated `NamespacedData` from the `rsmt2d` implementation. It is now a standalone function.

- **Update EDS Method**: Replaced the `EDS()` method with `Flattened`, similar to `rsmt2d`. Considered introducing two separate methods, `Flattened` and `FlattenedODS`, with the latter to be potentially added later. Proposed to park this suggestion in an issue for future consideration.

