### PR TITLE
feat: celestia node run

### DIFF
--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -15,6 +15,7 @@ func WithSubcommands() func(*cobra.Command, []*pflag.FlagSet) {
 		c.AddCommand(
 			cmdnode.Init(flags...),
 			cmdnode.Start(cmdnode.WithFlagSet(flags)),
+			cmdnode.Run(cmdnode.WithFlagSet(flags)),
 			cmdnode.AuthCmd(flags...),
 			cmdnode.ResetStore(flags...),
 			cmdnode.RemoveConfigCmd(flags...),

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
-
-	"github.com/celestiaorg/celestia-node/nodebuilder"
 )
 
 // Init constructs a CLI command to initialize Celestia Node of any type with the given flags.
@@ -14,9 +12,12 @@ func Init(fsets ...*flag.FlagSet) *cobra.Command {
 		Short: "Initialization for Celestia Node. Passed flags have persisted effect.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
+			node, err := NewRunner(cmd.Context())
+			if err != nil {
+				return err
+			}
 
-			return nodebuilder.Init(NodeConfig(ctx), StorePath(ctx), NodeType(ctx))
+			return node.Init(cmd.Context())
 		},
 	}
 	for _, set := range fsets {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -12,7 +12,8 @@ func Init(fsets ...*flag.FlagSet) *cobra.Command {
 		Short: "Initialization for Celestia Node. Passed flags have persisted effect.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			node, err := NewRunner(cmd.Context())
+			config := NodeConfig(cmd.Context())
+			node, err := NewRunner(&config)
 			if err != nil {
 				return err
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,7 +31,10 @@ func Run(options ...func(*cobra.Command)) *cobra.Command {
 
 			ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
-			node.Start(ctx)
+			err = node.Start(ctx)
+			if err != nil {
+				return err
+			}
 			<-ctx.Done()
 			cancel() // ensure we stop reading more signals for start context
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,7 +19,8 @@ func Run(options ...func(*cobra.Command)) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			ctx := cmd.Context()
 
-			node, err := NewRunner(ctx)
+			config := NodeConfig(ctx)
+			node, err := NewRunner(&config)
 			if err != nil {
 				return err
 			}

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -20,11 +20,9 @@ type Runner struct {
 	errChan chan error
 }
 
-func NewRunner(ctx context.Context) (*Runner, error) {
-	config := NodeConfig(ctx)
-
+func NewRunner(config *nodebuilder.Config) (*Runner, error) {
 	return &Runner{
-		config:  &config,
+		config:  config,
 		errChan: make(chan error, 1),
 	}, nil
 }
@@ -38,8 +36,11 @@ func (r *Runner) Finish() {
 }
 
 func (r *Runner) Init(ctx context.Context) error {
-	config := NodeConfig(ctx)
-	return nodebuilder.Init(config, StorePath(ctx), NodeType(ctx))
+	return nodebuilder.Init(
+		*r.config,
+		StorePath(ctx),
+		NodeType(ctx),
+	)
 }
 
 func (r *Runner) Start(ctx context.Context) error {

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	"github.com/celestiaorg/celestia-node/nodebuilder"
+)
+
+// Runner is a wrapper for the various celestia
+type Runner struct {
+	config  *nodebuilder.Config
+	store   nodebuilder.Store
+	node    *nodebuilder.Node
+	errChan chan error
+}
+
+func NewRunner(ctx context.Context) (*Runner, error) {
+	config := NodeConfig(ctx)
+
+	return &Runner{
+		config:  &config,
+		errChan: make(chan error, 1),
+	}, nil
+}
+
+func (r *Runner) Errors() <-chan error {
+	return r.errChan
+}
+
+func (r *Runner) Finish() {
+	close(r.errChan)
+}
+
+func (r *Runner) Init(ctx context.Context) error {
+	config := NodeConfig(ctx)
+	return nodebuilder.Init(config, StorePath(ctx), NodeType(ctx))
+}
+
+func (r *Runner) Start(ctx context.Context) context.Context {
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		defer cancel()
+
+		storePath := StorePath(ctx)
+		keysPath := filepath.Join(storePath, "keys")
+
+		encConf := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+		ring, err := keyring.New(
+			app.Name,
+			r.config.State.KeyringBackend,
+			keysPath,
+			os.Stdin,
+			encConf.Codec,
+		)
+		if err != nil {
+			r.errChan <- err
+			return
+		}
+
+		store, err := nodebuilder.OpenStore(storePath, ring)
+		if err != nil {
+			r.errChan <- err
+			return
+		}
+
+		node, err := nodebuilder.NewWithConfig(
+			NodeType(ctx),
+			Network(ctx),
+			store,
+			r.config,
+			NodeOptions(ctx)...,
+		)
+		if err != nil {
+			r.errChan <- err
+			return
+		}
+
+		r.store = store
+		r.node = node
+
+		err = r.node.Start(ctx)
+		if err != nil {
+			r.errChan <- err
+			return
+		}
+	}()
+
+	return ctx
+}
+
+func (r *Runner) Stop(ctx context.Context) <-chan struct{} {
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		defer cancel()
+
+		err := r.node.Stop(ctx)
+		if err != nil {
+			r.errChan <- err
+			return
+		}
+	}()
+
+	return ctx.Done()
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -25,7 +25,10 @@ Options passed on start override configuration options only on start and are not
 
 			ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
-			node.Start(ctx)
+			err = node.Start(ctx)
+			if err != nil {
+				return err
+			}
 			<-ctx.Done()
 			cancel() // ensure we stop reading more signals for start context
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,13 +18,15 @@ Options passed on start override configuration options only on start and are not
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			ctx := cmd.Context()
-			node, err := NewRunner(ctx)
+			config := NodeConfig(ctx)
+			node, err := NewRunner(&config)
 			if err != nil {
 				return err
 			}
 
 			ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
+
 			err = node.Start(ctx)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

Ok, been doing this in small bits over a few weeks and re-arranged the furniture multiple times, so hopefully it is still coherent, but figured it was time stop fiddling and open the PR even though i don't love it

### What it does?

- establishes `celestia light run` as its own command that will both init and start (request from @smuu refs #2279)
- tries to prevent code dupe of copying init.go and start.go into a run.go by introducing a 'runner' construct
- removes the `run` alias for start, therefore marked `breaking`

so, we now can

`celestia light init` -> `celestia light start`
`celestia light start`
`celestia light run`

What else

- i don't love or like the cmd/runner.go at all but i think its a fine/ok stop gap to get this running and done with small scope
- i think a next step would be a larger and further refactoring to move the runner/run thing into nodebuilder.go, but this should be part of a bigger refactor to clean up some of the usage of cmd/env.go (ie: StorePath, NodeConfig) that the existing init and start rely on and bundle this all into a refactoring of 'nodebuilder' closer to @Wondertan's original vision i will start on imminently...