### PR TITLE
fix(discovery): Remove discovery limit

### DIFF
--- a/share/p2p/discovery/discovery.go
+++ b/share/p2p/discovery/discovery.go
@@ -290,7 +290,7 @@ func (d *Discovery) discover(ctx context.Context) bool {
 		findCancel()
 	}()
 
-	peers, err := d.disc.FindPeers(findCtx, d.tag)
+	peers, err := d.disc.FindPeers(findCtx, d.tag, discovery.Limit(0))
 	if err != nil {
 		log.Error("unable to start discovery", "topic", d.tag, "err", err)
 		return false


### PR DESCRIPTION
Currently, `FindPeers` doesn't include a limit, resulting in using the [default hardcoded limit](https://github.com/libp2p/go-libp2p/blob/ad7da3b5bfb46fde977911bf3546d5028e473a32/p2p/discovery/routing/routing.go#L65-L68) of `100`. Celestia mainnet now includes [more than `100` peers](https://probelab.io/celestia/dht/2024-26/#agents), which means that some peers may not be discovered because of this default limit.

https://github.com/celestiaorg/celestia-node/blob/e2b2994591ac1466d1ea593d94654d61942c4015/share/p2p/discovery/discovery.go#L293

Using the limit of `0` ensures that [all advertisers are returned](https://github.com/libp2p/go-libp2p-kad-dht/blob/25d299e64f3cb9a3da337e9d4af1a1b722ae503d/routing.go#L491-L495).