### PR TITLE
misc(share/p2p): reduce frequency of discovery retries

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/ramin/reduce-discovery-retries
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/ramin/reduce-discovery-retries
   release:
     types: [published]
   pull_request:

--- a/share/p2p/discovery/discovery.go
+++ b/share/p2p/discovery/discovery.go
@@ -28,17 +28,10 @@ const (
 	// findPeersTimeout limits the FindPeers operation in time
 	findPeersTimeout = time.Minute
 
-	// advertiseRetryTimeout defines time interval between advertise attempts.
-	advertiseRetryTimeout = time.Second * 1
-
 	// logInterval defines the time interval at which a warning message will be logged
 	// if the desired number of nodes is not detected.
 	logInterval = 5 * time.Minute
 )
-
-// discoveryRetryTimeout defines time interval between discovery attempts
-// this is set independently for tests in discover_test.go
-var DiscoveryRetryTimeout = advertiseRetryTimeout * 60
 
 // Discovery combines advertise and discover services and allows to store discovered nodes.
 // TODO: The code here gets horribly hairy, so we should refactor this at some point
@@ -183,7 +176,7 @@ func (d *Discovery) Advertise(ctx context.Context) {
 			// we don't want retry indefinitely in busy loop
 			// internal discovery mechanism may need some time before attempts
 			select {
-			case <-time.After(advertiseRetryTimeout):
+			case <-time.After(d.params.AdvertiseRetryTimeout):
 				if !timer.Stop() {
 					<-timer.C
 				}
@@ -210,7 +203,7 @@ func (d *Discovery) Advertise(ctx context.Context) {
 // It initiates peer discovery upon request and restarts the process until the soft limit is
 // reached.
 func (d *Discovery) discoveryLoop(ctx context.Context) {
-	t := time.NewTicker(DiscoveryRetryTimeout)
+	t := time.NewTicker(d.params.DiscoveryRetryTimeout)
 	defer t.Stop()
 
 	warnTicker := time.NewTicker(logInterval)

--- a/share/p2p/discovery/discovery.go
+++ b/share/p2p/discovery/discovery.go
@@ -28,16 +28,17 @@ const (
 	// findPeersTimeout limits the FindPeers operation in time
 	findPeersTimeout = time.Minute
 
-	// retryTimeout defines time interval between discovery and advertise attempts.
-	retryTimeout = time.Second
+	// advertiseRetryTimeout defines time interval between advertise attempts.
+	advertiseRetryTimeout = time.Second * 1
 
 	// logInterval defines the time interval at which a warning message will be logged
 	// if the desired number of nodes is not detected.
 	logInterval = 5 * time.Minute
 )
 
-// discoveryRetryTimeout defines time interval between discovery attempts, needed for tests
-var discoveryRetryTimeout = retryTimeout
+// discoveryRetryTimeout defines time interval between discovery attempts
+// this is set independently for tests in discover_test.go
+var DiscoveryRetryTimeout = advertiseRetryTimeout * 60
 
 // Discovery combines advertise and discover services and allows to store discovered nodes.
 // TODO: The code here gets horribly hairy, so we should refactor this at some point
@@ -181,16 +182,13 @@ func (d *Discovery) Advertise(ctx context.Context) {
 
 			// we don't want retry indefinitely in busy loop
 			// internal discovery mechanism may need some time before attempts
-			errTimer := time.NewTimer(retryTimeout)
 			select {
-			case <-errTimer.C:
-				errTimer.Stop()
+			case <-time.After(advertiseRetryTimeout):
 				if !timer.Stop() {
 					<-timer.C
 				}
 				continue
 			case <-ctx.Done():
-				errTimer.Stop()
 				return
 			}
 		}
@@ -212,7 +210,7 @@ func (d *Discovery) Advertise(ctx context.Context) {
 // It initiates peer discovery upon request and restarts the process until the soft limit is
 // reached.
 func (d *Discovery) discoveryLoop(ctx context.Context) {
-	t := time.NewTicker(discoveryRetryTimeout)
+	t := time.NewTicker(DiscoveryRetryTimeout)
 	defer t.Stop()
 
 	warnTicker := time.NewTicker(logInterval)

--- a/share/p2p/discovery/discovery_test.go
+++ b/share/p2p/discovery/discovery_test.go
@@ -26,8 +26,6 @@ const (
 func TestDiscovery(t *testing.T) {
 	const nodes = 10 // higher number brings higher coverage
 
-	DiscoveryRetryTimeout = time.Millisecond * 100 // defined in discovery.go
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
 	t.Cleanup(cancel)
 
@@ -43,7 +41,7 @@ func TestDiscovery(t *testing.T) {
 	}
 
 	host, routingDisc := tn.peer()
-	params := DefaultParameters()
+	params := TestParameters()
 	params.PeersLimit = nodes
 
 	// start discovery listener service for peerA
@@ -103,7 +101,7 @@ func TestDiscoveryTagged(t *testing.T) {
 	// sub will discover both peers, but on different tags
 	sub, routingDisc := tn.peer()
 
-	params := DefaultParameters()
+	params := TestParameters()
 
 	// create 2 discovery services for sub, each with a different tag
 	done1 := make(chan struct{})

--- a/share/p2p/discovery/discovery_test.go
+++ b/share/p2p/discovery/discovery_test.go
@@ -26,7 +26,7 @@ const (
 func TestDiscovery(t *testing.T) {
 	const nodes = 10 // higher number brings higher coverage
 
-	discoveryRetryTimeout = time.Millisecond * 100 // defined in discovery.go
+	DiscoveryRetryTimeout = time.Millisecond * 100 // defined in discovery.go
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
 	t.Cleanup(cancel)

--- a/share/p2p/discovery/options.go
+++ b/share/p2p/discovery/options.go
@@ -21,7 +21,7 @@ type Parameters struct {
 	// NOTE: only full and bridge can advertise themselves.
 	AdvertiseInterval time.Duration
 
-	// advertiseRetryTimeout defines time interval between advertise attempts.
+	// AdvertiseRetryTimeout defines time interval between advertise attempts.
 	AdvertiseRetryTimeout time.Duration
 
 	// DiscoveryRetryTimeout defines time interval between discovery attempts

--- a/share/p2p/discovery/options_test.go
+++ b/share/p2p/discovery/options_test.go
@@ -1,0 +1,78 @@
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  Parameters
+		wantErr bool
+	}{
+		{
+			name: "valid parameters",
+			params: Parameters{
+				PeersLimit:            5,
+				AdvertiseInterval:     time.Hour,
+				AdvertiseRetryTimeout: time.Second,
+				DiscoveryRetryTimeout: time.Minute,
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative PeersLimit",
+			params: Parameters{
+				PeersLimit:            0,
+				AdvertiseInterval:     time.Hour,
+				AdvertiseRetryTimeout: time.Second,
+				DiscoveryRetryTimeout: time.Minute,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative AdvertiseInterval",
+			params: Parameters{
+				PeersLimit:            5,
+				AdvertiseInterval:     -time.Hour,
+				AdvertiseRetryTimeout: time.Second,
+				DiscoveryRetryTimeout: time.Minute,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative AdvertiseRetryTimeout",
+			params: Parameters{
+				PeersLimit:            5,
+				AdvertiseInterval:     time.Hour,
+				AdvertiseRetryTimeout: -time.Second,
+				DiscoveryRetryTimeout: time.Minute,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative DiscoveryRetryTimeout",
+			params: Parameters{
+				PeersLimit:            5,
+				AdvertiseInterval:     time.Hour,
+				AdvertiseRetryTimeout: time.Second,
+				DiscoveryRetryTimeout: -time.Minute,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.params.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/share/p2p/peers/manager_test.go
+++ b/share/p2p/peers/manager_test.go
@@ -455,7 +455,6 @@ func TestIntegration(t *testing.T) {
 		go bnDisc.Advertise(ctx)
 
 		select {
-
 		case <-waitCh:
 			require.Contains(t, fnPeerManager.nodes.peersList, bnHost.ID())
 		case <-ctx.Done():

--- a/share/p2p/peers/manager_test.go
+++ b/share/p2p/peers/manager_test.go
@@ -26,9 +26,13 @@ import (
 	"github.com/celestiaorg/celestia-node/share/p2p/shrexsub"
 )
 
+const (
+	defaultTimeout = time.Second * 5
+)
+
 func TestManager(t *testing.T) {
 	t.Run("Validate pool by headerSub", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		// create headerSub mock
@@ -49,7 +53,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("Validate pool by shrex.Getter", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		h := testHeader()
@@ -72,7 +76,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("validator", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		// create headerSub mock
@@ -108,7 +112,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("cleanup", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		// create headerSub mock
@@ -153,7 +157,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("no peers from shrex.Sub, get from discovery", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		// create headerSub mock
@@ -176,7 +180,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("no peers from shrex.Sub and from discovery. Wait", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		// create headerSub mock
@@ -218,7 +222,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("shrexSub sends a message lower than first headerSub header height, headerSub first", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		h := testHeader()
@@ -251,7 +255,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("shrexSub sends a message lower than first headerSub header height, shrexSub first", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		h := testHeader()
@@ -289,7 +293,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("pools store window", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		h := testHeader()
@@ -322,7 +326,7 @@ func TestIntegration(t *testing.T) {
 	t.Run("get peer from shrexsub", func(t *testing.T) {
 		nw, err := mocknet.FullMeshLinked(2)
 		require.NoError(t, err)
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		bnPubSub, err := shrexsub.NewPubSub(ctx, nw.Hosts()[0], "test")
@@ -365,7 +369,7 @@ func TestIntegration(t *testing.T) {
 		fullNodesTag := "fullNodes"
 		nw, err := mocknet.FullMeshConnected(3)
 		require.NoError(t, err)
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		t.Cleanup(cancel)
 
 		// set up bootstrapper
@@ -390,6 +394,9 @@ func TestIntegration(t *testing.T) {
 		bnHost := nw.Hosts()[1]
 		bnRouter, err := dht.New(ctx, bnHost, opts...)
 		require.NoError(t, err)
+
+		// hack
+		discovery.DiscoveryRetryTimeout = time.Millisecond * 100
 
 		params := discovery.DefaultParameters()
 		params.AdvertiseInterval = time.Second
@@ -450,6 +457,7 @@ func TestIntegration(t *testing.T) {
 		go bnDisc.Advertise(ctx)
 
 		select {
+
 		case <-waitCh:
 			require.Contains(t, fnPeerManager.nodes.peersList, bnHost.ID())
 		case <-ctx.Done():

--- a/share/p2p/peers/manager_test.go
+++ b/share/p2p/peers/manager_test.go
@@ -395,11 +395,9 @@ func TestIntegration(t *testing.T) {
 		bnRouter, err := dht.New(ctx, bnHost, opts...)
 		require.NoError(t, err)
 
-		// hack
-		discovery.DiscoveryRetryTimeout = time.Millisecond * 100
-
 		params := discovery.DefaultParameters()
 		params.AdvertiseInterval = time.Second
+		params.DiscoveryRetryTimeout = time.Millisecond * 100
 
 		bnDisc, err := discovery.NewDiscovery(
 			params,
@@ -433,7 +431,7 @@ func TestIntegration(t *testing.T) {
 		}
 
 		// set up discovery for full node with hook to peer manager and check discovered peer
-		params = discovery.DefaultParameters()
+		params = discovery.TestParameters()
 		params.AdvertiseInterval = time.Second
 		params.PeersLimit = 10
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

Fixes #3550 as suggested by [guillaumemichel](https://github.com/guillaumemichel). In adjusting the "1 liner" realized there was some relatively funky stuff in tests where we set/reset a package level var for the interval, so moved both AdvertiserRetryTimeout and DiscoveryRetryTimeout to parameters and allowed customization where NewDiscovery is called. Also adjusted some of the intervals to be faster in tests so they execute within the test context Timeout and thus, hopefully will fix #3115 
