### PR TITLE
ci: remove golangci-lint action warning

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ci/chore/golang-ci-warning
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci/chore/golang-ci-warning
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -45,8 +45,7 @@ jobs:
         with:
           args: --timeout 10m
           version: v1.59
-          skip-pkg-cache: true
-          skip-build-cache: true
+          skip-cache: true
 
   go_mod_tidy_check:
     needs: [setup]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

somewhere along the upgrades, the input parameters to the golangci-lint action changed where `skip-pkg-cache` and `skip-build-cache` became just `skip-cache`. CI would show a warning that these were no longer known inputs but not fail. Thus, updating.

eg:

<img width="1230" alt="warn" src="https://github.com/celestiaorg/celestia-node/assets/12677/8e1bd51f-8abc-47be-bc1d-a49f9d4a0a87">
