### PR TITLE
refactor(testing): replace require.TestingT with testing.TB

### DIFF
--- a/nodebuilder/store_test.go
+++ b/nodebuilder/store_test.go
@@ -268,7 +268,7 @@ type store struct {
 	edsStore *eds.Store
 }
 
-func newStore(ctx context.Context, t require.TestingT, params *eds.Parameters, dir string) store {
+func newStore(ctx context.Context, t testing.TB, params *eds.Parameters, dir string) store {
 	s, err := OpenStore(dir, nil)
 	require.NoError(t, err)
 	ds, err := s.Datastore()

--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -13,7 +13,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share/sharetest"
 )
 
-func RandByzantineEDS(t *testing.T, size int, options ...nmt.Option) *rsmt2d.ExtendedDataSquare {
+func RandByzantineEDS(t testing.TB, size int, options ...nmt.Option) *rsmt2d.ExtendedDataSquare {
 	eds := RandEDS(t, size)
 	shares := eds.Flattened()
 	copy(share.GetData(shares[0]), share.GetData(shares[1])) // corrupting eds
@@ -25,9 +25,8 @@ func RandByzantineEDS(t *testing.T, size int, options ...nmt.Option) *rsmt2d.Ext
 	return eds
 }
 
-// RandEDS generates EDS filled with the random data with the given size for original square. It
-// uses require.TestingT to be able to take both a *testing.T and a *testing.B.
-func RandEDS(t require.TestingT, size int) *rsmt2d.ExtendedDataSquare {
+// RandEDS generates EDS filled with the random data with the given size for original square.
+func RandEDS(t testing.TB, size int) *rsmt2d.ExtendedDataSquare {
 	shares := sharetest.RandShares(t, size*size)
 	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), wrapper.NewConstructor(uint64(size)))
 	require.NoError(t, err, "failure to recompute the extended data square")
@@ -35,7 +34,7 @@ func RandEDS(t require.TestingT, size int) *rsmt2d.ExtendedDataSquare {
 }
 
 func RandEDSWithNamespace(
-	t require.TestingT,
+	t testing.TB,
 	namespace share.Namespace,
 	size int,
 ) (*rsmt2d.ExtendedDataSquare, *share.Root) {

--- a/share/sharetest/testing.go
+++ b/share/sharetest/testing.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"sort"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -14,9 +15,8 @@ import (
 	"github.com/celestiaorg/celestia-node/share"
 )
 
-// RandShares generate 'total' amount of shares filled with random data. It uses require.TestingT
-// to be able to take both a *testing.T and a *testing.B.
-func RandShares(t require.TestingT, total int) []share.Share {
+// RandShares generate 'total' amount of shares filled with random data.
+func RandShares(t testing.TB, total int) []share.Share {
 	if total&(total-1) != 0 {
 		t.Errorf("total must be power of 2: %d", total)
 		t.FailNow()
@@ -38,7 +38,7 @@ func RandShares(t require.TestingT, total int) []share.Share {
 }
 
 // RandSharesWithNamespace is same the as RandShares, but sets same namespace for all shares.
-func RandSharesWithNamespace(t require.TestingT, namespace share.Namespace, total int) []share.Share {
+func RandSharesWithNamespace(t testing.TB, namespace share.Namespace, total int) []share.Share {
 	if total&(total-1) != 0 {
 		t.Errorf("total must be power of 2: %d", total)
 		t.FailNow()


### PR DESCRIPTION
Small refactoring to use testing.TB instead of require.T in testing pkgs