### PR TITLE
ci: update celestia shared dep to remove node 16 warning

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -55,7 +55,7 @@ jobs:
 
   # Dockerfile Linting
   hadolint:
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@ci/ramin/update-python # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@0.4.3 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
 
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: celestiaorg/.github/.github/actions/yamllint@v0.4.2
+      - uses: celestiaorg/.github/.github/actions/yamllint@v0.4.3
 
   markdown-lint:
     name: Markdown Lint

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -54,7 +54,7 @@ jobs:
 
   # Dockerfile Linting
   hadolint:
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@v0.4.2 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@ci/ramin/update-python # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
 

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ci/ramin/remove-warning
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci/ramin/remove-warning
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -55,7 +55,7 @@ jobs:
 
   # Dockerfile Linting
   hadolint:
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@0.4.3 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@v0.4.3 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
 

--- a/.github/workflows/create_release_tracking_epic.yml
+++ b/.github/workflows/create_release_tracking_epic.yml
@@ -7,7 +7,7 @@ on:
     types: [released]
 jobs:
   trigger_issue:
-    uses: celestiaorg/.github/.github/workflows/reusable_create_release_tracking_epic.yml@v0.4.2
+    uses: celestiaorg/.github/.github/workflows/reusable_create_release_tracking_epic.yml@v0.4.3
     secrets: inherit
     with:
       release-repo: ${{ github.repository }}

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@0.4.3 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.3 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
     secrets: inherit

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.2 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@ci/ramin/update-python # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
     secrets: inherit

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@ci/ramin/update-python # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@0.4.3 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
     secrets: inherit


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

pulling in update/change from https://github.com/celestiaorg/.github/pull/109 to remove the GitHub actions CI warning about using an action that uses node 16 which is deprecated, simple.
