### PR TITLE
fix(share/getters)!: return nil shares from all getters in non-inclusion case

### DIFF
--- a/share/getter.go
+++ b/share/getter.go
@@ -43,7 +43,7 @@ type NamespacedShares []NamespacedRow
 
 // Flatten returns the concatenated slice of all NamespacedRow shares.
 func (ns NamespacedShares) Flatten() []Share {
-	shares := make([]Share, 0)
+	var shares []Share
 	for _, row := range ns {
 		shares = append(shares, row.Shares...)
 	}

--- a/share/getters/getter_test.go
+++ b/share/getters/getter_test.go
@@ -96,7 +96,7 @@ func TestStoreGetter(t *testing.T) {
 		randNamespace := sharetest.RandV0Namespace()
 		emptyShares, err := sg.GetSharesByNamespace(ctx, eh, randNamespace)
 		require.NoError(t, err)
-		require.Empty(t, emptyShares.Flatten())
+		require.Nil(t, emptyShares.Flatten())
 
 		// root not found
 		emptyRoot := da.MinDataAvailabilityHeader()
@@ -229,7 +229,7 @@ func TestIPLDGetter(t *testing.T) {
 		randNamespace := sharetest.RandV0Namespace()
 		emptyShares, err := sg.GetSharesByNamespace(ctx, eh, randNamespace)
 		require.NoError(t, err)
-		require.Empty(t, emptyShares.Flatten())
+		require.Nil(t, emptyShares.Flatten())
 
 		// nid doesn't exist in root
 		emptyRoot := da.MinDataAvailabilityHeader()

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -110,6 +110,7 @@ func TestShrexGetter(t *testing.T) {
 			Height:   1,
 		})
 
+		// namespace inside root range
 		nID, err := addToNamespace(maxNamespace, -1)
 		require.NoError(t, err)
 		// check for namespace to be between max and min namespace in root
@@ -118,7 +119,19 @@ func TestShrexGetter(t *testing.T) {
 		emptyShares, err := getter.GetSharesByNamespace(ctx, eh, nID)
 		require.NoError(t, err)
 		// no shares should be returned
-		require.Empty(t, emptyShares.Flatten())
+		require.Nil(t, emptyShares.Flatten())
+		require.Nil(t, emptyShares.Verify(dah, nID))
+
+		// namespace outside root range
+		nID, err = addToNamespace(maxNamespace, 1)
+		require.NoError(t, err)
+		// check for namespace to be not in root
+		require.Len(t, ipld.FilterRootByNamespace(dah, nID), 0)
+
+		emptyShares, err = getter.GetSharesByNamespace(ctx, eh, nID)
+		require.NoError(t, err)
+		// no shares should be returned
+		require.Nil(t, emptyShares.Flatten())
 		require.Nil(t, emptyShares.Verify(dah, nID))
 	})
 

--- a/share/ipld/get_shares.go
+++ b/share/ipld/get_shares.go
@@ -55,6 +55,9 @@ func GetSharesByNamespace(
 	}
 
 	leaves := data.Leaves()
+	if len(leaves) == 0 {
+		return nil, data.Proof(), nil
+	}
 
 	shares := make([]share.Share, len(leaves))
 	for i, leaf := range leaves {
@@ -62,7 +65,7 @@ func GetSharesByNamespace(
 			shares[i] = leafToShare(leaf)
 		}
 	}
-	return shares, data.Proof(), err
+	return shares, data.Proof(), nil
 }
 
 // leafToShare converts an NMT leaf into a Share.


### PR DESCRIPTION
Make return of shares consistent accross tall getter, when encountering non-inclusion case
Improves unnecessary allocations of empty slice.

Resolves https://github.com/celestiaorg/celestia-node/issues/3448