### PR TITLE
feat(blob): blobsub

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -60,8 +60,6 @@ type Service struct {
 	headerGetter func(context.Context, uint64) (*header.ExtendedHeader, error)
 	// headerSub subscribes to new headers to supply to blob subscriptions.
 	headerSub func(ctx context.Context) (<-chan *header.ExtendedHeader, error)
-
-	mu sync.Mutex
 }
 
 func NewService(
@@ -95,7 +93,6 @@ type SubscriptionResponse struct {
 
 func (s *Service) Subscribe(ctx context.Context, ns share.Namespace) (<-chan *SubscriptionResponse, error) {
 	if s.ctx == nil {
-		s.mu.Unlock()
 		return nil, fmt.Errorf("service has not been started")
 	}
 

--- a/blob/service.go
+++ b/blob/service.go
@@ -6,9 +6,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"sync"
-
 	"slices"
+	"sync"
 
 	"github.com/cosmos/cosmos-sdk/types"
 	logging "github.com/ipfs/go-log/v2"
@@ -250,7 +249,11 @@ func (s *Service) GetAll(ctx context.Context, height uint64, namespaces []share.
 	return s.getAll(ctx, header, namespaces)
 }
 
-func (s *Service) getAll(ctx context.Context, header *header.ExtendedHeader, namespaces []share.Namespace) ([]*Blob, error) {
+func (s *Service) getAll(
+	ctx context.Context,
+	header *header.ExtendedHeader,
+	namespaces []share.Namespace
+) ([]*Blob, error) {
 	height := header.Height()
 	var (
 		resultBlobs = make([][]*Blob, len(namespaces))

--- a/blob/service.go
+++ b/blob/service.go
@@ -122,7 +122,7 @@ func (s *Service) Subscribe(ctx context.Context, ns share.Namespace) (<-chan *Su
 		return nil, err
 	}
 
-	blobCh := make(chan *SubscriptionResponse, 3)
+	blobCh := make(chan *SubscriptionResponse, 16)
 	go func() {
 		defer s.activeSubscriptions.Done()
 		defer close(blobCh)

--- a/blob/service.go
+++ b/blob/service.go
@@ -131,7 +131,7 @@ func (s *Service) Subscribe(ctx context.Context, ns share.Namespace) (<-chan *Su
 			select {
 			case header, ok := <-headerCh:
 				if ctx.Err() != nil {
-					log.Debug("blobsub: cancelling subscription due to user context closing")
+					log.Debug("blobsub: canceling subscription due to user context closing")
 					return
 				}
 				if !ok {
@@ -141,7 +141,7 @@ func (s *Service) Subscribe(ctx context.Context, ns share.Namespace) (<-chan *Su
 				blobs, err := s.getAll(ctx, header, []share.Namespace{ns})
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					// context canceled, continuing would lead to unexpected missed heights for the client
-					log.Debug("blobsub: cancelling subscription due to user context closing")
+					log.Debug("blobsub: canceling subscription due to user context closing")
 					return
 				}
 				if err != nil {
@@ -151,15 +151,15 @@ func (s *Service) Subscribe(ctx context.Context, ns share.Namespace) (<-chan *Su
 
 				select {
 				case <-ctx.Done():
-					log.Debug("blobsub: cancelling subscription with pending response due to user context closing")
+					log.Debug("blobsub: canceling subscription with pending response due to user context closing")
 					return
 				case blobCh <- &SubscriptionResponse{Blobs: blobs, Height: header.Height()}:
 				}
 			case <-ctx.Done():
-				log.Debug("blobsub: cancelling subscription due to user context closing")
+				log.Debug("blobsub: canceling subscription due to user context closing")
 				return
 			case <-s.ctx.Done():
-				log.Debug("blobsub: cancelling subscription due to service context closing")
+				log.Debug("blobsub: canceling subscription due to service context closing")
 				return
 			}
 		}

--- a/blob/service.go
+++ b/blob/service.go
@@ -132,12 +132,12 @@ func (s *Service) Subscribe(ctx context.Context, ns share.Namespace) (<-chan *Su
 				var blobs []*Blob
 				var err error
 				for {
-					if ctx.Err() != nil {
+					blobs, err = s.getAll(ctx, header, []share.Namespace{ns})
+							if ctx.Err() != nil {
 						// context canceled, continuing would lead to unexpected missed heights for the client
 						log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
 						return
 					}
-					blobs, err = s.getAll(ctx, header, []share.Namespace{ns})
 					if err == nil {
 						// operation successful, break the loop
 						break

--- a/blob/service.go
+++ b/blob/service.go
@@ -133,7 +133,7 @@ func (s *Service) Subscribe(ctx context.Context, ns share.Namespace) (<-chan *Su
 				var err error
 				for {
 					blobs, err = s.getAll(ctx, header, []share.Namespace{ns})
-							if ctx.Err() != nil {
+					if ctx.Err() != nil {
 						// context canceled, continuing would lead to unexpected missed heights for the client
 						log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
 						return

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -470,7 +470,10 @@ func TestService_GetSingleBlobWithoutPadding(t *testing.T) {
 	fn := func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 		return headerStore.GetByHeight(ctx, height)
 	}
-	service := NewService(nil, getters.NewIPLDGetter(bs), fn)
+	fn2 := func(ctx context.Context) (<-chan *header.ExtendedHeader, error) {
+		return nil, fmt.Errorf("not implemented")
+	}
+	service := NewService(nil, getters.NewIPLDGetter(bs), fn, fn2)
 
 	newBlob, err := service.Get(ctx, 1, blobs[1].Namespace(), blobs[1].Commitment)
 	require.NoError(t, err)
@@ -567,8 +570,10 @@ func TestService_GetAllWithoutPadding(t *testing.T) {
 	fn := func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 		return h, nil
 	}
-
-	service := NewService(nil, getters.NewIPLDGetter(bs), fn)
+	fn2 := func(ctx context.Context) (<-chan *header.ExtendedHeader, error) {
+		return nil, fmt.Errorf("not implemented")
+	}
+	service := NewService(nil, getters.NewIPLDGetter(bs), fn, fn2)
 
 	newBlobs, err := service.GetAll(ctx, 1, []share.Namespace{blobs[0].Namespace()})
 	require.NoError(t, err)
@@ -614,10 +619,12 @@ func TestAllPaddingSharesInEDS(t *testing.T) {
 	fn := func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 		return h, nil
 	}
-
-	service := NewService(nil, getters.NewIPLDGetter(bs), fn)
+	fn2 := func(ctx context.Context) (<-chan *header.ExtendedHeader, error) {
+		return nil, fmt.Errorf("not implemented")
+	}
+	service := NewService(nil, getters.NewIPLDGetter(bs), fn, fn2)
 	newBlobs, err := service.GetAll(ctx, 1, []share.Namespace{nid})
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Empty(t, newBlobs)
 }
 
@@ -657,8 +664,10 @@ func TestSkipPaddingsAndRetrieveBlob(t *testing.T) {
 	fn := func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 		return h, nil
 	}
-
-	service := NewService(nil, getters.NewIPLDGetter(bs), fn)
+	fn2 := func(ctx context.Context) (<-chan *header.ExtendedHeader, error) {
+		return nil, fmt.Errorf("not implemented")
+	}
+	service := NewService(nil, getters.NewIPLDGetter(bs), fn, fn2)
 	newBlob, err := service.GetAll(ctx, 1, []share.Namespace{nid})
 	require.NoError(t, err)
 	require.Len(t, newBlob, 1)
@@ -709,7 +718,10 @@ func createService(ctx context.Context, t testing.TB, blobs []*Blob) *Service {
 	fn := func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 		return headerStore.GetByHeight(ctx, height)
 	}
-	return NewService(nil, getters.NewIPLDGetter(bs), fn)
+	fn2 := func(ctx context.Context) (<-chan *header.ExtendedHeader, error) {
+		return nil, fmt.Errorf("not implemented")
+	}
+	return NewService(nil, getters.NewIPLDGetter(bs), fn, fn2)
 }
 
 // TestProveCommitmentAllCombinations tests proving all the commitments in a block.

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -394,7 +394,9 @@ func TestBlobService_Get(t *testing.T) {
 				shareGetterMock.EXPECT().
 					GetSharesByNamespace(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(
-						func(ctx context.Context, h *header.ExtendedHeader, ns share.Namespace) (share.NamespacedShares, error) {
+						func(
+							ctx context.Context, h *header.ExtendedHeader, ns share.Namespace,
+						) (share.NamespacedShares, error) {
 							if ns.Equals(blobsWithDiffNamespaces[0].Namespace()) {
 								return nil, errors.New("internal error")
 							}
@@ -750,7 +752,8 @@ func TestService_Subscribe(t *testing.T) {
 		// cancel the subscription context after receiving the first response
 		select {
 		case <-subCh:
-			service.Stop(context.Background())
+			err = service.Stop(context.Background())
+			require.NoError(t, err)
 		case <-time.After(time.Second * 2):
 			t.Fatal("timeout waiting for first subscription response")
 		}
@@ -761,7 +764,6 @@ func TestService_Subscribe(t *testing.T) {
 		case <-time.After(time.Second * 2):
 			t.Fatal("timeout waiting for subscription channel to close")
 		}
-
 	})
 }
 
@@ -779,6 +781,7 @@ func TestService_Subscribe_MultipleNamespaces(t *testing.T) {
 	blobs2, err := convertBlobs(appBlobs2...)
 	require.NoError(t, err)
 
+	//nolint: gocritic
 	allBlobs := append(blobs1, blobs2...)
 
 	service := createServiceWithSub(ctx, t, allBlobs)

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -754,7 +754,7 @@ func TestService_Subscribe(t *testing.T) {
 		// cancel the subscription context after receiving the last response
 		for range blobs {
 			select {
-			case val, _ := <-subCh:
+			case val := <-subCh:
 				if val.Height == uint64(len(blobs)) {
 					err = service.Stop(context.Background())
 					require.NoError(t, err)

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -42,11 +42,12 @@ type Module interface {
 		shareCommitment []byte,
 	) (*blob.CommitmentProof, error)
 	// Subscribe to published blobs from the given namespace as they are included.
-	Subscribe(_ context.Context, _ share.Namespace) (<-chan *blob.BlobsubResponse, error)
+	Subscribe(_ context.Context, _ share.Namespace) (<-chan *blob.SubscriptionResponse, error)
 }
 
 type API struct {
 	Internal struct {
+<<<<<<< HEAD
 		Submit func(
 			context.Context,
 			[]*blob.Blob,
@@ -85,7 +86,7 @@ type API struct {
 		Subscribe func(
 			context.Context,
 			share.Namespace,
-		) (<-chan *blob.BlobsubResponse, error) `perm:"read"`
+		) (<-chan *blob.SubscriptionResponse, error) `perm:"read"`
 	}
 }
 
@@ -137,6 +138,6 @@ func (api *API) Included(
 func (api *API) Subscribe(
 	ctx context.Context,
 	namespace share.Namespace,
-) (<-chan *blob.BlobsubResponse, error) {
+) (<-chan *blob.SubscriptionResponse, error) {
 	return api.Internal.Subscribe(ctx, namespace)
 }

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -23,8 +23,8 @@ type Module interface {
 	// If all blobs were found without any errors, the user will receive a list of blobs.
 	// If the BlobService couldn't find any blobs under the requested namespaces,
 	// the user will receive an empty list of blobs along with an empty error.
-	// If some of the requested namespaces were not found, the user will receive all the found blobs and an empty error.
-	// If there were internal errors during some of the requests,
+	// If some of the requested namespaces were not found, the user will receive all the found blobs
+	// and an empty error. If there were internal errors during some of the requests,
 	// the user will receive all found blobs along with a combined error message.
 	//
 	// All blobs will preserve the order of the namespaces that were requested.

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -47,7 +47,6 @@ type Module interface {
 
 type API struct {
 	Internal struct {
-<<<<<<< HEAD
 		Submit func(
 			context.Context,
 			[]*blob.Blob,

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -41,6 +41,8 @@ type Module interface {
 		namespace share.Namespace,
 		shareCommitment []byte,
 	) (*blob.CommitmentProof, error)
+	// Subscribe to published blobs from the given namespace as they are included.
+	Subscribe(_ context.Context, _ share.Namespace) (<-chan *blob.BlobsubResponse, error)
 }
 
 type API struct {
@@ -80,6 +82,10 @@ type API struct {
 			namespace share.Namespace,
 			shareCommitment []byte,
 		) (*blob.CommitmentProof, error) `perm:"read"`
+		Subscribe func(
+			context.Context,
+			share.Namespace,
+		) (<-chan *blob.BlobsubResponse, error) `perm:"read"`
 	}
 }
 
@@ -126,4 +132,11 @@ func (api *API) Included(
 	commitment blob.Commitment,
 ) (bool, error) {
 	return api.Internal.Included(ctx, height, namespace, proof, commitment)
+}
+
+func (api *API) Subscribe(
+	ctx context.Context,
+	namespace share.Namespace,
+) (<-chan *blob.BlobsubResponse, error) {
+	return api.Internal.Subscribe(ctx, namespace)
 }

--- a/nodebuilder/blob/module.go
+++ b/nodebuilder/blob/module.go
@@ -17,12 +17,20 @@ func ConstructModule() fx.Option {
 		fx.Provide(
 			func(service headerService.Module) func(context.Context, uint64) (*header.ExtendedHeader, error) {
 				return service.GetByHeight
-			}),
+			},
+		),
+		fx.Provide(
+			func(service headerService.Module) func(context.Context) (<-chan *header.ExtendedHeader, error) {
+				return service.Subscribe
+			},
+		),
 		fx.Provide(func(
 			state state.Module,
 			sGetter share.Getter,
 			getByHeightFn func(context.Context, uint64) (*header.ExtendedHeader, error),
+			subscribeFn func(context.Context) (<-chan *header.ExtendedHeader, error),
 		) Module {
-			return blob.NewService(state, sGetter, getByHeightFn)
-		}))
+			return blob.NewService(state, sGetter, getByHeightFn, subscribeFn)
+		}),
+	)
 }

--- a/nodebuilder/blob/module.go
+++ b/nodebuilder/blob/module.go
@@ -32,14 +32,14 @@ func ConstructModule() fx.Option {
 				subscribeFn func(context.Context) (<-chan *header.ExtendedHeader, error),
 			) *blob.Service {
 				return blob.NewService(state, sGetter, getByHeightFn, subscribeFn)
-			}),
+			},
 			fx.OnStart(func(ctx context.Context, serv *blob.Service) error {
 				return serv.Start(ctx)
 			}),
 			fx.OnStop(func(ctx context.Context, serv *blob.Service) error {
 				return serv.Stop(ctx)
 			}),
-		),
+		)),
 		fx.Provide(func(serv *blob.Service) Module {
 			return serv
 		}),

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -184,9 +184,9 @@ func (ca *CoreAccessor) cancelCtx() {
 	ca.cancel = nil
 }
 
-// SubmitPayForBlob builds, signs, and synchronously submits a MsgPayForBlob with additional options defined
-// in `TxConfig`. It blocks until the transaction is committed and returns the TxResponse.
-// The user can specify additional options that can bee applied to the Tx.
+// SubmitPayForBlob builds, signs, and synchronously submits a MsgPayForBlob with additional
+// options defined in `TxConfig`. It blocks until the transaction is committed and returns the
+// TxResponse. The user can specify additional options that can bee applied to the Tx.
 func (ca *CoreAccessor) SubmitPayForBlob(
 	ctx context.Context,
 	appblobs []*Blob,
@@ -583,7 +583,8 @@ func (ca *CoreAccessor) queryMinimumGasPrice(
 
 func (ca *CoreAccessor) setupTxClient(ctx context.Context, keyName string) (*user.TxClient, error) {
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
-	// explicitly set default address. Otherwise, there could be a mismatch between defaultKey and defaultAddress.
+	// explicitly set default address. Otherwise, there could be a mismatch between defaultKey and
+	// defaultAddress.
 	rec, err := ca.keyring.Key(keyName)
 	if err != nil {
 		return nil, err

--- a/state/tx_config.go
+++ b/state/tx_config.go
@@ -108,7 +108,8 @@ func (cfg *TxConfig) UnmarshalJSON(data []byte) error {
 }
 
 // estimateGas estimates gas in case it has not been set.
-// NOTE: final result of the estimation will be multiplied by the `gasMultiplier`(1.1) to cover additional costs.
+// NOTE: final result of the estimation will be multiplied by the `gasMultiplier`(1.1) to cover
+// additional costs.
 func estimateGas(ctx context.Context, client *user.TxClient, msg sdktypes.Msg) (uint64, error) {
 	// set fee as 1utia helps to simulate the tx more reliably.
 	gas, err := client.EstimateGas(ctx, []sdktypes.Msg{msg}, user.SetFee(1))
@@ -171,8 +172,9 @@ func WithKeyName(key string) ConfigOption {
 	}
 }
 
-// WithSignerAddress is an option that allows you to specify an address, that will sign the transaction.
-// This address must be stored locally in the key store. Default signerAddress will be used in case it wasn't specified.
+// WithSignerAddress is an option that allows you to specify an address, that will sign the
+// transaction. This address must be stored locally in the key store. Default signerAddress will be
+// used in case it wasn't specified.
 func WithSignerAddress(address string) ConfigOption {
 	return func(cfg *TxConfig) {
 		cfg.signerAddress = address


### PR DESCRIPTION
Introduces `blob.Subscribe`. Takes a `share.Namespace`, returns a `<-chan *BlobsubResponse` containing a `height uint64` and `blobs []*blob.Blob`. 

I made the decision to not support subscribing to multiple namespaces with one call, because the complexity of the return type mitigates the benefits for the client. It is likely more convenient to have one subscription per namespace:

Imagine you are watching two namespaces for different things. On the client side, you would have a `select` statement reading from the two channels in two cases. This is cleaner than receiving everything in one case, but then having to manually parse and send to the respective handlers yourself.  


This closes #2737 , with the caveat that we are not taking the map approach (see rationale above)
