### PR TITLE
fix(ci/release): golreleaser pre-release behavior

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,5 +65,7 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+release:
+  prerelease: auto
 git:
-  prerelease_suffix: "-"
+  prerelease_suffix: "-rc*"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

Changes goreleaser.yml config to ensure that tags/releases are not automatically promoted to latest by adding the `release.prerelease = auto` config (previously defaulted to false), also set a proper pre-release suffix for tag filtering etc. This allows us to create signed binaries for pre-releases/release candidates.

Tested on a private branch and ensured that with  `release.prerelease: auto` releases created in github and with the toggle "Set as a pre-release" set to true, goreleaser would NOT set them as latest upon publishing artifacts.
