### PR TITLE
ci(lint): correct cfmt argument in make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ lint: lint-imports
 	@echo "--> Running linter"
 	@golangci-lint run
 	@markdownlint --config .markdownlint.yaml '**/*.md'
-	@cfmt -m=100 ./...
+	@cfmt --m=120 ./...
 .PHONY: lint
 
 ## test-unit: Running unit tests


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->
 
basic and i just want to close the ticket really, but this fixes #1379 where we were incorrectly passing `-m` vs `--m` to cfmt, hence the discrepancy, also we allow 120 length in golangci hence why there is a difference between `make lint` and golangci-lint not finding same issue cc @distractedm1nd 