### PR TITLE
feat(shwap): Separate verify and validate for shwap ids

### DIFF
--- a/share/new_eds/validation.go
+++ b/share/new_eds/validation.go
@@ -39,18 +39,17 @@ func (f validation) Size(ctx context.Context) int {
 }
 
 func (f validation) Sample(ctx context.Context, rowIdx, colIdx int) (shwap.Sample, error) {
-	if err := validateIndexBounds(ctx, f, colIdx); err != nil {
-		return shwap.Sample{}, fmt.Errorf("col: %w", err)
-	}
-	if err := validateIndexBounds(ctx, f, rowIdx); err != nil {
-		return shwap.Sample{}, fmt.Errorf("row: %w", err)
+	_, err := shwap.NewSampleID(1, rowIdx, colIdx, f.Size(ctx))
+	if err != nil {
+		return shwap.Sample{}, fmt.Errorf("sample validation: %w", err)
 	}
 	return f.Accessor.Sample(ctx, rowIdx, colIdx)
 }
 
 func (f validation) AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (AxisHalf, error) {
-	if err := validateIndexBounds(ctx, f, axisIdx); err != nil {
-		return AxisHalf{}, fmt.Errorf("%s: %w", axisType, err)
+	_, err := shwap.NewRowID(1, axisIdx, f.Size(ctx))
+	if err != nil {
+		return AxisHalf{}, fmt.Errorf("axis half validation: %w", err)
 	}
 	return f.Accessor.AxisHalf(ctx, axisType, axisIdx)
 }
@@ -60,17 +59,9 @@ func (f validation) RowNamespaceData(
 	namespace share.Namespace,
 	rowIdx int,
 ) (shwap.RowNamespaceData, error) {
-	if err := validateIndexBounds(ctx, f, rowIdx); err != nil {
-		return shwap.RowNamespaceData{}, fmt.Errorf("row: %w", err)
+	_, err := shwap.NewRowNamespaceDataID(1, rowIdx, namespace, f.Size(ctx))
+	if err != nil {
+		return shwap.RowNamespaceData{}, fmt.Errorf("row namespace data validation: %w", err)
 	}
 	return f.Accessor.RowNamespaceData(ctx, namespace, rowIdx)
-}
-
-// validateIndexBounds checks if the index is within the bounds of the eds.
-func validateIndexBounds(ctx context.Context, f Accessor, idx int) error {
-	size := f.Size(ctx)
-	if idx < 0 || idx >= size {
-		return fmt.Errorf("%w: index %d is out of bounds: [0, %d)", ErrOutOfBounds, idx, size)
-	}
-	return nil
 }

--- a/share/new_eds/validation_test.go
+++ b/share/new_eds/validation_test.go
@@ -36,7 +36,7 @@ func TestValidation_Sample(t *testing.T) {
 
 			_, err := validation.Sample(context.Background(), tt.rowIdx, tt.colIdx)
 			if tt.expectFail {
-				require.ErrorIs(t, err, ErrOutOfBounds)
+				require.ErrorIs(t, err, shwap.ErrInvalidShwapID)
 			} else {
 				require.NoError(t, err)
 			}
@@ -65,7 +65,7 @@ func TestValidation_AxisHalf(t *testing.T) {
 
 			_, err := validation.AxisHalf(context.Background(), tt.axisType, tt.axisIdx)
 			if tt.expectFail {
-				require.ErrorIs(t, err, ErrOutOfBounds)
+				require.ErrorIs(t, err, shwap.ErrInvalidShwapID)
 			} else {
 				require.NoError(t, err)
 			}
@@ -94,7 +94,7 @@ func TestValidation_RowNamespaceData(t *testing.T) {
 			ns := sharetest.RandV0Namespace()
 			_, err := validation.RowNamespaceData(context.Background(), ns, tt.rowIdx)
 			if tt.expectFail {
-				require.ErrorIs(t, err, ErrOutOfBounds)
+				require.ErrorIs(t, err, shwap.ErrInvalidShwapID)
 			} else {
 				require.True(t, err == nil || errors.Is(err, shwap.ErrNamespaceOutsideRange), err)
 			}

--- a/share/shwap/eds_id.go
+++ b/share/shwap/eds_id.go
@@ -21,8 +21,7 @@ type EdsID struct {
 	Height uint64 // Height specifies the block height.
 }
 
-// NewEdsID creates a new EdsID using the given height and verifies it against the provided Root.
-// It returns an error if the verification fails.
+// NewEdsID creates a new EdsID using the given height.
 func NewEdsID(height uint64) (EdsID, error) {
 	eid := EdsID{
 		Height: height,
@@ -36,10 +35,14 @@ func EdsIDFromBinary(data []byte) (EdsID, error) {
 	if len(data) != EdsIDSize {
 		return EdsID{}, fmt.Errorf("invalid EdsID data length: %d != %d", len(data), EdsIDSize)
 	}
-	rid := EdsID{
+	eid := EdsID{
 		Height: binary.BigEndian.Uint64(data),
 	}
-	return rid, nil
+	if err := eid.Validate(); err != nil {
+		return EdsID{}, fmt.Errorf("validating EdsID: %w", err)
+	}
+
+	return eid, nil
 }
 
 // MarshalBinary encodes an EdsID into its binary form, primarily for storage or network
@@ -53,7 +56,7 @@ func (eid EdsID) MarshalBinary() ([]byte, error) {
 // It ensures that the EdsID is not constructed with a zero Height and that the root is not nil.
 func (eid EdsID) Validate() error {
 	if eid.Height == 0 {
-		return fmt.Errorf("%w: Height: %d", ErrInvalidShwapID, eid.Height)
+		return fmt.Errorf("%w: Height == 0", ErrInvalidShwapID)
 	}
 	return nil
 }

--- a/share/shwap/eds_id.go
+++ b/share/shwap/eds_id.go
@@ -2,13 +2,18 @@ package shwap
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
-
-	"github.com/celestiaorg/celestia-node/share"
 )
 
 // EdsIDSize defines the byte size of the EdsID.
 const EdsIDSize = 8
+
+// ErrOutOfBounds is returned whenever an index is out of bounds.
+var (
+	ErrInvalidShwapID = errors.New("invalid shwap ID")
+	ErrOutOfBounds    = fmt.Errorf("index out of bounds: %w", ErrInvalidShwapID)
+)
 
 // EdsID represents a unique identifier for a row, using the height of the block
 // to identify the data square in the chain.
@@ -18,11 +23,11 @@ type EdsID struct {
 
 // NewEdsID creates a new EdsID using the given height and verifies it against the provided Root.
 // It returns an error if the verification fails.
-func NewEdsID(height uint64, root *share.Root) (EdsID, error) {
+func NewEdsID(height uint64) (EdsID, error) {
 	eid := EdsID{
 		Height: height,
 	}
-	return eid, eid.Validate(root)
+	return eid, eid.Validate()
 }
 
 // EdsIDFromBinary decodes a byte slice into an EdsID, validating the length of the data.
@@ -46,12 +51,9 @@ func (eid EdsID) MarshalBinary() ([]byte, error) {
 
 // Validate checks the integrity of an EdsID's fields against the provided Root.
 // It ensures that the EdsID is not constructed with a zero Height and that the root is not nil.
-func (eid EdsID) Validate(root *share.Root) error {
-	if root == nil {
-		return fmt.Errorf("provided Root is nil")
-	}
+func (eid EdsID) Validate() error {
 	if eid.Height == 0 {
-		return fmt.Errorf("height cannot be zero")
+		return fmt.Errorf("%w: Height: %d", ErrInvalidShwapID, eid.Height)
 	}
 	return nil
 }

--- a/share/shwap/eds_id_test.go
+++ b/share/shwap/eds_id_test.go
@@ -5,17 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 )
 
 func TestEdsID(t *testing.T) {
-	square := edstest.RandEDS(t, 2)
-	root, err := share.NewRoot(square)
-	require.NoError(t, err)
-
-	id, err := NewEdsID(2, root)
+	id, err := NewEdsID(2)
 	require.NoError(t, err)
 
 	data, err := id.MarshalBinary()
@@ -25,6 +18,6 @@ func TestEdsID(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, id, idOut)
 
-	err = idOut.Validate(root)
+	err = idOut.Validate()
 	require.NoError(t, err)
 }

--- a/share/shwap/p2p/bitswap/row_block.go
+++ b/share/shwap/p2p/bitswap/row_block.go
@@ -41,8 +41,8 @@ type RowBlock struct {
 }
 
 // NewEmptyRowBlock constructs a new empty RowBlock.
-func NewEmptyRowBlock(height uint64, rowIdx int, root *share.Root) (*RowBlock, error) {
-	id, err := shwap.NewRowID(height, rowIdx, len(root.RowRoots))
+func NewEmptyRowBlock(height uint64, rowIdx, edsSize int) (*RowBlock, error) {
+	id, err := shwap.NewRowID(height, rowIdx, edsSize)
 	if err != nil {
 		return nil, err
 	}

--- a/share/shwap/p2p/bitswap/row_block.go
+++ b/share/shwap/p2p/bitswap/row_block.go
@@ -42,7 +42,7 @@ type RowBlock struct {
 
 // NewEmptyRowBlock constructs a new empty RowBlock.
 func NewEmptyRowBlock(height uint64, rowIdx int, root *share.Root) (*RowBlock, error) {
-	id, err := shwap.NewRowID(height, rowIdx, root)
+	id, err := shwap.NewRowID(height, rowIdx, len(root.RowRoots))
 	if err != nil {
 		return nil, err
 	}

--- a/share/shwap/p2p/bitswap/row_block_test.go
+++ b/share/shwap/p2p/bitswap/row_block_test.go
@@ -22,7 +22,7 @@ func TestRow_FetchRoundtrip(t *testing.T) {
 
 	blks := make([]Block, eds.Width())
 	for i := range blks {
-		blk, err := NewEmptyRowBlock(1, i, root)
+		blk, err := NewEmptyRowBlock(1, i, len(root.RowRoots))
 		require.NoError(t, err)
 		blks[i] = blk
 	}

--- a/share/shwap/p2p/bitswap/row_namespace_data_block.go
+++ b/share/shwap/p2p/bitswap/row_namespace_data_block.go
@@ -43,9 +43,9 @@ func NewEmptyRowNamespaceDataBlock(
 	height uint64,
 	rowIdx int,
 	namespace share.Namespace,
-	root *share.Root,
+	edsSize int,
 ) (*RowNamespaceDataBlock, error) {
-	id, err := shwap.NewRowNamespaceDataID(height, rowIdx, namespace, len(root.RowRoots))
+	id, err := shwap.NewRowNamespaceDataID(height, rowIdx, namespace, edsSize)
 	if err != nil {
 		return nil, err
 	}

--- a/share/shwap/p2p/bitswap/row_namespace_data_block.go
+++ b/share/shwap/p2p/bitswap/row_namespace_data_block.go
@@ -45,7 +45,7 @@ func NewEmptyRowNamespaceDataBlock(
 	namespace share.Namespace,
 	root *share.Root,
 ) (*RowNamespaceDataBlock, error) {
-	id, err := shwap.NewRowNamespaceDataID(height, rowIdx, namespace, root)
+	id, err := shwap.NewRowNamespaceDataID(height, rowIdx, namespace, len(root.RowRoots))
 	if err != nil {
 		return nil, err
 	}

--- a/share/shwap/p2p/bitswap/row_namespace_data_block_test.go
+++ b/share/shwap/p2p/bitswap/row_namespace_data_block_test.go
@@ -23,7 +23,7 @@ func TestRowNamespaceData_FetchRoundtrip(t *testing.T) {
 	rowIdxs := share.RowsWithNamespace(root, namespace)
 	blks := make([]Block, len(rowIdxs))
 	for i, rowIdx := range rowIdxs {
-		blk, err := NewEmptyRowNamespaceDataBlock(1, rowIdx, namespace, root)
+		blk, err := NewEmptyRowNamespaceDataBlock(1, rowIdx, namespace, len(root.RowRoots))
 		require.NoError(t, err)
 		blks[i] = blk
 	}

--- a/share/shwap/p2p/bitswap/sample_block.go
+++ b/share/shwap/p2p/bitswap/sample_block.go
@@ -40,7 +40,7 @@ type SampleBlock struct {
 
 // NewEmptySampleBlock constructs a new empty SampleBlock.
 func NewEmptySampleBlock(height uint64, rowIdx, colIdx int, root *share.Root) (*SampleBlock, error) {
-	id, err := shwap.NewSampleID(height, rowIdx, colIdx, root)
+	id, err := shwap.NewSampleID(height, rowIdx, colIdx, len(root.RowRoots))
 	if err != nil {
 		return nil, err
 	}

--- a/share/shwap/p2p/bitswap/sample_block.go
+++ b/share/shwap/p2p/bitswap/sample_block.go
@@ -39,8 +39,8 @@ type SampleBlock struct {
 }
 
 // NewEmptySampleBlock constructs a new empty SampleBlock.
-func NewEmptySampleBlock(height uint64, rowIdx, colIdx int, root *share.Root) (*SampleBlock, error) {
-	id, err := shwap.NewSampleID(height, rowIdx, colIdx, len(root.RowRoots))
+func NewEmptySampleBlock(height uint64, rowIdx, colIdx, edsSize int) (*SampleBlock, error) {
+	id, err := shwap.NewSampleID(height, rowIdx, colIdx, edsSize)
 	if err != nil {
 		return nil, err
 	}

--- a/share/shwap/p2p/bitswap/sample_block_test.go
+++ b/share/shwap/p2p/bitswap/sample_block_test.go
@@ -24,7 +24,7 @@ func TestSample_FetchRoundtrip(t *testing.T) {
 	blks := make([]Block, 0, width*width)
 	for x := 0; x < width; x++ {
 		for y := 0; y < width; y++ {
-			blk, err := NewEmptySampleBlock(1, x, y, root)
+			blk, err := NewEmptySampleBlock(1, x, y, len(root.RowRoots))
 			require.NoError(t, err)
 			blks = append(blks, blk)
 		}

--- a/share/shwap/row_id_test.go
+++ b/share/shwap/row_id_test.go
@@ -5,17 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 )
 
 func TestRowID(t *testing.T) {
-	square := edstest.RandEDS(t, 4)
-	root, err := share.NewRoot(square)
-	require.NoError(t, err)
+	edsSize := 4
 
-	id, err := NewRowID(2, 1, root)
+	id, err := NewRowID(2, 1, edsSize)
 	require.NoError(t, err)
 
 	data, err := id.MarshalBinary()
@@ -25,6 +20,6 @@ func TestRowID(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, id, idOut)
 
-	err = idOut.Validate(root)
+	err = idOut.Verify(edsSize)
 	require.NoError(t, err)
 }

--- a/share/shwap/row_namespace_data_id.go
+++ b/share/shwap/row_namespace_data_id.go
@@ -23,7 +23,7 @@ func NewRowNamespaceDataID(
 	height uint64,
 	rowIdx int,
 	namespace share.Namespace,
-	root *share.Root,
+	edsSize int,
 ) (RowNamespaceDataID, error) {
 	did := RowNamespaceDataID{
 		RowID: RowID{
@@ -35,7 +35,7 @@ func NewRowNamespaceDataID(
 		DataNamespace: namespace,
 	}
 
-	if err := did.Validate(root); err != nil {
+	if err := did.Verify(edsSize); err != nil {
 		return RowNamespaceDataID{}, err
 	}
 	return did, nil
@@ -75,14 +75,24 @@ func (s RowNamespaceDataID) MarshalBinary() ([]byte, error) {
 	return s.appendTo(data), nil
 }
 
+// Verify checks the validity of RowNamespaceDataID's fields, including the RowID and the
+// namespace.
+func (s RowNamespaceDataID) Verify(edsSize int) error {
+	if err := s.RowID.Verify(edsSize); err != nil {
+		return fmt.Errorf("error validating RowID: %w", err)
+	}
+
+	return s.Validate()
+}
+
 // Validate checks the validity of RowNamespaceDataID's fields, including the RowID and the
 // namespace.
-func (s RowNamespaceDataID) Validate(root *share.Root) error {
-	if err := s.RowID.Validate(root); err != nil {
+func (s RowNamespaceDataID) Validate() error {
+	if err := s.RowID.Validate(); err != nil {
 		return fmt.Errorf("error validating RowID: %w", err)
 	}
 	if err := s.DataNamespace.ValidateForData(); err != nil {
-		return fmt.Errorf("error validating DataNamespace: %w", err)
+		return fmt.Errorf("%w: error validating DataNamespace: %w", ErrInvalidShwapID, err)
 	}
 
 	return nil

--- a/share/shwap/row_namespace_data_id_test.go
+++ b/share/shwap/row_namespace_data_id_test.go
@@ -6,15 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 	"github.com/celestiaorg/celestia-node/share/sharetest"
 )
 
-func TestDataID(t *testing.T) {
+func TestRowNamespaceDataID(t *testing.T) {
+	edsSize := 4
 	ns := sharetest.RandV0Namespace()
-	_, root := edstest.RandEDSWithNamespace(t, ns, 8, 4)
 
-	id, err := NewRowNamespaceDataID(1, 1, ns, root)
+	id, err := NewRowNamespaceDataID(1, 1, ns, edsSize)
 	require.NoError(t, err)
 
 	data, err := id.MarshalBinary()
@@ -24,6 +23,6 @@ func TestDataID(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, id, sidOut)
 
-	err = sidOut.Validate(root)
+	err = sidOut.Verify(edsSize)
 	require.NoError(t, err)
 }

--- a/share/shwap/sample_id.go
+++ b/share/shwap/sample_id.go
@@ -15,8 +15,8 @@ type SampleID struct {
 	ShareIndex int // ShareIndex specifies the index of the sample within the row.
 }
 
-// NewSampleID constructs a new SampleID using the provided block height, sample index, and EDS size.
-// It calculates the row and share index based on the sample index and EDS size.
+// NewSampleID constructs a new SampleID using the provided block height, sample index, and EDS
+// size. It calculates the row and share index based on the sample index and EDS size.
 func NewSampleID(height uint64, rowIdx, colIdx, edsSize int) (SampleID, error) {
 	sid := SampleID{
 		RowID: RowID{

--- a/share/shwap/sample_id_test.go
+++ b/share/shwap/sample_id_test.go
@@ -5,17 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 )
 
 func TestSampleID(t *testing.T) {
-	square := edstest.RandEDS(t, 4)
-	root, err := share.NewRoot(square)
-	require.NoError(t, err)
+	edsSize := 4
 
-	id, err := NewSampleID(1, 1, 1, root)
+	id, err := NewSampleID(1, 1, 1, edsSize)
 	require.NoError(t, err)
 
 	data, err := id.MarshalBinary()
@@ -25,6 +20,6 @@ func TestSampleID(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, id, idOut)
 
-	err = idOut.Validate(root)
+	err = idOut.Verify(edsSize)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
PR separates Verify and validate functions for shwap id types. The change is crutial to allow server side application to do initial validation on shwapID, that server as requests in shwap, before accessing DAH. Verify is meant to be used only by server, after Validation passed and when there is access to the file. 