### PR TITLE
refactor(shwap):  rename share.root to axisRoots

### DIFF
--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -79,7 +79,7 @@ var ExampleValues = map[reflect.Type]interface{}{
 }
 
 func init() {
-	addToExampleValues(share.EmptyExtendedDataSquare())
+	addToExampleValues(share.EmptyEDS())
 	addr, err := sdk.AccAddressFromBech32("celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h")
 	if err != nil {
 		panic(err)

--- a/core/eds.go
+++ b/core/eds.go
@@ -28,7 +28,7 @@ import (
 // nil is returned in place of the eds.
 func extendBlock(data types.Data, appVersion uint64, options ...nmt.Option) (*rsmt2d.ExtendedDataSquare, error) {
 	if app.IsEmptyBlock(data, appVersion) {
-		return share.EmptyExtendedDataSquare(), nil
+		return share.EmptyEDS(), nil
 	}
 
 	// Construct the data square from the block's transactions
@@ -62,7 +62,7 @@ func storeEDS(
 	store *eds.Store,
 	window pruner.AvailabilityWindow,
 ) error {
-	if eds.Equals(share.EmptyExtendedDataSquare()) {
+	if eds.Equals(share.EmptyEDS()) {
 		return nil
 	}
 

--- a/core/eds_test.go
+++ b/core/eds_test.go
@@ -27,8 +27,8 @@ func TestTrulyEmptySquare(t *testing.T) {
 	require.True(t, eds.Equals(share.EmptyEDS()))
 }
 
-// TestEmptySquareWithZeroTxs tests that the DAH hash of a block with no transactions
-// is equal to the datahash for an empty eds even if SquareSize is set to
+// TestEmptySquareWithZeroTxs tests that the datahash of a block with no transactions
+// is equal to the datahash of an empty eds, even if SquareSize is set to
 // something non-zero. Technically, this block data is invalid because the
 // construction of the square is deterministic, and the rules which dictate the
 // square size do not allow for empty block data. However, should that ever

--- a/core/eds_test.go
+++ b/core/eds_test.go
@@ -48,5 +48,5 @@ func TestEmptySquareWithZeroTxs(t *testing.T) {
 
 	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
-	assert.Equal(t, share.EmptyEDSRoot().Hash(), roots.Hash())
+	assert.Equal(t, share.EmptyEDSRoots().Hash(), roots.Hash())
 }

--- a/core/eds_test.go
+++ b/core/eds_test.go
@@ -46,7 +46,7 @@ func TestEmptySquareWithZeroTxs(t *testing.T) {
 	eds, err = app.ExtendBlock(data, appconsts.LatestVersion)
 	require.NoError(t, err)
 
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
-	assert.Equal(t, share.EmptyEDSRoot().Hash(), dah.Hash())
+	assert.Equal(t, share.EmptyEDSRoot().Hash(), roots.Hash())
 }

--- a/core/eds_test.go
+++ b/core/eds_test.go
@@ -24,11 +24,11 @@ func TestTrulyEmptySquare(t *testing.T) {
 
 	eds, err := extendBlock(data, appconsts.LatestVersion)
 	require.NoError(t, err)
-	require.True(t, eds.Equals(share.EmptyExtendedDataSquare()))
+	require.True(t, eds.Equals(share.EmptyEDS()))
 }
 
 // TestEmptySquareWithZeroTxs tests that the DAH hash of a block with no transactions
-// is equal to the DAH hash for an empty root even if SquareSize is set to
+// is equal to the datahash for an empty eds even if SquareSize is set to
 // something non-zero. Technically, this block data is invalid because the
 // construction of the square is deterministic, and the rules which dictate the
 // square size do not allow for empty block data. However, should that ever
@@ -40,13 +40,13 @@ func TestEmptySquareWithZeroTxs(t *testing.T) {
 
 	eds, err := extendBlock(data, appconsts.LatestVersion)
 	require.NoError(t, err)
-	require.True(t, eds.Equals(share.EmptyExtendedDataSquare()))
+	require.True(t, eds.Equals(share.EmptyEDS()))
 
 	// force extend the square using an empty block and compare with the min DAH
 	eds, err = app.ExtendBlock(data, appconsts.LatestVersion)
 	require.NoError(t, err)
 
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
-	assert.Equal(t, share.EmptyRoot().Hash(), dah.Hash())
+	assert.Equal(t, share.EmptyEDSRoot().Hash(), dah.Hash())
 }

--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -96,7 +96,7 @@ func TestExchange_DoNotStoreHistoric(t *testing.T) {
 
 	// ensure none of the "historic" EDSs were stored
 	for _, h := range headers {
-		if bytes.Equal(h.DataHash, share.EmptyRoot().Hash()) {
+		if bytes.Equal(h.DataHash, share.EmptyEDSRoot().Hash()) {
 			continue
 		}
 		has, err := store.Has(ctx, h.DAH.Hash())
@@ -128,8 +128,8 @@ func createStore(t *testing.T) *eds.Store {
 	require.NoError(t, err)
 
 	// store an empty square to initialize EDS store
-	eds := share.EmptyExtendedDataSquare()
-	err = store.Put(ctx, share.EmptyRoot().Hash(), eds)
+	eds := share.EmptyEDS()
+	err = store.Put(ctx, share.EmptyEDSRoot().Hash(), eds)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -187,7 +187,7 @@ func generateNonEmptyBlocks(
 		case b, ok := <-sub:
 			require.True(t, ok)
 
-			if !bytes.Equal(b.Data.Hash(), share.EmptyRoot().Hash()) {
+			if !bytes.Equal(b.Data.Hash(), share.EmptyEDSRoot().Hash()) {
 				hashes = append(hashes, share.DataHash(b.Data.Hash()))
 				i++
 			}

--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -96,7 +96,7 @@ func TestExchange_DoNotStoreHistoric(t *testing.T) {
 
 	// ensure none of the "historic" EDSs were stored
 	for _, h := range headers {
-		if bytes.Equal(h.DataHash, share.EmptyEDSRoot().Hash()) {
+		if bytes.Equal(h.DataHash, share.EmptyEDSRoots().Hash()) {
 			continue
 		}
 		has, err := store.Has(ctx, h.DAH.Hash())
@@ -129,7 +129,7 @@ func createStore(t *testing.T) *eds.Store {
 
 	// store an empty square to initialize EDS store
 	eds := share.EmptyEDS()
-	err = store.Put(ctx, share.EmptyEDSRoot().Hash(), eds)
+	err = store.Put(ctx, share.EmptyEDSRoots().Hash(), eds)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -187,7 +187,7 @@ func generateNonEmptyBlocks(
 		case b, ok := <-sub:
 			require.True(t, ok)
 
-			if !bytes.Equal(b.Data.Hash(), share.EmptyEDSRoot().Hash()) {
+			if !bytes.Equal(b.Data.Hash(), share.EmptyEDSRoots().Hash()) {
 				hashes = append(hashes, share.DataHash(b.Data.Hash()))
 				i++
 			}

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -37,7 +37,7 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 	headerExt, err := header.MakeExtendedHeader(&b.Header, comm, val, eds)
 	require.NoError(t, err)
 
-	assert.Equal(t, share.EmptyEDSRoot(), headerExt.DAH)
+	assert.Equal(t, share.EmptyEDSRoots(), headerExt.DAH)
 }
 
 func TestMismatchedDataHash_ComputedRoot(t *testing.T) {

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -37,7 +37,7 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 	headerExt, err := header.MakeExtendedHeader(&b.Header, comm, val, eds)
 	require.NoError(t, err)
 
-	assert.Equal(t, share.EmptyRoot(), headerExt.DAH)
+	assert.Equal(t, share.EmptyEDSRoot(), headerExt.DAH)
 }
 
 func TestMismatchedDataHash_ComputedRoot(t *testing.T) {

--- a/core/listener_no_race_test.go
+++ b/core/listener_no_race_test.go
@@ -42,7 +42,7 @@ func TestListenerWithNonEmptyBlocks(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(sub.Cancel)
 
-	empty := share.EmptyRoot()
+	empty := share.EmptyEDSRoot()
 	// TODO extract 16
 	for i := 0; i < 16; i++ {
 		_, err := cctx.FillBlock(16, cfg.Accounts, flags.BroadcastBlock)

--- a/core/listener_no_race_test.go
+++ b/core/listener_no_race_test.go
@@ -42,7 +42,7 @@ func TestListenerWithNonEmptyBlocks(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(sub.Cancel)
 
-	empty := share.EmptyEDSRoot()
+	empty := share.EmptyEDSRoots()
 	// TODO extract 16
 	for i := 0; i < 16; i++ {
 		_, err := cctx.FillBlock(16, cfg.Accounts, flags.BroadcastBlock)

--- a/das/coordinator_test.go
+++ b/das/coordinator_test.go
@@ -432,7 +432,7 @@ func (m *mockSampler) discover(ctx context.Context, newHeight uint64, emit liste
 	emit(ctx, &header.ExtendedHeader{
 		Commit:    &types.Commit{},
 		RawHeader: header.RawHeader{Height: int64(newHeight)},
-		DAH:       &share.Root{RowRoots: make([][]byte, 0)},
+		DAH:       &share.AxisRoots{RowRoots: make([][]byte, 0)},
 	})
 }
 

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -335,9 +335,9 @@ func (m *mockGetter) fillSubWithHeaders(
 
 	index := 0
 	for i := startHeight; i < endHeight; i++ {
-		dah := availability_test.RandFillBS(t, 16, bServ)
+		roots := availability_test.RandFillBS(t, 16, bServ)
 
-		randHeader := headertest.RandExtendedHeaderWithRoot(t, dah)
+		randHeader := headertest.RandExtendedHeaderWithRoot(t, roots)
 		randHeader.RawHeader.Height = int64(i + 1)
 
 		sub.Headers[index] = randHeader
@@ -361,9 +361,9 @@ type mockGetter struct {
 
 func (m *mockGetter) generateHeaders(t *testing.T, bServ blockservice.BlockService, startHeight, endHeight int) {
 	for i := startHeight; i < endHeight; i++ {
-		dah := availability_test.RandFillBS(t, 16, bServ)
+		roots := availability_test.RandFillBS(t, 16, bServ)
 
-		randHeader := headertest.RandExtendedHeaderWithRoot(t, dah)
+		randHeader := headertest.RandExtendedHeaderWithRoot(t, roots)
 		randHeader.RawHeader.Height = int64(i + 1)
 
 		m.headers[int64(i+1)] = randHeader

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -407,7 +407,7 @@ type benchGetterStub struct {
 
 func newBenchGetter() benchGetterStub {
 	return benchGetterStub{header: &header.ExtendedHeader{
-		DAH: &share.Root{RowRoots: make([][]byte, 0)},
+		DAH: &share.AxisRoots{RowRoots: make([][]byte, 0)},
 	}}
 }
 
@@ -428,7 +428,7 @@ func (m getterStub) GetByHeight(_ context.Context, height uint64) (*header.Exten
 	return &header.ExtendedHeader{
 		Commit:    &types.Commit{},
 		RawHeader: header.RawHeader{Height: int64(height)},
-		DAH:       &share.Root{RowRoots: make([][]byte, 0)},
+		DAH:       &share.AxisRoots{RowRoots: make([][]byte, 0)},
 	}, nil
 }
 

--- a/header/headertest/testing.go
+++ b/header/headertest/testing.go
@@ -66,7 +66,7 @@ func NewTestSuite(t *testing.T, numValidators int, blockTime time.Duration) *Tes
 }
 
 func (s *TestSuite) genesis() *header.ExtendedHeader {
-	dah := share.EmptyEDSRoot()
+	dah := share.EmptyEDSRoots()
 
 	gen := RandRawHeader(s.t)
 
@@ -152,7 +152,7 @@ func (s *TestSuite) NextHeader() *header.ExtendedHeader {
 		return s.head
 	}
 
-	dah := share.EmptyEDSRoot()
+	dah := share.EmptyEDSRoots()
 	height := s.Head().Height() + 1
 	rh := s.GenRawHeader(height, s.Head().Hash(), libhead.Hash(s.Head().Commit.Hash()), dah.Hash())
 	s.head = &header.ExtendedHeader{
@@ -229,7 +229,7 @@ func RandExtendedHeader(t testing.TB) *header.ExtendedHeader {
 }
 
 func RandExtendedHeaderAtTimestamp(t testing.TB, timestamp time.Time) *header.ExtendedHeader {
-	dah := share.EmptyEDSRoot()
+	dah := share.EmptyEDSRoots()
 
 	rh := RandRawHeader(t)
 	rh.DataHash = dah.Hash()

--- a/header/headertest/testing.go
+++ b/header/headertest/testing.go
@@ -66,7 +66,7 @@ func NewTestSuite(t *testing.T, numValidators int, blockTime time.Duration) *Tes
 }
 
 func (s *TestSuite) genesis() *header.ExtendedHeader {
-	dah := share.EmptyRoot()
+	dah := share.EmptyEDSRoot()
 
 	gen := RandRawHeader(s.t)
 
@@ -152,7 +152,7 @@ func (s *TestSuite) NextHeader() *header.ExtendedHeader {
 		return s.head
 	}
 
-	dah := share.EmptyRoot()
+	dah := share.EmptyEDSRoot()
 	height := s.Head().Height() + 1
 	rh := s.GenRawHeader(height, s.Head().Hash(), libhead.Hash(s.Head().Commit.Hash()), dah.Hash())
 	s.head = &header.ExtendedHeader{
@@ -229,7 +229,7 @@ func RandExtendedHeader(t testing.TB) *header.ExtendedHeader {
 }
 
 func RandExtendedHeaderAtTimestamp(t testing.TB, timestamp time.Time) *header.ExtendedHeader {
-	dah := share.EmptyRoot()
+	dah := share.EmptyEDSRoot()
 
 	rh := RandRawHeader(t)
 	rh.DataHash = dah.Hash()
@@ -325,7 +325,7 @@ func RandBlockID(testing.TB) types.BlockID {
 func ExtendedHeaderFromEDS(t testing.TB, height uint64, eds *rsmt2d.ExtendedDataSquare) *header.ExtendedHeader {
 	valSet, vals := RandValidatorSet(10, 10)
 	gen := RandRawHeader(t)
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	gen.DataHash = dah.Hash()

--- a/libs/edssser/edssser.go
+++ b/libs/edssser/edssser.go
@@ -11,8 +11,7 @@ import (
 
 	"github.com/ipfs/go-datastore"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
-
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 )
@@ -162,12 +161,12 @@ func (ss *EDSsser) put(ctx context.Context, t *testing.T) (time.Duration, error)
 
 	// divide by 2 to get ODS size as expected by RandEDS
 	square := edstest.RandEDS(t, ss.config.EDSSize/2)
-	dah, err := da.NewDataAvailabilityHeader(square)
+	roots, err := share.NewAxisRoots(square)
 	if err != nil {
 		return 0, err
 	}
 
 	now := time.Now()
-	err = ss.edsstore.Put(ctx, dah.Hash(), square)
+	err = ss.edsstore.Put(ctx, roots.Hash(), square)
 	return time.Since(now), err
 }

--- a/nodebuilder/node_test.go
+++ b/nodebuilder/node_test.go
@@ -136,7 +136,7 @@ func TestEmptyBlockExists(t *testing.T) {
 		{tp: node.Bridge},
 		{tp: node.Full},
 		// technically doesn't need to be tested as a SharesAvailable call to
-		// light node short circuits on an empty Root
+		// light node short circuits on an empty AxisRoots
 		{tp: node.Light},
 	}
 	for i, tt := range test {
@@ -147,7 +147,7 @@ func TestEmptyBlockExists(t *testing.T) {
 
 			// ensure an empty block exists in store
 
-			eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyRoot())
+			eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyEDSRoot())
 			err = node.ShareServ.SharesAvailable(ctx, eh)
 			require.NoError(t, err)
 

--- a/nodebuilder/node_test.go
+++ b/nodebuilder/node_test.go
@@ -136,7 +136,7 @@ func TestEmptyBlockExists(t *testing.T) {
 		{tp: node.Bridge},
 		{tp: node.Full},
 		// technically doesn't need to be tested as a SharesAvailable call to
-		// light node short circuits on an empty AxisRoots
+		// light node short circuits on an empty EDS
 		{tp: node.Light},
 	}
 	for i, tt := range test {

--- a/nodebuilder/node_test.go
+++ b/nodebuilder/node_test.go
@@ -147,7 +147,7 @@ func TestEmptyBlockExists(t *testing.T) {
 
 			// ensure an empty block exists in store
 
-			eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyEDSRoot())
+			eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyEDSRoots())
 			err = node.ShareServ.SharesAvailable(ctx, eh)
 			require.NoError(t, err)
 

--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"errors"
-	"go.uber.org/zap"
 	"strings"
 	"time"
 
@@ -81,7 +80,6 @@ func GetNetworks() []Network {
 // listAvailableNetworks provides a string listing all known long-standing networks for things
 // like CLI hints.
 func listAvailableNetworks() string {
-	zap.New().
 	var networks []string
 	for _, net := range orderedNetworks {
 		// "private" networks are configured via env vars, so skip

--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"errors"
+	"go.uber.org/zap"
 	"strings"
 	"time"
 
@@ -80,6 +81,7 @@ func GetNetworks() []Network {
 // listAvailableNetworks provides a string listing all known long-standing networks for things
 // like CLI hints.
 func listAvailableNetworks() string {
+	zap.New().
 	var networks []string
 	for _, net := range orderedNetworks {
 		// "private" networks are configured via env vars, so skip

--- a/nodebuilder/share/cmd/share.go
+++ b/nodebuilder/share/cmd/share.go
@@ -32,7 +32,7 @@ var Cmd = &cobra.Command{
 
 var sharesAvailableCmd = &cobra.Command{
 	Use:   "available",
-	Short: "Subjectively validates if Shares committed to the given AxisRoots are available on the Network.",
+	Short: "Subjectively validates if Shares committed to the given EDS are available on the Network.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())

--- a/nodebuilder/share/cmd/share.go
+++ b/nodebuilder/share/cmd/share.go
@@ -32,7 +32,7 @@ var Cmd = &cobra.Command{
 
 var sharesAvailableCmd = &cobra.Command{
 	Use:   "available",
-	Short: "Subjectively validates if Shares committed to the given Root are available on the Network.",
+	Short: "Subjectively validates if Shares committed to the given AxisRoots are available on the Network.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())

--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -21,7 +21,7 @@ func newShareModule(getter share.Getter, avail share.Availability) Module {
 
 // ensureEmptyCARExists adds an empty EDS to the provided EDS store.
 func ensureEmptyCARExists(ctx context.Context, store *eds.Store) error {
-	emptyEDS := share.EmptyExtendedDataSquare()
+	emptyEDS := share.EmptyEDS()
 	emptyDAH, err := da.NewDataAvailabilityHeader(emptyEDS)
 	if err != nil {
 		return err

--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -7,8 +7,6 @@ import (
 	"github.com/filecoin-project/dagstore"
 	"github.com/ipfs/boxo/blockservice"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
-
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds"
 	"github.com/celestiaorg/celestia-node/share/getters"
@@ -22,12 +20,12 @@ func newShareModule(getter share.Getter, avail share.Availability) Module {
 // ensureEmptyCARExists adds an empty EDS to the provided EDS store.
 func ensureEmptyCARExists(ctx context.Context, store *eds.Store) error {
 	emptyEDS := share.EmptyEDS()
-	emptyDAH, err := da.NewDataAvailabilityHeader(emptyEDS)
+	emptyRoots, err := share.NewAxisRoots(emptyEDS)
 	if err != nil {
 		return err
 	}
 
-	err = store.Put(ctx, emptyDAH.Hash(), emptyEDS)
+	err = store.Put(ctx, emptyRoots.Hash(), emptyEDS)
 	if errors.Is(err, dagstore.ErrShardExists) {
 		return nil
 	}

--- a/nodebuilder/share/share_test.go
+++ b/nodebuilder/share/share_test.go
@@ -23,8 +23,8 @@ func Test_EmptyCARExists(t *testing.T) {
 	err = edsStore.Start(ctx)
 	require.NoError(t, err)
 
-	eds := share.EmptyExtendedDataSquare()
-	dah, err := share.NewRoot(eds)
+	eds := share.EmptyEDS()
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	// add empty EDS to store

--- a/nodebuilder/share/share_test.go
+++ b/nodebuilder/share/share_test.go
@@ -24,7 +24,7 @@ func Test_EmptyCARExists(t *testing.T) {
 	require.NoError(t, err)
 
 	eds := share.EmptyEDS()
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	// add empty EDS to store
@@ -32,12 +32,12 @@ func Test_EmptyCARExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	// assert that the empty car exists
-	has, err := edsStore.Has(ctx, dah.Hash())
+	has, err := edsStore.Has(ctx, roots.Hash())
 	assert.True(t, has)
 	assert.NoError(t, err)
 
 	// assert that the empty car is, in fact, empty
-	emptyEds, err := edsStore.Get(ctx, dah.Hash())
+	emptyEds, err := edsStore.Get(ctx, roots.Hash())
 	assert.Equal(t, eds.Flattened(), emptyEds.Flattened())
 	assert.NoError(t, err)
 }

--- a/nodebuilder/store_test.go
+++ b/nodebuilder/store_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -93,12 +92,12 @@ func BenchmarkStore(b *testing.B) {
 						nmt.NodeVisitor(adder.VisitFn())),
 				)
 				require.NoError(b, err)
-				dah, err := da.NewDataAvailabilityHeader(eds)
+				roots, err := share.NewAxisRoots(eds)
 				require.NoError(b, err)
 				ctx := ipld.CtxWithProofsAdder(ctx, adder)
 
 				b.StartTimer()
-				err = store.edsStore.Put(ctx, dah.Hash(), eds)
+				err = store.edsStore.Put(ctx, roots.Hash(), eds)
 				b.StopTimer()
 				require.NoError(b, err)
 			}
@@ -109,11 +108,11 @@ func BenchmarkStore(b *testing.B) {
 			b.StopTimer()
 			for i := 0; i < b.N; i++ {
 				eds := edstest.RandEDS(b, size)
-				dah, err := da.NewDataAvailabilityHeader(eds)
+				roots, err := share.NewAxisRoots(eds)
 				require.NoError(b, err)
 
 				b.StartTimer()
-				err = store.edsStore.Put(ctx, dah.Hash(), eds)
+				err = store.edsStore.Put(ctx, roots.Hash(), eds)
 				b.StopTimer()
 				require.NoError(b, err)
 			}
@@ -139,13 +138,13 @@ func TestStoreRestart(t *testing.T) {
 	for i := range hashes {
 		edss := edstest.RandEDS(t, size)
 		require.NoError(t, err)
-		dah, err := da.NewDataAvailabilityHeader(edss)
+		roots, err := share.NewAxisRoots(edss)
 		require.NoError(t, err)
-		err = store.edsStore.Put(ctx, dah.Hash(), edss)
+		err = store.edsStore.Put(ctx, roots.Hash(), edss)
 		require.NoError(t, err)
 
 		// store hashes for read loop later
-		hashes[i] = dah.Hash()
+		hashes[i] = roots.Hash()
 	}
 
 	// restart store

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -118,7 +118,7 @@ func TestArchivalBlobSync(t *testing.T) {
 		eh, err := archivalFN.HeaderServ.GetByHeight(ctx, uint64(i))
 		require.NoError(t, err)
 
-		if bytes.Equal(eh.DataHash, share.EmptyEDSRoot().Hash()) {
+		if bytes.Equal(eh.DataHash, share.EmptyEDSRoots().Hash()) {
 			i++
 			continue
 		}

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -118,7 +118,7 @@ func TestArchivalBlobSync(t *testing.T) {
 		eh, err := archivalFN.HeaderServ.GetByHeight(ctx, uint64(i))
 		require.NoError(t, err)
 
-		if bytes.Equal(eh.DataHash, share.EmptyRoot().Hash()) {
+		if bytes.Equal(eh.DataHash, share.EmptyEDSRoot().Hash()) {
 			i++
 			continue
 		}

--- a/pruner/full/pruner.go
+++ b/pruner/full/pruner.go
@@ -25,8 +25,8 @@ func NewPruner(store *eds.Store) *Pruner {
 }
 
 func (p *Pruner) Prune(ctx context.Context, eh *header.ExtendedHeader) error {
-	// short circuit on empty roots
-	if eh.DAH.Equals(share.EmptyRoot()) {
+	// short circuit on empty eds
+	if eh.DAH.Equals(share.EmptyEDSRoot()) {
 		return nil
 	}
 

--- a/pruner/full/pruner.go
+++ b/pruner/full/pruner.go
@@ -26,7 +26,7 @@ func NewPruner(store *eds.Store) *Pruner {
 
 func (p *Pruner) Prune(ctx context.Context, eh *header.ExtendedHeader) error {
 	// short circuit on empty eds
-	if eh.DAH.Equals(share.EmptyEDSRoot()) {
+	if eh.DAH.Equals(share.EmptyEDSRoots()) {
 		return nil
 	}
 

--- a/pruner/light/pruner.go
+++ b/pruner/light/pruner.go
@@ -24,7 +24,7 @@ func NewPruner(bstore blockstore.Blockstore, ds datastore.Batching) pruner.Prune
 
 func (p *Pruner) Prune(ctx context.Context, h *header.ExtendedHeader) error {
 	dah := h.DAH
-	if share.DataHash(dah.Hash()).IsEmptyRoot() {
+	if share.DataHash(dah.Hash()).IsEmptyEDS() {
 		return nil
 	}
 
@@ -41,6 +41,6 @@ func (p *Pruner) Prune(ctx context.Context, h *header.ExtendedHeader) error {
 	return p.ds.Delete(ctx, rootKey(dah))
 }
 
-func rootKey(root *share.Root) datastore.Key {
+func rootKey(root *share.AxisRoots) datastore.Key {
 	return datastore.NewKey(root.String())
 }

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -40,13 +40,13 @@ func NewShareAvailability(
 // enough Shares from the network.
 func (fa *ShareAvailability) SharesAvailable(ctx context.Context, header *header.ExtendedHeader) error {
 	dah := header.DAH
-	// short-circuit if the given root is minimum DAH of an empty data square, to avoid datastore hit
+	// short-circuit if the given root is an empty data square, to avoid datastore hit
 	if share.DataHash(dah.Hash()).IsEmptyEDS() {
 		return nil
 	}
 
 	// we assume the caller of this method has already performed basic validation on the
-	// given dah/root. If for some reason this has not happened, the node should panic.
+	// given roots. If for some reason this has not happened, the node should panic.
 	if err := dah.ValidateBasic(); err != nil {
 		log.Errorw("Availability validation cannot be performed on a malformed DataAvailabilityHeader",
 			"err", err)

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -41,7 +41,7 @@ func NewShareAvailability(
 func (fa *ShareAvailability) SharesAvailable(ctx context.Context, header *header.ExtendedHeader) error {
 	dah := header.DAH
 	// short-circuit if the given root is minimum DAH of an empty data square, to avoid datastore hit
-	if share.DataHash(dah.Hash()).IsEmptyRoot() {
+	if share.DataHash(dah.Hash()).IsEmptyEDS() {
 		return nil
 	}
 

--- a/share/availability/full/availability_test.go
+++ b/share/availability/full/availability_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
-
 	"github.com/celestiaorg/celestia-node/header/headertest"
 	"github.com/celestiaorg/celestia-node/share"
 	availability_test "github.com/celestiaorg/celestia-node/share/availability/test"
@@ -37,9 +35,9 @@ func TestSharesAvailable_Full(t *testing.T) {
 	defer cancel()
 
 	// RandServiceWithSquare creates a NewShareAvailability inside, so we can test it
-	getter, dah := GetterWithRandSquare(t, 16)
+	getter, roots := GetterWithRandSquare(t, 16)
 
-	eh := headertest.RandExtendedHeaderWithRoot(t, dah)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 	avail := TestAvailability(t, getter)
 	err := avail.SharesAvailable(ctx, eh)
 	assert.NoError(t, err)
@@ -50,13 +48,13 @@ func TestSharesAvailable_StoresToEDSStore(t *testing.T) {
 	defer cancel()
 
 	// RandServiceWithSquare creates a NewShareAvailability inside, so we can test it
-	getter, dah := GetterWithRandSquare(t, 16)
-	eh := headertest.RandExtendedHeaderWithRoot(t, dah)
+	getter, roots := GetterWithRandSquare(t, 16)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 	avail := TestAvailability(t, getter)
 	err := avail.SharesAvailable(ctx, eh)
 	assert.NoError(t, err)
 
-	has, err := avail.store.Has(ctx, dah.Hash())
+	has, err := avail.store.Has(ctx, roots.Hash())
 	assert.NoError(t, err)
 	assert.True(t, has)
 }
@@ -68,8 +66,8 @@ func TestSharesAvailable_Full_ErrNotAvailable(t *testing.T) {
 	defer cancel()
 
 	eds := edstest.RandEDS(t, 4)
-	dah, err := da.NewDataAvailabilityHeader(eds)
-	eh := headertest.RandExtendedHeaderWithRoot(t, &dah)
+	roots, err := share.NewAxisRoots(eds)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 	require.NoError(t, err)
 	avail := TestAvailability(t, getter)
 

--- a/share/availability/full/testing.go
+++ b/share/availability/full/testing.go
@@ -18,14 +18,14 @@ import (
 
 // GetterWithRandSquare provides a share.Getter filled with 'n' NMT
 // trees of 'n' random shares, essentially storing a whole square.
-func GetterWithRandSquare(t *testing.T, n int) (share.Getter, *share.Root) {
+func GetterWithRandSquare(t *testing.T, n int) (share.Getter, *share.AxisRoots) {
 	bServ := ipld.NewMemBlockservice()
 	getter := getters.NewIPLDGetter(bServ)
 	return getter, availability_test.RandFillBS(t, n, bServ)
 }
 
 // RandNode creates a Full Node filled with a random block of the given size.
-func RandNode(dn *availability_test.TestDagNet, squareSize int) (*availability_test.TestNode, *share.Root) {
+func RandNode(dn *availability_test.TestDagNet, squareSize int) (*availability_test.TestNode, *share.AxisRoots) {
 	nd := Node(dn)
 	return nd, availability_test.RandFillBS(dn.T, squareSize, nd.BlockService)
 }

--- a/share/availability/light/availability.go
+++ b/share/availability/light/availability.go
@@ -61,7 +61,7 @@ func NewShareAvailability(
 // ExtendedHeader. This way SharesAvailable subjectively verifies that Shares are available.
 func (la *ShareAvailability) SharesAvailable(ctx context.Context, header *header.ExtendedHeader) error {
 	dah := header.DAH
-	// short-circuit if the given root is minimum DAH of an empty data square
+	// short-circuit if the given root is an empty data square
 	if share.DataHash(dah.Hash()).IsEmptyEDS() {
 		return nil
 	}

--- a/share/availability/light/availability.go
+++ b/share/availability/light/availability.go
@@ -62,7 +62,7 @@ func NewShareAvailability(
 func (la *ShareAvailability) SharesAvailable(ctx context.Context, header *header.ExtendedHeader) error {
 	dah := header.DAH
 	// short-circuit if the given root is minimum DAH of an empty data square
-	if share.DataHash(dah.Hash()).IsEmptyRoot() {
+	if share.DataHash(dah.Hash()).IsEmptyEDS() {
 		return nil
 	}
 
@@ -153,7 +153,7 @@ func (la *ShareAvailability) SharesAvailable(ctx context.Context, header *header
 	return nil
 }
 
-func rootKey(root *share.Root) datastore.Key {
+func rootKey(root *share.AxisRoots) datastore.Key {
 	return datastore.NewKey(root.String())
 }
 

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -71,7 +71,7 @@ func TestSharesAvailableEmptyRoot(t *testing.T) {
 	getter, _ := GetterWithRandSquare(t, 16)
 	avail := TestAvailability(getter)
 
-	eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyRoot())
+	eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyEDSRoot())
 	err := avail.SharesAvailable(ctx, eh)
 	require.NoError(t, err)
 }
@@ -216,7 +216,7 @@ func TestGetShares(t *testing.T) {
 
 	eds, err := getter.GetEDS(ctx, eh)
 	require.NoError(t, err)
-	gotDAH, err := share.NewRoot(eds)
+	gotDAH, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	require.True(t, eh.DAH.Equals(gotDAH))

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -71,7 +71,7 @@ func TestSharesAvailableEmptyRoot(t *testing.T) {
 	getter, _ := GetterWithRandSquare(t, 16)
 	avail := TestAvailability(getter)
 
-	eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyEDSRoot())
+	eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyEDSRoots())
 	err := avail.SharesAvailable(ctx, eh)
 	require.NoError(t, err)
 }

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -23,7 +23,7 @@ func TestSharesAvailableCaches(t *testing.T) {
 	dah := eh.DAH
 	avail := TestAvailability(getter)
 
-	// cache doesn't have dah yet
+	// cache doesn't have eds yet
 	has, err := avail.ds.Has(ctx, rootKey(dah))
 	require.NoError(t, err)
 	require.False(t, has)
@@ -46,17 +46,17 @@ func TestSharesAvailableHitsCache(t *testing.T) {
 	getter, _ := GetterWithRandSquare(t, 16)
 	avail := TestAvailability(getter)
 
-	// create new dah, that is not available by getter
+	// create new roots, that is not available by getter
 	bServ := ipld.NewMemBlockservice()
-	dah := availability_test.RandFillBS(t, 16, bServ)
-	eh := headertest.RandExtendedHeaderWithRoot(t, dah)
+	roots := availability_test.RandFillBS(t, 16, bServ)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 
-	// blockstore doesn't actually have the dah
+	// blockstore doesn't actually have the eds
 	err := avail.SharesAvailable(ctx, eh)
 	require.ErrorIs(t, err, share.ErrNotAvailable)
 
 	// put success result in cache
-	err = avail.ds.Put(ctx, rootKey(dah), []byte{})
+	err = avail.ds.Put(ctx, rootKey(roots), []byte{})
 	require.NoError(t, err)
 
 	// should hit cache after putting
@@ -83,17 +83,17 @@ func TestSharesAvailableFailed(t *testing.T) {
 	getter, _ := GetterWithRandSquare(t, 16)
 	avail := TestAvailability(getter)
 
-	// create new dah, that is not available by getter
+	// create new eds, that is not available by getter
 	bServ := ipld.NewMemBlockservice()
-	dah := availability_test.RandFillBS(t, 16, bServ)
-	eh := headertest.RandExtendedHeaderWithRoot(t, dah)
+	roots := availability_test.RandFillBS(t, 16, bServ)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 
-	// blockstore doesn't actually have the dah, so it should fail
+	// blockstore doesn't actually have the eds, so it should fail
 	err := avail.SharesAvailable(ctx, eh)
 	require.ErrorIs(t, err, share.ErrNotAvailable)
 
 	// cache should have failed results now
-	result, err := avail.ds.Get(ctx, rootKey(dah))
+	result, err := avail.ds.Get(ctx, rootKey(roots))
 	require.NoError(t, err)
 
 	failed, err := decodeSamples(result)
@@ -216,10 +216,10 @@ func TestGetShares(t *testing.T) {
 
 	eds, err := getter.GetEDS(ctx, eh)
 	require.NoError(t, err)
-	gotDAH, err := share.NewAxisRoots(eds)
+	gotRoots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
-	require.True(t, eh.DAH.Equals(gotDAH))
+	require.True(t, eh.DAH.Equals(gotRoots))
 }
 
 func TestService_GetSharesByNamespaceNotFound(t *testing.T) {

--- a/share/availability/light/testing.go
+++ b/share/availability/light/testing.go
@@ -39,7 +39,7 @@ func EmptyGetter() (share.Getter, blockservice.BlockService) {
 }
 
 // RandNode creates a Light Node filled with a random block of the given size.
-func RandNode(dn *availability_test.TestDagNet, squareSize int) (*availability_test.TestNode, *share.Root) {
+func RandNode(dn *availability_test.TestDagNet, squareSize int) (*availability_test.TestNode, *share.AxisRoots) {
 	nd := Node(dn)
 	return nd, availability_test.RandFillBS(dn.T, squareSize, nd.BlockService)
 }

--- a/share/availability/test/testing.go
+++ b/share/availability/test/testing.go
@@ -23,16 +23,16 @@ import (
 )
 
 // RandFillBS fills the given BlockService with a random block of a given size.
-func RandFillBS(t *testing.T, n int, bServ blockservice.BlockService) *share.Root {
+func RandFillBS(t *testing.T, n int, bServ blockservice.BlockService) *share.AxisRoots {
 	shares := sharetest.RandShares(t, n*n)
 	return FillBS(t, bServ, shares)
 }
 
 // FillBS fills the given BlockService with the given shares.
-func FillBS(t *testing.T, bServ blockservice.BlockService, shares []share.Share) *share.Root {
+func FillBS(t *testing.T, bServ blockservice.BlockService, shares []share.Share) *share.AxisRoots {
 	eds, err := ipld.AddShares(context.TODO(), shares, bServ)
 	require.NoError(t, err)
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	return dah
 }

--- a/share/availability/test/testing.go
+++ b/share/availability/test/testing.go
@@ -32,9 +32,9 @@ func RandFillBS(t *testing.T, n int, bServ blockservice.BlockService) *share.Axi
 func FillBS(t *testing.T, bServ blockservice.BlockService, shares []share.Share) *share.AxisRoots {
 	eds, err := ipld.AddShares(context.TODO(), shares, bServ)
 	require.NoError(t, err)
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
-	return dah
+	return roots
 }
 
 type TestNode struct {

--- a/share/doc.go
+++ b/share/doc.go
@@ -5,7 +5,7 @@ block data.
 Though this package contains several useful methods for getting specific shares and/or
 sampling them at random, a particularly useful method is GetSharesByNamespace which retrieves
 all shares of block data of the given Namespace from the block associated with the given
-DataAvailabilityHeader (DAH, but referred to as Root within this package).
+DataAvailabilityHeader (DAH, but referred to as AxisRoots within this package).
 
 This package also contains declaration of the Availability interface. Implementations of
 the interface (light, full) are located in the availability sub-folder.

--- a/share/eds/blockstore_test.go
+++ b/share/eds/blockstore_test.go
@@ -25,25 +25,25 @@ func TestBlockstore_Operations(t *testing.T) {
 	err = edsStore.Start(ctx)
 	require.NoError(t, err)
 
-	eds, dah := randomEDS(t)
-	err = edsStore.Put(ctx, dah.Hash(), eds)
+	eds, roots := randomEDS(t)
+	err = edsStore.Put(ctx, roots.Hash(), eds)
 	require.NoError(t, err)
 
-	r, err := edsStore.GetCAR(ctx, dah.Hash())
+	r, err := edsStore.GetCAR(ctx, roots.Hash())
 	require.NoError(t, err)
 	carReader, err := car.NewCarReader(r)
 	require.NoError(t, err)
 
 	topLevelBS := edsStore.Blockstore()
-	carBS, err := edsStore.CARBlockstore(ctx, dah.Hash())
+	carBS, err := edsStore.CARBlockstore(ctx, roots.Hash())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, carBS.Close())
 	}()
 
-	root, err := edsStore.GetDAH(ctx, dah.Hash())
+	root, err := edsStore.GetDAH(ctx, roots.Hash())
 	require.NoError(t, err)
-	require.True(t, dah.Equals(root))
+	require.True(t, roots.Equals(root))
 
 	blockstores := []dagstore.ReadBlockstore{topLevelBS, carBS}
 

--- a/share/eds/byzantine/bad_encoding_test.go
+++ b/share/eds/byzantine/bad_encoding_test.go
@@ -166,7 +166,7 @@ func TestIncorrectBadEncodingFraudProof(t *testing.T) {
 	eds, err := ipld.AddShares(ctx, shares, bServ)
 	require.NoError(t, err)
 
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	// get an arbitrary row

--- a/share/eds/byzantine/bad_encoding_test.go
+++ b/share/eds/byzantine/bad_encoding_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	core "github.com/tendermint/tendermint/types"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/test/util/malicious"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -31,16 +30,16 @@ func TestBEFP_Validate(t *testing.T) {
 	bServ := ipld.NewMemBlockservice()
 
 	square := edstest.RandByzantineEDS(t, 16)
-	dah, err := da.NewDataAvailabilityHeader(square)
+	roots, err := share.NewAxisRoots(square)
 	require.NoError(t, err)
 	err = ipld.ImportEDS(ctx, square, bServ)
 	require.NoError(t, err)
 
 	var errRsmt2d *rsmt2d.ErrByzantineData
-	err = square.Repair(dah.RowRoots, dah.ColumnRoots)
+	err = square.Repair(roots.RowRoots, roots.ColumnRoots)
 	require.ErrorAs(t, err, &errRsmt2d)
 
-	byzantine := NewErrByzantine(ctx, bServ.Blockstore(), &dah, errRsmt2d)
+	byzantine := NewErrByzantine(ctx, bServ.Blockstore(), roots, errRsmt2d)
 	var errByz *ErrByzantine
 	require.ErrorAs(t, byzantine, &errByz)
 
@@ -55,7 +54,7 @@ func TestBEFP_Validate(t *testing.T) {
 		{
 			name: "valid BEFP",
 			prepareFn: func() error {
-				return proof.Validate(&header.ExtendedHeader{DAH: &dah})
+				return proof.Validate(&header.ExtendedHeader{DAH: roots})
 			},
 			expectedResult: func(err error) {
 				require.NoError(t, err)
@@ -65,12 +64,12 @@ func TestBEFP_Validate(t *testing.T) {
 			name: "invalid BEFP for valid header",
 			prepareFn: func() error {
 				validSquare := edstest.RandEDS(t, 2)
-				validDah, err := da.NewDataAvailabilityHeader(validSquare)
+				validRoots, err := share.NewAxisRoots(validSquare)
 				require.NoError(t, err)
 				err = ipld.ImportEDS(ctx, validSquare, bServ)
 				require.NoError(t, err)
 				validShares := validSquare.Flattened()
-				errInvalidByz := NewErrByzantine(ctx, bServ.Blockstore(), &validDah,
+				errInvalidByz := NewErrByzantine(ctx, bServ.Blockstore(), validRoots,
 					&rsmt2d.ErrByzantineData{
 						Axis:   rsmt2d.Row,
 						Index:  0,
@@ -80,7 +79,7 @@ func TestBEFP_Validate(t *testing.T) {
 				var errInvalid *ErrByzantine
 				require.ErrorAs(t, errInvalidByz, &errInvalid)
 				invalidBefp := CreateBadEncodingProof([]byte("hash"), 0, errInvalid)
-				return invalidBefp.Validate(&header.ExtendedHeader{DAH: &validDah})
+				return invalidBefp.Validate(&header.ExtendedHeader{DAH: validRoots})
 			},
 			expectedResult: func(err error) {
 				require.ErrorIs(t, err, errNMTTreeRootsMatch)
@@ -93,7 +92,7 @@ func TestBEFP_Validate(t *testing.T) {
 				sh := sharetest.RandShares(t, 2)
 				nmtProof := nmt.NewInclusionProof(0, 1, nil, false)
 				befp.Shares[0] = &ShareWithProof{sh[0], &nmtProof, rsmt2d.Row}
-				return proof.Validate(&header.ExtendedHeader{DAH: &dah})
+				return proof.Validate(&header.ExtendedHeader{DAH: roots})
 			},
 			expectedResult: func(err error) {
 				require.ErrorIs(t, err, errIncorrectShare)
@@ -103,7 +102,7 @@ func TestBEFP_Validate(t *testing.T) {
 			name: "invalid amount of shares",
 			prepareFn: func() error {
 				befp.Shares = befp.Shares[0 : len(befp.Shares)/2]
-				return proof.Validate(&header.ExtendedHeader{DAH: &dah})
+				return proof.Validate(&header.ExtendedHeader{DAH: roots})
 			},
 			expectedResult: func(err error) {
 				require.ErrorIs(t, err, errIncorrectAmountOfShares)
@@ -113,7 +112,7 @@ func TestBEFP_Validate(t *testing.T) {
 			name: "not enough shares to recompute the root",
 			prepareFn: func() error {
 				befp.Shares[0] = nil
-				return proof.Validate(&header.ExtendedHeader{DAH: &dah})
+				return proof.Validate(&header.ExtendedHeader{DAH: roots})
 			},
 			expectedResult: func(err error) {
 				require.ErrorIs(t, err, errIncorrectAmountOfShares)
@@ -123,7 +122,7 @@ func TestBEFP_Validate(t *testing.T) {
 			name: "index out of bounds",
 			prepareFn: func() error {
 				befp.Index = 100
-				return proof.Validate(&header.ExtendedHeader{DAH: &dah})
+				return proof.Validate(&header.ExtendedHeader{DAH: roots})
 			},
 			expectedResult: func(err error) {
 				require.ErrorIs(t, err, errIncorrectIndex)
@@ -136,7 +135,7 @@ func TestBEFP_Validate(t *testing.T) {
 					RawHeader: core.Header{
 						Height: 42,
 					},
-					DAH: &dah,
+					DAH: roots,
 				})
 			},
 			expectedResult: func(err error) {
@@ -166,14 +165,14 @@ func TestIncorrectBadEncodingFraudProof(t *testing.T) {
 	eds, err := ipld.AddShares(ctx, shares, bServ)
 	require.NoError(t, err)
 
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	// get an arbitrary row
 	rowIdx := squareSize / 2
 	shareProofs := make([]*ShareWithProof, 0, eds.Width())
 	for i := range shareProofs {
-		proof, err := GetShareWithProof(ctx, bServ, dah, shares[i], rsmt2d.Row, rowIdx, i)
+		proof, err := GetShareWithProof(ctx, bServ, roots, shares[i], rsmt2d.Row, rowIdx, i)
 		require.NoError(t, err)
 		shareProofs = append(shareProofs, proof)
 	}
@@ -189,7 +188,7 @@ func TestIncorrectBadEncodingFraudProof(t *testing.T) {
 		RawHeader: core.Header{
 			Height: 420,
 		},
-		DAH: dah,
+		DAH: roots,
 		Commit: &core.Commit{
 			BlockID: core.BlockID{
 				Hash: []byte("made up hash"),
@@ -221,22 +220,22 @@ func TestBEFP_ValidateOutOfOrderShares(t *testing.T) {
 	)
 	require.NoError(t, err, "failure to recompute the extended data square")
 
-	dah, err := da.NewDataAvailabilityHeader(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	var errRsmt2d *rsmt2d.ErrByzantineData
-	err = eds.Repair(dah.RowRoots, dah.ColumnRoots)
+	err = eds.Repair(roots.RowRoots, roots.ColumnRoots)
 	require.ErrorAs(t, err, &errRsmt2d)
 
 	err = batchAddr.Commit()
 	require.NoError(t, err)
 
-	byzantine := NewErrByzantine(ctx, bServ.Blockstore(), &dah, errRsmt2d)
+	byzantine := NewErrByzantine(ctx, bServ.Blockstore(), roots, errRsmt2d)
 	var errByz *ErrByzantine
 	require.ErrorAs(t, byzantine, &errByz)
 
 	befp := CreateBadEncodingProof([]byte("hash"), 0, errByz)
-	err = befp.Validate(&header.ExtendedHeader{DAH: &dah})
+	err = befp.Validate(&header.ExtendedHeader{DAH: roots})
 	require.NoError(t, err)
 }
 

--- a/share/eds/byzantine/byzantine.go
+++ b/share/eds/byzantine/byzantine.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ipfs/boxo/blockstore"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/ipld"
 )
 
@@ -32,7 +32,7 @@ func (e *ErrByzantine) Error() string {
 func NewErrByzantine(
 	ctx context.Context,
 	bStore blockstore.Blockstore,
-	dah *da.DataAvailabilityHeader,
+	roots *share.AxisRoots,
 	errByz *rsmt2d.ErrByzantineData,
 ) error {
 	sharesWithProof := make([]*ShareWithProof, len(errByz.Shares))
@@ -42,7 +42,7 @@ func NewErrByzantine(
 		if len(share) == 0 {
 			continue
 		}
-		swp, err := GetShareWithProof(ctx, bGetter, dah, share, errByz.Axis, int(errByz.Index), index)
+		swp, err := GetShareWithProof(ctx, bGetter, roots, share, errByz.Axis, int(errByz.Index), index)
 		if err != nil {
 			log.Warn("requesting proof failed",
 				"errByz", errByz,
@@ -53,12 +53,12 @@ func NewErrByzantine(
 
 		sharesWithProof[index] = swp
 		// it is enough to collect half of the shares to construct the befp
-		if count++; count >= len(dah.RowRoots)/2 {
+		if count++; count >= len(roots.RowRoots)/2 {
 			break
 		}
 	}
 
-	if count < len(dah.RowRoots)/2 {
+	if count < len(roots.RowRoots)/2 {
 		return fmt.Errorf("failed to collect proof")
 	}
 

--- a/share/eds/byzantine/share_proof.go
+++ b/share/eds/byzantine/share_proof.go
@@ -29,7 +29,7 @@ type ShareWithProof struct {
 }
 
 // Validate validates inclusion of the share under the given root CID.
-func (s *ShareWithProof) Validate(dah *share.Root, axisType rsmt2d.Axis, axisIdx, shrIdx int) bool {
+func (s *ShareWithProof) Validate(dah *share.AxisRoots, axisType rsmt2d.Axis, axisIdx, shrIdx int) bool {
 	var rootHash []byte
 	switch axisType {
 	case rsmt2d.Row:
@@ -75,7 +75,7 @@ func (s *ShareWithProof) ShareWithProofToProto() *pb.Share {
 func GetShareWithProof(
 	ctx context.Context,
 	bGetter blockservice.BlockGetter,
-	dah *share.Root,
+	dah *share.AxisRoots,
 	share share.Share,
 	axisType rsmt2d.Axis, axisIdx, shrIdx int,
 ) (*ShareWithProof, error) {
@@ -139,7 +139,7 @@ func ProtoToProof(protoProof *nmt_pb.Proof) nmt.Proof {
 	)
 }
 
-func rootHashForCoordinates(r *share.Root, axisType rsmt2d.Axis, x, y int) []byte {
+func rootHashForCoordinates(r *share.AxisRoots, axisType rsmt2d.Axis, x, y int) []byte {
 	if axisType == rsmt2d.Row {
 		return r.RowRoots[y]
 	}

--- a/share/eds/byzantine/share_proof.go
+++ b/share/eds/byzantine/share_proof.go
@@ -29,16 +29,16 @@ type ShareWithProof struct {
 }
 
 // Validate validates inclusion of the share under the given root CID.
-func (s *ShareWithProof) Validate(dah *share.AxisRoots, axisType rsmt2d.Axis, axisIdx, shrIdx int) bool {
+func (s *ShareWithProof) Validate(roots *share.AxisRoots, axisType rsmt2d.Axis, axisIdx, shrIdx int) bool {
 	var rootHash []byte
 	switch axisType {
 	case rsmt2d.Row:
-		rootHash = rootHashForCoordinates(dah, s.Axis, shrIdx, axisIdx)
+		rootHash = rootHashForCoordinates(roots, s.Axis, shrIdx, axisIdx)
 	case rsmt2d.Col:
-		rootHash = rootHashForCoordinates(dah, s.Axis, axisIdx, shrIdx)
+		rootHash = rootHashForCoordinates(roots, s.Axis, axisIdx, shrIdx)
 	}
 
-	edsSize := len(dah.RowRoots)
+	edsSize := len(roots.RowRoots)
 	isParity := shrIdx >= edsSize/2 || axisIdx >= edsSize/2
 	namespace := share.ParitySharesNamespace
 	if !isParity {
@@ -75,16 +75,16 @@ func (s *ShareWithProof) ShareWithProofToProto() *pb.Share {
 func GetShareWithProof(
 	ctx context.Context,
 	bGetter blockservice.BlockGetter,
-	dah *share.AxisRoots,
+	roots *share.AxisRoots,
 	share share.Share,
 	axisType rsmt2d.Axis, axisIdx, shrIdx int,
 ) (*ShareWithProof, error) {
 	if axisType == rsmt2d.Col {
 		axisIdx, shrIdx, axisType = shrIdx, axisIdx, rsmt2d.Row
 	}
-	width := len(dah.RowRoots)
+	width := len(roots.RowRoots)
 	// try row proofs
-	root := dah.RowRoots[axisIdx]
+	root := roots.RowRoots[axisIdx]
 	proof, err := ipld.GetProof(ctx, bGetter, root, shrIdx, width)
 	if err == nil {
 		shareWithProof := &ShareWithProof{
@@ -92,13 +92,13 @@ func GetShareWithProof(
 			Proof: &proof,
 			Axis:  rsmt2d.Row,
 		}
-		if shareWithProof.Validate(dah, axisType, axisIdx, shrIdx) {
+		if shareWithProof.Validate(roots, axisType, axisIdx, shrIdx) {
 			return shareWithProof, nil
 		}
 	}
 
 	// try column proofs
-	root = dah.ColumnRoots[shrIdx]
+	root = roots.ColumnRoots[shrIdx]
 	proof, err = ipld.GetProof(ctx, bGetter, root, axisIdx, width)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func GetShareWithProof(
 		Proof: &proof,
 		Axis:  rsmt2d.Col,
 	}
-	if shareWithProof.Validate(dah, axisType, axisIdx, shrIdx) {
+	if shareWithProof.Validate(roots, axisType, axisIdx, shrIdx) {
 		return shareWithProof, nil
 	}
 	return nil, errors.New("failed to collect proof")

--- a/share/eds/eds.go
+++ b/share/eds/eds.go
@@ -258,14 +258,14 @@ func ReadEDS(ctx context.Context, r io.Reader, root share.DataHash) (eds *rsmt2d
 		return nil, fmt.Errorf("share: computing eds: %w", err)
 	}
 
-	newDah, err := share.NewAxisRoots(eds)
+	newRoots, err := share.NewAxisRoots(eds)
 	if err != nil {
 		return nil, err
 	}
-	if !bytes.Equal(newDah.Hash(), root) {
+	if !bytes.Equal(newRoots.Hash(), root) {
 		return nil, fmt.Errorf(
 			"share: content integrity mismatch: imported root %s doesn't match expected root %s",
-			newDah.Hash(),
+			newRoots.Hash(),
 			root,
 		)
 	}

--- a/share/eds/eds.go
+++ b/share/eds/eds.go
@@ -258,7 +258,7 @@ func ReadEDS(ctx context.Context, r io.Reader, root share.DataHash) (eds *rsmt2d
 		return nil, fmt.Errorf("share: computing eds: %w", err)
 	}
 
-	newDah, err := share.NewRoot(eds)
+	newDah, err := share.NewAxisRoots(eds)
 	if err != nil {
 		return nil, err
 	}

--- a/share/eds/eds_test.go
+++ b/share/eds/eds_test.go
@@ -138,7 +138,7 @@ func TestWriteEDSInQuadrantOrder(t *testing.T) {
 
 func TestReadWriteRoundtrip(t *testing.T) {
 	eds := writeRandomEDS(t)
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	f := openWrittenEDS(t)
 	defer f.Close()
@@ -196,7 +196,7 @@ func BenchmarkReadWriteEDS(b *testing.B) {
 	b.Cleanup(cancel)
 	for originalDataWidth := 4; originalDataWidth <= 64; originalDataWidth *= 2 {
 		eds := edstest.RandEDS(b, originalDataWidth)
-		dah, err := share.NewRoot(eds)
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(b, err)
 		b.Run(fmt.Sprintf("Writing %dx%d", originalDataWidth, originalDataWidth), func(b *testing.B) {
 			b.ReportAllocs()
@@ -268,7 +268,7 @@ func createTestData(t *testing.T, testDir string) { //nolint:unused
 	err = WriteEDS(ctx, eds, f)
 	require.NoError(t, err, "writing EDS to file")
 	f.Close()
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	header, err := json.MarshalIndent(dah, "", "")

--- a/share/eds/eds_test.go
+++ b/share/eds/eds_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/tendermint/tendermint/libs/rand"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -138,12 +137,12 @@ func TestWriteEDSInQuadrantOrder(t *testing.T) {
 
 func TestReadWriteRoundtrip(t *testing.T) {
 	eds := writeRandomEDS(t)
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	f := openWrittenEDS(t)
 	defer f.Close()
 
-	loaded, err := ReadEDS(context.Background(), f, dah.Hash())
+	loaded, err := ReadEDS(context.Background(), f, roots.Hash())
 	require.NoError(t, err, "error reading EDS from file")
 
 	rowRoots, err := eds.RowRoots()
@@ -163,28 +162,28 @@ func TestReadEDS(t *testing.T) {
 	f, err := f.Open("testdata/example.car")
 	require.NoError(t, err, "error opening file")
 
-	var dah da.DataAvailabilityHeader
-	err = json.Unmarshal([]byte(exampleRoot), &dah)
+	var roots share.AxisRoots
+	err = json.Unmarshal([]byte(exampleRoot), &roots)
 	require.NoError(t, err, "error unmarshaling example root")
 
-	loaded, err := ReadEDS(context.Background(), f, dah.Hash())
+	loaded, err := ReadEDS(context.Background(), f, roots.Hash())
 	require.NoError(t, err, "error reading EDS from file")
 	rowRoots, err := loaded.RowRoots()
 	require.NoError(t, err)
-	require.Equal(t, dah.RowRoots, rowRoots)
+	require.Equal(t, roots.RowRoots, rowRoots)
 	colRoots, err := loaded.ColRoots()
 	require.NoError(t, err)
-	require.Equal(t, dah.ColumnRoots, colRoots)
+	require.Equal(t, roots.ColumnRoots, colRoots)
 }
 
 func TestReadEDSContentIntegrityMismatch(t *testing.T) {
 	writeRandomEDS(t)
-	dah, err := da.NewDataAvailabilityHeader(edstest.RandEDS(t, 4))
+	roots, err := share.NewAxisRoots(edstest.RandEDS(t, 4))
 	require.NoError(t, err)
 	f := openWrittenEDS(t)
 	defer f.Close()
 
-	_, err = ReadEDS(context.Background(), f, dah.Hash())
+	_, err = ReadEDS(context.Background(), f, roots.Hash())
 	require.ErrorContains(t, err, "share: content integrity mismatch: imported root")
 }
 
@@ -196,7 +195,7 @@ func BenchmarkReadWriteEDS(b *testing.B) {
 	b.Cleanup(cancel)
 	for originalDataWidth := 4; originalDataWidth <= 64; originalDataWidth *= 2 {
 		eds := edstest.RandEDS(b, originalDataWidth)
-		dah, err := share.NewAxisRoots(eds)
+		roots, err := share.NewAxisRoots(eds)
 		require.NoError(b, err)
 		b.Run(fmt.Sprintf("Writing %dx%d", originalDataWidth, originalDataWidth), func(b *testing.B) {
 			b.ReportAllocs()
@@ -213,7 +212,7 @@ func BenchmarkReadWriteEDS(b *testing.B) {
 				f := new(bytes.Buffer)
 				_ = WriteEDS(ctx, eds, f)
 				b.StartTimer()
-				_, err := ReadEDS(ctx, f, dah.Hash())
+				_, err := ReadEDS(ctx, f, roots.Hash())
 				require.NoError(b, err)
 			}
 		})
@@ -268,10 +267,10 @@ func createTestData(t *testing.T, testDir string) { //nolint:unused
 	err = WriteEDS(ctx, eds, f)
 	require.NoError(t, err, "writing EDS to file")
 	f.Close()
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
-	header, err := json.MarshalIndent(dah, "", "")
+	header, err := json.MarshalIndent(roots, "", "")
 	require.NoError(t, err, "marshaling example root")
 	os.RemoveAll("example-root.json")
 	require.NoError(t, err, "removing old file")

--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -43,7 +43,7 @@ func RandEDSWithNamespace(
 	shares := sharetest.RandSharesWithNamespace(t, namespace, namespacedAmount, size*size)
 	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), wrapper.NewConstructor(uint64(size)))
 	require.NoError(t, err, "failure to recompute the extended data square")
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
-	return eds, dah
+	return eds, roots
 }

--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -39,11 +39,11 @@ func RandEDSWithNamespace(
 	t testing.TB,
 	namespace share.Namespace,
 	namespacedAmount, size int,
-) (*rsmt2d.ExtendedDataSquare, *share.Root) {
+) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots) {
 	shares := sharetest.RandSharesWithNamespace(t, namespace, namespacedAmount, size*size)
 	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), wrapper.NewConstructor(uint64(size)))
 	require.NoError(t, err, "failure to recompute the extended data square")
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	return eds, dah
 }

--- a/share/eds/ods_test.go
+++ b/share/eds/ods_test.go
@@ -25,12 +25,12 @@ func TestODSReader(t *testing.T) {
 	require.NoError(t, err)
 
 	// generate random eds data and put it into the store
-	eds, dah := randomEDS(t)
-	err = edsStore.Put(ctx, dah.Hash(), eds)
+	eds, roots := randomEDS(t)
+	err = edsStore.Put(ctx, roots.Hash(), eds)
 	require.NoError(t, err)
 
 	// get CAR reader from store
-	r, err := edsStore.GetCAR(ctx, dah.Hash())
+	r, err := edsStore.GetCAR(ctx, roots.Hash())
 	assert.NoError(t, err)
 	defer func() {
 		require.NoError(t, r.Close())
@@ -77,12 +77,12 @@ func TestODSReaderReconstruction(t *testing.T) {
 	require.NoError(t, err)
 
 	// generate random eds data and put it into the store
-	eds, dah := randomEDS(t)
-	err = edsStore.Put(ctx, dah.Hash(), eds)
+	eds, roots := randomEDS(t)
+	err = edsStore.Put(ctx, roots.Hash(), eds)
 	require.NoError(t, err)
 
 	// get CAR reader from store
-	r, err := edsStore.GetCAR(ctx, dah.Hash())
+	r, err := edsStore.GetCAR(ctx, roots.Hash())
 	assert.NoError(t, err)
 	defer func() {
 		require.NoError(t, r.Close())
@@ -93,7 +93,7 @@ func TestODSReaderReconstruction(t *testing.T) {
 	assert.NoError(t, err)
 
 	// reconstruct EDS from ODSReader
-	loaded, err := ReadEDS(ctx, odsR, dah.Hash())
+	loaded, err := ReadEDS(ctx, odsR, roots.Hash())
 	assert.NoError(t, err)
 
 	rowRoots, err := eds.RowRoots()

--- a/share/eds/retriever.go
+++ b/share/eds/retriever.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -57,18 +56,18 @@ func NewRetriever(bServ blockservice.BlockService) *Retriever {
 // data square and reconstructs the other three quadrants (3/4). If the requested quadrant is not
 // available within RetrieveQuadrantTimeout, it starts requesting another quadrant until either the
 // data is reconstructed, context is canceled or ErrByzantine is generated.
-func (r *Retriever) Retrieve(ctx context.Context, dah *da.DataAvailabilityHeader) (*rsmt2d.ExtendedDataSquare, error) {
+func (r *Retriever) Retrieve(ctx context.Context, roots *share.AxisRoots) (*rsmt2d.ExtendedDataSquare, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel() // cancels all the ongoing requests if reconstruction succeeds early
 
 	ctx, span := tracer.Start(ctx, "retrieve-square")
 	defer span.End()
 	span.SetAttributes(
-		attribute.Int("size", len(dah.RowRoots)),
+		attribute.Int("size", len(roots.RowRoots)),
 	)
 
-	log.Debugw("retrieving data square", "data_hash", dah.String(), "size", len(dah.RowRoots))
-	ses, err := r.newSession(ctx, dah)
+	log.Debugw("retrieving data square", "data_hash", roots.String(), "size", len(roots.RowRoots))
+	ses, err := r.newSession(ctx, roots)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +90,7 @@ func (r *Retriever) Retrieve(ctx context.Context, dah *da.DataAvailabilityHeader
 				// nmt proofs computed during the session
 				ses.close(false)
 				span.RecordError(err)
-				return nil, byzantine.NewErrByzantine(ctx, r.bServ.Blockstore(), dah, errByz)
+				return nil, byzantine.NewErrByzantine(ctx, r.bServ.Blockstore(), roots, errByz)
 			}
 
 			log.Warnw("not enough shares to reconstruct data square, requesting more...", "err", err)
@@ -107,7 +106,7 @@ func (r *Retriever) Retrieve(ctx context.Context, dah *da.DataAvailabilityHeader
 // quadrant request retries. Also, provides an API
 // to reconstruct the block once enough shares are fetched.
 type retrievalSession struct {
-	dah   *da.DataAvailabilityHeader
+	roots *share.AxisRoots
 	bget  blockservice.BlockGetter
 	adder *ipld.NmtNodeAdder
 
@@ -125,8 +124,8 @@ type retrievalSession struct {
 }
 
 // newSession creates a new retrieval session and kicks off requesting process.
-func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHeader) (*retrievalSession, error) {
-	size := len(dah.RowRoots)
+func (r *Retriever) newSession(ctx context.Context, roots *share.AxisRoots) (*retrievalSession, error) {
+	size := len(roots.RowRoots)
 
 	adder := ipld.NewNmtNodeAdder(ctx, r.bServ, ipld.MaxSizeBatchOption(size))
 	proofsVisitor := ipld.ProofsAdderFromCtx(ctx).VisitFn()
@@ -149,10 +148,10 @@ func (r *Retriever) newSession(ctx context.Context, dah *da.DataAvailabilityHead
 	}
 
 	ses := &retrievalSession{
-		dah:             dah,
+		roots:           roots,
 		bget:            blockservice.NewSession(ctx, r.bServ),
 		adder:           adder,
-		squareQuadrants: newQuadrants(dah),
+		squareQuadrants: newQuadrants(roots),
 		squareCellsLks:  make([][]sync.Mutex, size),
 		squareSig:       make(chan struct{}, 1),
 		squareDn:        make(chan struct{}),
@@ -187,12 +186,12 @@ func (rs *retrievalSession) Reconstruct(ctx context.Context) (*rsmt2d.ExtendedDa
 	defer span.End()
 
 	// and try to repair with what we have
-	err := rs.square.Repair(rs.dah.RowRoots, rs.dah.ColumnRoots)
+	err := rs.square.Repair(rs.roots.RowRoots, rs.roots.ColumnRoots)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
 	}
-	log.Infow("data square reconstructed", "data_hash", rs.dah.String(), "size", len(rs.dah.RowRoots))
+	log.Infow("data square reconstructed", "data_hash", rs.roots.String(), "size", len(rs.roots.RowRoots))
 	close(rs.squareDn)
 	return rs.square, nil
 }

--- a/share/eds/retriever_no_race_test.go
+++ b/share/eds/retriever_no_race_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -46,10 +45,10 @@ func TestRetriever_ByzantineError(t *testing.T) {
 	require.NoError(t, err)
 
 	// ensure we rcv an error
-	dah, err := da.NewDataAvailabilityHeader(attackerEDS)
+	roots, err := share.NewAxisRoots(attackerEDS)
 	require.NoError(t, err)
 	r := NewRetriever(bserv)
-	_, err = r.Retrieve(ctx, &dah)
+	_, err = r.Retrieve(ctx, roots)
 	var errByz *byzantine.ErrByzantine
 	require.ErrorAs(t, err, &errByz)
 }

--- a/share/eds/retriever_quadrant.go
+++ b/share/eds/retriever_quadrant.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ipfs/go-cid"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/ipld"
 )
 
@@ -49,11 +49,11 @@ type quadrant struct {
 // newQuadrants constructs a slice of quadrants from DAHeader.
 // There are always 4 quadrants per each source (row and col), so 8 in total.
 // The ordering of quadrants is random.
-func newQuadrants(dah *da.DataAvailabilityHeader) []*quadrant {
+func newQuadrants(roots *share.AxisRoots) []*quadrant {
 	// combine all the roots into one slice, so they can be easily accessible by index
 	daRoots := [][][]byte{
-		dah.RowRoots,
-		dah.ColumnRoots,
+		roots.RowRoots,
+		roots.ColumnRoots,
 	}
 	// create a quadrant slice for each source(row;col)
 	sources := [][]*quadrant{

--- a/share/eds/retriever_test.go
+++ b/share/eds/retriever_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/header"
@@ -56,9 +55,9 @@ func TestRetriever_Retrieve(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, time.Minute*5) // the timeout is big for the max size which is long
 			defer cancel()
 
-			dah, err := da.NewDataAvailabilityHeader(in)
+			roots, err := share.NewAxisRoots(in)
 			require.NoError(t, err)
-			out, err := r.Retrieve(ctx, &dah)
+			out, err := r.Retrieve(ctx, roots)
 			require.NoError(t, err)
 			assert.True(t, in.Equals(out))
 		})
@@ -81,9 +80,9 @@ func TestRetriever_MultipleRandQuadrants(t *testing.T) {
 	in, err := ipld.AddShares(ctx, shares, bServ)
 	require.NoError(t, err)
 
-	dah, err := da.NewDataAvailabilityHeader(in)
+	roots, err := share.NewAxisRoots(in)
 	require.NoError(t, err)
-	ses, err := r.newSession(ctx, &dah)
+	ses, err := r.newSession(ctx, roots)
 	require.NoError(t, err)
 
 	// wait until two additional quadrants requested

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -411,7 +411,7 @@ func (s *Store) carBlockstore(
 }
 
 // GetDAH returns the DataAvailabilityHeader for the EDS identified by DataHash.
-func (s *Store) GetDAH(ctx context.Context, root share.DataHash) (*share.Root, error) {
+func (s *Store) GetDAH(ctx context.Context, root share.DataHash) (*share.AxisRoots, error) {
 	ctx, span := tracer.Start(ctx, "store/car-dah")
 	tnow := time.Now()
 	r, err := s.getDAH(ctx, root)
@@ -420,7 +420,7 @@ func (s *Store) GetDAH(ctx context.Context, root share.DataHash) (*share.Root, e
 	return r, err
 }
 
-func (s *Store) getDAH(ctx context.Context, root share.DataHash) (*share.Root, error) {
+func (s *Store) getDAH(ctx context.Context, root share.DataHash) (*share.AxisRoots, error) {
 	r, err := s.getCAR(ctx, root)
 	if err != nil {
 		return nil, fmt.Errorf("eds/store: failed to get CAR file: %w", err)
@@ -440,13 +440,13 @@ func (s *Store) getDAH(ctx context.Context, root share.DataHash) (*share.Root, e
 }
 
 // dahFromCARHeader returns the DataAvailabilityHeader stored in the CIDs of a CARv1 header.
-func dahFromCARHeader(carHeader *carv1.CarHeader) *share.Root {
+func dahFromCARHeader(carHeader *carv1.CarHeader) *share.AxisRoots {
 	rootCount := len(carHeader.Roots)
 	rootBytes := make([][]byte, 0, rootCount)
 	for _, root := range carHeader.Roots {
 		rootBytes = append(rootBytes, ipld.NamespacedSha256FromCID(root))
 	}
-	return &share.Root{
+	return &share.AxisRoots{
 		RowRoots:    rootBytes[:rootCount/2],
 		ColumnRoots: rootBytes[rootCount/2:],
 	}
@@ -474,7 +474,7 @@ func (s *Store) getAccessor(ctx context.Context, key shard.Key) (cache.Accessor,
 	}
 }
 
-// Remove removes EDS from Store by the given share.Root hash and cleans up all
+// Remove removes EDS from Store by the given datahash and cleans up all
 // the indexing.
 func (s *Store) Remove(ctx context.Context, root share.DataHash) error {
 	ctx, span := tracer.Start(ctx, "store/remove")
@@ -554,7 +554,7 @@ func (s *Store) get(ctx context.Context, root share.DataHash) (eds *rsmt2d.Exten
 	return eds, nil
 }
 
-// Has checks if EDS exists by the given share.Root hash.
+// Has checks if EDS exists by the given datahash.
 func (s *Store) Has(ctx context.Context, root share.DataHash) (has bool, err error) {
 	ctx, span := tracer.Start(ctx, "store/has")
 	tnow := time.Now()

--- a/share/eds/store.go
+++ b/share/eds/store.go
@@ -432,11 +432,11 @@ func (s *Store) getDAH(ctx context.Context, root share.DataHash) (*share.AxisRoo
 		return nil, fmt.Errorf("eds/store: failed to read car header: %w", err)
 	}
 
-	dah := dahFromCARHeader(carHeader)
-	if !bytes.Equal(dah.Hash(), root) {
+	roots := dahFromCARHeader(carHeader)
+	if !bytes.Equal(roots.Hash(), root) {
 		return nil, fmt.Errorf("eds/store: content integrity mismatch from CAR for root %x", root)
 	}
-	return dah, nil
+	return roots, nil
 }
 
 // dahFromCARHeader returns the DataAvailabilityHeader stored in the CIDs of a CARv1 header.

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -440,7 +440,7 @@ func BenchmarkStore(b *testing.B) {
 			// pause the timer for initializing test data
 			b.StopTimer()
 			eds := edstest.RandEDS(b, 128)
-			dah, err := share.NewRoot(eds)
+			dah, err := share.NewAxisRoots(eds)
 			require.NoError(b, err)
 			b.StartTimer()
 
@@ -456,7 +456,7 @@ func BenchmarkStore(b *testing.B) {
 			// pause the timer for initializing test data
 			b.StopTimer()
 			eds := edstest.RandEDS(b, 128)
-			dah, err := share.NewRoot(eds)
+			dah, err := share.NewAxisRoots(eds)
 			require.NoError(b, err)
 			_ = edsStore.Put(ctx, dah.Hash(), eds)
 			b.StartTimer()
@@ -530,9 +530,9 @@ func newStore(t *testing.T) (*Store, error) {
 	return NewStore(DefaultParameters(), t.TempDir(), ds)
 }
 
-func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.Root) {
+func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	return eds, dah

--- a/share/eds/store_test.go
+++ b/share/eds/store_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -38,31 +37,31 @@ func TestEDSStore(t *testing.T) {
 
 	// PutRegistersShard tests if Put registers the shard on the underlying DAGStore
 	t.Run("PutRegistersShard", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 
 		// shard hasn't been registered yet
-		has, err := edsStore.Has(ctx, dah.Hash())
+		has, err := edsStore.Has(ctx, roots.Hash())
 		assert.False(t, has)
 		assert.NoError(t, err)
 
-		err = edsStore.Put(ctx, dah.Hash(), eds)
+		err = edsStore.Put(ctx, roots.Hash(), eds)
 		assert.NoError(t, err)
 
-		_, err = edsStore.dgstr.GetShardInfo(shard.KeyFromString(dah.String()))
+		_, err = edsStore.dgstr.GetShardInfo(shard.KeyFromString(roots.String()))
 		assert.NoError(t, err)
 	})
 
 	// PutIndexesEDS ensures that Putting an EDS indexes it into the car index
 	t.Run("PutIndexesEDS", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 
-		stat, _ := edsStore.carIdx.StatFullIndex(shard.KeyFromString(dah.String()))
+		stat, _ := edsStore.carIdx.StatFullIndex(shard.KeyFromString(roots.String()))
 		assert.False(t, stat.Exists)
 
-		err = edsStore.Put(ctx, dah.Hash(), eds)
+		err = edsStore.Put(ctx, roots.Hash(), eds)
 		assert.NoError(t, err)
 
-		stat, err = edsStore.carIdx.StatFullIndex(shard.KeyFromString(dah.String()))
+		stat, err = edsStore.carIdx.StatFullIndex(shard.KeyFromString(roots.String()))
 		assert.True(t, stat.Exists)
 		assert.NoError(t, err)
 	})
@@ -70,12 +69,12 @@ func TestEDSStore(t *testing.T) {
 	// GetCAR ensures that the reader returned from GetCAR is capable of reading the CAR header and
 	// ODS.
 	t.Run("GetCAR", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 
-		err = edsStore.Put(ctx, dah.Hash(), eds)
+		err = edsStore.Put(ctx, roots.Hash(), eds)
 		require.NoError(t, err)
 
-		r, err := edsStore.GetCAR(ctx, dah.Hash())
+		r, err := edsStore.GetCAR(ctx, roots.Hash())
 		assert.NoError(t, err)
 		defer func() {
 			require.NoError(t, r.Close())
@@ -106,48 +105,48 @@ func TestEDSStore(t *testing.T) {
 	})
 
 	t.Run("Remove", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 
-		err = edsStore.Put(ctx, dah.Hash(), eds)
+		err = edsStore.Put(ctx, roots.Hash(), eds)
 		require.NoError(t, err)
 
 		// assert that file now exists
-		_, err = os.Stat(edsStore.basepath + blocksPath + dah.String())
+		_, err = os.Stat(edsStore.basepath + blocksPath + roots.String())
 		assert.NoError(t, err)
 
 		// accessor will be registered in cache async on put, so give it some time to settle
 		time.Sleep(time.Millisecond * 100)
 
-		err = edsStore.Remove(ctx, dah.Hash())
+		err = edsStore.Remove(ctx, roots.Hash())
 		assert.NoError(t, err)
 
 		// shard should no longer be registered on the dagstore
-		_, err = edsStore.dgstr.GetShardInfo(shard.KeyFromString(dah.String()))
+		_, err = edsStore.dgstr.GetShardInfo(shard.KeyFromString(roots.String()))
 		assert.Error(t, err, "shard not found")
 
 		// shard should have been dropped from the index, which also removes the file under /index/
-		indexStat, err := edsStore.carIdx.StatFullIndex(shard.KeyFromString(dah.String()))
+		indexStat, err := edsStore.carIdx.StatFullIndex(shard.KeyFromString(roots.String()))
 		assert.NoError(t, err)
 		assert.False(t, indexStat.Exists)
 
 		// file no longer exists
-		_, err = os.Stat(edsStore.basepath + blocksPath + dah.String())
+		_, err = os.Stat(edsStore.basepath + blocksPath + roots.String())
 		assert.ErrorContains(t, err, "no such file or directory")
 	})
 
 	t.Run("Remove after OpShardFail", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 
-		err = edsStore.Put(ctx, dah.Hash(), eds)
+		err = edsStore.Put(ctx, roots.Hash(), eds)
 		require.NoError(t, err)
 
 		// assert that shard now exists
-		ok, err := edsStore.Has(ctx, dah.Hash())
+		ok, err := edsStore.Has(ctx, roots.Hash())
 		assert.NoError(t, err)
 		assert.True(t, ok)
 
 		// assert that file now exists
-		path := edsStore.basepath + blocksPath + dah.String()
+		path := edsStore.basepath + blocksPath + roots.String()
 		_, err = os.Stat(path)
 		assert.NoError(t, err)
 
@@ -158,10 +157,10 @@ func TestEDSStore(t *testing.T) {
 		time.Sleep(time.Millisecond * 100)
 
 		// remove non-failed accessor from cache
-		err = edsStore.cache.Load().Remove(shard.KeyFromString(dah.String()))
+		err = edsStore.cache.Load().Remove(shard.KeyFromString(roots.String()))
 		assert.NoError(t, err)
 
-		_, err = edsStore.GetCAR(ctx, dah.Hash())
+		_, err = edsStore.GetCAR(ctx, roots.Hash())
 		assert.Error(t, err)
 
 		ticker := time.NewTicker(time.Millisecond * 100)
@@ -169,7 +168,7 @@ func TestEDSStore(t *testing.T) {
 		for {
 			select {
 			case <-ticker.C:
-				has, err := edsStore.Has(ctx, dah.Hash())
+				has, err := edsStore.Has(ctx, roots.Hash())
 				if err == nil && !has {
 					// shard no longer exists after OpShardFail was detected from GetCAR call
 					return
@@ -181,30 +180,30 @@ func TestEDSStore(t *testing.T) {
 	})
 
 	t.Run("Has", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 
-		ok, err := edsStore.Has(ctx, dah.Hash())
+		ok, err := edsStore.Has(ctx, roots.Hash())
 		assert.NoError(t, err)
 		assert.False(t, ok)
 
-		err = edsStore.Put(ctx, dah.Hash(), eds)
+		err = edsStore.Put(ctx, roots.Hash(), eds)
 		assert.NoError(t, err)
 
-		ok, err = edsStore.Has(ctx, dah.Hash())
+		ok, err = edsStore.Has(ctx, roots.Hash())
 		assert.NoError(t, err)
 		assert.True(t, ok)
 	})
 
 	t.Run("RecentBlocksCache", func(t *testing.T) {
-		eds, dah := randomEDS(t)
-		err = edsStore.Put(ctx, dah.Hash(), eds)
+		eds, roots := randomEDS(t)
+		err = edsStore.Put(ctx, roots.Hash(), eds)
 		require.NoError(t, err)
 
 		// accessor will be registered in cache async on put, so give it some time to settle
 		time.Sleep(time.Millisecond * 100)
 
 		// check, that the key is in the cache after put
-		shardKey := shard.KeyFromString(dah.String())
+		shardKey := shard.KeyFromString(roots.String())
 		_, err = edsStore.cache.Load().Get(shardKey)
 		assert.NoError(t, err)
 	})
@@ -213,10 +212,10 @@ func TestEDSStore(t *testing.T) {
 		const amount = 10
 		hashes := make([]share.DataHash, 0, amount)
 		for range make([]byte, amount) {
-			eds, dah := randomEDS(t)
-			err = edsStore.Put(ctx, dah.Hash(), eds)
+			eds, roots := randomEDS(t)
+			err = edsStore.Put(ctx, roots.Hash(), eds)
 			require.NoError(t, err)
-			hashes = append(hashes, dah.Hash())
+			hashes = append(hashes, roots.Hash())
 		}
 
 		hashesOut, err := edsStore.List()
@@ -228,14 +227,14 @@ func TestEDSStore(t *testing.T) {
 
 	t.Run("Parallel put", func(t *testing.T) {
 		const amount = 20
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 
 		wg := sync.WaitGroup{}
 		for i := 1; i < amount; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err := edsStore.Put(ctx, dah.Hash(), eds)
+				err := edsStore.Put(ctx, roots.Hash(), eds)
 				if err != nil {
 					require.ErrorIs(t, err, dagstore.ErrShardExists)
 				}
@@ -243,11 +242,11 @@ func TestEDSStore(t *testing.T) {
 		}
 		wg.Wait()
 
-		eds, err := edsStore.Get(ctx, dah.Hash())
+		eds, err := edsStore.Get(ctx, roots.Hash())
 		require.NoError(t, err)
-		newDah, err := da.NewDataAvailabilityHeader(eds)
+		newRoots, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
-		require.Equal(t, dah.Hash(), newDah.Hash())
+		require.Equal(t, roots.Hash(), newRoots.Hash())
 	})
 }
 
@@ -264,10 +263,10 @@ func TestEDSStore_GC(t *testing.T) {
 	err = edsStore.Start(ctx)
 	require.NoError(t, err)
 
-	eds, dah := randomEDS(t)
-	shardKey := shard.KeyFromString(dah.String())
+	eds, roots := randomEDS(t)
+	shardKey := shard.KeyFromString(roots.String())
 
-	err = edsStore.Put(ctx, dah.Hash(), eds)
+	err = edsStore.Put(ctx, roots.Hash(), eds)
 	require.NoError(t, err)
 
 	// accessor will be registered in cache async on put, so give it some time to settle
@@ -275,7 +274,7 @@ func TestEDSStore_GC(t *testing.T) {
 
 	// remove links to the shard from cache
 	time.Sleep(time.Millisecond * 100)
-	key := shard.KeyFromString(share.DataHash(dah.Hash()).String())
+	key := shard.KeyFromString(share.DataHash(roots.Hash()).String())
 	err = edsStore.cache.Load().Remove(key)
 	require.NoError(t, err)
 
@@ -307,12 +306,12 @@ func Test_BlockstoreCache(t *testing.T) {
 	// store eds to the store with noopCache to allow clean cache after put
 	swap := edsStore.cache.Load()
 	edsStore.cache.Store(cache.NewDoubleCache(cache.NoopCache{}, cache.NoopCache{}))
-	eds, dah := randomEDS(t)
-	err = edsStore.Put(ctx, dah.Hash(), eds)
+	eds, roots := randomEDS(t)
+	err = edsStore.Put(ctx, roots.Hash(), eds)
 	require.NoError(t, err)
 
 	// get any key from saved eds
-	bs, err := edsStore.carBlockstore(ctx, dah.Hash())
+	bs, err := edsStore.carBlockstore(ctx, roots.Hash())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, bs.Close())
@@ -330,7 +329,7 @@ func Test_BlockstoreCache(t *testing.T) {
 	edsStore.cache.Store(swap)
 
 	// key shouldn't be in cache yet, check for returned errCacheMiss
-	shardKey := shard.KeyFromString(dah.String())
+	shardKey := shard.KeyFromString(roots.String())
 	_, err = edsStore.cache.Load().Get(shardKey)
 	require.Error(t, err)
 
@@ -354,26 +353,26 @@ func Test_CachedAccessor(t *testing.T) {
 	err = edsStore.Start(ctx)
 	require.NoError(t, err)
 
-	eds, dah := randomEDS(t)
-	err = edsStore.Put(ctx, dah.Hash(), eds)
+	eds, roots := randomEDS(t)
+	err = edsStore.Put(ctx, roots.Hash(), eds)
 	require.NoError(t, err)
 
 	// accessor will be registered in cache async on put, so give it some time to settle
 	time.Sleep(time.Millisecond * 100)
 
 	// accessor should be in cache
-	_, err = edsStore.cache.Load().Get(shard.KeyFromString(dah.String()))
+	_, err = edsStore.cache.Load().Get(shard.KeyFromString(roots.String()))
 	require.NoError(t, err)
 
 	// first read from cached accessor
-	carReader, err := edsStore.getCAR(ctx, dah.Hash())
+	carReader, err := edsStore.getCAR(ctx, roots.Hash())
 	require.NoError(t, err)
 	firstBlock, err := io.ReadAll(carReader)
 	require.NoError(t, err)
 	require.NoError(t, carReader.Close())
 
 	// second read from cached accessor
-	carReader, err = edsStore.getCAR(ctx, dah.Hash())
+	carReader, err = edsStore.getCAR(ctx, roots.Hash())
 	require.NoError(t, err)
 	secondBlock, err := io.ReadAll(carReader)
 	require.NoError(t, err)
@@ -395,26 +394,26 @@ func Test_NotCachedAccessor(t *testing.T) {
 	// replace cache with noopCache to
 	edsStore.cache.Store(cache.NewDoubleCache(cache.NoopCache{}, cache.NoopCache{}))
 
-	eds, dah := randomEDS(t)
-	err = edsStore.Put(ctx, dah.Hash(), eds)
+	eds, roots := randomEDS(t)
+	err = edsStore.Put(ctx, roots.Hash(), eds)
 	require.NoError(t, err)
 
 	// accessor will be registered in cache async on put, so give it some time to settle
 	time.Sleep(time.Millisecond * 100)
 
 	// accessor should not be in cache
-	_, err = edsStore.cache.Load().Get(shard.KeyFromString(dah.String()))
+	_, err = edsStore.cache.Load().Get(shard.KeyFromString(roots.String()))
 	require.Error(t, err)
 
 	// first read from direct accessor (not from cache)
-	carReader, err := edsStore.getCAR(ctx, dah.Hash())
+	carReader, err := edsStore.getCAR(ctx, roots.Hash())
 	require.NoError(t, err)
 	firstBlock, err := io.ReadAll(carReader)
 	require.NoError(t, err)
 	require.NoError(t, carReader.Close())
 
 	// second read from direct accessor (not from cache)
-	carReader, err = edsStore.getCAR(ctx, dah.Hash())
+	carReader, err = edsStore.getCAR(ctx, roots.Hash())
 	require.NoError(t, err)
 	secondBlock, err := io.ReadAll(carReader)
 	require.NoError(t, err)
@@ -440,11 +439,11 @@ func BenchmarkStore(b *testing.B) {
 			// pause the timer for initializing test data
 			b.StopTimer()
 			eds := edstest.RandEDS(b, 128)
-			dah, err := share.NewAxisRoots(eds)
+			roots, err := share.NewAxisRoots(eds)
 			require.NoError(b, err)
 			b.StartTimer()
 
-			err = edsStore.Put(ctx, dah.Hash(), eds)
+			err = edsStore.Put(ctx, roots.Hash(), eds)
 			require.NoError(b, err)
 		}
 	})
@@ -456,12 +455,12 @@ func BenchmarkStore(b *testing.B) {
 			// pause the timer for initializing test data
 			b.StopTimer()
 			eds := edstest.RandEDS(b, 128)
-			dah, err := share.NewAxisRoots(eds)
+			roots, err := share.NewAxisRoots(eds)
 			require.NoError(b, err)
-			_ = edsStore.Put(ctx, dah.Hash(), eds)
+			_ = edsStore.Put(ctx, roots.Hash(), eds)
 			b.StartTimer()
 
-			_, err = edsStore.Get(ctx, dah.Hash())
+			_, err = edsStore.Get(ctx, roots.Hash())
 			require.NoError(b, err)
 		}
 	})
@@ -496,13 +495,13 @@ func BenchmarkCacheEviction(b *testing.B) {
 	cids := make([]cid.Cid, blocks)
 	for i := range cids {
 		eds := edstest.RandEDS(b, size)
-		dah, err := da.NewDataAvailabilityHeader(eds)
+		roots, err := share.NewAxisRoots(eds)
 		require.NoError(b, err)
-		err = edsStore.Put(ctx, dah.Hash(), eds)
+		err = edsStore.Put(ctx, roots.Hash(), eds)
 		require.NoError(b, err)
 
 		// store cids for read loop later
-		cids[i] = ipld.MustCidFromNamespacedSha256(dah.RowRoots[0])
+		cids[i] = ipld.MustCidFromNamespacedSha256(roots.RowRoots[0])
 	}
 
 	// restart store to clear cache
@@ -532,8 +531,8 @@ func newStore(t *testing.T) (*Store, error) {
 
 func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
-	return eds, dah
+	return eds, roots
 }

--- a/share/eds/utils.go
+++ b/share/eds/utils.go
@@ -62,7 +62,7 @@ func closeAndLog(name string, closer io.Closer) {
 func RetrieveNamespaceFromStore(
 	ctx context.Context,
 	store *Store,
-	dah *share.Root,
+	dah *share.AxisRoots,
 	namespace share.Namespace,
 ) (shares share.NamespacedShares, err error) {
 	if err = namespace.ValidateForData(); err != nil {
@@ -107,11 +107,11 @@ func RetrieveNamespaceFromStore(
 	return shares, nil
 }
 
-// CollectSharesByNamespace collects NamespaceShares within the given namespace from share.Root.
+// CollectSharesByNamespace collects NamespaceShares within the given namespace from EDS.
 func CollectSharesByNamespace(
 	ctx context.Context,
 	bg blockservice.BlockGetter,
-	root *share.Root,
+	root *share.AxisRoots,
 	namespace share.Namespace,
 ) (shares share.NamespacedShares, err error) {
 	ctx, span := tracer.Start(ctx, "collect-shares-by-namespace", trace.WithAttributes(

--- a/share/empty.go
+++ b/share/empty.go
@@ -11,14 +11,14 @@ import (
 	"github.com/celestiaorg/rsmt2d"
 )
 
-// EmptyRoot returns Root of the empty block EDS.
-func EmptyRoot() *Root {
+// EmptyEDSRoot returns AxisRoots of the empty block EDS.
+func EmptyEDSRoot() *AxisRoots {
 	initEmpty()
 	return emptyBlockRoot
 }
 
-// EmptyExtendedDataSquare returns the EDS of the empty block data square.
-func EmptyExtendedDataSquare() *rsmt2d.ExtendedDataSquare {
+// EmptyEDS returns the EDS of the empty block data square.
+func EmptyEDS() *rsmt2d.ExtendedDataSquare {
 	initEmpty()
 	return emptyBlockEDS
 }
@@ -31,7 +31,7 @@ func EmptyBlockShares() []Share {
 
 var (
 	emptyMu          sync.Mutex
-	emptyBlockRoot   *Root
+	emptyBlockRoot   *AxisRoots
 	emptyBlockEDS    *rsmt2d.ExtendedDataSquare
 	emptyBlockShares []Share
 )
@@ -54,7 +54,7 @@ func initEmpty() {
 	}
 	emptyBlockEDS = eds
 
-	emptyBlockRoot, err = NewRoot(eds)
+	emptyBlockRoot, err = NewAxisRoots(eds)
 	if err != nil {
 		panic(fmt.Errorf("failed to create empty DAH: %w", err))
 	}

--- a/share/empty.go
+++ b/share/empty.go
@@ -11,8 +11,8 @@ import (
 	"github.com/celestiaorg/rsmt2d"
 )
 
-// EmptyEDSRoot returns AxisRoots of the empty block EDS.
-func EmptyEDSRoot() *AxisRoots {
+// EmptyEDSRoots returns AxisRoots of the empty block EDS.
+func EmptyEDSRoots() *AxisRoots {
 	initEmpty()
 	return emptyBlockRoot
 }

--- a/share/getter.go
+++ b/share/getter.go
@@ -57,7 +57,7 @@ type NamespacedRow struct {
 }
 
 // Verify validates NamespacedShares by checking every row with nmt inclusion proof.
-func (ns NamespacedShares) Verify(root *Root, namespace Namespace) error {
+func (ns NamespacedShares) Verify(root *AxisRoots, namespace Namespace) error {
 	var originalRoots [][]byte
 	for _, row := range root.RowRoots {
 		if !namespace.IsOutsideRange(row, row) {

--- a/share/getters/getter_test.go
+++ b/share/getters/getter_test.go
@@ -313,7 +313,7 @@ func BenchmarkIPLDGetterOverBusyCache(b *testing.B) {
 
 func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *header.ExtendedHeader) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	eh := headertest.RandExtendedHeaderWithRoot(t, dah)
 	return eds, eh
@@ -348,7 +348,7 @@ func randomEDSWithDoubledNamespace(
 		wrapper.NewConstructor(uint64(size)),
 	)
 	require.NoError(t, err, "failure to recompute the extended data square")
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	eh := headertest.RandExtendedHeaderWithRoot(t, dah)
 

--- a/share/getters/getter_test.go
+++ b/share/getters/getter_test.go
@@ -75,7 +75,7 @@ func TestStoreGetter(t *testing.T) {
 		assert.True(t, randEds.Equals(retrievedEDS))
 
 		// root not found
-		eh.DAH = share.EmptyEDSRoot()
+		eh.DAH = share.EmptyEDSRoots()
 		_, err = sg.GetEDS(ctx, eh)
 		require.ErrorIs(t, err, share.ErrNotFound)
 	})
@@ -97,7 +97,7 @@ func TestStoreGetter(t *testing.T) {
 		require.Nil(t, emptyShares.Flatten())
 
 		// root not found
-		eh.DAH = share.EmptyEDSRoot()
+		eh.DAH = share.EmptyEDSRoots()
 		_, err = sg.GetSharesByNamespace(ctx, eh, namespace)
 		require.ErrorIs(t, err, share.ErrNotFound)
 	})
@@ -229,7 +229,7 @@ func TestIPLDGetter(t *testing.T) {
 		require.Nil(t, emptyShares.Flatten())
 
 		// nid doesn't exist in root
-		eh.DAH = share.EmptyEDSRoot()
+		eh.DAH = share.EmptyEDSRoots()
 		emptyShares, err = sg.GetSharesByNamespace(ctx, eh, namespace)
 		require.NoError(t, err)
 		require.Empty(t, emptyShares.Flatten())

--- a/share/getters/shrex.go
+++ b/share/getters/shrex.go
@@ -152,8 +152,8 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, header *header.ExtendedHeader
 	}()
 
 	// short circuit if the data root is empty
-	if header.DAH.Equals(share.EmptyRoot()) {
-		return share.EmptyExtendedDataSquare(), nil
+	if header.DAH.Equals(share.EmptyEDSRoot()) {
+		return share.EmptyEDS(), nil
 	}
 
 	var attempt int

--- a/share/getters/shrex.go
+++ b/share/getters/shrex.go
@@ -152,7 +152,7 @@ func (sg *ShrexGetter) GetEDS(ctx context.Context, header *header.ExtendedHeader
 	}()
 
 	// short circuit if the data root is empty
-	if header.DAH.Equals(share.EmptyEDSRoot()) {
+	if header.DAH.Equals(share.EmptyEDSRoots()) {
 		return share.EmptyEDS(), nil
 	}
 

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -70,17 +70,17 @@ func TestShrexGetter(t *testing.T) {
 		// generate test data
 		size := 64
 		namespace := sharetest.RandV0Namespace()
-		randEDS, dah := edstest.RandEDSWithNamespace(t, namespace, size*size, size)
-		eh := headertest.RandExtendedHeaderWithRoot(t, dah)
-		require.NoError(t, edsStore.Put(ctx, dah.Hash(), randEDS))
+		randEDS, roots := edstest.RandEDSWithNamespace(t, namespace, size*size, size)
+		eh := headertest.RandExtendedHeaderWithRoot(t, roots)
+		require.NoError(t, edsStore.Put(ctx, roots.Hash(), randEDS))
 		fullPeerManager.Validate(ctx, srvHost.ID(), shrexsub.Notification{
-			DataHash: dah.Hash(),
+			DataHash: roots.Hash(),
 			Height:   1,
 		})
 
 		got, err := getter.GetSharesByNamespace(ctx, eh, namespace)
 		require.NoError(t, err)
-		require.NoError(t, got.Verify(dah, namespace))
+		require.NoError(t, got.Verify(roots, namespace))
 	})
 
 	t.Run("ND_err_not_found", func(t *testing.T) {
@@ -88,10 +88,10 @@ func TestShrexGetter(t *testing.T) {
 		t.Cleanup(cancel)
 
 		// generate test data
-		_, dah, namespace := generateTestEDS(t)
-		eh := headertest.RandExtendedHeaderWithRoot(t, dah)
+		_, roots, namespace := generateTestEDS(t)
+		eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 		fullPeerManager.Validate(ctx, srvHost.ID(), shrexsub.Notification{
-			DataHash: dah.Hash(),
+			DataHash: roots.Hash(),
 			Height:   1,
 		})
 
@@ -104,11 +104,11 @@ func TestShrexGetter(t *testing.T) {
 		t.Cleanup(cancel)
 
 		// generate test data
-		eds, dah, maxNamespace := generateTestEDS(t)
-		eh := headertest.RandExtendedHeaderWithRoot(t, dah)
-		require.NoError(t, edsStore.Put(ctx, dah.Hash(), eds))
+		eds, roots, maxNamespace := generateTestEDS(t)
+		eh := headertest.RandExtendedHeaderWithRoot(t, roots)
+		require.NoError(t, edsStore.Put(ctx, roots.Hash(), eds))
 		fullPeerManager.Validate(ctx, srvHost.ID(), shrexsub.Notification{
-			DataHash: dah.Hash(),
+			DataHash: roots.Hash(),
 			Height:   1,
 		})
 
@@ -116,25 +116,25 @@ func TestShrexGetter(t *testing.T) {
 		nID, err := addToNamespace(maxNamespace, -1)
 		require.NoError(t, err)
 		// check for namespace to be between max and min namespace in root
-		require.Len(t, ipld.FilterRootByNamespace(dah, nID), 1)
+		require.Len(t, ipld.FilterRootByNamespace(roots, nID), 1)
 
 		emptyShares, err := getter.GetSharesByNamespace(ctx, eh, nID)
 		require.NoError(t, err)
 		// no shares should be returned
 		require.Nil(t, emptyShares.Flatten())
-		require.Nil(t, emptyShares.Verify(dah, nID))
+		require.Nil(t, emptyShares.Verify(roots, nID))
 
 		// namespace outside root range
 		nID, err = addToNamespace(maxNamespace, 1)
 		require.NoError(t, err)
 		// check for namespace to be not in root
-		require.Len(t, ipld.FilterRootByNamespace(dah, nID), 0)
+		require.Len(t, ipld.FilterRootByNamespace(roots, nID), 0)
 
 		emptyShares, err = getter.GetSharesByNamespace(ctx, eh, nID)
 		require.NoError(t, err)
 		// no shares should be returned
 		require.Nil(t, emptyShares.Flatten())
-		require.Nil(t, emptyShares.Verify(dah, nID))
+		require.Nil(t, emptyShares.Verify(roots, nID))
 	})
 
 	t.Run("ND_namespace_not_in_dah", func(t *testing.T) {
@@ -142,24 +142,24 @@ func TestShrexGetter(t *testing.T) {
 		t.Cleanup(cancel)
 
 		// generate test data
-		eds, dah, maxNamespace := generateTestEDS(t)
-		eh := headertest.RandExtendedHeaderWithRoot(t, dah)
-		require.NoError(t, edsStore.Put(ctx, dah.Hash(), eds))
+		eds, roots, maxNamespace := generateTestEDS(t)
+		eh := headertest.RandExtendedHeaderWithRoot(t, roots)
+		require.NoError(t, edsStore.Put(ctx, roots.Hash(), eds))
 		fullPeerManager.Validate(ctx, srvHost.ID(), shrexsub.Notification{
-			DataHash: dah.Hash(),
+			DataHash: roots.Hash(),
 			Height:   1,
 		})
 
 		namespace, err := addToNamespace(maxNamespace, 1)
 		require.NoError(t, err)
 		// check for namespace to be not in root
-		require.Len(t, ipld.FilterRootByNamespace(dah, namespace), 0)
+		require.Len(t, ipld.FilterRootByNamespace(roots, namespace), 0)
 
 		emptyShares, err := getter.GetSharesByNamespace(ctx, eh, namespace)
 		require.NoError(t, err)
 		// no shares should be returned
 		require.Empty(t, emptyShares.Flatten())
-		require.Nil(t, emptyShares.Verify(dah, namespace))
+		require.Nil(t, emptyShares.Verify(roots, namespace))
 	})
 
 	t.Run("EDS_Available", func(t *testing.T) {
@@ -167,11 +167,11 @@ func TestShrexGetter(t *testing.T) {
 		t.Cleanup(cancel)
 
 		// generate test data
-		randEDS, dah, _ := generateTestEDS(t)
-		eh := headertest.RandExtendedHeaderWithRoot(t, dah)
-		require.NoError(t, edsStore.Put(ctx, dah.Hash(), randEDS))
+		randEDS, roots, _ := generateTestEDS(t)
+		eh := headertest.RandExtendedHeaderWithRoot(t, roots)
+		require.NoError(t, edsStore.Put(ctx, roots.Hash(), randEDS))
 		fullPeerManager.Validate(ctx, srvHost.ID(), shrexsub.Notification{
-			DataHash: dah.Hash(),
+			DataHash: roots.Hash(),
 			Height:   1,
 		})
 
@@ -184,10 +184,10 @@ func TestShrexGetter(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 
 		// generate test data
-		_, dah, _ := generateTestEDS(t)
-		eh := headertest.RandExtendedHeaderWithRoot(t, dah)
+		_, roots, _ := generateTestEDS(t)
+		eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 		fullPeerManager.Validate(ctx, srvHost.ID(), shrexsub.Notification{
-			DataHash: dah.Hash(),
+			DataHash: roots.Hash(),
 			Height:   1,
 		})
 
@@ -201,10 +201,10 @@ func TestShrexGetter(t *testing.T) {
 		t.Cleanup(cancel)
 
 		// generate test data
-		_, dah, _ := generateTestEDS(t)
-		eh := headertest.RandExtendedHeaderWithRoot(t, dah)
+		_, roots, _ := generateTestEDS(t)
+		eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 		fullPeerManager.Validate(ctx, srvHost.ID(), shrexsub.Notification{
-			DataHash: dah.Hash(),
+			DataHash: roots.Hash(),
 			Height:   1,
 		})
 
@@ -251,10 +251,10 @@ func newStore(t *testing.T) (*eds.Store, error) {
 
 func generateTestEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots, share.Namespace) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
-	max := nmt.MaxNamespace(dah.RowRoots[(len(dah.RowRoots))/2-1], share.NamespaceSize)
-	return eds, dah, max
+	max := nmt.MaxNamespace(roots.RowRoots[(len(roots.RowRoots))/2-1], share.NamespaceSize)
+	return eds, roots, max
 }
 
 func testManager(

--- a/share/getters/shrex_test.go
+++ b/share/getters/shrex_test.go
@@ -249,9 +249,9 @@ func newStore(t *testing.T) (*eds.Store, error) {
 	return eds.NewStore(eds.DefaultParameters(), t.TempDir(), ds)
 }
 
-func generateTestEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.Root, share.Namespace) {
+func generateTestEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots, share.Namespace) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	max := nmt.MaxNamespace(dah.RowRoots[(len(dah.RowRoots))/2-1], share.NamespaceSize)
 	return eds, dah, max

--- a/share/getters/testing.go
+++ b/share/getters/testing.go
@@ -19,8 +19,8 @@ import (
 // TestGetter provides a testing SingleEDSGetter and the root of the EDS it holds.
 func TestGetter(t *testing.T) (share.Getter, *header.ExtendedHeader) {
 	eds := edstest.RandEDS(t, 8)
-	dah, err := share.NewAxisRoots(eds)
-	eh := headertest.RandExtendedHeaderWithRoot(t, dah)
+	roots, err := share.NewAxisRoots(eds)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
 	require.NoError(t, err)
 	return &SingleEDSGetter{
 		EDS: eds,
@@ -39,7 +39,7 @@ func (seg *SingleEDSGetter) GetShare(
 	header *header.ExtendedHeader,
 	row, col int,
 ) (share.Share, error) {
-	err := seg.checkRoot(header.DAH)
+	err := seg.checkRoots(header.DAH)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (seg *SingleEDSGetter) GetEDS(
 	_ context.Context,
 	header *header.ExtendedHeader,
 ) (*rsmt2d.ExtendedDataSquare, error) {
-	err := seg.checkRoot(header.DAH)
+	err := seg.checkRoots(header.DAH)
 	if err != nil {
 		return nil, err
 	}
@@ -64,13 +64,13 @@ func (seg *SingleEDSGetter) GetSharesByNamespace(context.Context, *header.Extend
 	panic("SingleEDSGetter: GetSharesByNamespace is not implemented")
 }
 
-func (seg *SingleEDSGetter) checkRoot(root *share.AxisRoots) error {
+func (seg *SingleEDSGetter) checkRoots(roots *share.AxisRoots) error {
 	dah, err := da.NewDataAvailabilityHeader(seg.EDS)
 	if err != nil {
 		return err
 	}
-	if !root.Equals(&dah) {
-		return fmt.Errorf("unknown EDS: have %s, asked %s", dah.String(), root.String())
+	if !roots.Equals(&dah) {
+		return fmt.Errorf("unknown EDS: have %s, asked %s", dah.String(), roots.String())
 	}
 	return nil
 }

--- a/share/getters/testing.go
+++ b/share/getters/testing.go
@@ -19,7 +19,7 @@ import (
 // TestGetter provides a testing SingleEDSGetter and the root of the EDS it holds.
 func TestGetter(t *testing.T) (share.Getter, *header.ExtendedHeader) {
 	eds := edstest.RandEDS(t, 8)
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	eh := headertest.RandExtendedHeaderWithRoot(t, dah)
 	require.NoError(t, err)
 	return &SingleEDSGetter{
@@ -64,7 +64,7 @@ func (seg *SingleEDSGetter) GetSharesByNamespace(context.Context, *header.Extend
 	panic("SingleEDSGetter: GetSharesByNamespace is not implemented")
 }
 
-func (seg *SingleEDSGetter) checkRoot(root *share.Root) error {
+func (seg *SingleEDSGetter) checkRoot(root *share.AxisRoots) error {
 	dah, err := da.NewDataAvailabilityHeader(seg.EDS)
 	if err != nil {
 		return err

--- a/share/ipld/nmt.go
+++ b/share/ipld/nmt.go
@@ -17,7 +17,6 @@ import (
 	mhcore "github.com/multiformats/go-multihash/core"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/nmt"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -158,12 +157,12 @@ func MustCidFromNamespacedSha256(hash []byte) cid.Cid {
 
 // Translate transforms square coordinates into IPLD NMT tree path to a leaf node.
 // It also adds randomization to evenly spread fetching from Rows and Columns.
-func Translate(dah *da.DataAvailabilityHeader, row, col int) (cid.Cid, int) {
+func Translate(roots *share.AxisRoots, row, col int) (cid.Cid, int) {
 	if rand.Intn(2) == 0 { //nolint:gosec
-		return MustCidFromNamespacedSha256(dah.ColumnRoots[col]), row
+		return MustCidFromNamespacedSha256(roots.ColumnRoots[col]), row
 	}
 
-	return MustCidFromNamespacedSha256(dah.RowRoots[row]), col
+	return MustCidFromNamespacedSha256(roots.RowRoots[row]), col
 }
 
 // NamespacedSha256FromCID derives the Namespaced hash from the given CID.

--- a/share/ipld/nmt_test.go
+++ b/share/ipld/nmt_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
+	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 )
 
@@ -26,10 +26,10 @@ func TestNamespaceFromCID(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			dah, err := da.NewDataAvailabilityHeader(tt.eds)
+			roots, err := share.NewAxisRoots(tt.eds)
 			require.NoError(t, err)
 			// check to make sure NamespacedHash is correctly derived from CID
-			for _, row := range dah.RowRoots {
+			for _, row := range roots.RowRoots {
 				c, err := CidFromNamespacedSha256(row)
 				require.NoError(t, err)
 

--- a/share/ipld/proofs_test.go
+++ b/share/ipld/proofs_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -26,16 +25,16 @@ func TestGetProof(t *testing.T) {
 	in, err := AddShares(ctx, shares, bServ)
 	require.NoError(t, err)
 
-	dah, err := da.NewDataAvailabilityHeader(in)
+	axisRoots, err := share.NewAxisRoots(in)
 	require.NoError(t, err)
 
 	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
 		var roots [][]byte
 		switch proofType {
 		case rsmt2d.Row:
-			roots = dah.RowRoots
+			roots = axisRoots.RowRoots
 		case rsmt2d.Col:
-			roots = dah.ColumnRoots
+			roots = axisRoots.ColumnRoots
 		}
 		for axisIdx := 0; axisIdx < width*2; axisIdx++ {
 			root := roots[axisIdx]
@@ -58,7 +57,7 @@ func TestGetProof(t *testing.T) {
 				case rsmt2d.Col:
 					rowIdx, colIdx = shrIdx, axisIdx
 				}
-				err = sample.Validate(&dah, rowIdx, colIdx)
+				err = sample.Validate(axisRoots, rowIdx, colIdx)
 				require.NoError(t, err)
 			}
 		}

--- a/share/ipld/utils.go
+++ b/share/ipld/utils.go
@@ -6,8 +6,9 @@ import (
 	"github.com/celestiaorg/celestia-node/share"
 )
 
-// FilterRootByNamespace returns the row roots from the given share.Root that contain the namespace.
-func FilterRootByNamespace(root *share.Root, namespace share.Namespace) []cid.Cid {
+// FilterRootByNamespace returns the row roots from the given share.AxisRoots that contain the
+// namespace.
+func FilterRootByNamespace(root *share.AxisRoots, namespace share.Namespace) []cid.Cid {
 	rowRootCIDs := make([]cid.Cid, 0, len(root.RowRoots))
 	for _, row := range root.RowRoots {
 		if !namespace.IsOutsideRange(row, row) {

--- a/share/new_eds/nd.go
+++ b/share/new_eds/nd.go
@@ -13,7 +13,7 @@ import (
 // avoiding the need to recalculate the row roots for each row.
 func NamespacedData(
 	ctx context.Context,
-	root *share.Root,
+	root *share.AxisRoots,
 	eds Accessor,
 	namespace share.Namespace,
 ) (shwap.NamespacedData, error) {

--- a/share/new_eds/rsmt2d.go
+++ b/share/new_eds/rsmt2d.go
@@ -26,11 +26,11 @@ func (eds *Rsmt2D) Size(context.Context) int {
 
 // DataRoot returns data hash of the Accessor.
 func (eds *Rsmt2D) DataRoot(context.Context) (share.DataHash, error) {
-	dah, err := share.NewAxisRoots(eds.ExtendedDataSquare)
+	roots, err := share.NewAxisRoots(eds.ExtendedDataSquare)
 	if err != nil {
 		return share.DataHash{}, fmt.Errorf("while creating data root: %w", err)
 	}
-	return dah.Hash(), nil
+	return roots.Hash(), nil
 }
 
 // Sample returns share and corresponding proof for row and column indices.

--- a/share/new_eds/rsmt2d.go
+++ b/share/new_eds/rsmt2d.go
@@ -26,7 +26,7 @@ func (eds *Rsmt2D) Size(context.Context) int {
 
 // DataRoot returns data hash of the Accessor.
 func (eds *Rsmt2D) DataRoot(context.Context) (share.DataHash, error) {
-	dah, err := share.NewRoot(eds.ExtendedDataSquare)
+	dah, err := share.NewAxisRoots(eds.ExtendedDataSquare)
 	if err != nil {
 		return share.DataHash{}, fmt.Errorf("while creating data root: %w", err)
 	}

--- a/share/new_eds/rsmt2d_test.go
+++ b/share/new_eds/rsmt2d_test.go
@@ -68,9 +68,9 @@ func TestRsmt2dSampleForProofAxis(t *testing.T) {
 	}
 }
 
-func randRsmt2dAccsessor(t *testing.T, size int) (Rsmt2D, *share.Root) {
+func randRsmt2dAccsessor(t *testing.T, size int) (Rsmt2D, *share.AxisRoots) {
 	eds := edstest.RandEDS(t, size)
-	root, err := share.NewRoot(eds)
+	root, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	return Rsmt2D{ExtendedDataSquare: eds}, root
 }

--- a/share/new_eds/testing.go
+++ b/share/new_eds/testing.go
@@ -73,7 +73,7 @@ func testAccessorSample(
 	eds := edstest.RandEDS(t, odsSize)
 	fl := createAccessor(t, eds)
 
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	width := int(eds.Width())
@@ -104,7 +104,7 @@ func testSample(
 	ctx context.Context,
 	t *testing.T,
 	fl Accessor,
-	dah *share.Root,
+	dah *share.AxisRoots,
 	rowIdx, colIdx int,
 ) {
 	shr, err := fl.Sample(ctx, rowIdx, colIdx)
@@ -158,7 +158,7 @@ func testAccessorRowNamespaceData(
 	t.Run("not included", func(t *testing.T) {
 		// generate EDS with random data and some Shares with the same namespace
 		eds := edstest.RandEDS(t, odsSize)
-		dah, err := share.NewRoot(eds)
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 
 		// loop over first half of the rows, because the second half is parity and does not contain

--- a/share/p2p/shrexeds/exchange_test.go
+++ b/share/p2p/shrexeds/exchange_test.go
@@ -34,7 +34,7 @@ func TestExchange_RequestEDS(t *testing.T) {
 	// Testcase: EDS is immediately available
 	t.Run("EDS_Available", func(t *testing.T) {
 		eds := edstest.RandEDS(t, 4)
-		dah, err := share.NewRoot(eds)
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 		err = store.Put(ctx, dah.Hash(), eds)
 		require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestExchange_RequestEDS(t *testing.T) {
 	// Testcase: EDS is unavailable initially, but is found after multiple requests
 	t.Run("EDS_AvailableAfterDelay", func(t *testing.T) {
 		eds := edstest.RandEDS(t, 4)
-		dah, err := share.NewRoot(eds)
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 
 		lock := make(chan struct{})
@@ -84,7 +84,7 @@ func TestExchange_RequestEDS(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
 		t.Cleanup(cancel)
 		eds := edstest.RandEDS(t, 4)
-		dah, err := share.NewRoot(eds)
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 		_, err = client.RequestEDS(timeoutCtx, dah.Hash(), server.host.ID())
 		require.ErrorIs(t, err, p2p.ErrNotFound)

--- a/share/p2p/shrexnd/client.go
+++ b/share/p2p/shrexnd/client.go
@@ -45,10 +45,10 @@ func NewClient(params *Parameters, host host.Host) (*Client, error) {
 }
 
 // RequestND requests namespaced data from the given peer.
-// Returns NamespacedShares with unverified inclusion proofs against the share.Root.
+// Returns NamespacedShares with unverified inclusion proofs against the share.AxisRoots.
 func (c *Client) RequestND(
 	ctx context.Context,
-	root *share.Root,
+	root *share.AxisRoots,
 	namespace share.Namespace,
 	peer peer.ID,
 ) (share.NamespacedShares, error) {
@@ -81,7 +81,7 @@ func (c *Client) RequestND(
 
 func (c *Client) doRequest(
 	ctx context.Context,
-	root *share.Root,
+	root *share.AxisRoots,
 	namespace share.Namespace,
 	peerID peer.ID,
 ) (share.NamespacedShares, error) {

--- a/share/p2p/shrexnd/exchange_test.go
+++ b/share/p2p/shrexnd/exchange_test.go
@@ -31,7 +31,7 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		t.Cleanup(cancel)
 
-		root := share.Root{}
+		root := share.AxisRoots{}
 		namespace := sharetest.RandV0Namespace()
 		_, err := client.RequestND(ctx, &root, namespace, server.host.ID())
 		require.ErrorIs(t, err, p2p.ErrNotFound)
@@ -42,7 +42,7 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		t.Cleanup(cancel)
 
 		eds := edstest.RandEDS(t, 4)
-		dah, err := share.NewRoot(eds)
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 		require.NoError(t, edsStore.Put(ctx, dah.Hash(), eds))
 

--- a/share/p2p/shrexnd/exchange_test.go
+++ b/share/p2p/shrexnd/exchange_test.go
@@ -42,12 +42,12 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		t.Cleanup(cancel)
 
 		eds := edstest.RandEDS(t, 4)
-		dah, err := share.NewAxisRoots(eds)
+		roots, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
-		require.NoError(t, edsStore.Put(ctx, dah.Hash(), eds))
+		require.NoError(t, edsStore.Put(ctx, roots.Hash(), eds))
 
 		namespace := sharetest.RandV0Namespace()
-		emptyShares, err := client.RequestND(ctx, dah, namespace, server.host.ID())
+		emptyShares, err := client.RequestND(ctx, roots, namespace, server.host.ID())
 		require.NoError(t, err)
 		require.Empty(t, emptyShares.Flatten())
 	})

--- a/share/p2p/shrexnd/server.go
+++ b/share/p2p/shrexnd/server.go
@@ -176,7 +176,7 @@ func (srv *Server) readRequest(
 func (srv *Server) getNamespaceData(ctx context.Context,
 	hash share.DataHash, namespace share.Namespace,
 ) (share.NamespacedShares, pb.StatusCode, error) {
-	dah, err := srv.store.GetDAH(ctx, hash)
+	roots, err := srv.store.GetDAH(ctx, hash)
 	if err != nil {
 		if errors.Is(err, eds.ErrNotFound) {
 			return nil, pb.StatusCode_NOT_FOUND, nil
@@ -184,7 +184,7 @@ func (srv *Server) getNamespaceData(ctx context.Context,
 		return nil, pb.StatusCode_INTERNAL, fmt.Errorf("retrieving DAH: %w", err)
 	}
 
-	shares, err := eds.RetrieveNamespaceFromStore(ctx, srv.store, dah, namespace)
+	shares, err := eds.RetrieveNamespaceFromStore(ctx, srv.store, roots, namespace)
 	if err != nil {
 		return nil, pb.StatusCode_INTERNAL, fmt.Errorf("retrieving shares: %w", err)
 	}

--- a/share/p2p/shrexsub/pubsub.go
+++ b/share/p2p/shrexsub/pubsub.go
@@ -111,7 +111,7 @@ func (v ValidatorFn) validate(ctx context.Context, p peer.ID, msg *pubsub.Messag
 		DataHash: pbmsg.DataHash,
 		Height:   pbmsg.Height,
 	}
-	if n.Height == 0 || n.DataHash.IsEmptyRoot() || n.DataHash.Validate() != nil {
+	if n.Height == 0 || n.DataHash.IsEmptyEDS() || n.DataHash.Validate() != nil {
 		// hard reject malicious height (height 0 does not exist) and
 		// empty/invalid datahashes
 		return pubsub.ValidationReject
@@ -129,7 +129,7 @@ func (s *PubSub) Subscribe() (*Subscription, error) {
 
 // Broadcast sends the EDS notification (DataHash) to every connected peer.
 func (s *PubSub) Broadcast(ctx context.Context, notification Notification) error {
-	if notification.DataHash.IsEmptyRoot() {
+	if notification.DataHash.IsEmptyEDS() {
 		// no need to broadcast datahash of an empty block EDS
 		return nil
 	}

--- a/share/root.go
+++ b/share/root.go
@@ -11,11 +11,11 @@ import (
 	"github.com/celestiaorg/rsmt2d"
 )
 
-// Root represents root commitment to multiple Shares.
+// AxisRoots represents root commitment to multiple Shares.
 // In practice, it is a commitment to all the Data in a square.
-type Root = da.DataAvailabilityHeader
+type AxisRoots = da.DataAvailabilityHeader
 
-// DataHash is a representation of the Root hash.
+// DataHash is a representation of the AxisRoots hash.
 type DataHash []byte
 
 func (dh DataHash) Validate() error {
@@ -29,9 +29,9 @@ func (dh DataHash) String() string {
 	return fmt.Sprintf("%X", []byte(dh))
 }
 
-// IsEmptyRoot check whether DataHash corresponds to the root of an empty block EDS.
-func (dh DataHash) IsEmptyRoot() bool {
-	return bytes.Equal(EmptyRoot().Hash(), dh)
+// IsEmptyEDS check whether DataHash corresponds to the root of an empty block EDS.
+func (dh DataHash) IsEmptyEDS() bool {
+	return bytes.Equal(EmptyEDSRoot().Hash(), dh)
 }
 
 // NewSHA256Hasher returns a new instance of a SHA-256 hasher.
@@ -39,9 +39,9 @@ func NewSHA256Hasher() hash.Hash {
 	return sha256.New()
 }
 
-// NewRoot generates Root(DataAvailabilityHeader) using the
+// NewAxisRoots generates AxisRoots(DataAvailabilityHeader) using the
 // provided extended data square.
-func NewRoot(eds *rsmt2d.ExtendedDataSquare) (*Root, error) {
+func NewAxisRoots(eds *rsmt2d.ExtendedDataSquare) (*AxisRoots, error) {
 	dah, err := da.NewDataAvailabilityHeader(eds)
 	if err != nil {
 		return nil, err
@@ -49,9 +49,9 @@ func NewRoot(eds *rsmt2d.ExtendedDataSquare) (*Root, error) {
 	return &dah, nil
 }
 
-// RowsWithNamespace inspects the Root for the Namespace and provides
+// RowsWithNamespace inspects the AxisRoots for the Namespace and provides
 // a slices of Row indexes containing the namespace.
-func RowsWithNamespace(root *Root, namespace Namespace) (idxs []int) {
+func RowsWithNamespace(root *AxisRoots, namespace Namespace) (idxs []int) {
 	for i, row := range root.RowRoots {
 		if !namespace.IsOutsideRange(row, row) {
 			idxs = append(idxs, i)
@@ -61,7 +61,7 @@ func RowsWithNamespace(root *Root, namespace Namespace) (idxs []int) {
 }
 
 // RootHashForCoordinates returns the root hash for the given coordinates.
-func RootHashForCoordinates(r *Root, axisType rsmt2d.Axis, rowIdx, colIdx uint) []byte {
+func RootHashForCoordinates(r *AxisRoots, axisType rsmt2d.Axis, rowIdx, colIdx uint) []byte {
 	if axisType == rsmt2d.Row {
 		return r.RowRoots[rowIdx]
 	}

--- a/share/root.go
+++ b/share/root.go
@@ -31,7 +31,7 @@ func (dh DataHash) String() string {
 
 // IsEmptyEDS check whether DataHash corresponds to the root of an empty block EDS.
 func (dh DataHash) IsEmptyEDS() bool {
-	return bytes.Equal(EmptyEDSRoot().Hash(), dh)
+	return bytes.Equal(EmptyEDSRoots().Hash(), dh)
 }
 
 // NewSHA256Hasher returns a new instance of a SHA-256 hasher.

--- a/share/shwap/namespace_data.go
+++ b/share/shwap/namespace_data.go
@@ -20,7 +20,7 @@ func (ns NamespacedData) Flatten() []share.Share {
 }
 
 // Validate checks the integrity of the NamespacedData against a provided root and namespace.
-func (ns NamespacedData) Validate(root *share.Root, namespace share.Namespace) error {
+func (ns NamespacedData) Validate(root *share.AxisRoots, namespace share.Namespace) error {
 	rowIdxs := share.RowsWithNamespace(root, namespace)
 	if len(rowIdxs) != len(ns) {
 		return fmt.Errorf("expected %d rows, found %d rows", len(rowIdxs), len(ns))

--- a/share/shwap/p2p/bitswap/block.go
+++ b/share/shwap/p2p/bitswap/block.go
@@ -29,8 +29,8 @@ type Block interface {
 	// MUST exclude the Shwap ID.
 	Marshal() ([]byte, error)
 	// UnmarshalFn returns closure that unmarshal the Block with the Shwap container.
-	// Unmarshalling involves data validation against the given Root.
-	UnmarshalFn(*share.Root) UnmarshalFn
+	// Unmarshalling involves data validation against the given AxisRoots.
+	UnmarshalFn(*share.AxisRoots) UnmarshalFn
 }
 
 // UnmarshalFn is a closure produced by a Block that unmarshalls and validates

--- a/share/shwap/p2p/bitswap/block_fetch.go
+++ b/share/shwap/p2p/bitswap/block_fetch.go
@@ -31,10 +31,16 @@ func WithStore(store blockstore.Blockstore) FetchOption {
 
 // Fetch fetches and populates given Blocks using Fetcher wrapping Bitswap.
 //
-// Validates Block against the given Root and skips Blocks that are already populated.
+// Validates Block against the given AxisRoots and skips Blocks that are already populated.
 // Gracefully synchronize identical Blocks requested simultaneously.
 // Blocks until either context is canceled or all Blocks are fetched and populated.
-func Fetch(ctx context.Context, exchg exchange.Interface, root *share.Root, blks []Block, opts ...FetchOption) error {
+func Fetch(
+	ctx context.Context,
+	exchg exchange.Interface,
+	root *share.AxisRoots,
+	blks []Block,
+	opts ...FetchOption,
+) error {
 	var from, to int
 	for to < len(blks) {
 		from, to = to, to+maxPerFetch
@@ -60,7 +66,13 @@ const maxPerFetch = 1024
 
 // fetch fetches given Blocks.
 // See [Fetch] for detailed description.
-func fetch(ctx context.Context, exchg exchange.Interface, root *share.Root, blks []Block, opts ...FetchOption) error {
+func fetch(
+	ctx context.Context,
+	exchg exchange.Interface,
+	root *share.AxisRoots,
+	blks []Block,
+	opts ...FetchOption,
+) error {
 	var options fetchOptions
 	for _, opt := range opts {
 		opt(&options)

--- a/share/shwap/p2p/bitswap/block_test.go
+++ b/share/shwap/p2p/bitswap/block_test.go
@@ -103,7 +103,7 @@ func (t *testBlock) Marshal() ([]byte, error) {
 	return t.data, nil
 }
 
-func (t *testBlock) UnmarshalFn(*share.Root) UnmarshalFn {
+func (t *testBlock) UnmarshalFn(*share.AxisRoots) UnmarshalFn {
 	return func(bytes []byte) error {
 		t.data = bytes
 		time.Sleep(time.Millisecond * 1)

--- a/share/shwap/p2p/bitswap/row_block.go
+++ b/share/shwap/p2p/bitswap/row_block.go
@@ -96,7 +96,7 @@ func (rb *RowBlock) Populate(ctx context.Context, eds eds.Accessor) error {
 	return nil
 }
 
-func (rb *RowBlock) UnmarshalFn(root *share.Root) UnmarshalFn {
+func (rb *RowBlock) UnmarshalFn(root *share.AxisRoots) UnmarshalFn {
 	return func(data []byte) error {
 		if !rb.Container.IsEmpty() {
 			return nil

--- a/share/shwap/p2p/bitswap/row_block_test.go
+++ b/share/shwap/p2p/bitswap/row_block_test.go
@@ -16,7 +16,7 @@ func TestRow_FetchRoundtrip(t *testing.T) {
 	defer cancel()
 
 	eds := edstest.RandEDS(t, 4)
-	root, err := share.NewRoot(eds)
+	root, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	exchange := newExchangeOverEDS(ctx, t, eds)
 

--- a/share/shwap/p2p/bitswap/row_namespace_data_block.go
+++ b/share/shwap/p2p/bitswap/row_namespace_data_block.go
@@ -100,7 +100,7 @@ func (rndb *RowNamespaceDataBlock) Populate(ctx context.Context, eds eds.Accesso
 	return nil
 }
 
-func (rndb *RowNamespaceDataBlock) UnmarshalFn(root *share.Root) UnmarshalFn {
+func (rndb *RowNamespaceDataBlock) UnmarshalFn(root *share.AxisRoots) UnmarshalFn {
 	return func(data []byte) error {
 		if !rndb.Container.IsEmpty() {
 			return nil

--- a/share/shwap/p2p/bitswap/sample_block.go
+++ b/share/shwap/p2p/bitswap/sample_block.go
@@ -95,7 +95,7 @@ func (sb *SampleBlock) Populate(ctx context.Context, eds eds.Accessor) error {
 	return nil
 }
 
-func (sb *SampleBlock) UnmarshalFn(root *share.Root) UnmarshalFn {
+func (sb *SampleBlock) UnmarshalFn(root *share.AxisRoots) UnmarshalFn {
 	return func(data []byte) error {
 		if !sb.Container.IsEmpty() {
 			return nil

--- a/share/shwap/p2p/bitswap/sample_block_test.go
+++ b/share/shwap/p2p/bitswap/sample_block_test.go
@@ -16,7 +16,7 @@ func TestSample_FetchRoundtrip(t *testing.T) {
 	defer cancel()
 
 	eds := edstest.RandEDS(t, 32)
-	root, err := share.NewRoot(eds)
+	root, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	exchange := newExchangeOverEDS(ctx, t, eds)
 

--- a/share/shwap/row.go
+++ b/share/shwap/row.go
@@ -82,11 +82,11 @@ func (r Row) IsEmpty() bool {
 
 // Validate checks if the row's shares match the expected number from the root data and validates
 // the side of the row.
-func (r Row) Validate(dah *share.AxisRoots, idx int) error {
+func (r Row) Validate(roots *share.AxisRoots, idx int) error {
 	if len(r.halfShares) == 0 {
 		return fmt.Errorf("empty half row")
 	}
-	expectedShares := len(dah.RowRoots) / 2
+	expectedShares := len(roots.RowRoots) / 2
 	if len(r.halfShares) != expectedShares {
 		return fmt.Errorf("shares size doesn't match root size: %d != %d", len(r.halfShares), expectedShares)
 	}
@@ -97,7 +97,7 @@ func (r Row) Validate(dah *share.AxisRoots, idx int) error {
 		return fmt.Errorf("invalid RowSide: %d", r.side)
 	}
 
-	if err := r.verifyInclusion(dah, idx); err != nil {
+	if err := r.verifyInclusion(roots, idx); err != nil {
 		return fmt.Errorf("%w: %w", ErrFailedVerification, err)
 	}
 	return nil
@@ -105,7 +105,7 @@ func (r Row) Validate(dah *share.AxisRoots, idx int) error {
 
 // verifyInclusion verifies the integrity of the row's shares against the provided root hash for the
 // given row index.
-func (r Row) verifyInclusion(dah *share.AxisRoots, idx int) error {
+func (r Row) verifyInclusion(roots *share.AxisRoots, idx int) error {
 	shrs, err := r.Shares()
 	if err != nil {
 		return fmt.Errorf("while extending shares: %w", err)
@@ -124,8 +124,8 @@ func (r Row) verifyInclusion(dah *share.AxisRoots, idx int) error {
 		return fmt.Errorf("while computing NMT root: %w", err)
 	}
 
-	if !bytes.Equal(dah.RowRoots[idx], root) {
-		return fmt.Errorf("invalid root hash: %X != %X", root, dah.RowRoots[idx])
+	if !bytes.Equal(roots.RowRoots[idx], root) {
+		return fmt.Errorf("invalid root hash: %X != %X", root, roots.RowRoots[idx])
 	}
 	return nil
 }

--- a/share/shwap/row.go
+++ b/share/shwap/row.go
@@ -82,7 +82,7 @@ func (r Row) IsEmpty() bool {
 
 // Validate checks if the row's shares match the expected number from the root data and validates
 // the side of the row.
-func (r Row) Validate(dah *share.Root, idx int) error {
+func (r Row) Validate(dah *share.AxisRoots, idx int) error {
 	if len(r.halfShares) == 0 {
 		return fmt.Errorf("empty half row")
 	}
@@ -105,7 +105,7 @@ func (r Row) Validate(dah *share.Root, idx int) error {
 
 // verifyInclusion verifies the integrity of the row's shares against the provided root hash for the
 // given row index.
-func (r Row) verifyInclusion(dah *share.Root, idx int) error {
+func (r Row) verifyInclusion(dah *share.AxisRoots, idx int) error {
 	shrs, err := r.Shares()
 	if err != nil {
 		return fmt.Errorf("while extending shares: %w", err)

--- a/share/shwap/row_namespace_data.go
+++ b/share/shwap/row_namespace_data.go
@@ -139,7 +139,7 @@ func (rnd RowNamespaceData) IsEmpty() bool {
 }
 
 // Validate checks validity of the RowNamespaceData against the AxisRoots, Namespace and Row index.
-func (rnd RowNamespaceData) Validate(dah *share.AxisRoots, namespace share.Namespace, rowIdx int) error {
+func (rnd RowNamespaceData) Validate(roots *share.AxisRoots, namespace share.Namespace, rowIdx int) error {
 	if rnd.Proof == nil || rnd.Proof.IsEmptyProof() {
 		return fmt.Errorf("nil proof")
 	}
@@ -155,7 +155,7 @@ func (rnd RowNamespaceData) Validate(dah *share.AxisRoots, namespace share.Names
 		return fmt.Errorf("invalid shares: %w", err)
 	}
 
-	rowRoot := dah.RowRoots[rowIdx]
+	rowRoot := roots.RowRoots[rowIdx]
 	if namespace.IsOutsideRange(rowRoot, rowRoot) {
 		return fmt.Errorf("namespace out of range for row %d", rowIdx)
 	}

--- a/share/shwap/row_namespace_data.go
+++ b/share/shwap/row_namespace_data.go
@@ -138,8 +138,8 @@ func (rnd RowNamespaceData) IsEmpty() bool {
 	return rnd.Proof == nil
 }
 
-// Validate checks validity of the RowNamespaceData against the Root, Namespace and Row index.
-func (rnd RowNamespaceData) Validate(dah *share.Root, namespace share.Namespace, rowIdx int) error {
+// Validate checks validity of the RowNamespaceData against the AxisRoots, Namespace and Row index.
+func (rnd RowNamespaceData) Validate(dah *share.AxisRoots, namespace share.Namespace, rowIdx int) error {
 	if rnd.Proof == nil || rnd.Proof.IsEmptyProof() {
 		return fmt.Errorf("nil proof")
 	}

--- a/share/shwap/row_test.go
+++ b/share/shwap/row_test.go
@@ -36,7 +36,7 @@ func TestRowFromShares(t *testing.T) {
 func TestRowValidate(t *testing.T) {
 	const odsSize = 8
 	eds := edstest.RandEDS(t, odsSize)
-	root, err := share.NewRoot(eds)
+	root, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	for rowIdx := 0; rowIdx < odsSize*2; rowIdx++ {
@@ -54,7 +54,7 @@ func TestRowValidate(t *testing.T) {
 
 func TestRowValidateNegativeCases(t *testing.T) {
 	eds := edstest.RandEDS(t, 8) // Generate a random Extended Data Square of size 8
-	root, err := share.NewRoot(eds)
+	root, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	shares := eds.Row(0)
 	row := RowFromShares(shares, Left)
@@ -105,7 +105,7 @@ func TestRowProtoEncoding(t *testing.T) {
 func BenchmarkRowValidate(b *testing.B) {
 	const odsSize = 32
 	eds := edstest.RandEDS(b, odsSize)
-	root, err := share.NewRoot(eds)
+	root, err := share.NewAxisRoots(eds)
 	require.NoError(b, err)
 	shares := eds.Row(0)
 	row := RowFromShares(shares, Left)

--- a/share/shwap/sample.go
+++ b/share/shwap/sample.go
@@ -85,7 +85,7 @@ func (s Sample) IsEmpty() bool {
 
 // Validate checks the inclusion of the share using its Merkle proof under the specified root.
 // Returns an error if the proof is invalid or does not correspond to the indicated proof type.
-func (s Sample) Validate(dah *share.Root, rowIdx, colIdx int) error {
+func (s Sample) Validate(dah *share.AxisRoots, rowIdx, colIdx int) error {
 	if s.Proof == nil || s.Proof.IsEmptyProof() {
 		return errors.New("nil proof")
 	}
@@ -102,7 +102,7 @@ func (s Sample) Validate(dah *share.Root, rowIdx, colIdx int) error {
 }
 
 // verifyInclusion checks if the share is included in the given root hash at the specified indices.
-func (s Sample) verifyInclusion(dah *share.Root, rowIdx, colIdx int) bool {
+func (s Sample) verifyInclusion(dah *share.AxisRoots, rowIdx, colIdx int) bool {
 	size := len(dah.RowRoots)
 	namespace := inclusionNamespace(s.Share, rowIdx, colIdx, size)
 	rootHash := share.RootHashForCoordinates(dah, s.ProofType, uint(rowIdx), uint(colIdx))

--- a/share/shwap/sample.go
+++ b/share/shwap/sample.go
@@ -85,7 +85,7 @@ func (s Sample) IsEmpty() bool {
 
 // Validate checks the inclusion of the share using its Merkle proof under the specified root.
 // Returns an error if the proof is invalid or does not correspond to the indicated proof type.
-func (s Sample) Validate(dah *share.AxisRoots, rowIdx, colIdx int) error {
+func (s Sample) Validate(roots *share.AxisRoots, rowIdx, colIdx int) error {
 	if s.Proof == nil || s.Proof.IsEmptyProof() {
 		return errors.New("nil proof")
 	}
@@ -95,17 +95,17 @@ func (s Sample) Validate(dah *share.AxisRoots, rowIdx, colIdx int) error {
 	if s.ProofType != rsmt2d.Row && s.ProofType != rsmt2d.Col {
 		return fmt.Errorf("invalid SampleProofType: %d", s.ProofType)
 	}
-	if !s.verifyInclusion(dah, rowIdx, colIdx) {
+	if !s.verifyInclusion(roots, rowIdx, colIdx) {
 		return ErrFailedVerification
 	}
 	return nil
 }
 
 // verifyInclusion checks if the share is included in the given root hash at the specified indices.
-func (s Sample) verifyInclusion(dah *share.AxisRoots, rowIdx, colIdx int) bool {
-	size := len(dah.RowRoots)
+func (s Sample) verifyInclusion(roots *share.AxisRoots, rowIdx, colIdx int) bool {
+	size := len(roots.RowRoots)
 	namespace := inclusionNamespace(s.Share, rowIdx, colIdx, size)
-	rootHash := share.RootHashForCoordinates(dah, s.ProofType, uint(rowIdx), uint(colIdx))
+	rootHash := share.RootHashForCoordinates(roots, s.ProofType, uint(rowIdx), uint(colIdx))
 	return s.Proof.VerifyInclusion(
 		share.NewSHA256Hasher(),
 		namespace.ToNMT(),

--- a/share/shwap/sample.go
+++ b/share/shwap/sample.go
@@ -83,7 +83,7 @@ func (s Sample) IsEmpty() bool {
 	return s.Proof == nil
 }
 
-// Validate checks the inclusion of the share using its Merkle proof under the specified root.
+// Validate checks the inclusion of the share using its Merkle proof under the specified AxisRoots.
 // Returns an error if the proof is invalid or does not correspond to the indicated proof type.
 func (s Sample) Validate(roots *share.AxisRoots, rowIdx, colIdx int) error {
 	if s.Proof == nil || s.Proof.IsEmptyProof() {

--- a/share/shwap/sample_test.go
+++ b/share/shwap/sample_test.go
@@ -17,7 +17,7 @@ import (
 func TestSampleValidate(t *testing.T) {
 	const odsSize = 8
 	randEDS := edstest.RandEDS(t, odsSize)
-	root, err := share.NewRoot(randEDS)
+	root, err := share.NewAxisRoots(randEDS)
 	require.NoError(t, err)
 	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
 
@@ -37,7 +37,7 @@ func TestSampleValidate(t *testing.T) {
 func TestSampleNegativeVerifyInclusion(t *testing.T) {
 	const odsSize = 8
 	randEDS := edstest.RandEDS(t, odsSize)
-	root, err := share.NewRoot(randEDS)
+	root, err := share.NewAxisRoots(randEDS)
 	require.NoError(t, err)
 	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
 
@@ -95,7 +95,7 @@ func TestSampleProtoEncoding(t *testing.T) {
 func BenchmarkSampleValidate(b *testing.B) {
 	const odsSize = 32
 	randEDS := edstest.RandEDS(b, odsSize)
-	root, err := share.NewRoot(randEDS)
+	root, err := share.NewAxisRoots(randEDS)
 	require.NoError(b, err)
 	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
 	sample, err := inMem.SampleForProofAxis(0, 0, rsmt2d.Row)

--- a/store/store.go
+++ b/store/store.go
@@ -21,7 +21,7 @@ import (
 var (
 	log = logging.Logger("share/eds")
 
-	emptyAccessor = &eds.Rsmt2D{ExtendedDataSquare: share.EmptyExtendedDataSquare()}
+	emptyAccessor = &eds.Rsmt2D{ExtendedDataSquare: share.EmptyEDS()}
 )
 
 const (
@@ -106,7 +106,7 @@ func (s *Store) Put(
 	defer lock.unlock()
 
 	path := s.basepath + blocksPath + datahash.String()
-	if datahash.IsEmptyRoot() {
+	if datahash.IsEmptyEDS() {
 		err := s.ensureHeightLink(path, height)
 		return err
 	}
@@ -173,7 +173,7 @@ func (s *Store) ensureHeightLink(path string, height uint64) error {
 }
 
 func (s *Store) GetByDataRoot(ctx context.Context, datahash share.DataHash) (eds.AccessorStreamer, error) {
-	if datahash.IsEmptyRoot() {
+	if datahash.IsEmptyEDS() {
 		return emptyAccessor, nil
 	}
 	lock := s.stripLock.byDatahash(datahash)
@@ -226,7 +226,7 @@ func (s *Store) openFile(path string) (eds.AccessorStreamer, error) {
 }
 
 func (s *Store) HasByHash(ctx context.Context, datahash share.DataHash) (bool, error) {
-	if datahash.IsEmptyRoot() {
+	if datahash.IsEmptyEDS() {
 		return true, nil
 	}
 	lock := s.stripLock.byDatahash(datahash)
@@ -305,7 +305,7 @@ func (s *Store) removeLink(height uint64) error {
 
 func (s *Store) removeFile(hash share.DataHash) error {
 	// we don't need to remove the empty file, it should always be there
-	if hash.IsEmptyRoot() {
+	if hash.IsEmptyEDS() {
 		return nil
 	}
 
@@ -361,20 +361,20 @@ func pathExists(path string) (bool, error) {
 }
 
 func ensureEmptyFile(basepath string) error {
-	path := basepath + blocksPath + share.DataHash(share.EmptyRoot().Hash()).String()
+	path := basepath + blocksPath + share.DataHash(share.EmptyEDSRoot().Hash()).String()
 	ok, err := pathExists(path)
 	if err != nil {
-		return fmt.Errorf("checking empty root: %w", err)
+		return fmt.Errorf("checking empty file path: %w", err)
 	}
 	if ok {
 		return nil
 	}
 	f, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("creating empty root file: %w", err)
+		return fmt.Errorf("creating empty eds file: %w", err)
 	}
 	if err = f.Close(); err != nil {
-		return fmt.Errorf("closing empty root file: %w", err)
+		return fmt.Errorf("closing empty eds file: %w", err)
 	}
 	return nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -25,8 +26,8 @@ var (
 )
 
 const (
-	blocksPath  = "/blocks/"
-	heightsPath = blocksPath + "heights/"
+	blocksPath  = "blocks"
+	heightsPath = blocksPath + "/heights"
 
 	defaultDirPerm = 0o755
 )
@@ -54,14 +55,14 @@ func NewStore(params *Parameters, basePath string) (*Store, error) {
 	}
 
 	// Ensure the blocks folder exists or is created.
-	blocksFolderPath := basePath + blocksPath
+	blocksFolderPath := filepath.Join(basePath, blocksPath)
 	if err := ensureFolder(blocksFolderPath); err != nil {
 		log.Errorf("Failed to ensure the existence of the blocks folder at '%s': %s", blocksFolderPath, err)
 		return nil, fmt.Errorf("ensure blocks folder '%s': %w", blocksFolderPath, err)
 	}
 
 	// Ensure the heights folder exists or is created.
-	heightsFolderPath := basePath + heightsPath
+	heightsFolderPath := filepath.Join(basePath, heightsPath)
 	if err := ensureFolder(heightsFolderPath); err != nil {
 		log.Errorf("Failed to ensure the existence of the heights folder at '%s': %s", heightsFolderPath, err)
 		return nil, fmt.Errorf("ensure heights folder '%s': %w", heightsFolderPath, err)
@@ -105,7 +106,7 @@ func (s *Store) Put(
 	lock.lock()
 	defer lock.unlock()
 
-	path := s.basepath + blocksPath + datahash.String()
+	path := filepath.Join(s.basepath, blocksPath, datahash.String())
 	if datahash.IsEmptyEDS() {
 		err := s.ensureHeightLink(path, height)
 		return err
@@ -164,7 +165,7 @@ func (s *Store) createFile(
 
 func (s *Store) ensureHeightLink(path string, height uint64) error {
 	// create hard link with height as name
-	linkPath := s.basepath + heightsPath + strconv.Itoa(int(height))
+	linkPath := filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
 	err := os.Link(path, linkPath)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		return fmt.Errorf("creating hard link: %w", err)
@@ -187,7 +188,7 @@ func (s *Store) GetByDataRoot(ctx context.Context, datahash share.DataHash) (eds
 }
 
 func (s *Store) getByDataRoot(datahash share.DataHash) (eds.AccessorStreamer, error) {
-	path := s.basepath + blocksPath + datahash.String()
+	path := filepath.Join(s.basepath, blocksPath, datahash.String())
 	return s.openFile(path)
 }
 
@@ -207,7 +208,7 @@ func (s *Store) getByHeight(height uint64) (eds.AccessorStreamer, error) {
 	if err == nil {
 		return f, nil
 	}
-	path := s.basepath + heightsPath + strconv.Itoa(int(height))
+	path := filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
 	return s.openFile(path)
 }
 
@@ -240,7 +241,7 @@ func (s *Store) HasByHash(ctx context.Context, datahash share.DataHash) (bool, e
 }
 
 func (s *Store) hasByHash(datahash share.DataHash) (bool, error) {
-	path := s.basepath + blocksPath + datahash.String()
+	path := filepath.Join(s.basepath, blocksPath, datahash.String())
 	return pathExists(path)
 }
 
@@ -261,7 +262,7 @@ func (s *Store) hasByHeight(height uint64) (bool, error) {
 		return true, nil
 	}
 
-	path := s.basepath + heightsPath + strconv.Itoa(int(height))
+	path := filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
 	return pathExists(path)
 }
 
@@ -295,7 +296,7 @@ func (s *Store) removeLink(height uint64) error {
 	}
 
 	// remove hard link by height
-	heightPath := s.basepath + heightsPath + strconv.Itoa(int(height))
+	heightPath := filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
 	err := os.Remove(heightPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -309,7 +310,7 @@ func (s *Store) removeFile(hash share.DataHash) error {
 		return nil
 	}
 
-	hashPath := s.basepath + blocksPath + hash.String()
+	hashPath := filepath.Join(s.basepath, blocksPath, hash.String())
 	err := os.Remove(hashPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -361,7 +362,8 @@ func pathExists(path string) (bool, error) {
 }
 
 func ensureEmptyFile(basepath string) error {
-	path := basepath + blocksPath + share.DataHash(share.EmptyEDSRoot().Hash()).String()
+	emptyFile := share.DataHash(share.EmptyEDSRoots().Hash()).String()
+	path := filepath.Join(basepath, blocksPath, emptyFile)
 	ok, err := pathExists(path)
 	if err != nil {
 		return fmt.Errorf("checking empty file path: %w", err)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -172,8 +172,8 @@ func TestEDSStore(t *testing.T) {
 	})
 
 	t.Run("empty EDS returned by hash", func(t *testing.T) {
-		eds := share.EmptyExtendedDataSquare()
-		dah, err := share.NewRoot(eds)
+		eds := share.EmptyEDS()
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 
 		// assert that the empty file exists
@@ -186,12 +186,12 @@ func TestEDSStore(t *testing.T) {
 		require.NoError(t, err)
 		hash, err := f.DataRoot(ctx)
 		require.NoError(t, err)
-		require.True(t, hash.IsEmptyRoot())
+		require.True(t, hash.IsEmptyEDS())
 	})
 
 	t.Run("empty EDS returned by height", func(t *testing.T) {
-		eds := share.EmptyExtendedDataSquare()
-		dah, err := share.NewRoot(eds)
+		eds := share.EmptyEDS()
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 		height := height.Add(1)
 
@@ -208,7 +208,7 @@ func TestEDSStore(t *testing.T) {
 		require.NoError(t, err)
 		hash, err := f.DataRoot(ctx)
 		require.NoError(t, err)
-		require.True(t, hash.IsEmptyRoot())
+		require.True(t, hash.IsEmptyEDS())
 		require.NoError(t, f.Close())
 	})
 
@@ -217,8 +217,8 @@ func TestEDSStore(t *testing.T) {
 		edsStore, err := NewStore(DefaultParameters(), dir)
 		require.NoError(t, err)
 
-		eds := share.EmptyExtendedDataSquare()
-		dah, err := share.NewRoot(eds)
+		eds := share.EmptyEDS()
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 		from, to := 10, 20
 
@@ -239,7 +239,7 @@ func TestEDSStore(t *testing.T) {
 			require.NoError(t, err)
 			hash, err := f.DataRoot(ctx)
 			require.NoError(t, err)
-			require.True(t, hash.IsEmptyRoot())
+			require.True(t, hash.IsEmptyEDS())
 			require.NoError(t, f.Close())
 		}
 	})
@@ -275,7 +275,7 @@ func BenchmarkStore(b *testing.B) {
 		// disable cache
 		edsStore.cache = cache.NewDoubleCache(cache.NoopCache{}, cache.NoopCache{})
 
-		dah, err := share.NewRoot(eds)
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(b, err)
 
 		height := uint64(1984)
@@ -298,7 +298,7 @@ func BenchmarkStore(b *testing.B) {
 		// disable cache
 		edsStore.cache = cache.NewDoubleCache(cache.NoopCache{}, cache.NoopCache{})
 
-		dah, err := share.NewRoot(eds)
+		dah, err := share.NewAxisRoots(eds)
 		require.NoError(b, err)
 
 		height := uint64(1984)
@@ -314,9 +314,9 @@ func BenchmarkStore(b *testing.B) {
 	})
 }
 
-func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.Root) {
+func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := share.NewRoot(eds)
+	dah, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
 	return eds, dah

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -30,14 +30,14 @@ func TestEDSStore(t *testing.T) {
 
 	// PutRegistersShard tests if Put registers the shard on the underlying DAGStore
 	t.Run("Put", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 		height := height.Add(1)
 
-		err := edsStore.Put(ctx, dah.Hash(), height, eds)
+		err := edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(t, err)
 
 		// file should become available by hash
-		has, err := edsStore.HasByHash(ctx, dah.Hash())
+		has, err := edsStore.HasByHash(ctx, roots.Hash())
 		require.NoError(t, err)
 		require.True(t, has)
 
@@ -51,10 +51,10 @@ func TestEDSStore(t *testing.T) {
 		edsStore, err := NewStore(DefaultParameters(), t.TempDir())
 		require.NoError(t, err)
 
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 		height := height.Add(1)
 
-		err = edsStore.Put(ctx, dah.Hash(), height, eds)
+		err = edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(t, err)
 
 		// file should be cached after put
@@ -71,23 +71,23 @@ func TestEDSStore(t *testing.T) {
 	})
 
 	t.Run("Second Put should be noop", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 		height := height.Add(1)
 
-		err := edsStore.Put(ctx, dah.Hash(), height, eds)
+		err := edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(t, err)
 
-		err = edsStore.Put(ctx, dah.Hash(), height, eds)
+		err = edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(t, err)
 		// TODO: check amount of files in the store after the second Put
 		// after store supports listing
 	})
 
 	t.Run("GetByHeight", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 		height := height.Add(1)
 
-		err = edsStore.Put(ctx, dah.Hash(), height, eds)
+		err = edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(t, err)
 
 		f, err := edsStore.GetByHeight(ctx, height)
@@ -102,13 +102,13 @@ func TestEDSStore(t *testing.T) {
 	})
 
 	t.Run("GetByDataRoot", func(t *testing.T) {
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 		height := height.Add(1)
 
-		err := edsStore.Put(ctx, dah.Hash(), height, eds)
+		err := edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(t, err)
 
-		f, err := edsStore.GetByDataRoot(ctx, dah.Hash())
+		f, err := edsStore.GetByDataRoot(ctx, roots.Hash())
 		require.NoError(t, err)
 
 		// check that cached file is the same eds
@@ -120,10 +120,10 @@ func TestEDSStore(t *testing.T) {
 	})
 
 	t.Run("Does not exist", func(t *testing.T) {
-		_, dah := randomEDS(t)
+		_, roots := randomEDS(t)
 		height := height.Add(1)
 
-		has, err := edsStore.HasByHash(ctx, dah.Hash())
+		has, err := edsStore.HasByHash(ctx, roots.Hash())
 		require.NoError(t, err)
 		require.False(t, has)
 
@@ -134,7 +134,7 @@ func TestEDSStore(t *testing.T) {
 		_, err = edsStore.GetByHeight(ctx, height)
 		require.ErrorIs(t, err, ErrNotFound)
 
-		_, err = edsStore.GetByDataRoot(ctx, dah.Hash())
+		_, err = edsStore.GetByDataRoot(ctx, roots.Hash())
 		require.ErrorIs(t, err, ErrNotFound)
 	})
 
@@ -144,12 +144,12 @@ func TestEDSStore(t *testing.T) {
 		err := edsStore.Remove(ctx, missingHeight, share.DataHash{0x01, 0x02})
 		require.NoError(t, err)
 
-		eds, dah := randomEDS(t)
+		eds, roots := randomEDS(t)
 		height := height.Add(1)
-		err = edsStore.Put(ctx, dah.Hash(), height, eds)
+		err = edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(t, err)
 
-		err = edsStore.Remove(ctx, height, dah.Hash())
+		err = edsStore.Remove(ctx, height, roots.Hash())
 		require.NoError(t, err)
 
 		// file should be removed from cache
@@ -157,12 +157,12 @@ func TestEDSStore(t *testing.T) {
 		require.ErrorIs(t, err, cache.ErrCacheMiss)
 
 		// file should not be accessible by hash
-		has, err := edsStore.HasByHash(ctx, dah.Hash())
+		has, err := edsStore.HasByHash(ctx, roots.Hash())
 		require.NoError(t, err)
 		require.False(t, has)
 
 		// subsequent remove should be noop
-		err = edsStore.Remove(ctx, height, dah.Hash())
+		err = edsStore.Remove(ctx, height, roots.Hash())
 		require.NoError(t, err)
 
 		// file should not be accessible by height
@@ -173,16 +173,16 @@ func TestEDSStore(t *testing.T) {
 
 	t.Run("empty EDS returned by hash", func(t *testing.T) {
 		eds := share.EmptyEDS()
-		dah, err := share.NewAxisRoots(eds)
+		roots, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 
 		// assert that the empty file exists
-		has, err := edsStore.HasByHash(ctx, dah.Hash())
+		has, err := edsStore.HasByHash(ctx, roots.Hash())
 		require.NoError(t, err)
 		require.True(t, has)
 
 		// assert that the empty file is, in fact, empty
-		f, err := edsStore.GetByDataRoot(ctx, dah.Hash())
+		f, err := edsStore.GetByDataRoot(ctx, roots.Hash())
 		require.NoError(t, err)
 		hash, err := f.DataRoot(ctx)
 		require.NoError(t, err)
@@ -191,7 +191,7 @@ func TestEDSStore(t *testing.T) {
 
 	t.Run("empty EDS returned by height", func(t *testing.T) {
 		eds := share.EmptyEDS()
-		dah, err := share.NewAxisRoots(eds)
+		roots, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 		height := height.Add(1)
 
@@ -200,7 +200,7 @@ func TestEDSStore(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, has)
 
-		err = edsStore.Put(ctx, dah.Hash(), height, eds)
+		err = edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(t, err)
 
 		// assert that the empty file can be accessed by height
@@ -218,13 +218,13 @@ func TestEDSStore(t *testing.T) {
 		require.NoError(t, err)
 
 		eds := share.EmptyEDS()
-		dah, err := share.NewAxisRoots(eds)
+		roots, err := share.NewAxisRoots(eds)
 		require.NoError(t, err)
 		from, to := 10, 20
 
 		// store empty EDSs
 		for i := from; i <= to; i++ {
-			err := edsStore.Put(ctx, dah.Hash(), uint64(i), eds)
+			err := edsStore.Put(ctx, roots.Hash(), uint64(i), eds)
 			require.NoError(t, err)
 		}
 
@@ -275,11 +275,11 @@ func BenchmarkStore(b *testing.B) {
 		// disable cache
 		edsStore.cache = cache.NewDoubleCache(cache.NoopCache{}, cache.NoopCache{})
 
-		dah, err := share.NewAxisRoots(eds)
+		roots, err := share.NewAxisRoots(eds)
 		require.NoError(b, err)
 
 		height := uint64(1984)
-		err = edsStore.Put(ctx, dah.Hash(), height, eds)
+		err = edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(b, err)
 
 		b.ResetTimer()
@@ -298,16 +298,16 @@ func BenchmarkStore(b *testing.B) {
 		// disable cache
 		edsStore.cache = cache.NewDoubleCache(cache.NoopCache{}, cache.NoopCache{})
 
-		dah, err := share.NewAxisRoots(eds)
+		roots, err := share.NewAxisRoots(eds)
 		require.NoError(b, err)
 
 		height := uint64(1984)
-		err = edsStore.Put(ctx, dah.Hash(), height, eds)
+		err = edsStore.Put(ctx, roots.Hash(), height, eds)
 		require.NoError(b, err)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			f, err := edsStore.GetByDataRoot(ctx, dah.Hash())
+			f, err := edsStore.GetByDataRoot(ctx, roots.Hash())
 			require.NoError(b, err)
 			require.NoError(b, f.Close())
 		}
@@ -316,8 +316,8 @@ func BenchmarkStore(b *testing.B) {
 
 func randomEDS(t *testing.T) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots) {
 	eds := edstest.RandEDS(t, 4)
-	dah, err := share.NewAxisRoots(eds)
+	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 
-	return eds, dah
+	return eds, roots
 }


### PR DESCRIPTION
- rename share.Root to share.AxisRoots. The value contains set of RowRoots and ColRoots, which are easier to refer as axisRoots, as root might be subjective to context.
- rename empty Root to empty EDS. Adjusting to refer empty content of block, rather than root.
- rename dah to roots where appropriate
- replace da.NewAvailabilityHeader with share.NewAxisRoots where appropriate