### PR TITLE
feat(metrics): add common labels to prometheus

### DIFF
--- a/nodebuilder/p2p/metrics.go
+++ b/nodebuilder/p2p/metrics.go
@@ -6,9 +6,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/fx"
+
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
 // WithMetrics option sets up native libp2p metrics up.
@@ -23,6 +26,10 @@ func WithMetrics() fx.Option {
 const (
 	promAgentEndpoint = "/metrics"
 	promAgentPort     = "8890"
+
+	networkLabel  = "network"
+	nodeTypeLabel = "node_type"
+	peerIDLabel   = "peer_id"
 )
 
 // prometheusMetrics option sets up native libp2p metrics up
@@ -58,6 +65,16 @@ func prometheusMetrics(lifecycle fx.Lifecycle, registerer prometheus.Registerer)
 	return nil
 }
 
-func prometheusRegisterer() prometheus.Registerer {
-	return prometheus.NewRegistry()
+func prometheusRegisterer(
+	peerID peer.ID,
+	nodeType node.Type,
+	network Network,
+) prometheus.Registerer {
+	reg := prometheus.NewRegistry()
+	labels := prometheus.Labels{
+		networkLabel:  network.String(),
+		nodeTypeLabel: nodeType.String(),
+		peerIDLabel:   peerID.String(),
+	}
+	return prometheus.WrapRegistererWith(labels, reg)
 }


### PR DESCRIPTION
Adds common labels to prometheus based metrics:
- node_type
- peer_id
- network