### PR TITLE
refactor(pruner): reset maxHeadersPerLoop properly

### DIFF
--- a/pruner/find.go
+++ b/pruner/find.go
@@ -10,7 +10,7 @@ import (
 // maxHeadersPerLoop is the maximum number of headers to fetch
 // for a prune loop (prevents fetching too many headers at a
 // time for nodes that have a large number of pruneable headers).
-var maxHeadersPerLoop = uint64(512)
+var maxHeadersPerLoop = 512
 
 // findPruneableHeaders returns all headers that are eligible for pruning
 // (outside the sampling window).
@@ -56,7 +56,7 @@ func (s *Service) findPruneableHeaders(
 	// loop we could increase by a range every iteration
 	headerCount := len(headers)
 	for {
-		if headerCount > int(maxHeadersPerLoop) {
+		if headerCount > maxHeadersPerLoop {
 			headers = headers[:maxHeadersPerLoop]
 			break
 		}
@@ -106,8 +106,8 @@ func (s *Service) calculateEstimatedCutoff(
 		estimatedCutoffHeight = head.Height()
 	}
 
-	if estimatedCutoffHeight-lastPruned.Height() > maxHeadersPerLoop {
-		estimatedCutoffHeight = lastPruned.Height() + maxHeadersPerLoop
+	if estimatedCutoffHeight-lastPruned.Height() > uint64(maxHeadersPerLoop) {
+		estimatedCutoffHeight = lastPruned.Height() + uint64(maxHeadersPerLoop)
 	}
 
 	return estimatedCutoffHeight, nil

--- a/pruner/service.go
+++ b/pruner/service.go
@@ -177,7 +177,7 @@ func (s *Service) prune(
 			return lastPrunedHeader
 		}
 
-		if uint64(len(headers)) < maxHeadersPerLoop {
+		if len(headers) < maxHeadersPerLoop {
 			// we've pruned all the blocks we can
 			return lastPrunedHeader
 		}

--- a/pruner/service_test.go
+++ b/pruner/service_test.go
@@ -159,10 +159,9 @@ func TestPrune_LargeNumberOfBlocks(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	maxHeadersPerLoop = 10
-	t.Cleanup(func() {
-		maxHeadersPerLoop = 1024
-	})
+	var maxHeadersPerLoopOld int
+	maxHeadersPerLoopOld, maxHeadersPerLoop = maxHeadersPerLoop, 10
+	t.Cleanup(func() { maxHeadersPerLoop = maxHeadersPerLoopOld })
 
 	blockTime := time.Nanosecond
 	availabilityWindow := AvailabilityWindow(blockTime * 10)
@@ -170,7 +169,7 @@ func TestPrune_LargeNumberOfBlocks(t *testing.T) {
 	// all headers generated in suite are timestamped to time.Now(), so
 	// they will all be considered "pruneable" within the availability window
 	suite := headertest.NewTestSuite(t, 1, blockTime)
-	store := headertest.NewCustomStore(t, suite, int(maxHeadersPerLoop*6)) // add small buffer
+	store := headertest.NewCustomStore(t, suite, maxHeadersPerLoop*6) // add small buffer
 
 	mp := &mockPruner{failHeight: make(map[uint64]int, 0)}
 

--- a/pruner/service_test.go
+++ b/pruner/service_test.go
@@ -195,7 +195,7 @@ func TestPrune_LargeNumberOfBlocks(t *testing.T) {
 	_ = serv.prune(ctx, lastPruned)
 
 	// ensure all headers have been pruned
-	assert.Equal(t, maxHeadersPerLoop*5, serv.checkpoint.LastPrunedHeight)
+	assert.Equal(t, uint64(maxHeadersPerLoop*5), serv.checkpoint.LastPrunedHeight)
 	assert.Len(t, serv.checkpoint.FailedHeaders, 0)
 }
 


### PR DESCRIPTION
We were resetting `maxHeadersPerLoop` to a different value (`1024`) which has no relations to the default value (`512`). Which isn't that bad because it's a test but still we have a side-effect in the `TestPrune_LargeNumberOfBlocks` test.

Also, changing type of `maxHeadersPerLoop` to `int` 'cause in most places we use it as an `int` and not `int64`.