### PR TITLE
feat(share/pruner): disallow converting pruned node to archival

### DIFF
--- a/blob/parser.go
+++ b/blob/parser.go
@@ -70,7 +70,8 @@ func (p *parser) addShares(shares []shares.Share) (shrs []shares.Share, isComple
 	return shares[index+1:], true
 }
 
-// parse ensures that correct amount of shares was collected and create a blob from the existing shares.
+// parse ensures that correct amount of shares was collected and create a blob from the existing
+// shares.
 func (p *parser) parse() (*Blob, error) {
 	if p.length != len(p.shares) {
 		return nil, fmt.Errorf("invalid shares amount. want:%d, have:%d", p.length, len(p.shares))

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -426,8 +426,8 @@ func TestService_Get(t *testing.T) {
 }
 
 // TestService_GetAllWithoutPadding it retrieves all blobs under the given namespace:
-// the amount of the blobs is known and equal to 5. Then it ensures that each blob has a correct index inside the eds
-// by requesting share and comparing them.
+// the amount of the blobs is known and equal to 5. Then it ensures that each blob has a correct
+// index inside the eds by requesting share and comparing them.
 func TestService_GetAllWithoutPadding(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)

--- a/nodebuilder/tests/fraud_test.go
+++ b/nodebuilder/tests/fraud_test.go
@@ -88,7 +88,7 @@ func TestFraudProofHandling(t *testing.T) {
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
 	cfg.Share.UseShareExchange = false
 	store := nodebuilder.MockStore(t, cfg)
-	full := sw.NewNodeWithStore(node.Full, store)
+	full := sw.MustNewNodeWithStore(node.Full, store)
 
 	// 4.
 	err = full.Start(ctx)
@@ -147,7 +147,7 @@ func TestFraudProofHandling(t *testing.T) {
 	cfg = nodebuilder.DefaultConfig(node.Light)
 	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
 	lnStore := nodebuilder.MockStore(t, cfg)
-	light := sw.NewNodeWithStore(node.Light, lnStore)
+	light := sw.MustNewNodeWithStore(node.Light, lnStore)
 	require.NoError(t, light.Start(ctx))
 	lightClient := getAdminClient(ctx, light, t)
 
@@ -165,7 +165,7 @@ func TestFraudProofHandling(t *testing.T) {
 	}
 
 	// 9.
-	fN := sw.NewNodeWithStore(node.Full, store)
+	fN := sw.MustNewNodeWithStore(node.Full, store)
 	err = fN.Start(ctx)
 	var fpExist *fraud.ErrFraudExists[*header.ExtendedHeader]
 	require.ErrorAs(t, err, &fpExist)

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -201,16 +201,16 @@ func (s *Swamp) DefaultTestConfig(tp node.Type) *nodebuilder.Config {
 }
 
 // NewBridgeNode creates a new instance of a BridgeNode providing a default config
-// and a mockstore to the NewNodeWithStore method
+// and a mockstore to the MustNewNodeWithStore method
 func (s *Swamp) NewBridgeNode(options ...fx.Option) *nodebuilder.Node {
 	cfg := s.DefaultTestConfig(node.Bridge)
 	store := nodebuilder.MockStore(s.t, cfg)
 
-	return s.NewNodeWithStore(node.Bridge, store, options...)
+	return s.MustNewNodeWithStore(node.Bridge, store, options...)
 }
 
 // NewFullNode creates a new instance of a FullNode providing a default config
-// and a mockstore to the NewNodeWithStore method
+// and a mockstore to the MustNewNodeWithStore method
 func (s *Swamp) NewFullNode(options ...fx.Option) *nodebuilder.Node {
 	cfg := s.DefaultTestConfig(node.Full)
 	cfg.Header.TrustedPeers = []string{
@@ -222,11 +222,11 @@ func (s *Swamp) NewFullNode(options ...fx.Option) *nodebuilder.Node {
 	}
 	store := nodebuilder.MockStore(s.t, cfg)
 
-	return s.NewNodeWithStore(node.Full, store, options...)
+	return s.MustNewNodeWithStore(node.Full, store, options...)
 }
 
 // NewLightNode creates a new instance of a LightNode providing a default config
-// and a mockstore to the NewNodeWithStore method
+// and a mockstore to the MustNewNodeWithStore method
 func (s *Swamp) NewLightNode(options ...fx.Option) *nodebuilder.Node {
 	cfg := s.DefaultTestConfig(node.Light)
 	cfg.Header.TrustedPeers = []string{
@@ -239,7 +239,7 @@ func (s *Swamp) NewLightNode(options ...fx.Option) *nodebuilder.Node {
 
 	store := nodebuilder.MockStore(s.t, cfg)
 
-	return s.NewNodeWithStore(node.Light, store, options...)
+	return s.MustNewNodeWithStore(node.Light, store, options...)
 }
 
 func (s *Swamp) NewNodeWithConfig(nodeType node.Type, cfg *nodebuilder.Config, options ...fx.Option) *nodebuilder.Node {
@@ -248,7 +248,18 @@ func (s *Swamp) NewNodeWithConfig(nodeType node.Type, cfg *nodebuilder.Config, o
 	for _, bootstrapper := range s.Bootstrappers {
 		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bootstrapper.String())
 	}
-	return s.NewNodeWithStore(nodeType, store, options...)
+	return s.MustNewNodeWithStore(nodeType, store, options...)
+}
+
+// MustNewNodeWithStore creates a new instance of Node with predefined Store.
+func (s *Swamp) MustNewNodeWithStore(
+	tp node.Type,
+	store nodebuilder.Store,
+	options ...fx.Option,
+) *nodebuilder.Node {
+	nd, err := s.NewNodeWithStore(tp, store, options...)
+	require.NoError(s.t, err)
+	return nd
 }
 
 // NewNodeWithStore creates a new instance of Node with predefined Store.
@@ -256,7 +267,7 @@ func (s *Swamp) NewNodeWithStore(
 	tp node.Type,
 	store nodebuilder.Store,
 	options ...fx.Option,
-) *nodebuilder.Node {
+) (*nodebuilder.Node, error) {
 	options = append(options,
 		state.WithKeyring(s.ClientContext.Keyring),
 		state.WithKeyName(state.AccountName(s.Accounts[0])),
@@ -270,16 +281,21 @@ func (s *Swamp) NewNodeWithStore(
 	default:
 	}
 
-	nd := s.newNode(tp, store, options...)
+	nd, err := s.newNode(tp, store, options...)
+	if err != nil {
+		return nil, err
+	}
 	s.nodesMu.Lock()
 	s.nodes[nd] = struct{}{}
 	s.nodesMu.Unlock()
-	return nd
+	return nd, nil
 }
 
-func (s *Swamp) newNode(t node.Type, store nodebuilder.Store, options ...fx.Option) *nodebuilder.Node {
+func (s *Swamp) newNode(t node.Type, store nodebuilder.Store, options ...fx.Option) (*nodebuilder.Node, error) {
 	ks, err := store.Keystore()
-	require.NoError(s.t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	// TODO(@Bidon15): If for some reason, we receive one of existing options
 	// like <core, host, hash> from the test case, we need to check them and not use
@@ -296,9 +312,7 @@ func (s *Swamp) newNode(t node.Type, store nodebuilder.Store, options ...fx.Opti
 			return store.Init(ctx, s.genesis)
 		}),
 	)
-	node, err := nodebuilder.New(t, p2p.Private, store, options...)
-	require.NoError(s.t, err)
-	return node
+	return nodebuilder.New(t, p2p.Private, store, options...)
 }
 
 // StopNode stops the node and removes from Swamp.
@@ -331,7 +345,7 @@ func (s *Swamp) Disconnect(t *testing.T, peerA, peerB *nodebuilder.Node) {
 // Swamp test suite. Every new full or light node created on the suite afterwards
 // will automatically add the suite's bootstrappers as trusted peers to their config.
 // NOTE: Bridge nodes do not automatically add the bootstrappers as trusted peers.
-// NOTE: Use `NewNodeWithStore` to avoid this automatic configuration.
+// NOTE: Use `MustNewNodeWithStore` to avoid this automatic configuration.
 func (s *Swamp) SetBootstrapper(t *testing.T, bootstrappers ...*nodebuilder.Node) {
 	for _, trusted := range bootstrappers {
 		addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(trusted.Host))

--- a/pruner/checkpoint.go
+++ b/pruner/checkpoint.go
@@ -13,14 +13,15 @@ import (
 )
 
 var (
-	storePrefix           = datastore.NewKey("pruner")
-	checkpointKey         = datastore.NewKey("checkpoint")
-	errCheckpointNotFound = errors.New("checkpoint not found")
 	// ErrDisallowRevertToArchival is returned when a node has been run with pruner enabled before and
 	// launching it with archival mode.
 	ErrDisallowRevertToArchival = errors.New(
 		"node has been run with pruner enabled before, it is not safe to convert to an archival" +
 			"Run with --experimental-pruning enabled or consider re-initializing the store")
+
+	storePrefix           = datastore.NewKey("pruner")
+	checkpointKey         = datastore.NewKey("checkpoint")
+	errCheckpointNotFound = errors.New("checkpoint not found")
 )
 
 // checkpoint contains information related to the state of the

--- a/pruner/checkpoint.go
+++ b/pruner/checkpoint.go
@@ -7,13 +7,20 @@ import (
 	"fmt"
 
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 
 	"github.com/celestiaorg/celestia-node/header"
 )
 
 var (
-	storePrefix   = datastore.NewKey("pruner")
-	checkpointKey = datastore.NewKey("checkpoint")
+	storePrefix           = datastore.NewKey("pruner")
+	checkpointKey         = datastore.NewKey("checkpoint")
+	errCheckpointNotFound = errors.New("checkpoint not found")
+	// ErrDisallowRevertToArchival is returned when a node has been run with pruner enabled before and
+	// launching it with archival mode.
+	ErrDisallowRevertToArchival = errors.New(
+		"node has been run with pruner enabled before, it is not safe to convert to an archival" +
+			"Run with --experimental-pruning enabled or consider re-initializing the store")
 )
 
 // checkpoint contains information related to the state of the
@@ -23,25 +30,60 @@ type checkpoint struct {
 	FailedHeaders    map[uint64]struct{} `json:"failed"`
 }
 
-// initializeCheckpoint initializes the checkpoint, storing the earliest header in the chain.
-func (s *Service) initializeCheckpoint(ctx context.Context) error {
-	return s.updateCheckpoint(ctx, uint64(1), nil)
+// DetectPreviousRun checks if the pruner has run before by checking for the existence of a
+// checkpoint.
+func DetectPreviousRun(ctx context.Context, ds datastore.Datastore) error {
+	_, err := getCheckpoint(ctx, namespace.Wrap(ds, storePrefix))
+	if errors.Is(err, errCheckpointNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to load checkpoint: %w", err)
+	}
+	return ErrDisallowRevertToArchival
 }
 
-// loadCheckpoint loads the last checkpoint from disk, initializing it if it does not already exist.
-func (s *Service) loadCheckpoint(ctx context.Context) error {
-	bin, err := s.ds.Get(ctx, checkpointKey)
+// storeCheckpoint persists the checkpoint to disk.
+func storeCheckpoint(ctx context.Context, ds datastore.Datastore, c *checkpoint) error {
+	bin, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	return ds.Put(ctx, checkpointKey, bin)
+}
+
+// getCheckpoint loads the last checkpoint from disk.
+func getCheckpoint(ctx context.Context, ds datastore.Datastore) (*checkpoint, error) {
+	bin, err := ds.Get(ctx, checkpointKey)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
-			return s.initializeCheckpoint(ctx)
+			return nil, errCheckpointNotFound
 		}
-		return fmt.Errorf("failed to load checkpoint: %w", err)
+		return nil, fmt.Errorf("failed to load checkpoint: %w", err)
 	}
 
 	var cp *checkpoint
 	err = json.Unmarshal(bin, &cp)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal checkpoint: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal checkpoint: %w", err)
+	}
+
+	return cp, nil
+}
+
+// loadCheckpoint loads the last checkpoint from disk, initializing it if it does not already exist.
+func (s *Service) loadCheckpoint(ctx context.Context) error {
+	cp, err := getCheckpoint(ctx, s.ds)
+	if err != nil {
+		if errors.Is(err, errCheckpointNotFound) {
+			s.checkpoint = &checkpoint{
+				LastPrunedHeight: 1,
+				FailedHeaders:    map[uint64]struct{}{},
+			}
+			return storeCheckpoint(ctx, s.ds, s.checkpoint)
+		}
+		return err
 	}
 
 	s.checkpoint = cp
@@ -60,13 +102,7 @@ func (s *Service) updateCheckpoint(
 	}
 
 	s.checkpoint.LastPrunedHeight = lastPrunedHeight
-
-	bin, err := json.Marshal(s.checkpoint)
-	if err != nil {
-		return err
-	}
-
-	return s.ds.Put(ctx, checkpointKey, bin)
+	return storeCheckpoint(ctx, s.ds, s.checkpoint)
 }
 
 func (s *Service) lastPruned(ctx context.Context) (*header.ExtendedHeader, error) {

--- a/pruner/checkpoint_test.go
+++ b/pruner/checkpoint_test.go
@@ -1,0 +1,26 @@
+package pruner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	c := &checkpoint{
+		LastPrunedHeight: 1,
+		FailedHeaders:    map[uint64]struct{}{1: {}},
+	}
+
+	err := storeCheckpoint(ctx, ds, c)
+	require.NoError(t, err)
+
+	c2, err := getCheckpoint(ctx, ds)
+	require.NoError(t, err)
+	require.Equal(t, c, c2)
+}

--- a/share/eds/byzantine/share_proof.go
+++ b/share/eds/byzantine/share_proof.go
@@ -72,8 +72,8 @@ func (s *ShareWithProof) ShareWithProofToProto() *pb.Share {
 	}
 }
 
-// GetShareWithProof attempts to get a share with proof for the given share. It first tries to get a row proof
-// and if that fails or proof is invalid, it tries to get a column proof.
+// GetShareWithProof attempts to get a share with proof for the given share. It first tries to get
+// a row proof and if that fails or proof is invalid, it tries to get a column proof.
 func GetShareWithProof(
 	ctx context.Context,
 	bGetter blockservice.BlockGetter,


### PR DESCRIPTION
This PR add safety check, that prevents node runner from converting previously pruned node to archival, because it is not supported.