### PR TITLE
feat(shwap): add Q1Q4 file

### DIFF
--- a/share/new_eds/testing.go
+++ b/share/new_eds/testing.go
@@ -246,6 +246,10 @@ func BenchGetHalfAxisFromAccessor(
 			for _, squareHalf := range []int{0, 1} {
 				name := fmt.Sprintf("Size:%v/ProofType:%s/squareHalf:%s", size, axisType, strconv.Itoa(squareHalf))
 				b.Run(name, func(b *testing.B) {
+					// warm up cache
+					_, err := f.AxisHalf(ctx, axisType, f.Size(ctx)/2*(squareHalf))
+					require.NoError(b, err)
+
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
 						_, err := f.AxisHalf(ctx, axisType, f.Size(ctx)/2*(squareHalf))

--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -29,7 +29,10 @@ type ODSFile struct {
 	// repeated file reads. - Serving full ODS data by Shares().
 	// Storing the square in memory allows for efficient single-read operations, avoiding the need for
 	// piecemeal reads by rows or columns, and facilitates quick access to data for these operations.
-	ods          square
+	ods square
+	// disableCache is a flag that, when set to true, disables the in-memory cache of the original data
+	// Used for testing and benchmarking purposes, this flag allows for the evaluation of the
+	// performance.
 	disableCache bool
 }
 
@@ -232,7 +235,6 @@ func (f *ODSFile) readODS() (square, error) {
 	}
 
 	if !f.disableCache {
-		fmt.Println("STORE ODS")
 		f.ods = square
 	}
 	return square, nil

--- a/store/file/ods_test.go
+++ b/store/file/ods_test.go
@@ -48,9 +48,9 @@ func TestReadODSFromFile(t *testing.T) {
 	f, err := CreateODSFile(path, []byte{}, eds)
 	require.NoError(t, err)
 
-	err = f.readODS()
+	ods, err := f.readODS()
 	require.NoError(t, err)
-	for i, row := range f.ods {
+	for i, row := range ods {
 		original := eds.Row(uint(i))[:eds.Width()/2]
 		require.True(t, len(original) == len(row))
 		require.Equal(t, original, row)
@@ -65,19 +65,18 @@ func TestODSFile(t *testing.T) {
 	eds.TestSuiteAccessor(ctx, t, createODSFile, ODSSize)
 }
 
-// ReconstructSome, default codec
-// BenchmarkAxisFromODSFile/Size:32/Axis:row/squareHalf:first(original)-10         	  455848	      2588 ns/op
-// BenchmarkAxisFromODSFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    9015	    203950 ns/op
-// BenchmarkAxisFromODSFile/Size:32/Axis:col/squareHalf:first(original)-10         	   52734	     21178 ns/op
-// BenchmarkAxisFromODSFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    8830	    127452 ns/op
-// BenchmarkAxisFromODSFile/Size:64/Axis:row/squareHalf:first(original)-10         	  303834	      4763 ns/op
-// BenchmarkAxisFromODSFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    2940	    426246 ns/op
-// BenchmarkAxisFromODSFile/Size:64/Axis:col/squareHalf:first(original)-10         	   27758	     42842 ns/op
-// BenchmarkAxisFromODSFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    3385	    353868 ns/op
-// BenchmarkAxisFromODSFile/Size:128/Axis:row/squareHalf:first(original)-10        	  172086	      6455 ns/op
-// BenchmarkAxisFromODSFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     672	   1550386 ns/op
-// BenchmarkAxisFromODSFile/Size:128/Axis:col/squareHalf:first(original)-10        	   14202	     84316 ns/op
-// BenchmarkAxisFromODSFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     978	   1230980 ns/op
+// BenchmarkAxisFromODSFile/Size:32/ProofType:row/squareHalf:0-10         	  460231	      2555 ns/op
+// BenchmarkAxisFromODSFile/Size:32/ProofType:row/squareHalf:1-10         	    5320	    218609 ns/op
+// BenchmarkAxisFromODSFile/Size:32/ProofType:col/squareHalf:0-10         	 4572247	       256.7 ns/op
+// BenchmarkAxisFromODSFile/Size:32/ProofType:col/squareHalf:1-10         	    5170	    212567 ns/op
+// BenchmarkAxisFromODSFile/Size:64/ProofType:row/squareHalf:0-10         	  299281	      3777 ns/op
+// BenchmarkAxisFromODSFile/Size:64/ProofType:row/squareHalf:1-10         	    1646	    661930 ns/op
+// BenchmarkAxisFromODSFile/Size:64/ProofType:col/squareHalf:0-10         	 3318733	       359.1 ns/op
+// BenchmarkAxisFromODSFile/Size:64/ProofType:col/squareHalf:1-10         	    1600	    648482 ns/op
+// BenchmarkAxisFromODSFile/Size:128/ProofType:row/squareHalf:0-10        	  170642	      6347 ns/op
+// BenchmarkAxisFromODSFile/Size:128/ProofType:row/squareHalf:1-10        	     328	   3194674 ns/op
+// BenchmarkAxisFromODSFile/Size:128/ProofType:col/squareHalf:0-10        	 1931910	       640.9 ns/op
+// BenchmarkAxisFromODSFile/Size:128/ProofType:col/squareHalf:1-10        	     387	   3304090 ns/op
 func BenchmarkAxisFromODSFile(b *testing.B) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	b.Cleanup(cancel)
@@ -90,19 +89,43 @@ func BenchmarkAxisFromODSFile(b *testing.B) {
 	eds.BenchGetHalfAxisFromAccessor(ctx, b, newFile, minSize, maxSize)
 }
 
-// BenchmarkShareFromODSFile/Size:32/Axis:row/squareHalf:first(original)-10         	   10339	    111328 ns/op
-// BenchmarkShareFromODSFile/Size:32/Axis:row/squareHalf:second(extended)-10        	    3392	    359180 ns/op
-// BenchmarkShareFromODSFile/Size:32/Axis:col/squareHalf:first(original)-10         	    8925	    131352 ns/op
-// BenchmarkShareFromODSFile/Size:32/Axis:col/squareHalf:second(extended)-10        	    3447	    346218 ns/op
-// BenchmarkShareFromODSFile/Size:64/Axis:row/squareHalf:first(original)-10         	    5503	    215833 ns/op
-// BenchmarkShareFromODSFile/Size:64/Axis:row/squareHalf:second(extended)-10        	    1231	   1001053 ns/op
-// BenchmarkShareFromODSFile/Size:64/Axis:col/squareHalf:first(original)-10         	    4711	    250001 ns/op
-// BenchmarkShareFromODSFile/Size:64/Axis:col/squareHalf:second(extended)-10        	    1315	    910079 ns/op
-// BenchmarkShareFromODSFile/Size:128/Axis:row/squareHalf:first(original)-10        	    2364	    435748 ns/op
-// BenchmarkShareFromODSFile/Size:128/Axis:row/squareHalf:second(extended)-10       	     358	   3330620 ns/op
-// BenchmarkShareFromODSFile/Size:128/Axis:col/squareHalf:first(original)-10        	    2114	    514642 ns/op
-// BenchmarkShareFromODSFile/Size:128/Axis:col/squareHalf:second(extended)-10       	     373	   3068104 ns/op
-func BenchmarkShareFromODSFile(b *testing.B) {
+// BenchmarkAxisFromODSFileDisabledCache/Size:32/ProofType:row/squareHalf:0-10         	  481326	      2447 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:32/ProofType:row/squareHalf:1-10         	    5134	    218191 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:32/ProofType:col/squareHalf:0-10         	   56260	     21109 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:32/ProofType:col/squareHalf:1-10         	    5608	    217877 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:64/ProofType:row/squareHalf:0-10         	  321994	      3941 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:64/ProofType:row/squareHalf:1-10         	    1237	    919419 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:64/ProofType:col/squareHalf:0-10         	   28233	     43209 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:64/ProofType:col/squareHalf:1-10         	    1334	    898654 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:128/ProofType:row/squareHalf:0-10        	  179788	      6839 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:128/ProofType:row/squareHalf:1-10        	     310	   3935097 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:128/ProofType:col/squareHalf:0-10        	   13867	     85854 ns/op
+// BenchmarkAxisFromODSFileDisabledCache/Size:128/ProofType:col/squareHalf:1-10        	     298	   3900021 ns/op
+func BenchmarkAxisFromODSFileDisabledCache(b *testing.B) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	b.Cleanup(cancel)
+
+	minSize, maxSize := 32, 128
+	newFile := func(size int) eds.Accessor {
+		eds := edstest.RandEDS(b, size)
+		return createODSFileDisabledCache(b, eds)
+	}
+	eds.BenchGetHalfAxisFromAccessor(ctx, b, newFile, minSize, maxSize)
+}
+
+// BenchmarkSampleFromODSFile/Size:32/quadrant:1-10         	   10908	    104872 ns/op
+// BenchmarkSampleFromODSFile/Size:32/quadrant:2-10         	    9906	    104641 ns/op
+// BenchmarkSampleFromODSFile/Size:32/quadrant:3-10         	    8983	    123384 ns/op
+// BenchmarkSampleFromODSFile/Size:32/quadrant:4-10         	    3476	    343850 ns/op
+// BenchmarkSampleFromODSFile/Size:64/quadrant:1-10         	    5835	    200151 ns/op
+// BenchmarkSampleFromODSFile/Size:64/quadrant:2-10         	    5401	    201271 ns/op
+// BenchmarkSampleFromODSFile/Size:64/quadrant:3-10         	    4648	    239045 ns/op
+// BenchmarkSampleFromODSFile/Size:64/quadrant:4-10         	    1263	    895983 ns/op
+// BenchmarkSampleFromODSFile/Size:128/quadrant:1-10        	    2475	    409687 ns/op
+// BenchmarkSampleFromODSFile/Size:128/quadrant:2-10        	    2790	    411153 ns/op
+// BenchmarkSampleFromODSFile/Size:128/quadrant:3-10        	    2286	    487123 ns/op
+// BenchmarkSampleFromODSFile/Size:128/quadrant:4-10        	     321	   3698735 ns/op
+func BenchmarkSampleFromODSFile(b *testing.B) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	b.Cleanup(cancel)
 
@@ -114,9 +137,41 @@ func BenchmarkShareFromODSFile(b *testing.B) {
 	eds.BenchGetSampleFromAccessor(ctx, b, newFile, minSize, maxSize)
 }
 
+// BenchmarkSampleFromODSFileDisabledCache/Size:32/quadrant:1-10         	   11040	    106378 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:32/quadrant:2-10         	    9936	    106403 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:32/quadrant:3-10         	    8635	    124142 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:32/quadrant:4-10         	    1940	    596330 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:64/quadrant:1-10         	    5930	    199782 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:64/quadrant:2-10         	    5494	    201658 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:64/quadrant:3-10         	    4756	    237897 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:64/quadrant:4-10         	     638	   1874038 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:128/quadrant:1-10        	    2500	    408092 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:128/quadrant:2-10        	    2696	    410861 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:128/quadrant:3-10        	    2290	    490488 ns/op
+// BenchmarkSampleFromODSFileDisabledCache/Size:128/quadrant:4-10        	     159	   7660843 ns/op
+func BenchmarkSampleFromODSFileDisabledCache(b *testing.B) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	b.Cleanup(cancel)
+
+	minSize, maxSize := 32, 128
+	newFile := func(size int) eds.Accessor {
+		eds := edstest.RandEDS(b, size)
+		return createODSFileDisabledCache(b, eds)
+	}
+	eds.BenchGetSampleFromAccessor(ctx, b, newFile, minSize, maxSize)
+}
+
 func createODSFile(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.Accessor {
 	path := t.TempDir() + "/" + strconv.Itoa(rand.Intn(1000))
 	fl, err := CreateODSFile(path, []byte{}, eds)
 	require.NoError(t, err)
+	return fl
+}
+
+func createODSFileDisabledCache(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.Accessor {
+	path := t.TempDir() + "/" + strconv.Itoa(rand.Intn(1000))
+	fl, err := CreateODSFile(path, []byte{}, eds)
+	require.NoError(t, err)
+	fl.disableCache = true
 	return fl
 }

--- a/store/file/q1q4_file.go
+++ b/store/file/q1q4_file.go
@@ -1,0 +1,135 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share"
+	eds "github.com/celestiaorg/celestia-node/share/new_eds"
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+var _ eds.AccessorCloser = (*Q1Q4File)(nil)
+
+type Q1Q4File struct {
+	ods *ODSFile
+}
+
+func OpenQ1Q4File(path string) (*Q1Q4File, error) {
+	ods, err := OpenODSFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Q1Q4File{
+		ods: ods,
+	}, nil
+}
+
+func CreateQ1Q4File(path string, datahash share.DataHash, eds *rsmt2d.ExtendedDataSquare,
+) (*Q1Q4File, error) {
+	ods, err := CreateODSFile(path, datahash, eds)
+	if err != nil {
+		return nil, err
+	}
+
+	err = writeQ4(ods.fl, eds)
+	if err != nil {
+		return nil, fmt.Errorf("writing Q4: %w", err)
+	}
+
+	return &Q1Q4File{
+		ods: ods,
+	}, nil
+}
+
+func (f *Q1Q4File) Size(ctx context.Context) int {
+	return f.ods.Size(ctx)
+}
+
+func (f *Q1Q4File) Sample(ctx context.Context, rowIdx, colIdx int) (shwap.Sample, error) {
+	// use native AxisHalf implementation, to read axis from Q4 quandrant when possible
+	half, err := f.AxisHalf(ctx, rsmt2d.Row, rowIdx)
+	if err != nil {
+		return shwap.Sample{}, fmt.Errorf("reading axis: %w", err)
+	}
+	shares, err := half.Extended()
+	if err != nil {
+		return shwap.Sample{}, fmt.Errorf("extending shares: %w", err)
+	}
+	return shwap.SampleFromShares(shares, rsmt2d.Row, rowIdx, colIdx)
+}
+
+func (f *Q1Q4File) AxisHalf(_ context.Context, axisType rsmt2d.Axis, axisIdx int) (eds.AxisHalf, error) {
+	if axisIdx < f.ods.size()/2 {
+		half, err := f.ods.readAxisHalf(axisType, axisIdx)
+		if err != nil {
+			return eds.AxisHalf{}, fmt.Errorf("reading axis half: %w", err)
+		}
+		return half, nil
+	}
+
+	shares, err := f.readSharesFromQ4(axisType, axisIdx)
+	if err != nil {
+		return eds.AxisHalf{}, err
+	}
+	return eds.AxisHalf{
+		Shares:   shares,
+		IsParity: true,
+	}, nil
+}
+
+func (f *Q1Q4File) RowNamespaceData(ctx context.Context,
+	namespace share.Namespace,
+	rowIdx int,
+) (shwap.RowNamespaceData, error) {
+	half, err := f.AxisHalf(ctx, rsmt2d.Row, rowIdx)
+	if err != nil {
+		return shwap.RowNamespaceData{}, fmt.Errorf("reading axis: %w", err)
+	}
+	shares, err := half.Extended()
+	if err != nil {
+		return shwap.RowNamespaceData{}, fmt.Errorf("extending shares: %w", err)
+	}
+	return shwap.RowNamespaceDataFromShares(shares, namespace, rowIdx)
+}
+
+func (f *Q1Q4File) Shares(ctx context.Context) ([]share.Share, error) {
+	return f.ods.Shares(ctx)
+}
+
+func (f *Q1Q4File) Close() error {
+	return f.ods.Close()
+}
+
+func writeQ4(w io.Writer, eds *rsmt2d.ExtendedDataSquare) error {
+	odsLn := int(eds.Width()) / 2
+	for x := odsLn; x < int(eds.Width()); x++ {
+		for y := odsLn; y < int(eds.Width()); y++ {
+			_, err := w.Write(eds.GetCell(uint(x), uint(y)))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *Q1Q4File) readSharesFromQ4(axisType rsmt2d.Axis, axisIdx int) ([]share.Share, error) {
+	q4idx := axisIdx - f.ods.size()/2
+	if q4idx < 0 {
+		return nil, errors.New("invalid index requested from Q4")
+	}
+	switch axisType {
+	case rsmt2d.Col:
+		return readCol(f.ods.fl, f.ods.hdr, q4idx, 1)
+	case rsmt2d.Row:
+		return readRow(f.ods.fl, f.ods.hdr, q4idx, 1)
+	default:
+		return nil, fmt.Errorf("invalid axis type: %d", axisType)
+	}
+}

--- a/store/file/q1q4_file.go
+++ b/store/file/q1q4_file.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -119,7 +118,7 @@ func writeQ4(w io.Writer, eds *rsmt2d.ExtendedDataSquare) error {
 func (f *Q1Q4File) readAxisHalfFromQ4(axisType rsmt2d.Axis, axisIdx int) (eds.AxisHalf, error) {
 	q4idx := axisIdx - f.ods.size()/2
 	if q4idx < 0 {
-		return eds.AxisHalf{}, errors.New("invalid index requested from Q4")
+		return eds.AxisHalf{}, fmt.Errorf("invalid axis index for Q4: %d", axisIdx)
 	}
 	switch axisType {
 	case rsmt2d.Col:

--- a/store/file/q1q4_file_test.go
+++ b/store/file/q1q4_file_test.go
@@ -1,0 +1,104 @@
+package file
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/rand"
+
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	eds "github.com/celestiaorg/celestia-node/share/new_eds"
+)
+
+func TestCreateQ1Q4File(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	edsIn := edstest.RandEDS(t, 8)
+	datahash := share.DataHash(rand.Bytes(32))
+	path := t.TempDir() + "/" + datahash.String()
+	f, err := CreateQ1Q4File(path, datahash, edsIn)
+	require.NoError(t, err)
+
+	shares, err := f.Shares(ctx)
+	require.NoError(t, err)
+	expected := edsIn.FlattenedODS()
+	require.Equal(t, expected, shares)
+	require.NoError(t, f.Close())
+
+	f, err = OpenQ1Q4File(path)
+	require.NoError(t, err)
+	shares, err = f.Shares(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expected, shares)
+	require.NoError(t, f.Close())
+}
+
+func TestQ1Q4File(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	ODSSize := 8
+	eds.TestSuiteAccessor(ctx, t, createQ1Q4File, ODSSize)
+}
+
+// BenchmarkAxisFromQ1Q4File/Size:32/ProofType:row/squareHalf:0-10         	  481144	      2413 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:32/ProofType:row/squareHalf:1-10         	  479437	      2431 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:32/ProofType:col/squareHalf:0-10         	   56775	     21272 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:32/ProofType:col/squareHalf:1-10         	   57283	     20941 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:64/ProofType:row/squareHalf:0-10         	  301357	      3870 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:64/ProofType:row/squareHalf:1-10         	  329796	      3913 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:64/ProofType:col/squareHalf:0-10         	   28035	     42560 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:64/ProofType:col/squareHalf:1-10         	   28179	     42447 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:128/ProofType:row/squareHalf:0-10        	  170607	      6368 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:128/ProofType:row/squareHalf:1-10        	  184579	      6517 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:128/ProofType:col/squareHalf:0-10        	   13952	     84004 ns/op
+// BenchmarkAxisFromQ1Q4File/Size:128/ProofType:col/squareHalf:1-10        	   14398	     83240 ns/op
+func BenchmarkAxisFromQ1Q4File(b *testing.B) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	b.Cleanup(cancel)
+
+	minSize, maxSize := 32, 128
+	newFile := func(size int) eds.Accessor {
+		eds := edstest.RandEDS(b, size)
+		return createQ1Q4File(b, eds)
+	}
+	eds.BenchGetHalfAxisFromAccessor(ctx, b, newFile, minSize, maxSize)
+}
+
+// BenchmarkSampleFromQ1Q4File/Size:32/quadrant:1-10         	   11000	    103665 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:32/quadrant:2-10         	    9757	    105395 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:32/quadrant:3-10         	    8880	    119081 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:32/quadrant:4-10         	    9049	    118572 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:64/quadrant:1-10         	    5372	    200685 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:64/quadrant:2-10         	    5499	    200007 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:64/quadrant:3-10         	    4879	    233044 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:64/quadrant:4-10         	    4802	    232696 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:128/quadrant:1-10        	    2810	    398169 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:128/quadrant:2-10        	    2830	    407077 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:128/quadrant:3-10        	    2434	    478656 ns/op
+// BenchmarkSampleFromQ1Q4File/Size:128/quadrant:4-10        	    2368	    478021 ns/op
+func BenchmarkSampleFromQ1Q4File(b *testing.B) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	b.Cleanup(cancel)
+
+	minSize, maxSize := 32, 128
+	newFile := func(size int) eds.Accessor {
+		eds := edstest.RandEDS(b, size)
+		return createQ1Q4File(b, eds)
+	}
+	eds.BenchGetSampleFromAccessor(ctx, b, newFile, minSize, maxSize)
+}
+
+func createQ1Q4File(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.Accessor {
+	path := t.TempDir() + "/" + strconv.Itoa(rand.Intn(1000))
+	fl, err := CreateQ1Q4File(path, []byte{}, eds)
+	require.NoError(t, err)
+	return fl
+}


### PR DESCRIPTION
Q1Q4 file stores 2 quadrants and allow more efficient reads of Q4 samples compared to ODS file