### PR TITLE
fix(.github): change workflow to only work on releases

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   release:
-    types: [published]
+    types: [released]
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Fixes an issue where RCs are turned into releases after some time.