### PR TITLE
chore(share/p2p/discovery): Change success case logging for advertisement to INFO level

### DIFF
--- a/nodebuilder/fraud/lifecycle.go
+++ b/nodebuilder/fraud/lifecycle.go
@@ -69,7 +69,7 @@ func (breaker *ServiceBreaker[S, H]) Stop(ctx context.Context) error {
 
 	if breaker.ctx.Err() != nil {
 		// short circuit if the service was already stopped
-		return nil
+		return nil //nolint:nilerr
 	}
 
 	breaker.sub.Cancel()

--- a/nodebuilder/fraud/lifecycle.go
+++ b/nodebuilder/fraud/lifecycle.go
@@ -69,7 +69,7 @@ func (breaker *ServiceBreaker[S, H]) Stop(ctx context.Context) error {
 
 	if breaker.ctx.Err() != nil {
 		// short circuit if the service was already stopped
-		return nil //nolint:nilerr
+		return nil
 	}
 
 	breaker.sub.Cancel()

--- a/nodebuilder/p2p/misc.go
+++ b/nodebuilder/p2p/misc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	connmgri "github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/peerstore"
-	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds" //nolint:staticcheck
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds" //nolint:staticcheck //nolint:nolintlint
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 

--- a/share/eds/cache/noop.go
+++ b/share/eds/cache/noop.go
@@ -38,7 +38,7 @@ var _ Accessor = (*NoopAccessor)(nil)
 type NoopAccessor struct{}
 
 func (n NoopAccessor) Blockstore() (dagstore.ReadBlockstore, error) {
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }
 
 func (n NoopAccessor) Reader() io.Reader {

--- a/share/eds/cache/noop.go
+++ b/share/eds/cache/noop.go
@@ -38,7 +38,6 @@ var _ Accessor = (*NoopAccessor)(nil)
 type NoopAccessor struct{}
 
 func (n NoopAccessor) Blockstore() (dagstore.ReadBlockstore, error) {
-	//nolint:nilnil
 	return nil, nil
 }
 

--- a/share/p2p/discovery/discovery.go
+++ b/share/p2p/discovery/discovery.go
@@ -170,7 +170,7 @@ func (d *Discovery) Advertise(ctx context.Context) {
 	timer := time.NewTimer(d.params.AdvertiseInterval)
 	defer timer.Stop()
 	for {
-		log.Debugf("advertising to topic %s", d.tag)
+		log.Infof("advertising to topic %s", d.tag)
 		_, err := d.disc.Advertise(ctx, d.tag)
 		d.metrics.observeAdvertise(ctx, err)
 		if err != nil {
@@ -195,7 +195,7 @@ func (d *Discovery) Advertise(ctx context.Context) {
 			}
 		}
 
-		log.Debugf("successfully advertised to topic %s", d.tag)
+		log.Infof("successfully advertised to topic %s", d.tag)
 		if !timer.Stop() {
 			<-timer.C
 		}


### PR DESCRIPTION
These logs would happen infrequently anyway (hourly) and we only logged error case so would be nice to see the success case without having to enable debug logs.

Also some random linter failure fixes on my end.