### PR TITLE
chore(deps): upgrade to celestia-app v1.12.0

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # upgrade go version throughout pipeline here
-      GO_VERSION: "1.22"
+      GO_VERSION: "1.22.4"
     outputs:
       go-version: ${{ steps.set-vars.outputs.go-version }}
       branch: ${{ steps.trim_ref.outputs.branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.22-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.22.4-alpine3.18 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.22.4-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.22.4-alpine3.20 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Continue reading [here](https://blog.celestia.org/celestia-mvp-release-data-avai
 
 | Requirement | Notes          |
 | ----------- |----------------|
-| Go version  | 1.22 or higher |
+| Go version  | 1.22.4 or higher |
 
 ## System Requirements
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/celestia-node
 
-go 1.22.3
+go 1.22.4
 
 require (
 	cosmossdk.io/errors v1.0.1
@@ -8,7 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
 	github.com/benbjohnson/clock v1.3.5
-	github.com/celestiaorg/celestia-app v1.11.0
+	github.com/celestiaorg/celestia-app v1.12.0
 	github.com/celestiaorg/go-fraud v0.2.1
 	github.com/celestiaorg/go-header v0.6.2
 	github.com/celestiaorg/go-libp2p-messenger v0.2.0
@@ -356,5 +356,5 @@ replace (
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	// broken goleveldb needs to be replaced for the cosmos-sdk and celestia-app
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.36.1-tm-v0.34.29
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.37.0-tm-v0.34.29
 )

--- a/go.sum
+++ b/go.sum
@@ -353,10 +353,10 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-app v1.11.0 h1:NV2nWR4r75qWY0reawrzoMnVRRbUgVtrgtFT9+ytmGQ=
-github.com/celestiaorg/celestia-app v1.11.0/go.mod h1:aKJkApIZnGt/q5ZYtsf6UM21MJR+D62rwWn2mCHKBNE=
-github.com/celestiaorg/celestia-core v1.36.1-tm-v0.34.29 h1:BuYworCMtFxAYyM5l1C0gx6PT/ViHosVRydvYd7vCqs=
-github.com/celestiaorg/celestia-core v1.36.1-tm-v0.34.29/go.mod h1:AL7kotb6ucKF4bpKKhGIzGhGL7dwYj2nFstiFC6PGxM=
+github.com/celestiaorg/celestia-app v1.12.0 h1:7SMTI/sB8jxp7QPJQRi/liAREnToAD5nOyA7M+naPIc=
+github.com/celestiaorg/celestia-app v1.12.0/go.mod h1:O/idsViCLLFdcaE4cJ+iZctZLX0KWfRheKT2W18W2uM=
+github.com/celestiaorg/celestia-core v1.37.0-tm-v0.34.29 h1:9nJDE37cTg/Cx+f4FS2g7yYeoLrsaNJg36XsQ47sS1A=
+github.com/celestiaorg/celestia-core v1.37.0-tm-v0.34.29/go.mod h1:IIdMu9gnDtjUmZkFuBN4Bf11z/rBtlL2rtwbQxdbRAU=
 github.com/celestiaorg/cosmos-sdk v1.23.0-sdk-v0.46.16 h1:N2uETI13szEKnGAdKhtTR0EsrpcW0AwRKYER74WLnuw=
 github.com/celestiaorg/cosmos-sdk v1.23.0-sdk-v0.46.16/go.mod h1:Bpl1LSWiDpQumgOhhMTZBMopqa0j7fRasIhvTZB44P0=
 github.com/celestiaorg/dagstore v0.0.0-20230824094345-537c012aa403 h1:Lj73O3S+KJx5/hgZ+IeOLEIoLsAveJN/7/ZtQQtPSVw=


### PR DESCRIPTION
## Motivation

We want testnets to use whichever version of celestia-app is specified by celestia-node's go.mod so this PR bumps the celestia-app dependency so that v1.12.0 can get deployed.