### PR TITLE
feat(shwap): Add axis roots to Accessor

### DIFF
--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -50,6 +49,7 @@ func RandEDSWithNamespace(
 	return eds, roots
 }
 
+// RandomAxisRoots generates random share.AxisRoots for the given eds size.
 func RandomAxisRoots(t testing.TB, size int) *share.AxisRoots {
 	roots := make([][]byte, size*2)
 	for i := range roots {
@@ -61,7 +61,7 @@ func RandomAxisRoots(t testing.TB, size int) *share.AxisRoots {
 
 	rows := roots[:size]
 	cols := roots[size:]
-	return &da.DataAvailabilityHeader{
+	return &share.AxisRoots{
 		RowRoots:    rows,
 		ColumnRoots: cols,
 	}

--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -1,10 +1,12 @@
 package edstest
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -46,4 +48,21 @@ func RandEDSWithNamespace(
 	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)
 	return eds, roots
+}
+
+func RandomAxisRoots(t testing.TB, size int) *share.AxisRoots {
+	roots := make([][]byte, size*2)
+	for i := range roots {
+		root := make([]byte, size)
+		_, err := rand.Read(root)
+		require.NoError(t, err)
+		roots[i] = root
+	}
+
+	rows := roots[:size]
+	cols := roots[size:]
+	return &da.DataAvailabilityHeader{
+		RowRoots:    rows,
+		ColumnRoots: cols,
+	}
 }

--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -50,17 +50,17 @@ func RandEDSWithNamespace(
 }
 
 // RandomAxisRoots generates random share.AxisRoots for the given eds size.
-func RandomAxisRoots(t testing.TB, size int) *share.AxisRoots {
-	roots := make([][]byte, size*2)
+func RandomAxisRoots(t testing.TB, edsSize int) *share.AxisRoots {
+	roots := make([][]byte, edsSize*2)
 	for i := range roots {
-		root := make([]byte, size)
+		root := make([]byte, edsSize)
 		_, err := rand.Read(root)
 		require.NoError(t, err)
 		roots[i] = root
 	}
 
-	rows := roots[:size]
-	cols := roots[size:]
+	rows := roots[:edsSize]
+	cols := roots[edsSize:]
 	return &share.AxisRoots{
 		RowRoots:    rows,
 		ColumnRoots: cols,

--- a/share/new_eds/accessor.go
+++ b/share/new_eds/accessor.go
@@ -16,7 +16,7 @@ type Accessor interface {
 	Size(ctx context.Context) int
 	// DataHash returns data hash of the Accessor.
 	DataHash(ctx context.Context) (share.DataHash, error)
-	// AxisRoots returns axis roots of the Accessor.
+	// AxisRoots returns share.AxisRoots (DataAvailabilityHeader) of the Accessor.
 	AxisRoots(ctx context.Context) (*share.AxisRoots, error)
 	// Sample returns share and corresponding proof for row and column indices. Implementation can
 	// choose which axis to use for proof. Chosen axis for proof should be indicated in the returned

--- a/share/new_eds/accessor.go
+++ b/share/new_eds/accessor.go
@@ -16,6 +16,8 @@ type Accessor interface {
 	Size(ctx context.Context) int
 	// DataHash returns data hash of the Accessor.
 	DataHash(ctx context.Context) (share.DataHash, error)
+	// AxisRoots returns axis roots of the Accessor.
+	AxisRoots(ctx context.Context) (*share.AxisRoots, error)
 	// Sample returns share and corresponding proof for row and column indices. Implementation can
 	// choose which axis to use for proof. Chosen axis for proof should be indicated in the returned
 	// Sample.

--- a/share/new_eds/close_once.go
+++ b/share/new_eds/close_once.go
@@ -49,6 +49,14 @@ func (c *closeOnce) DataHash(ctx context.Context) (share.DataHash, error) {
 	return c.f.DataHash(ctx)
 }
 
+// AxisRoots returns AxisRoots of Accessor's underlying EDS.
+func (c *closeOnce) AxisRoots(ctx context.Context) (*share.AxisRoots, error) {
+	if c.closed.Load() {
+		return nil, errAccessorClosed
+	}
+	return c.f.AxisRoots(ctx)
+}
+
 func (c *closeOnce) Sample(ctx context.Context, rowIdx, colIdx int) (shwap.Sample, error) {
 	if c.closed.Load() {
 		return shwap.Sample{}, errAccessorClosed

--- a/share/new_eds/close_once.go
+++ b/share/new_eds/close_once.go
@@ -49,7 +49,6 @@ func (c *closeOnce) DataHash(ctx context.Context) (share.DataHash, error) {
 	return c.f.DataHash(ctx)
 }
 
-// AxisRoots returns AxisRoots of Accessor's underlying EDS.
 func (c *closeOnce) AxisRoots(ctx context.Context) (*share.AxisRoots, error) {
 	if c.closed.Load() {
 		return nil, errAccessorClosed

--- a/share/new_eds/close_once_test.go
+++ b/share/new_eds/close_once_test.go
@@ -51,7 +51,11 @@ func (s *stubEdsAccessorCloser) Size(context.Context) int {
 }
 
 func (s *stubEdsAccessorCloser) DataHash(context.Context) (share.DataHash, error) {
-	return nil, nil
+	return share.DataHash{}, nil
+}
+
+func (s *stubEdsAccessorCloser) AxisRoots(context.Context) (*share.AxisRoots, error) {
+	return &share.AxisRoots{}, nil
 }
 
 func (s *stubEdsAccessorCloser) Sample(context.Context, int, int) (shwap.Sample, error) {

--- a/share/new_eds/nd.go
+++ b/share/new_eds/nd.go
@@ -13,13 +13,15 @@ import (
 // avoiding the need to recalculate the row roots for each row.
 func NamespacedData(
 	ctx context.Context,
-	root *share.AxisRoots,
 	eds Accessor,
 	namespace share.Namespace,
 ) (shwap.NamespacedData, error) {
-	rowIdxs := share.RowsWithNamespace(root, namespace)
+	roots, err := eds.AxisRoots(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get root: %w", err)
+	}
+	rowIdxs := share.RowsWithNamespace(roots, namespace)
 	rows := make(shwap.NamespacedData, len(rowIdxs))
-	var err error
 	for i, idx := range rowIdxs {
 		rows[i], err = eds.RowNamespaceData(ctx, namespace, idx)
 		if err != nil {

--- a/share/new_eds/nd.go
+++ b/share/new_eds/nd.go
@@ -18,7 +18,7 @@ func NamespacedData(
 ) (shwap.NamespacedData, error) {
 	roots, err := eds.AxisRoots(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get root: %w", err)
+		return nil, fmt.Errorf("failed to get AxisRoots: %w", err)
 	}
 	rowIdxs := share.RowsWithNamespace(roots, namespace)
 	rows := make(shwap.NamespacedData, len(rowIdxs))

--- a/share/new_eds/nd_test.go
+++ b/share/new_eds/nd_test.go
@@ -21,7 +21,7 @@ func TestNamespacedData(t *testing.T) {
 	for amount := 1; amount < sharesAmount; amount++ {
 		eds, root := edstest.RandEDSWithNamespace(t, namespace, amount, odsSize)
 		rsmt2d := &Rsmt2D{ExtendedDataSquare: eds}
-		nd, err := NamespacedData(ctx, root, rsmt2d, namespace)
+		nd, err := NamespacedData(ctx, rsmt2d, namespace)
 		require.NoError(t, err)
 		require.True(t, len(nd) > 0)
 		require.Len(t, nd.Flatten(), amount)

--- a/share/new_eds/rsmt2d.go
+++ b/share/new_eds/rsmt2d.go
@@ -33,6 +33,15 @@ func (eds *Rsmt2D) DataHash(context.Context) (share.DataHash, error) {
 	return roots.Hash(), nil
 }
 
+// AxisRoots returns AxisRoots of the Accessor.
+func (eds *Rsmt2D) AxisRoots(context.Context) (*share.AxisRoots, error) {
+	roots, err := share.NewAxisRoots(eds.ExtendedDataSquare)
+	if err != nil {
+		return nil, fmt.Errorf("while creating axis roots: %w", err)
+	}
+	return roots, nil
+}
+
 // Sample returns share and corresponding proof for row and column indices.
 func (eds *Rsmt2D) Sample(
 	_ context.Context,

--- a/share/new_eds/testing.go
+++ b/share/new_eds/testing.go
@@ -35,6 +35,14 @@ func TestSuiteAccessor(
 		t.Errorf("minSize must be power of 2: %v", maxSize)
 	}
 	for size := minSize; size <= maxSize; size *= 2 {
+		t.Run(fmt.Sprintf("DataRoot:%d", size), func(t *testing.T) {
+			testAccessorDataRoot(ctx, t, createAccessor, size)
+		})
+
+		t.Run(fmt.Sprintf("AxisRoots:%d", size), func(t *testing.T) {
+			testAccessorAxisRoots(ctx, t, createAccessor, size)
+		})
+
 		t.Run(fmt.Sprintf("Sample:%d", size), func(t *testing.T) {
 			testAccessorSample(ctx, t, createAccessor, size)
 		})
@@ -62,6 +70,40 @@ func TestStreamer(
 	t.Run("Reader", func(t *testing.T) {
 		testAccessorReader(ctx, t, create, odsSize)
 	})
+}
+
+func testAccessorDataRoot(
+	ctx context.Context,
+	t *testing.T,
+	createAccessor createAccessor,
+	odsSize int,
+) {
+	eds := edstest.RandEDS(t, odsSize)
+	fl := createAccessor(t, eds)
+
+	roots, err := share.NewAxisRoots(eds)
+	require.NoError(t, err)
+
+	datahash, err := fl.DataHash(ctx)
+	require.NoError(t, err)
+	require.Equal(t, share.DataHash(roots.Hash()), datahash)
+}
+
+func testAccessorAxisRoots(
+	ctx context.Context,
+	t *testing.T,
+	createAccessor createAccessor,
+	odsSize int,
+) {
+	eds := edstest.RandEDS(t, odsSize)
+	fl := createAccessor(t, eds)
+
+	roots, err := share.NewAxisRoots(eds)
+	require.NoError(t, err)
+
+	axisRoots, err := fl.AxisRoots(ctx)
+	require.NoError(t, err)
+	require.True(t, roots.Equals(axisRoots))
 }
 
 func testAccessorSample(

--- a/share/new_eds/testing.go
+++ b/share/new_eds/testing.go
@@ -35,8 +35,8 @@ func TestSuiteAccessor(
 		t.Errorf("minSize must be power of 2: %v", maxSize)
 	}
 	for size := minSize; size <= maxSize; size *= 2 {
-		t.Run(fmt.Sprintf("DataRoot:%d", size), func(t *testing.T) {
-			testAccessorDataRoot(ctx, t, createAccessor, size)
+		t.Run(fmt.Sprintf("DataHash:%d", size), func(t *testing.T) {
+			testAccessorDataHash(ctx, t, createAccessor, size)
 		})
 
 		t.Run(fmt.Sprintf("AxisRoots:%d", size), func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestStreamer(
 	})
 }
 
-func testAccessorDataRoot(
+func testAccessorDataHash(
 	ctx context.Context,
 	t *testing.T,
 	createAccessor createAccessor,

--- a/share/root.go
+++ b/share/root.go
@@ -14,8 +14,8 @@ import (
 const (
 	// DataHashSize is the size of the DataHash.
 	DataHashSize = 32
-	// AxisRootsSize is the size of the single root in AxisRoots.
-	AxisRootsSize = 90
+	// AxisRootSize is the size of the single root in AxisRoots.
+	AxisRootSize = 90
 )
 
 // AxisRoots represents root commitment to multiple Shares.

--- a/share/root.go
+++ b/share/root.go
@@ -11,6 +11,13 @@ import (
 	"github.com/celestiaorg/rsmt2d"
 )
 
+const (
+	// DataHashSize is the size of the DataHash.
+	DataHashSize = 32
+	// AxisRootsSize is the size of the single root in AxisRoots.
+	AxisRootsSize = 90
+)
+
 // AxisRoots represents root commitment to multiple Shares.
 // In practice, it is a commitment to all the Data in a square.
 type AxisRoots = da.DataAvailabilityHeader
@@ -19,7 +26,7 @@ type AxisRoots = da.DataAvailabilityHeader
 type DataHash []byte
 
 func (dh DataHash) Validate() error {
-	if len(dh) != 32 {
+	if len(dh) != DataHashSize {
 		return fmt.Errorf("invalid hash size, expected 32, got %d", len(dh))
 	}
 	return nil

--- a/share/shwap/row_namespace_data_test.go
+++ b/share/shwap/row_namespace_data_test.go
@@ -66,7 +66,7 @@ func TestValidateNamespacedRow(t *testing.T) {
 	for amount := 1; amount < sharesAmount; amount++ {
 		randEDS, root := edstest.RandEDSWithNamespace(t, namespace, amount, odsSize)
 		rsmt2d := &eds.Rsmt2D{ExtendedDataSquare: randEDS}
-		nd, err := eds.NamespacedData(ctx, root, rsmt2d, namespace)
+		nd, err := eds.NamespacedData(ctx, rsmt2d, namespace)
 		require.NoError(t, err)
 		require.True(t, len(nd) > 0)
 
@@ -86,9 +86,9 @@ func TestNamespacedRowProtoEncoding(t *testing.T) {
 
 	const odsSize = 8
 	namespace := sharetest.RandV0Namespace()
-	randEDS, root := edstest.RandEDSWithNamespace(t, namespace, odsSize, odsSize)
+	randEDS, _ := edstest.RandEDSWithNamespace(t, namespace, odsSize, odsSize)
 	rsmt2d := &eds.Rsmt2D{ExtendedDataSquare: randEDS}
-	nd, err := eds.NamespacedData(ctx, root, rsmt2d, namespace)
+	nd, err := eds.NamespacedData(ctx, rsmt2d, namespace)
 	require.NoError(t, err)
 	require.True(t, len(nd) > 0)
 

--- a/store/cache/accessor_cache_test.go
+++ b/store/cache/accessor_cache_test.go
@@ -304,6 +304,10 @@ func (m *mockAccessor) DataHash(context.Context) (share.DataHash, error) {
 	panic("implement me")
 }
 
+func (m *mockAccessor) AxisRoots(context.Context) (*share.AxisRoots, error) {
+	panic("implement me")
+}
+
 func (m *mockAccessor) Sample(context.Context, int, int) (shwap.Sample, error) {
 	panic("implement me")
 }

--- a/store/cache/noop.go
+++ b/store/cache/noop.go
@@ -46,9 +46,12 @@ func (n NoopFile) Size(context.Context) int {
 	return 0
 }
 
-// DataHash returns root hash of Accessor's underlying EDS.
 func (n NoopFile) DataHash(context.Context) (share.DataHash, error) {
-	return nil, nil
+	return share.DataHash{}, nil
+}
+
+func (n NoopFile) AxisRoots(context.Context) (*share.AxisRoots, error) {
+	return &share.AxisRoots{}, nil
 }
 
 func (n NoopFile) Sample(context.Context, int, int) (shwap.Sample, error) {

--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -155,8 +155,8 @@ func (f *ODSFile) AxisRoots(context.Context) (*share.AxisRoots, error) {
 	rowRoots := make([][]byte, f.size())
 	colRoots := make([][]byte, f.size())
 	for i := 0; i < f.size(); i++ {
-		rowRoots[i] = roots[i*share.AxisRootsSize : (i+1)*share.AxisRootsSize]
-		colRoots[i] = roots[(f.size()+i)*share.AxisRootsSize : (f.size()+i+1)*share.AxisRootsSize]
+		rowRoots[i] = roots[i*share.AxisRootSize : (i+1)*share.AxisRootSize]
+		colRoots[i] = roots[(f.size()+i)*share.AxisRootSize : (f.size()+i+1)*share.AxisRootSize]
 	}
 	axisRoots := &share.AxisRoots{
 		RowRoots:    rowRoots,
@@ -289,7 +289,7 @@ func (f *ODSFile) sharesOffset() int {
 }
 
 func (f *ODSFile) axisRootsSize() int {
-	return share.AxisRootsSize * 2 * f.size()
+	return share.AxisRootSize * 2 * f.size()
 }
 
 func (f *ODSFile) readODS() (square, error) {

--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -103,7 +103,6 @@ func writeODSFile(w io.Writer, eds *rsmt2d.ExtendedDataSquare, axisRoots *share.
 		return nil, fmt.Errorf("writing header: %w", err)
 	}
 
-	// write axisRoots
 	err = writeAxisRoots(w, axisRoots)
 	if err != nil {
 		return nil, fmt.Errorf("writing axis roots: %w", err)
@@ -142,7 +141,8 @@ func (f *ODSFile) DataHash(context.Context) (share.DataHash, error) {
 	return f.hdr.datahash, nil
 }
 
-// AxisRoots returns axis roots of the Accessor.
+// AxisRoots reads AxisRoots stored in the file. AxisRoots are stored after the header and before the
+// ODS data.
 func (f *ODSFile) AxisRoots(context.Context) (*share.AxisRoots, error) {
 	roots := make([]byte, f.axisRootsSize())
 	n, err := f.fl.ReadAt(roots, int64(f.hdr.Size()))
@@ -289,6 +289,8 @@ func (f *ODSFile) sharesOffset() int {
 }
 
 func (f *ODSFile) axisRootsSize() int {
+	// axis roots are stored in two parts: row roots and column roots, each part has size equal to
+	// the square size. Thus, the total amount of roots is equal to the square size * 2.
 	return share.AxisRootSize * 2 * f.size()
 }
 

--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -63,7 +63,7 @@ func OpenODSFile(path string) (*ODSFile, error) {
 // CreateODSFile creates a new file. File has to be closed after usage.
 func CreateODSFile(
 	path string,
-	datahash share.DataHash,
+	roots *share.AxisRoots,
 	eds *rsmt2d.ExtendedDataSquare,
 ) (*ODSFile, error) {
 	mod := os.O_RDWR | os.O_CREATE | os.O_EXCL // ensure we fail if already exist
@@ -72,15 +72,7 @@ func CreateODSFile(
 		return nil, fmt.Errorf("file create: %w", err)
 	}
 
-	h := &headerV0{
-		fileVersion: fileV0,
-		fileType:    ods,
-		shareSize:   share.Size,
-		squareSize:  uint16(eds.Width()),
-		datahash:    datahash,
-	}
-
-	err = writeODSFile(f, h, eds)
+	h, err := writeODSFile(f, eds, roots)
 	if err != nil {
 		return nil, fmt.Errorf("writing ODS file: %w", err)
 	}
@@ -97,15 +89,40 @@ func CreateODSFile(
 	}, nil
 }
 
-func writeODSFile(w io.Writer, h *headerV0, eds *rsmt2d.ExtendedDataSquare) error {
+func writeODSFile(w io.Writer, eds *rsmt2d.ExtendedDataSquare, axisRoots *share.AxisRoots) (*headerV0, error) {
+	// write header
+	h := &headerV0{
+		fileVersion: fileV0,
+		fileType:    ods,
+		shareSize:   share.Size,
+		squareSize:  uint16(eds.Width()),
+		datahash:    axisRoots.Hash(),
+	}
 	err := writeHeader(w, h)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("writing header: %w", err)
+	}
+
+	// write axisRoots
+	err = writeAxisRoots(w, axisRoots)
+	if err != nil {
+		return nil, fmt.Errorf("writing axis roots: %w", err)
 	}
 
 	for _, shr := range eds.FlattenedODS() {
 		if _, err := w.Write(shr); err != nil {
-			return err
+			return nil, fmt.Errorf("writing shares: %w", err)
+		}
+	}
+	return h, nil
+}
+
+func writeAxisRoots(w io.Writer, roots *share.AxisRoots) error {
+	for _, roots := range [][][]byte{roots.RowRoots, roots.ColumnRoots} {
+		for _, root := range roots {
+			if _, err := w.Write(root); err != nil {
+				return fmt.Errorf("writing axis root: %w", err)
+			}
 		}
 	}
 	return nil
@@ -123,6 +140,29 @@ func (f *ODSFile) size() int {
 // DataHash returns root hash of Accessor's underlying EDS.
 func (f *ODSFile) DataHash(context.Context) (share.DataHash, error) {
 	return f.hdr.datahash, nil
+}
+
+// AxisRoots returns axis roots of the Accessor.
+func (f *ODSFile) AxisRoots(context.Context) (*share.AxisRoots, error) {
+	roots := make([]byte, f.axisRootsSize())
+	n, err := f.fl.ReadAt(roots, int64(f.hdr.Size()))
+	if err != nil {
+		return nil, fmt.Errorf("reading axis roots: %w", err)
+	}
+	if n != len(roots) {
+		return nil, fmt.Errorf("reading axis roots: expected %d bytes, got %d", len(roots), n)
+	}
+	rowRoots := make([][]byte, f.size())
+	colRoots := make([][]byte, f.size())
+	for i := 0; i < f.size(); i++ {
+		rowRoots[i] = roots[i*share.AxisRootsSize : (i+1)*share.AxisRootsSize]
+		colRoots[i] = roots[(f.size()+i)*share.AxisRootsSize : (f.size()+i+1)*share.AxisRootsSize]
+	}
+	axisRoots := &share.AxisRoots{
+		RowRoots:    rowRoots,
+		ColumnRoots: colRoots,
+	}
+	return axisRoots, nil
 }
 
 // Close closes the file.
@@ -212,9 +252,9 @@ func (f *ODSFile) Reader() (io.Reader, error) {
 		return ods.reader()
 	}
 
-	offset := int64(f.hdr.Size())
+	offset := f.sharesOffset()
 	total := int64(f.hdr.shareSize) * int64(f.size()*f.size()/4)
-	reader := io.NewSectionReader(f.fl, offset, total)
+	reader := io.NewSectionReader(f.fl, int64(offset), total)
 	return reader, nil
 }
 
@@ -226,21 +266,30 @@ func (f *ODSFile) readAxisHalf(axisType rsmt2d.Axis, axisIdx int) (eds.AxisHalf,
 		return f.ods.axisHalf(axisType, axisIdx)
 	}
 
+	offset := f.sharesOffset()
 	switch axisType {
 	case rsmt2d.Col:
-		col, err := readCol(f.fl, f.hdr, axisIdx, 0)
+		col, err := readCol(f.fl, f.hdr, offset, 0, axisIdx)
 		return eds.AxisHalf{
 			Shares:   col,
 			IsParity: false,
 		}, err
 	case rsmt2d.Row:
-		row, err := readRow(f.fl, f.hdr, axisIdx, 0)
+		row, err := readRow(f.fl, f.hdr, offset, 0, axisIdx)
 		return eds.AxisHalf{
 			Shares:   row,
 			IsParity: false,
 		}, err
 	}
 	return eds.AxisHalf{}, fmt.Errorf("unknown axis")
+}
+
+func (f *ODSFile) sharesOffset() int {
+	return f.hdr.Size() + f.axisRootsSize()
+}
+
+func (f *ODSFile) axisRootsSize() int {
+	return share.AxisRootsSize * 2 * f.size()
 }
 
 func (f *ODSFile) readODS() (square, error) {
@@ -252,7 +301,8 @@ func (f *ODSFile) readODS() (square, error) {
 	}
 
 	// reset file pointer to the beginning of the file shares data
-	_, err := f.fl.Seek(int64(f.hdr.Size()), io.SeekStart)
+	offset := f.hdr.Size() + f.axisRootsSize()
+	_, err := f.fl.Seek(int64(offset), io.SeekStart)
 	if err != nil {
 		return nil, fmt.Errorf("discarding header: %w", err)
 	}
@@ -270,15 +320,15 @@ func (f *ODSFile) readODS() (square, error) {
 	return square, nil
 }
 
-func readRow(fl io.ReaderAt, hdr *headerV0, rowIdx, quadrantIdx int) ([]share.Share, error) {
+func readRow(fl io.ReaderAt, hdr *headerV0, sharesOffset, quadrantIdx, rowIdx int) ([]share.Share, error) {
 	shrLn := int(hdr.shareSize)
 	odsLn := int(hdr.squareSize / 2)
 	quadrantOffset := quadrantIdx * odsLn * odsLn * shrLn
 
 	shares := make([]share.Share, odsLn)
 
-	pos := rowIdx * odsLn
-	offset := hdr.Size() + quadrantOffset + pos*shrLn
+	rowOffset := rowIdx * odsLn * shrLn
+	offset := sharesOffset + quadrantOffset + rowOffset
 
 	axsData := make([]byte, odsLn*shrLn)
 	if _, err := fl.ReadAt(axsData, int64(offset)); err != nil {
@@ -291,7 +341,7 @@ func readRow(fl io.ReaderAt, hdr *headerV0, rowIdx, quadrantIdx int) ([]share.Sh
 	return shares, nil
 }
 
-func readCol(fl io.ReaderAt, hdr *headerV0, colIdx, quadrantIdx int) ([]share.Share, error) {
+func readCol(fl io.ReaderAt, hdr *headerV0, sharesOffset, quadrantIdx, colIdx int) ([]share.Share, error) {
 	shrLn := int(hdr.shareSize)
 	odsLn := int(hdr.squareSize / 2)
 	quadrantOffset := quadrantIdx * odsLn * odsLn * shrLn
@@ -299,7 +349,7 @@ func readCol(fl io.ReaderAt, hdr *headerV0, colIdx, quadrantIdx int) ([]share.Sh
 	shares := make([]share.Share, odsLn)
 	for i := range shares {
 		pos := colIdx + i*odsLn
-		offset := hdr.Size() + quadrantOffset + pos*shrLn
+		offset := sharesOffset + quadrantOffset + pos*shrLn
 
 		shr := make(share.Share, shrLn)
 		if _, err := fl.ReadAt(shr, int64(offset)); err != nil {

--- a/store/file/q1q4_file.go
+++ b/store/file/q1q4_file.go
@@ -33,8 +33,8 @@ func OpenQ1Q4File(path string) (*Q1Q4File, error) {
 	}, nil
 }
 
-func CreateQ1Q4File(path string, datahash share.DataHash, eds *rsmt2d.ExtendedDataSquare) (*Q1Q4File, error) {
-	ods, err := CreateODSFile(path, datahash, eds)
+func CreateQ1Q4File(path string, roots *share.AxisRoots, eds *rsmt2d.ExtendedDataSquare) (*Q1Q4File, error) {
+	ods, err := CreateODSFile(path, roots, eds)
 	if err != nil {
 		return nil, err
 	}
@@ -55,6 +55,10 @@ func (f *Q1Q4File) Size(ctx context.Context) int {
 
 func (f *Q1Q4File) DataHash(ctx context.Context) (share.DataHash, error) {
 	return f.ods.DataHash(ctx)
+}
+
+func (f *Q1Q4File) AxisRoots(ctx context.Context) (*share.AxisRoots, error) {
+	return f.ods.AxisRoots(ctx)
 }
 
 func (f *Q1Q4File) Sample(ctx context.Context, rowIdx, colIdx int) (shwap.Sample, error) {
@@ -127,9 +131,10 @@ func (f *Q1Q4File) readAxisHalfFromQ4(axisType rsmt2d.Axis, axisIdx int) (eds.Ax
 	if q4idx < 0 {
 		return eds.AxisHalf{}, fmt.Errorf("invalid axis index for Q4: %d", axisIdx)
 	}
+	offset := f.ods.sharesOffset()
 	switch axisType {
 	case rsmt2d.Col:
-		shares, err := readCol(f.ods.fl, f.ods.hdr, q4idx, 1)
+		shares, err := readCol(f.ods.fl, f.ods.hdr, offset, 1, q4idx)
 		if err != nil {
 			return eds.AxisHalf{}, err
 		}
@@ -138,7 +143,7 @@ func (f *Q1Q4File) readAxisHalfFromQ4(axisType rsmt2d.Axis, axisIdx int) (eds.Ax
 			IsParity: true,
 		}, nil
 	case rsmt2d.Row:
-		shares, err := readRow(f.ods.fl, f.ods.hdr, q4idx, 1)
+		shares, err := readRow(f.ods.fl, f.ods.hdr, offset, 1, q4idx)
 		if err != nil {
 			return eds.AxisHalf{}, err
 		}

--- a/store/file/q1q4_file_test.go
+++ b/store/file/q1q4_file_test.go
@@ -21,9 +21,10 @@ func TestCreateQ1Q4File(t *testing.T) {
 	t.Cleanup(cancel)
 
 	edsIn := edstest.RandEDS(t, 8)
-	datahash := share.DataHash(rand.Bytes(32))
-	path := t.TempDir() + "/" + datahash.String()
-	f, err := CreateQ1Q4File(path, datahash, edsIn)
+	roots, err := share.NewAxisRoots(edsIn)
+	require.NoError(t, err)
+	path := t.TempDir() + "/" + roots.String()
+	f, err := CreateQ1Q4File(path, roots, edsIn)
 	require.NoError(t, err)
 
 	shares, err := f.Shares(ctx)
@@ -98,7 +99,9 @@ func BenchmarkSampleFromQ1Q4File(b *testing.B) {
 
 func createQ1Q4File(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.Accessor {
 	path := t.TempDir() + "/" + strconv.Itoa(rand.Intn(1000))
-	fl, err := CreateQ1Q4File(path, []byte{}, eds)
+	roots, err := share.NewAxisRoots(eds)
+	require.NoError(t, err)
+	fl, err := CreateQ1Q4File(path, roots, eds)
 	require.NoError(t, err)
 	return fl
 }

--- a/store/store.go
+++ b/store/store.go
@@ -108,8 +108,7 @@ func (s *Store) Put(
 	defer lock.unlock()
 
 	if datahash.IsEmptyEDS() {
-		path := filepath.Join(s.basepath, blocksPath, roots.String())
-		err := s.ensureHeightLink(path, height)
+		err := s.ensureHeightLink(roots.Hash(), height)
 		return err
 	}
 
@@ -139,7 +138,7 @@ func (s *Store) createFile(
 	roots *share.AxisRoots,
 	height uint64,
 ) (exists bool, err error) {
-	path := filepath.Join(s.basepath, blocksPath, roots.String())
+	path := s.hashToPath(roots.Hash())
 	f, err := file.CreateQ1Q4File(path, roots, square)
 	if errors.Is(err, os.ErrExist) {
 		return true, nil
@@ -155,7 +154,7 @@ func (s *Store) createFile(
 	}
 
 	// create hard link with height as name
-	err = s.ensureHeightLink(path, height)
+	err = s.ensureHeightLink(roots.Hash(), height)
 	if err != nil {
 		// remove the file if we failed to create a hard link
 		removeErr := s.removeFile(roots.Hash())
@@ -164,9 +163,10 @@ func (s *Store) createFile(
 	return false, nil
 }
 
-func (s *Store) ensureHeightLink(path string, height uint64) error {
+func (s *Store) ensureHeightLink(datahash share.DataHash, height uint64) error {
+	path := s.hashToPath(datahash)
 	// create hard link with height as name
-	linkPath := filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
+	linkPath := s.heightToPath(height)
 	err := os.Link(path, linkPath)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		return fmt.Errorf("creating hard link: %w", err)
@@ -189,7 +189,7 @@ func (s *Store) GetByDataRoot(ctx context.Context, datahash share.DataHash) (eds
 }
 
 func (s *Store) getByDataRoot(datahash share.DataHash) (eds.AccessorStreamer, error) {
-	path := filepath.Join(s.basepath, blocksPath, datahash.String())
+	path := s.hashToPath(datahash)
 	return s.openFile(path)
 }
 
@@ -209,7 +209,7 @@ func (s *Store) getByHeight(height uint64) (eds.AccessorStreamer, error) {
 	if err == nil {
 		return f, nil
 	}
-	path := filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
+	path := s.heightToPath(height)
 	return s.openFile(path)
 }
 
@@ -242,7 +242,7 @@ func (s *Store) HasByHash(ctx context.Context, datahash share.DataHash) (bool, e
 }
 
 func (s *Store) hasByHash(datahash share.DataHash) (bool, error) {
-	path := filepath.Join(s.basepath, blocksPath, datahash.String())
+	path := s.hashToPath(datahash)
 	return pathExists(path)
 }
 
@@ -263,7 +263,7 @@ func (s *Store) hasByHeight(height uint64) (bool, error) {
 		return true, nil
 	}
 
-	path := filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
+	path := s.heightToPath(height)
 	return pathExists(path)
 }
 
@@ -297,7 +297,7 @@ func (s *Store) removeLink(height uint64) error {
 	}
 
 	// remove hard link by height
-	heightPath := filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
+	heightPath := s.heightToPath(height)
 	err := os.Remove(heightPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -311,12 +311,20 @@ func (s *Store) removeFile(hash share.DataHash) error {
 		return nil
 	}
 
-	hashPath := filepath.Join(s.basepath, blocksPath, hash.String())
+	hashPath := s.hashToPath(hash)
 	err := os.Remove(hashPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	return nil
+}
+
+func (s *Store) hashToPath(datahash share.DataHash) string {
+	return filepath.Join(s.basepath, blocksPath, datahash.String())
+}
+
+func (s *Store) heightToPath(height uint64) string {
+	return filepath.Join(s.basepath, heightsPath, strconv.Itoa(int(height)))
 }
 
 func accessorLoader(accessor eds.AccessorStreamer) cache.OpenAccessorFn {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2,14 +2,12 @@ package store
 
 import (
 	"context"
-	"crypto/rand"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/share"
@@ -260,7 +258,7 @@ func BenchmarkStore(b *testing.B) {
 	b.Run("put 128", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			roots := randomAxisRoots(b)
+			roots := edstest.RandomAxisRoots(b, 1)
 			_ = edsStore.Put(ctx, roots, uint64(i), eds)
 		}
 	})
@@ -319,12 +317,4 @@ func randomEDS(t testing.TB) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots) {
 	require.NoError(t, err)
 
 	return eds, roots
-}
-
-func randomAxisRoots(t testing.TB) *share.AxisRoots {
-	row := make([]byte, 32)
-	_, err := rand.Read(row)
-	require.NoError(t, err)
-	roots := da.DataAvailabilityHeader{RowRoots: [][]byte{row}}
-	return &roots
 }


### PR DESCRIPTION
Add axis roots to all Accessor implementations. It will allow server side to handle namespace requests without the need to know exact rowIdxes beforehand. 