### PR TITLE
fix(nodebuilder/p2p): remove prepended v against detected semantic version 

### DIFF
--- a/nodebuilder/node/buildInfo.go
+++ b/nodebuilder/node/buildInfo.go
@@ -32,7 +32,7 @@ func (b *BuildInfo) GetSemanticVersion() string {
 		return emptyValue
 	}
 
-	return fmt.Sprintf("v%s", b.SemanticVersion)
+	return fmt.Sprintf("%s", b.SemanticVersion)
 }
 
 func (b *BuildInfo) CommitShortSha() string {

--- a/nodebuilder/node/buildInfo.go
+++ b/nodebuilder/node/buildInfo.go
@@ -32,7 +32,7 @@ func (b *BuildInfo) GetSemanticVersion() string {
 		return emptyValue
 	}
 
-	return fmt.Sprintf("%s", b.SemanticVersion)
+	return b.SemanticVersion
 }
 
 func (b *BuildInfo) CommitShortSha() string {

--- a/nodebuilder/node/buildinfo_test.go
+++ b/nodebuilder/node/buildinfo_test.go
@@ -29,11 +29,17 @@ func TestGetSemanticVersion(t *testing.T) {
 		{
 			name: "Non-empty Semantic Version",
 			buildInfo: BuildInfo{
-				SemanticVersion: "1.2.3",
+				SemanticVersion: "v1.2.3",
 			},
 			expectedVersion: "v1.2.3",
 		},
-		// Add more test cases as needed
+		{
+			name: "Non-empty Semantic Version without v prefix",
+			buildInfo: BuildInfo{
+				SemanticVersion: "1.2.3",
+			},
+			expectedVersion: "1.2.3",
+		},
 	}
 
 	for _, tc := range tests {

--- a/nodebuilder/p2p/host_test.go
+++ b/nodebuilder/p2p/host_test.go
@@ -20,7 +20,7 @@ func TestUserAgent(t *testing.T) {
 			tp:       node.Full,
 			expected: "celestia-node/testnet/full/v1.0.0/abcdefg",
 			build: &node.BuildInfo{
-				SemanticVersion: "1.0.0",
+				SemanticVersion: "v1.0.0",
 				LastCommit:      "abcdefg",
 			},
 		},
@@ -30,7 +30,7 @@ func TestUserAgent(t *testing.T) {
 			expected: "celestia-node/mainnet/light/v1.0.0/abcdefg",
 			tp:       node.Light,
 			build: &node.BuildInfo{
-				SemanticVersion: "1.0.0",
+				SemanticVersion: "v1.0.0",
 				LastCommit:      "abcdefg",
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

It looks as though when the useragent name request of #2932 was addressed in https://github.com/celestiaorg/celestia-node/pull/2956 a 'v' was added to the string formatting with the `BuildInfo.SemanticVersion` which is added to the useragent. (see: https://github.com/celestiaorg/celestia-node/pull/2956/files#diff-78ab4bf0b5adebb93a427d5c0222a637919ca538457678126428146a3bf3c663R35) and carried over in the PR with tests and refactoring (https://github.com/celestiaorg/celestia-node/commit/86f4b2aa1dd54a390dd213d5011b48ab51aa7321#diff-4bbc044dfe14e79d9f168542d12302c631a91f5b5d9c17f55e5ef81ea7fb5611R35)

We actually set this SemanticVersion from git tags at build time [here](https://github.com/celestiaorg/celestia-node/blob/main/Makefile#L6) with ldflags and the tag already has `v` in the naming of the tag. This introduced our useragent having two v, like a va-va-voom, eg: `rcelestia-node/celestia/light/vv0.14.0/13439cc`

This removes the `v` added in the string and takes the tag and set SemanticVersion value as is, removing the vv-stutter