### PR TITLE
refactor(pruner): modify pruner checkpoint to init at height 0

### DIFF
--- a/header/header.go
+++ b/header/header.go
@@ -17,6 +17,9 @@ import (
 	"github.com/celestiaorg/rsmt2d"
 )
 
+// ErrHeightZero returned when the provided block height is equal to 0.
+var ErrHeightZero = errors.New("height is equal to 0")
+
 // ConstructFn aliases a function that creates an ExtendedHeader.
 type ConstructFn = func(
 	*core.Header,
@@ -82,7 +85,11 @@ func (eh *ExtendedHeader) ChainID() string {
 	return eh.RawHeader.ChainID
 }
 
+// Height is safe to use when ExtendedHeader is nil -> it will return default value 0
 func (eh *ExtendedHeader) Height() uint64 {
+	if eh == nil {
+		return 0
+	}
 	return uint64(eh.RawHeader.Height)
 }
 

--- a/nodebuilder/header/service.go
+++ b/nodebuilder/header/service.go
@@ -13,9 +13,6 @@ import (
 	modfraud "github.com/celestiaorg/celestia-node/nodebuilder/fraud"
 )
 
-// ErrHeightZero returned when the provided block height is equal to 0.
-var ErrHeightZero = errors.New("height is equal to 0")
-
 // Service represents the header Service that can be started / stopped on a node.
 // Service's main function is to manage its sub-services. Service can contain several
 // sub-services, such as Exchange, ExchangeServer, Syncer, and so forth.
@@ -68,7 +65,7 @@ func (s *Service) GetRangeByHeight(
 
 func (s *Service) GetByHeight(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 	if height == 0 {
-		return nil, ErrHeightZero
+		return nil, header.ErrHeightZero
 	}
 	head, err := s.syncer.Head(ctx)
 	switch {

--- a/pruner/checkpoint.go
+++ b/pruner/checkpoint.go
@@ -79,7 +79,7 @@ func (s *Service) loadCheckpoint(ctx context.Context) error {
 	if err != nil {
 		if errors.Is(err, errCheckpointNotFound) {
 			s.checkpoint = &checkpoint{
-				LastPrunedHeight: 1,
+				LastPrunedHeight: 0,
 				FailedHeaders:    map[uint64]struct{}{},
 			}
 			return storeCheckpoint(ctx, s.ds, s.checkpoint)

--- a/pruner/service.go
+++ b/pruner/service.go
@@ -2,6 +2,7 @@ package pruner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -103,7 +104,7 @@ func (s *Service) run() {
 	defer ticker.Stop()
 
 	lastPrunedHeader, err := s.lastPruned(s.ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, header.ErrHeightZero) {
 		log.Errorw("failed to get last pruned header", "height", s.checkpoint.LastPrunedHeight,
 			"err", err)
 		log.Warn("exiting pruner service!")
@@ -126,6 +127,7 @@ func (s *Service) run() {
 	}
 }
 
+// prune accepts nil lastPrunedHeader as we may not have pruned any header at startup
 func (s *Service) prune(
 	ctx context.Context,
 	lastPrunedHeader *header.ExtendedHeader,

--- a/pruner/service_test.go
+++ b/pruner/service_test.go
@@ -54,8 +54,9 @@ func TestService(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 2)
 
-	lastPruned, err := serv.lastPruned(ctx)
-	require.NoError(t, err)
+	// as last prune height is 0, there is no existing last prune
+	var lastPruned *header.ExtendedHeader
+	// trigger a prune job
 	lastPruned = serv.prune(ctx, lastPruned)
 
 	assert.Greater(t, lastPruned.Height(), uint64(2))
@@ -97,9 +98,9 @@ func TestService_FailedAreRecorded(t *testing.T) {
 	// ensures at least 13 blocks are prune-able
 	time.Sleep(time.Millisecond * 50)
 
+	// as last prune height is 0, there is no existing last prune
+	var lastPruned *header.ExtendedHeader
 	// trigger a prune job
-	lastPruned, err := serv.lastPruned(ctx)
-	require.NoError(t, err)
 	_ = serv.prune(ctx, lastPruned)
 
 	assert.Len(t, serv.checkpoint.FailedHeaders, 3)
@@ -138,7 +139,7 @@ func TestServiceCheckpointing(t *testing.T) {
 	require.NoError(t, err)
 
 	// ensure checkpoint was initialized correctly
-	assert.Equal(t, uint64(1), serv.checkpoint.LastPrunedHeight)
+	assert.Equal(t, uint64(0), serv.checkpoint.LastPrunedHeight)
 	assert.Empty(t, serv.checkpoint.FailedHeaders)
 
 	// update checkpoint
@@ -189,9 +190,9 @@ func TestPrune_LargeNumberOfBlocks(t *testing.T) {
 	// ensures availability window has passed
 	time.Sleep(availabilityWindow.Duration() + time.Millisecond*100)
 
+	// as last prune height is 0, there is no existing last prune
+	var lastPruned *header.ExtendedHeader
 	// trigger a prune job
-	lastPruned, err := serv.lastPruned(ctx)
-	require.NoError(t, err)
 	_ = serv.prune(ctx, lastPruned)
 
 	// ensure all headers have been pruned
@@ -265,8 +266,8 @@ func TestFindPruneableHeaders(t *testing.T) {
 			err = serv.Start(ctx)
 			require.NoError(t, err)
 
-			lastPruned, err := serv.lastPruned(ctx)
-			require.NoError(t, err)
+			// as last prune height is 0, there is no existing last prune
+			var lastPruned *header.ExtendedHeader
 
 			pruneable, err := serv.findPruneableHeaders(ctx, lastPruned)
 			require.NoError(t, err)


### PR DESCRIPTION
Closes #3474 

This changes the init of pruner checkpoint to start from height 0.

I moved one error in a common package as I cannot use direct reference to a injected dependency.

I modified logic to use possible nil lastPruned header as we have no pruned header at height 0. nothing looks broken regarding the tests but a special attention may be useful.
I am wondering if this change is correct at https://github.com/najeal/celestia-node/blob/df230c411f2f3f1f282806b3f3da4d6b12ad070e/pruner/find.go#L23-L27