### PR TITLE
feat(shwap/p2p): Bitswap Getter

### DIFF
--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -1,0 +1,172 @@
+package bitswap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ipfs/boxo/blockstore"
+	"github.com/ipfs/boxo/exchange"
+
+	"github.com/celestiaorg/celestia-app/pkg/wrapper"
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share"
+)
+
+// Getter implements share.Getter.
+type Getter struct {
+	exchange exchange.SessionExchange
+	bstore   blockstore.Blockstore
+	session  exchange.Fetcher
+	cancel   context.CancelFunc
+}
+
+// NewGetter constructs a new Getter.
+func NewGetter(exchange exchange.SessionExchange, bstore blockstore.Blockstore) *Getter {
+	return &Getter{exchange: exchange, bstore: bstore}
+}
+
+// Start kicks off internal fetching session.
+func (g *Getter) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	g.session = g.exchange.NewSession(ctx)
+	g.cancel = cancel
+}
+
+// Stop shuts down Getter's internal fetching session.
+func (g *Getter) Stop() {
+	g.cancel()
+}
+
+// TODO(@Wondertan): Rework API to get coordinates as a single param to make it ergonomic.
+func (g *Getter) GetShares(
+	ctx context.Context,
+	hdr *header.ExtendedHeader,
+	rowIdxs, colIdxs []int,
+) ([]share.Share, error) {
+	if len(rowIdxs) != len(colIdxs) {
+		return nil, fmt.Errorf("row indecies and col indecies must be same length")
+	}
+
+	if len(rowIdxs) == 0 {
+		return nil, fmt.Errorf("empty coordinates")
+	}
+
+	blks := make([]Block, 0, len(rowIdxs))
+	for i, rowIdx := range rowIdxs {
+		sid, err := NewEmptySampleBlock(hdr.Height(), rowIdx, colIdxs[i], len(hdr.DAH.RowRoots))
+		if err != nil {
+			return nil, err
+		}
+
+		blks[i] = sid
+	}
+
+	err := Fetch(ctx, g.exchange, hdr.DAH, blks, WithStore(g.bstore))
+	if err != nil {
+		return nil, err
+	}
+
+	shares := make([]share.Share, len(blks))
+	for i, blk := range blks {
+		shares[i] = blk.(*SampleBlock).Container.Share
+	}
+
+	return shares, nil
+}
+
+func (g *Getter) GetShare(
+	ctx context.Context,
+	hdr *header.ExtendedHeader,
+	row, col int,
+) (share.Share, error) {
+	shrs, err := g.GetShares(ctx, hdr, []int{row}, []int{col})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(shrs) != 1 {
+		return nil, fmt.Errorf("expected 1 share row, got %d", len(shrs))
+	}
+
+	return shrs[0], nil
+}
+
+func (g *Getter) GetEDS(
+	ctx context.Context,
+	hdr *header.ExtendedHeader,
+) (*rsmt2d.ExtendedDataSquare, error) {
+	sqrLn := len(hdr.DAH.RowRoots)
+	blks := make([]Block, sqrLn/2)
+	for i := 0; i < sqrLn/2; i++ {
+		blk, err := NewEmptyRowBlock(hdr.Height(), i, sqrLn)
+		if err != nil {
+			return nil, err
+		}
+
+		blks[i] = blk
+	}
+
+	err := Fetch(ctx, g.exchange, hdr.DAH, blks, WithFetcher(g.session))
+	if err != nil {
+		return nil, err
+	}
+
+	shrs := make([]share.Share, 0, sqrLn*sqrLn)
+	for _, row := range blks {
+		rowShrs, err := row.(*RowBlock).Container.Shares()
+		if err != nil {
+			return nil, fmt.Errorf("decoding Shares out of Row: %w", err)
+		}
+		shrs = append(shrs, rowShrs...)
+	}
+
+	square, err := rsmt2d.ComputeExtendedDataSquare(
+		shrs,
+		share.DefaultRSMT2DCodec(),
+		wrapper.NewConstructor(uint64(sqrLn/2)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("computing EDS: %w", err)
+	}
+
+	return square, nil
+}
+
+func (g *Getter) GetSharesByNamespace(
+	ctx context.Context,
+	hdr *header.ExtendedHeader,
+	ns share.Namespace,
+) (share.NamespacedShares, error) {
+	if err := ns.ValidateForData(); err != nil {
+		return nil, err
+	}
+
+	rowIdxs := share.RowsWithNamespace(hdr.DAH, ns)
+	blks := make([]Block, len(rowIdxs))
+	for i, rowNdIdx := range rowIdxs {
+		rndblk, err := NewEmptyRowNamespaceDataBlock(hdr.Height(), rowNdIdx, ns, len(hdr.DAH.RowRoots))
+		if err != nil {
+			return nil, err
+		}
+		blks[i] = rndblk
+	}
+
+	err := Fetch(ctx, g.exchange, hdr.DAH, blks, WithFetcher(g.session))
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(@Wondertan): this must use shwap types eventually
+	nsShrs := make(share.NamespacedShares, len(blks))
+	for i, blk := range blks {
+		rnd := blk.(*RowNamespaceDataBlock).Container
+		nsShrs[i] = share.NamespacedRow{
+			Shares: rnd.Shares,
+			Proof:  rnd.Proof,
+		}
+	}
+
+	return nsShrs, nil
+}

--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -204,7 +204,8 @@ func (g *Getter) session(hdr *header.ExtendedHeader) exchange.Fetcher {
 	return g.archivalSession
 }
 
-// edsFromRows imports given Rows and computes EDS out of them, assuming enough were Rows provided.
+// edsFromRows imports given Rows and computes EDS out of them, assuming enough Rows were provided.
+// It is designed to reuse Row halves computed during verification on [Fetch] level.
 func edsFromRows(roots *share.AxisRoots, rows []shwap.Row) (*rsmt2d.ExtendedDataSquare, error) {
 	shrs := make([]share.Share, len(roots.RowRoots)*len(roots.RowRoots))
 	for i, row := range rows {

--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/celestiaorg/celestia-app/pkg/wrapper"
-	"github.com/celestiaorg/rsmt2d"
 	"github.com/ipfs/boxo/blockstore"
 	"github.com/ipfs/boxo/exchange"
+
+	"github.com/celestiaorg/celestia-app/pkg/wrapper"
+	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/pruner"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/shwap"
 )
 
 // Getter implements share.Getter.
@@ -139,25 +141,14 @@ func (g *Getter) GetEDS(
 		return nil, err
 	}
 
-	shrs := make([]share.Share, 0, sqrLn/2*sqrLn/2)
-	for i, row := range blks {
-		rowShrs, err := row.(*RowBlock).Container.Shares()
-		if err != nil {
-			return nil, fmt.Errorf("decoding Shares out of Row: %w", err)
-		}
-
-		for j, shr := range rowShrs {
-			shrs[i*j] = shr
-		}
+	rows := make([]shwap.Row, len(blks))
+	for i, blk := range blks {
+		rows[i] = blk.(*RowBlock).Container
 	}
 
-	square, err := rsmt2d.ImportExtendedDataSquare(
-		shrs,
-		share.DefaultRSMT2DCodec(),
-		wrapper.NewConstructor(uint64(sqrLn/2)),
-	)
+	square, err := edsFromRows(hdr.DAH, rows)
 	if err != nil {
-		return nil, fmt.Errorf("computing EDS: %w", err)
+		return nil, err
 	}
 
 	return square, nil
@@ -211,4 +202,35 @@ func (g *Getter) session(hdr *header.ExtendedHeader) exchange.Fetcher {
 	}
 
 	return g.archivalSession
+}
+
+// edsFromRows imports given Rows and computes EDS out of them, assuming enough were Rows provided.
+func edsFromRows(roots *share.Root, rows []shwap.Row) (*rsmt2d.ExtendedDataSquare, error) {
+	shrs := make([]share.Share, len(roots.RowRoots)*len(roots.RowRoots))
+	for i, row := range rows {
+		rowShrs, err := row.Shares()
+		if err != nil {
+			return nil, fmt.Errorf("decoding Shares out of Row: %w", err)
+		}
+
+		for j, shr := range rowShrs {
+			shrs[j+(i*len(roots.RowRoots))] = shr
+		}
+	}
+
+	square, err := rsmt2d.ImportExtendedDataSquare(
+		shrs,
+		share.DefaultRSMT2DCodec(),
+		wrapper.NewConstructor(uint64(len(roots.RowRoots)/2)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("importing EDS: %w", err)
+	}
+
+	err = square.Repair(roots.RowRoots, roots.ColumnRoots)
+	if err != nil {
+		return nil, fmt.Errorf("repairing EDS: %w", err)
+	}
+
+	return square, nil
 }

--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -67,7 +67,7 @@ func (g *Getter) GetShares(
 	rowIdxs, colIdxs []int,
 ) ([]share.Share, error) {
 	if len(rowIdxs) != len(colIdxs) {
-		return nil, fmt.Errorf("row indecies and col indecies must be same length")
+		return nil, fmt.Errorf("row indecies and col indices must be same length")
 	}
 
 	if len(rowIdxs) == 0 {
@@ -205,7 +205,7 @@ func (g *Getter) session(hdr *header.ExtendedHeader) exchange.Fetcher {
 }
 
 // edsFromRows imports given Rows and computes EDS out of them, assuming enough were Rows provided.
-func edsFromRows(roots *share.Root, rows []shwap.Row) (*rsmt2d.ExtendedDataSquare, error) {
+func edsFromRows(roots *share.AxisRoots, rows []shwap.Row) (*rsmt2d.ExtendedDataSquare, error) {
 	shrs := make([]share.Share, len(roots.RowRoots)*len(roots.RowRoots))
 	for i, row := range rows {
 		rowShrs, err := row.Shares()

--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -39,6 +39,7 @@ func (g *Getter) Stop() {
 	g.cancel()
 }
 
+// GetShares uses [SampleBlock] and [Fetch] to get and verify samples for given coordinates.
 // TODO(@Wondertan): Rework API to get coordinates as a single param to make it ergonomic.
 func (g *Getter) GetShares(
 	ctx context.Context,
@@ -53,7 +54,7 @@ func (g *Getter) GetShares(
 		return nil, fmt.Errorf("empty coordinates")
 	}
 
-	blks := make([]Block, 0, len(rowIdxs))
+	blks := make([]Block, len(rowIdxs))
 	for i, rowIdx := range rowIdxs {
 		sid, err := NewEmptySampleBlock(hdr.Height(), rowIdx, colIdxs[i], len(hdr.DAH.RowRoots))
 		if err != nil {
@@ -93,6 +94,8 @@ func (g *Getter) GetShare(
 	return shrs[0], nil
 }
 
+// GetEDS uses [RowBlock] and [Fetch] to get half of the first EDS quadrant(ODS) and
+// recomputes the whole EDS from it.
 func (g *Getter) GetEDS(
 	ctx context.Context,
 	hdr *header.ExtendedHeader,
@@ -113,7 +116,7 @@ func (g *Getter) GetEDS(
 		return nil, err
 	}
 
-	shrs := make([]share.Share, 0, sqrLn*sqrLn)
+	shrs := make([]share.Share, 0, sqrLn/2*sqrLn/2)
 	for _, row := range blks {
 		rowShrs, err := row.(*RowBlock).Container.Shares()
 		if err != nil {
@@ -134,6 +137,8 @@ func (g *Getter) GetEDS(
 	return square, nil
 }
 
+// GetSharesByNamespace uses [RowNamespaceDataBlock] and [Fetch] to get all the data
+// by the given namespace.
 func (g *Getter) GetSharesByNamespace(
 	ctx context.Context,
 	hdr *header.ExtendedHeader,

--- a/share/shwap/p2p/bitswap/getter_test.go
+++ b/share/shwap/p2p/bitswap/getter_test.go
@@ -1,0 +1,27 @@
+package bitswap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+func TestEDSFromRows(t *testing.T) {
+	edsIn := edstest.RandEDS(t, 8)
+	roots, err := share.NewRoot(edsIn)
+	require.NoError(t, err)
+
+	rows := make([]shwap.Row, edsIn.Width()/2)
+	for i := range edsIn.Width() / 2 {
+		rowShrs := edsIn.Row(i)[:edsIn.Width()/2]
+		rows[i] = shwap.NewRow(rowShrs, shwap.Left)
+	}
+
+	edsOut, err := edsFromRows(roots, rows)
+	require.NoError(t, err)
+	require.True(t, edsIn.Equals(edsOut))
+}

--- a/share/shwap/p2p/bitswap/getter_test.go
+++ b/share/shwap/p2p/bitswap/getter_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestEDSFromRows(t *testing.T) {
 	edsIn := edstest.RandEDS(t, 8)
-	roots, err := share.NewRoot(edsIn)
+	roots, err := share.NewAxisRoots(edsIn)
 	require.NoError(t, err)
 
 	rows := make([]shwap.Row, edsIn.Width()/2)


### PR DESCRIPTION
Implements new `Getter` over Bitswap p2p composition.

This PR does not intend to implement unit tests for the Getter itself. Adding them here is not trivial as we don't have the `Getter` test suite, which will soon be replaced with the `Accessor` interface. The current coverage of every `Block` is sufficient to prove every method works while `Getter` itself is simply an adapter. We need this `Getter` _temporary_ to accelerate testing of `Shwap` and replace it with an `Accesor` once we allocate time for refactorings. 