### PR TITLE
fix(nodebuilder/core): non default values from config.toml are written over by flag defaults in specific circumstances

### DIFF
--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -53,6 +53,7 @@ func ParseNodeFlags(ctx context.Context, cmd *cobra.Command, network p2p.Network
 	if nodeConfig != "" {
 		// try to load config from given path
 		cfg, err := nodebuilder.LoadConfig(nodeConfig)
+
 		if err != nil {
 			return ctx, fmt.Errorf("cmd: while parsing '%s': %w", nodeConfigFlag, err)
 		}

--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -53,7 +53,6 @@ func ParseNodeFlags(ctx context.Context, cmd *cobra.Command, network p2p.Network
 	if nodeConfig != "" {
 		// try to load config from given path
 		cfg, err := nodebuilder.LoadConfig(nodeConfig)
-
 		if err != nil {
 			return ctx, fmt.Errorf("cmd: while parsing '%s': %w", nodeConfigFlag, err)
 		}

--- a/nodebuilder/core/config.go
+++ b/nodebuilder/core/config.go
@@ -7,6 +7,11 @@ import (
 	"github.com/celestiaorg/celestia-node/libs/utils"
 )
 
+const (
+	DefaultRPCPort  = "26657"
+	DefaultGRPCPort = "9090"
+)
+
 var MetricsEnabled bool
 
 // Config combines all configuration fields for managing the relationship with a Core node.
@@ -21,8 +26,8 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		IP:       "",
-		RPCPort:  "26657",
-		GRPCPort: "9090",
+		RPCPort:  DefaultRPCPort,
+		GRPCPort: DefaultGRPCPort,
 	}
 }
 

--- a/nodebuilder/core/config.go
+++ b/nodebuilder/core/config.go
@@ -37,6 +37,13 @@ func (cfg *Config) Validate() error {
 		return nil
 	}
 
+	if cfg.RPCPort == "" {
+		return fmt.Errorf("nodebuilder/core: rpc port is not set")
+	}
+	if cfg.GRPCPort == "" {
+		return fmt.Errorf("nodebuilder/core: grpc port is not set")
+	}
+
 	ip, err := utils.ValidateAddr(cfg.IP)
 	if err != nil {
 		return err

--- a/nodebuilder/core/config_test.go
+++ b/nodebuilder/core/config_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       Config
+		expectErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectErr: false,
+		},
+		{
+			name:      "empty config, no endpoint",
+			cfg:       Config{},
+			expectErr: false,
+		},
+		{
+			name: "missing RPC port",
+			cfg: Config{
+				IP:       "127.0.0.1",
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing GRPC port",
+			cfg: Config{
+				IP:      "127.0.0.1",
+				RPCPort: DefaultRPCPort,
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid IP",
+			cfg: Config{
+				IP:       "invalid-ip",
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid RPC port",
+			cfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  "invalid-port",
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid GRPC port",
+			cfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: "invalid-port",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/nodebuilder/core/flags.go
+++ b/nodebuilder/core/flags.go
@@ -50,14 +50,11 @@ func ParseFlags(
 		return nil
 	}
 
-	// in the case that the RPC port is not set, use the default port
-	// or in the case a value has been set via flag,
-	// set that as highest precedence
-	if cfg.RPCPort == "" || cmd.Flag(coreRPCFlag).Changed {
+	if cmd.Flag(coreRPCFlag).Changed {
 		rpc := cmd.Flag(coreRPCFlag).Value.String()
 		cfg.RPCPort = rpc
 	}
-	if cfg.GRPCPort == "" || cmd.Flag(coreGRPCFlag).Changed {
+	if cmd.Flag(coreGRPCFlag).Changed {
 		grpc := cmd.Flag(coreGRPCFlag).Value.String()
 		cfg.GRPCPort = grpc
 	}

--- a/nodebuilder/core/flags.go
+++ b/nodebuilder/core/flags.go
@@ -54,6 +54,7 @@ func ParseFlags(
 		rpc := cmd.Flag(coreRPCFlag).Value.String()
 		cfg.RPCPort = rpc
 	}
+
 	if cmd.Flag(coreGRPCFlag).Changed {
 		grpc := cmd.Flag(coreGRPCFlag).Value.String()
 		cfg.GRPCPort = grpc

--- a/nodebuilder/core/flags.go
+++ b/nodebuilder/core/flags.go
@@ -26,12 +26,12 @@ func Flags() *flag.FlagSet {
 	)
 	flags.String(
 		coreRPCFlag,
-		"26657",
+		DefaultRPCPort,
 		"Set a custom RPC port for the core node connection. The --core.ip flag must also be provided.",
 	)
 	flags.String(
 		coreGRPCFlag,
-		"9090",
+		DefaultGRPCPort,
 		"Set a custom gRPC port for the core node connection. The --core.ip flag must also be provided.",
 	)
 	return flags
@@ -50,11 +50,15 @@ func ParseFlags(
 		return nil
 	}
 
-	rpc := cmd.Flag(coreRPCFlag).Value.String()
-	grpc := cmd.Flag(coreGRPCFlag).Value.String()
+	if cmd.Flag(coreRPCFlag).Changed {
+		rpc := cmd.Flag(coreRPCFlag).Value.String()
+		cfg.RPCPort = rpc
+	}
+	if cmd.Flag(coreGRPCFlag).Changed {
+		grpc := cmd.Flag(coreGRPCFlag).Value.String()
+		cfg.GRPCPort = grpc
+	}
 
 	cfg.IP = coreIP
-	cfg.RPCPort = rpc
-	cfg.GRPCPort = grpc
 	return cfg.Validate()
 }

--- a/nodebuilder/core/flags.go
+++ b/nodebuilder/core/flags.go
@@ -50,11 +50,14 @@ func ParseFlags(
 		return nil
 	}
 
-	if cmd.Flag(coreRPCFlag).Changed {
+	// in the case that the RPC port is not set, use the default port
+	// or in the case a value has been set via flag,
+	// set that as highest precedence
+	if cfg.RPCPort == "" || cmd.Flag(coreRPCFlag).Changed {
 		rpc := cmd.Flag(coreRPCFlag).Value.String()
 		cfg.RPCPort = rpc
 	}
-	if cmd.Flag(coreGRPCFlag).Changed {
+	if cfg.GRPCPort == "" || cmd.Flag(coreGRPCFlag).Changed {
 		grpc := cmd.Flag(coreGRPCFlag).Value.String()
 		cfg.GRPCPort = grpc
 	}

--- a/nodebuilder/core/flags_test.go
+++ b/nodebuilder/core/flags_test.go
@@ -49,7 +49,7 @@ func TestParseFlags(t *testing.T) {
 				RPCPort:  DefaultRPCPort,
 				GRPCPort: DefaultGRPCPort,
 			},
-			expectError: false,
+			expectError: true,
 		},
 		{
 			name: "no flags, values from input config.toml ",

--- a/nodebuilder/core/flags_test.go
+++ b/nodebuilder/core/flags_test.go
@@ -41,6 +41,17 @@ func TestParseFlags(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:     "only core.ip, empty port values",
+			args:     []string{"--core.ip=127.0.0.1"},
+			inputCfg: Config{},
+			expectedCfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectError: false,
+		},
+		{
 			name: "no flags, values from input config.toml ",
 			args: []string{},
 			inputCfg: Config{

--- a/nodebuilder/core/flags_test.go
+++ b/nodebuilder/core/flags_test.go
@@ -1,0 +1,143 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		inputCfg    Config // config that could be read from ctx
+		expectedCfg Config
+		expectError bool
+	}{
+		{
+			name:     "no flags",
+			args:     []string{},
+			inputCfg: Config{},
+			expectedCfg: Config{
+				IP:       "",
+				RPCPort:  "",
+				GRPCPort: "",
+			},
+			expectError: false,
+		},
+		{
+			name: "only core.ip",
+			args: []string{"--core.ip=127.0.0.1"},
+			inputCfg: Config{
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectedCfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectError: false,
+		},
+		{
+			name: "no flags, values from input config.toml ",
+			args: []string{},
+			inputCfg: Config{
+				IP:       "127.162.36.1",
+				RPCPort:  "1234",
+				GRPCPort: "5678",
+			},
+			expectedCfg: Config{
+				IP:       "127.162.36.1",
+				RPCPort:  "1234",
+				GRPCPort: "5678",
+			},
+			expectError: false,
+		},
+		{
+			name: "only core.ip, with config.toml overridden defaults for ports",
+			args: []string{"--core.ip=127.0.0.1"},
+			inputCfg: Config{
+				RPCPort:  "1234",
+				GRPCPort: "5678",
+			},
+			expectedCfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  "1234",
+				GRPCPort: "5678",
+			},
+			expectError: false,
+		},
+		{
+			name: "core.ip and core.rpc.port",
+			args: []string{"--core.ip=127.0.0.1", "--core.rpc.port=12345"},
+			inputCfg: Config{
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectedCfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  "12345",
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectError: false,
+		},
+		{
+			name: "core.ip and core.grpc.port",
+			args: []string{"--core.ip=127.0.0.1", "--core.grpc.port=54321"},
+			inputCfg: Config{
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectedCfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: "54321",
+			},
+			expectError: false,
+		},
+		{
+			name: "core.ip, core.rpc.port, and core.grpc.port",
+			args: []string{"--core.ip=127.0.0.1", "--core.rpc.port=12345", "--core.grpc.port=54321"},
+			expectedCfg: Config{
+				IP:       "127.0.0.1",
+				RPCPort:  "12345",
+				GRPCPort: "54321",
+			},
+			expectError: false,
+		},
+		{
+			name:        "core.rpc.port without core.ip",
+			args:        []string{"--core.rpc.port=12345"},
+			expectedCfg: Config{},
+			expectError: true,
+		},
+		{
+			name:        "core.grpc.port without core.ip",
+			args:        []string{"--core.grpc.port=54321"},
+			expectedCfg: Config{},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			flags := Flags()
+			cmd.Flags().AddFlagSet(flags)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			require.NoError(t, err)
+
+			err = ParseFlags(cmd, &tt.inputCfg)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedCfg, tt.inputCfg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

identified by @tac0turtle (TYBG) whereby, in the specific case where you had edited you node store's config values to be non-default for `Core.RPCPort` or `Core.GRPCPort`, if you were to then provide a different value for Core.IP via the `--core.ip` flag at node start time, then the flag defaults for `core.rpc.port` and `core.grpc.port` would revert the values to defaults and override the custom values in config.toml. Fix is to check that the default value had been reset in the flag, and only use the default if no value had been set in the passed in config, which in most cases is already loaded as default or the config.toml values.

Took liberty to add some tests, and update some duplication of default values while in here.

fixes #3523 
