### PR TITLE
feat(shwap): Add bufferisation for writing ods/Q1Q4 files

### DIFF
--- a/store/file/q1q4_file.go
+++ b/store/file/q1q4_file.go
@@ -39,7 +39,7 @@ func CreateQ1Q4File(path string, roots *share.AxisRoots, eds *rsmt2d.ExtendedDat
 		return nil, err
 	}
 
-	err = writeQuadrant(ods.fl, eds, 3)
+	err = writeQuadrant(ods.fl, eds, int(ods.hdr.shareSize), 3)
 	if err != nil {
 		return nil, fmt.Errorf("writing Q4: %w", err)
 	}

--- a/store/file/q1q4_file.go
+++ b/store/file/q1q4_file.go
@@ -39,7 +39,7 @@ func CreateQ1Q4File(path string, roots *share.AxisRoots, eds *rsmt2d.ExtendedDat
 		return nil, err
 	}
 
-	err = writeQ4(ods.fl, eds)
+	err = writeQuadrant(ods.fl, eds, 3)
 	if err != nil {
 		return nil, fmt.Errorf("writing Q4: %w", err)
 	}
@@ -111,19 +111,6 @@ func (f *Q1Q4File) Reader() (io.Reader, error) {
 
 func (f *Q1Q4File) Close() error {
 	return f.ods.Close()
-}
-
-func writeQ4(w io.Writer, eds *rsmt2d.ExtendedDataSquare) error {
-	odsLn := int(eds.Width()) / 2
-	for x := odsLn; x < int(eds.Width()); x++ {
-		for y := odsLn; y < int(eds.Width()); y++ {
-			_, err := w.Write(eds.GetCell(uint(x), uint(y)))
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func (f *Q1Q4File) readAxisHalfFromQ4(axisType rsmt2d.Axis, axisIdx int) (eds.AxisHalf, error) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -254,7 +254,7 @@ func BenchmarkStore(b *testing.B) {
 	eds := edstest.RandEDS(b, 128)
 	require.NoError(b, err)
 
-	// BenchmarkStore/bench_put_128-10         	      27	  79025268 ns/op (~79ms)
+	// BenchmarkStore/bench_put_128-10         	      27	  19209780 ns/op (~19ms)
 	b.Run("put 128", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Use buffered write of eds shares and axis roots to the disk. According to benchmark it improves write time for writing single block from 79ms -> 19ms (4x).