### PR TITLE
fix(nodebuilder/share): Pass `light.Window` to shrex getter construction regardless of node type / pruning mode

### DIFF
--- a/nodebuilder/share/module.go
+++ b/nodebuilder/share/module.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
-	"github.com/celestiaorg/celestia-node/pruner"
+	lightprune "github.com/celestiaorg/celestia-node/pruner/light"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/availability/full"
 	"github.com/celestiaorg/celestia-node/share/availability/light"
@@ -92,17 +92,13 @@ func shrexComponents(tp node.Type, cfg *Config) fx.Option {
 				edsClient *shrexeds.Client,
 				ndClient *shrexnd.Client,
 				managers map[string]*peers.Manager,
-				window pruner.AvailabilityWindow,
 			) *getters.ShrexGetter {
 				return getters.NewShrexGetter(
 					edsClient,
 					ndClient,
 					managers[fullNodesTag],
 					managers[archivalNodesTag],
-					// TODO @renaynay: Pruned FNs should pass `light.Window` to shrex getter
-					//  best route requests (as full.Window serves as a buffer for serving data while
-					//  the request router itself should just stick to light.Window)
-					window,
+					lightprune.Window,
 				)
 			},
 			fx.OnStart(func(ctx context.Context, getter *getters.ShrexGetter) error {

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/headertest"
 	"github.com/celestiaorg/celestia-node/pruner/full"
+	"github.com/celestiaorg/celestia-node/pruner/light"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
@@ -59,7 +60,7 @@ func TestShrexGetter(t *testing.T) {
 	archivalPeerManager, err := testManager(ctx, clHost, sub)
 	require.NoError(t, err)
 
-	getter := NewShrexGetter(edsClient, ndClient, fullPeerManager, archivalPeerManager, full.Window)
+	getter := NewShrexGetter(edsClient, ndClient, fullPeerManager, archivalPeerManager, light.Window)
 	require.NoError(t, getter.Start(ctx))
 
 	t.Run("ND_Available, total data size > 1mb", func(t *testing.T) {


### PR DESCRIPTION
Since it is a network constant, shrex getter request routing should be based on the hardcoded light.Window rather than the avail window that is passed to it. `light.Window` should be used network-wide to determine which peer pool (`full` or `archival`) would be most likely to serve the request.

This also fixes a bug where archival nodes would not route historic EDS requests to the archival pool due to AvailabilityWindow being 0.