### PR TITLE
refactor(header): `Validate` should check that the raw header's app version is not greater than latest app version

### DIFF
--- a/blob/commitment_proof.go
+++ b/blob/commitment_proof.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/pkg/shares"
+	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v2/pkg/proof"
+	"github.com/celestiaorg/go-square/inclusion"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"
 
@@ -98,7 +98,7 @@ func (commitmentProof *CommitmentProof) Verify(root []byte, subtreeRootThreshold
 	// the subtree roots width is defined in ADR-013:
 	//
 	//https://github.com/celestiaorg/celestia-app/blob/main/docs/architecture/adr-013-non-interactive-default-rules-for-zero-padding.md
-	subtreeRootsWidth := shares.SubTreeWidth(numberOfShares, subtreeRootThreshold)
+	subtreeRootsWidth := inclusion.SubTreeWidth(numberOfShares, subtreeRootThreshold)
 
 	// verify the proof of the subtree roots
 	subtreeRootsCursor := 0

--- a/blob/helper_test.go
+++ b/blob/helper_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
 	squareblob "github.com/celestiaorg/go-square/blob"
 	"github.com/celestiaorg/go-square/namespace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBlobsToShares(t *testing.T) {

--- a/blob/service.go
+++ b/blob/service.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
 	pkgproof "github.com/celestiaorg/celestia-app/v2/pkg/proof"
 	"github.com/celestiaorg/go-square/inclusion"
 	appns "github.com/celestiaorg/go-square/namespace"

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,5 +57,6 @@ func TestBadAppVersion(t *testing.T) {
 	header.RawHeader.Version.App = appconsts.LatestVersion + 1
 
 	err := header.Validate()
-	assert.Contains(t, err.Error(), "app version must be less than the latest app version")
+	assert.Contains(t, err.Error(), fmt.Sprintf("has version %d, this node supports up to version %d. Please "+
+		"upgrade to support new version", header.RawHeader.Version.App, appconsts.LatestVersion))
 }

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/rand"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/headertest"
 	"github.com/celestiaorg/celestia-node/share"
@@ -47,4 +49,12 @@ func TestMismatchedDataHash_ComputedRoot(t *testing.T) {
 	err := header.Validate()
 	assert.Contains(t, err.Error(), "mismatch between data hash commitment from"+
 		" core header and computed data root")
+}
+
+func TestBadAppVersion(t *testing.T) {
+	header := headertest.RandExtendedHeader(t)
+	header.RawHeader.Version.App = appconsts.LatestVersion + 1
+
+	err := header.Validate()
+	assert.Contains(t, err.Error(), "app version must be less than the latest app version")
 }

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/rand"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/headertest"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
 	github.com/benbjohnson/clock v1.3.5
-	github.com/celestiaorg/celestia-app v1.13.0
 	github.com/celestiaorg/celestia-app/v2 v2.0.0
 	github.com/celestiaorg/go-fraud v0.2.1
 	github.com/celestiaorg/go-header v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,6 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0 h1:h1Y4V3EMQ2mFmNtWt2sIhZIuyASInj1a9ExI8xOsTOw=
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0/go.mod h1:x4DKyfKOSv1ZJM9NwV+Pw01kH2CD7N5zTFclXIVJ6GQ=
-github.com/celestiaorg/celestia-app v1.13.0 h1:7MWEox6lim6WDyiP84Y2/ERfWUJxWPfZlKxzO6OFcig=
-github.com/celestiaorg/celestia-app v1.13.0/go.mod h1:CF9VZwWAlTU0Is/BOsmxqkbkYnnmrgl0YRlSBIzr0m0=
 github.com/celestiaorg/celestia-app/v2 v2.0.0 h1:cGrkLbqbaNqj+g+LhvmQ0iFKFyrD/GdU5z3WQI/bq8E=
 github.com/celestiaorg/celestia-app/v2 v2.0.0/go.mod h1:0wP0W+GLghvsODxLhAYToKsy0RFKeg1HdZftQG90W5A=
 github.com/celestiaorg/celestia-core v1.38.0-tm-v0.34.29 h1:HwbA4OegRvXX0aNchBA7Cmu+oIxnH7xRcOhISuDP0ak=

--- a/header/header.go
+++ b/header/header.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tendermint/tendermint/light"
 	core "github.com/tendermint/tendermint/types"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v2/pkg/da"
 	libhead "github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/rsmt2d"

--- a/header/header.go
+++ b/header/header.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tendermint/tendermint/light"
 	core "github.com/tendermint/tendermint/types"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v2/pkg/da"
 	libhead "github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/rsmt2d"
@@ -113,7 +114,7 @@ func (eh *ExtendedHeader) Validate() error {
 		return fmt.Errorf("ValidateBasic error on RawHeader at height %d: %w", eh.Height(), err)
 	}
 
-	if eh.RawHeader.Version.App > appconsts.LatestVersion || eh.RawHeader.Version.App == 0 {
+	if eh.RawHeader.Version.App == 0 || eh.RawHeader.Version.App > appconsts.LatestVersion {
 		return fmt.Errorf("header received at height %d has version %d, this node supports up "+
 			"to version %d. Please upgrade to support new version. Note, 0 is not a valid version",
 			eh.RawHeader.Height, eh.RawHeader.Version.App, appconsts.LatestVersion)

--- a/header/header.go
+++ b/header/header.go
@@ -114,8 +114,8 @@ func (eh *ExtendedHeader) Validate() error {
 	}
 
 	if eh.RawHeader.Version.App > appconsts.LatestVersion {
-		return fmt.Errorf("app version must be less than the latest app version %d, got %d",
-			appconsts.LatestVersion, eh.RawHeader.Version.App)
+		return fmt.Errorf("header received at height %d has version %d, this node supports up to version %d. Please upgrade to support new version",
+			eh.RawHeader.Height, eh.RawHeader.Version.App, appconsts.LatestVersion)
 	}
 
 	err = eh.Commit.ValidateBasic()

--- a/header/header.go
+++ b/header/header.go
@@ -11,8 +11,6 @@ import (
 	"github.com/tendermint/tendermint/light"
 	core "github.com/tendermint/tendermint/types"
 
-	v1 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v1"
-	v2 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v2"
 	"github.com/celestiaorg/celestia-app/v2/pkg/da"
 	libhead "github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/rsmt2d"
@@ -115,13 +113,9 @@ func (eh *ExtendedHeader) Validate() error {
 		return fmt.Errorf("ValidateBasic error on RawHeader at height %d: %w", eh.Height(), err)
 	}
 
-	if eh.RawHeader.Version.App != v1.Version && eh.RawHeader.Version.App != v2.Version {
-		return fmt.Errorf(
-			"app version mismatch, expected: %d or %d, got %d",
-			v1.Version,
-			v2.Version,
-			eh.RawHeader.Version.App,
-		)
+	if eh.RawHeader.Version.App > appconsts.LatestVersion {
+		return fmt.Errorf("app version must be less than the latest app version %d, got %d",
+			appconsts.LatestVersion, eh.RawHeader.Version.App)
 	}
 
 	err = eh.Commit.ValidateBasic()

--- a/header/header.go
+++ b/header/header.go
@@ -113,9 +113,9 @@ func (eh *ExtendedHeader) Validate() error {
 		return fmt.Errorf("ValidateBasic error on RawHeader at height %d: %w", eh.Height(), err)
 	}
 
-	if eh.RawHeader.Version.App > appconsts.LatestVersion {
+	if eh.RawHeader.Version.App > appconsts.LatestVersion || eh.RawHeader.Version.App == 0 {
 		return fmt.Errorf("header received at height %d has version %d, this node supports up to version %d. "+
-			"Please upgrade to support new version",
+			"Please upgrade to support new version. Note, 0 is not a valid version",
 			eh.RawHeader.Height, eh.RawHeader.Version.App, appconsts.LatestVersion)
 	}
 

--- a/header/header.go
+++ b/header/header.go
@@ -114,8 +114,8 @@ func (eh *ExtendedHeader) Validate() error {
 	}
 
 	if eh.RawHeader.Version.App > appconsts.LatestVersion || eh.RawHeader.Version.App == 0 {
-		return fmt.Errorf("header received at height %d has version %d, this node supports up to version %d. "+
-			"Please upgrade to support new version. Note, 0 is not a valid version",
+		return fmt.Errorf("header received at height %d has version %d, this node supports up "+
+			"to version %d. Please upgrade to support new version. Note, 0 is not a valid version",
 			eh.RawHeader.Height, eh.RawHeader.Version.App, appconsts.LatestVersion)
 	}
 

--- a/header/header.go
+++ b/header/header.go
@@ -114,7 +114,8 @@ func (eh *ExtendedHeader) Validate() error {
 	}
 
 	if eh.RawHeader.Version.App > appconsts.LatestVersion {
-		return fmt.Errorf("header received at height %d has version %d, this node supports up to version %d. Please upgrade to support new version",
+		return fmt.Errorf("header received at height %d has version %d, this node supports up to version %d. "+
+			"Please upgrade to support new version",
 			eh.RawHeader.Height, eh.RawHeader.Version.App, appconsts.LatestVersion)
 	}
 

--- a/header/headertest/validate_test.go
+++ b/header/headertest/validate_test.go
@@ -1,7 +1,6 @@
 package headertest
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -19,26 +18,30 @@ import (
 func TestValidate(t *testing.T) {
 	testCases := []struct {
 		extendedHeader *header.ExtendedHeader
-		wantErr        error
+		wantErr        string
 	}{
 		{
 			extendedHeader: getExtendedHeader(t, 1),
-			wantErr:        nil,
+			wantErr:        "",
 		},
 		{
 			extendedHeader: getExtendedHeader(t, 2),
-			wantErr:        nil,
+			wantErr:        "",
 		},
 		{
 			extendedHeader: getExtendedHeader(t, 3),
-			wantErr:        fmt.Errorf("app version mismatch, expected: 1 or 2, got 3"),
+			wantErr:        "has version 3, this node supports up to version 2. Please upgrade to support new version. Note, 0 is not a valid version",
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got := tc.extendedHeader.Validate()
-			assert.Equal(t, tc.wantErr, got)
+			if tc.wantErr == "" {
+				assert.NoError(t, got)
+				return
+			}
+			assert.ErrorContains(t, got, tc.wantErr)
 		})
 	}
 }

--- a/header/headertest/validate_test.go
+++ b/header/headertest/validate_test.go
@@ -30,7 +30,8 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			extendedHeader: getExtendedHeader(t, 3),
-			wantErr:        "has version 3, this node supports up to version 2. Please upgrade to support new version. Note, 0 is not a valid version",
+			wantErr: "has version 3, this node supports up to version 2. " +
+				"Please upgrade to support new version. Note, 0 is not a valid version",
 		},
 	}
 

--- a/nodebuilder/blobstream/module.go
+++ b/nodebuilder/blobstream/module.go
@@ -1,6 +1,8 @@
 package blobstream
 
-import "go.uber.org/fx"
+import (
+	"go.uber.org/fx"
+)
 
 func ConstructModule() fx.Option {
 	return fx.Module("blobstream",


### PR DESCRIPTION
In preparation for V2, we should change the header validation logic to ensure that we support validation for V2 and below.