### PR TITLE
feat(shwap): Add discovery version

### DIFF
--- a/nodebuilder/p2p/config.go
+++ b/nodebuilder/p2p/config.go
@@ -2,15 +2,12 @@ package p2p
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
-
-const defaultRoutingRefreshPeriod = time.Minute
 
 // Config combines all configuration fields for P2P subsystem.
 type Config struct {
@@ -29,8 +26,7 @@ type Config struct {
 	// This is enabled by default for Bootstrappers.
 	PeerExchange bool
 	// ConnManager is a configuration tuple for ConnectionManager.
-	ConnManager               connManagerConfig
-	RoutingTableRefreshPeriod time.Duration
+	ConnManager connManagerConfig
 
 	// Allowlist for IPColocation PubSub parameter, a list of string CIDRs
 	IPColocationWhitelist []string
@@ -64,10 +60,9 @@ func DefaultConfig(tp node.Type) Config {
 			"/ip4/127.0.0.1/tcp/2121",
 			"/ip6/::/tcp/2121",
 		},
-		MutualPeers:               []string{},
-		PeerExchange:              tp == node.Bridge || tp == node.Full,
-		ConnManager:               defaultConnManagerConfig(tp),
-		RoutingTableRefreshPeriod: defaultRoutingRefreshPeriod,
+		MutualPeers:  []string{},
+		PeerExchange: tp == node.Bridge || tp == node.Full,
+		ConnManager:  defaultConnManagerConfig(tp),
 	}
 }
 
@@ -81,15 +76,6 @@ func (cfg *Config) mutualPeers() (_ []peer.AddrInfo, err error) {
 	}
 
 	return peer.AddrInfosFromP2pAddrs(maddrs...)
-}
-
-// Validate performs basic validation of the config.
-func (cfg *Config) Validate() error {
-	if cfg.RoutingTableRefreshPeriod <= 0 {
-		cfg.RoutingTableRefreshPeriod = defaultRoutingRefreshPeriod
-		log.Warnf("routingTableRefreshPeriod is not valid. restoring to default value: %d", cfg.RoutingTableRefreshPeriod)
-	}
-	return nil
 }
 
 // Upgrade updates the `ListenAddresses` and `NoAnnounceAddresses` to

--- a/nodebuilder/p2p/module.go
+++ b/nodebuilder/p2p/module.go
@@ -14,9 +14,7 @@ var log = logging.Logger("module/p2p")
 // ConstructModule collects all the components and services related to p2p.
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	// sanitize config values before constructing module
-	cfgErr := cfg.Validate()
 	baseComponents := fx.Options(
-		fx.Error(cfgErr),
 		fx.Supply(cfg),
 		fx.Provide(Key),
 		fx.Provide(id),
@@ -28,7 +26,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 		fx.Provide(pubSub),
 		fx.Provide(ipld.NewBlockservice),
 		fx.Provide(peerRouting),
-		fx.Provide(contentRouting),
+		fx.Provide(newDHT),
 		fx.Provide(addrsFactory(cfg.AnnounceAddresses, cfg.NoAnnounceAddresses)),
 		fx.Provide(metrics.NewBandwidthCounter),
 		fx.Provide(newModule),

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -32,6 +32,12 @@ func newDHT(
 		return nil, fmt.Errorf("unsupported node type: %s", tp)
 	}
 
+	// no bootstrappers for a bootstrapper ¯\_(ツ)_/¯
+	// otherwise dht.Bootstrap(OnStart hook) will deadlock
+	if isBootstrapper() {
+		bootsrappers = nil
+	}
+
 	dht, err := discovery.NewDHT(ctx, network.String(), bootsrappers, host, dataStore, mode)
 	if err != nil {
 		return nil, err

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -6,70 +6,46 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
-	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	"github.com/celestiaorg/celestia-node/share/shwap/p2p/discovery"
 )
 
-// contentRouting constructs nil content routing,
-// as for our use-case existing ContentRouting mechanisms, e.g DHT, are unsuitable
-func contentRouting(r routing.PeerRouting) routing.ContentRouting {
-	return r.(*dht.IpfsDHT)
-}
-
-// peerRouting provides constructor for PeerRouting over DHT.
-// Basically, this provides a way to discover peer addresses by respecting public keys.
-func peerRouting(cfg *Config, tp node.Type, params routingParams) (routing.PeerRouting, error) {
-	opts := []dht.Option{
-		dht.BootstrapPeers(params.Peers...),
-		dht.ProtocolPrefix(protocol.ID(fmt.Sprintf("/celestia/%s", params.Net))),
-		dht.Datastore(params.DataStore),
-		dht.RoutingTableRefreshPeriod(cfg.RoutingTableRefreshPeriod),
-	}
-
-	if isBootstrapper() {
-		opts = append(opts,
-			dht.BootstrapPeers(), // no bootstrappers for a bootstrapper ¯\_(ツ)_/¯
-		)
-	}
-
+func newDHT(
+	ctx context.Context,
+	lc fx.Lifecycle,
+	tp node.Type,
+	network Network,
+	bootsrappers Bootstrappers,
+	host HostBase,
+	dataStore datastore.Batching,
+) (*dht.IpfsDHT, error) {
+	var mode dht.ModeOpt
 	switch tp {
 	case node.Light:
-		opts = append(opts,
-			dht.Mode(dht.ModeClient),
-		)
+		mode = dht.ModeClient
 	case node.Bridge, node.Full:
-		opts = append(opts,
-			dht.Mode(dht.ModeServer),
-		)
+		mode = dht.ModeServer
 	default:
 		return nil, fmt.Errorf("unsupported node type: %s", tp)
 	}
 
-	d, err := dht.New(params.Ctx, params.Host, opts...)
+	dht, err := discovery.NewDHT(ctx, network.String(), bootsrappers, host, dataStore, mode)
 	if err != nil {
 		return nil, err
 	}
-	params.Lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
-			return d.Bootstrap(ctx)
-		},
-		OnStop: func(context.Context) error {
-			return d.Close()
-		},
+	stopFn := func(context.Context) error {
+		return dht.Close()
+	}
+	lc.Append(fx.Hook{
+		OnStart: dht.Bootstrap,
+		OnStop:  stopFn,
 	})
-	return d, nil
+	return dht, nil
 }
 
-type routingParams struct {
-	fx.In
-
-	Ctx       context.Context
-	Net       Network
-	Peers     Bootstrappers
-	Lc        fx.Lifecycle
-	Host      HostBase
-	DataStore datastore.Batching
+func peerRouting(dht *dht.IpfsDHT) routing.PeerRouting {
+	return dht
 }

--- a/nodebuilder/share/p2p_constructors.go
+++ b/nodebuilder/share/p2p_constructors.go
@@ -25,6 +25,10 @@ const (
 	// archivalNodesTag is the tag used to identify archival nodes in the
 	// discovery service.
 	archivalNodesTag = "archival"
+
+	// discovery version is a prefix for all tags used in discovery. It is bumped when
+	// there are protocol breaking changes.
+	version = "v1"
 )
 
 // TODO @renaynay: rename
@@ -81,6 +85,7 @@ func fullDiscoveryAndPeerManager(tp node.Type, cfg *Config) fx.Option {
 				cfg.Discovery,
 				host,
 				disc,
+				version,
 				fullNodesTag,
 				discOpts...,
 			)
@@ -128,6 +133,7 @@ func archivalDiscoveryAndPeerManager(tp node.Type, cfg *Config) fx.Option {
 				cfg.Discovery,
 				h,
 				disc,
+				version,
 				archivalNodesTag,
 				discOpts...,
 			)

--- a/nodebuilder/share/p2p_constructors.go
+++ b/nodebuilder/share/p2p_constructors.go
@@ -1,8 +1,9 @@
 package share
 
 import (
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	p2pdisc "github.com/libp2p/go-libp2p/core/discovery"
 	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/routing"
 	routingdisc "github.com/libp2p/go-libp2p/p2p/discovery/routing"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"go.uber.org/fx"
@@ -29,6 +30,7 @@ const (
 // TODO @renaynay: rename
 func peerComponents(tp node.Type, cfg *Config) fx.Option {
 	return fx.Options(
+		fx.Provide(routingDiscovery),
 		fullDiscoveryAndPeerManager(tp, cfg),
 		archivalDiscoveryAndPeerManager(tp, cfg),
 	)
@@ -42,8 +44,8 @@ func fullDiscoveryAndPeerManager(tp node.Type, cfg *Config) fx.Option {
 		func(
 			lc fx.Lifecycle,
 			host host.Host,
-			r routing.ContentRouting,
 			connGater *conngater.BasicConnectionGater,
+			disc p2pdisc.Discovery,
 			shrexSub *shrexsub.PubSub,
 			headerSub libhead.Subscriber[*header.ExtendedHeader],
 			// we must ensure Syncer is started before PeerManager
@@ -78,7 +80,7 @@ func fullDiscoveryAndPeerManager(tp node.Type, cfg *Config) fx.Option {
 			fullDisc, err := discovery.NewDiscovery(
 				cfg.Discovery,
 				host,
-				routingdisc.NewRoutingDiscovery(r),
+				disc,
 				fullNodesTag,
 				discOpts...,
 			)
@@ -100,10 +102,10 @@ func archivalDiscoveryAndPeerManager(tp node.Type, cfg *Config) fx.Option {
 		func(
 			lc fx.Lifecycle,
 			pruneCfg *modprune.Config,
-			d *discovery.Discovery,
-			manager *peers.Manager,
+			fullDisc *discovery.Discovery,
+			fullManager *peers.Manager,
 			h host.Host,
-			r routing.ContentRouting,
+			disc p2pdisc.Discovery,
 			gater *conngater.BasicConnectionGater,
 		) (map[string]*peers.Manager, []*discovery.Discovery, error) {
 			archivalPeerManager, err := peers.NewManager(
@@ -125,7 +127,7 @@ func archivalDiscoveryAndPeerManager(tp node.Type, cfg *Config) fx.Option {
 			archivalDisc, err := discovery.NewDiscovery(
 				cfg.Discovery,
 				h,
-				routingdisc.NewRoutingDiscovery(r),
+				disc,
 				archivalNodesTag,
 				discOpts...,
 			)
@@ -137,7 +139,11 @@ func archivalDiscoveryAndPeerManager(tp node.Type, cfg *Config) fx.Option {
 				OnStop:  archivalDisc.Stop,
 			})
 
-			managers := map[string]*peers.Manager{fullNodesTag: manager, archivalNodesTag: archivalPeerManager}
-			return managers, []*discovery.Discovery{d, archivalDisc}, nil
+			managers := map[string]*peers.Manager{fullNodesTag: fullManager, archivalNodesTag: archivalPeerManager}
+			return managers, []*discovery.Discovery{fullDisc, archivalDisc}, nil
 		})
+}
+
+func routingDiscovery(dht *dht.IpfsDHT) p2pdisc.Discovery {
+	return routingdisc.NewRoutingDiscovery(dht)
 }

--- a/nodebuilder/tests/helpers_test.go
+++ b/nodebuilder/tests/helpers_test.go
@@ -30,6 +30,5 @@ func getAdminClient(ctx context.Context, nd *nodebuilder.Node, t *testing.T) *cl
 }
 
 func setTimeInterval(cfg *nodebuilder.Config, interval time.Duration) {
-	cfg.P2P.RoutingTableRefreshPeriod = interval
 	cfg.Share.Discovery.AdvertiseInterval = interval
 }

--- a/share/shwap/p2p/discovery/dht.go
+++ b/share/shwap/p2p/discovery/dht.go
@@ -14,10 +14,6 @@ import (
 
 const (
 	defaultRoutingRefreshPeriod = time.Minute
-
-	// discovery version is a prefix for all tags used in discovery. It is bumped when
-	// there are protocol breaking changes.
-	version = "v1"
 )
 
 // PeerRouting provides constructor for PeerRouting over DHT.
@@ -32,7 +28,7 @@ func NewDHT(
 ) (*dht.IpfsDHT, error) {
 	opts := []dht.Option{
 		dht.BootstrapPeers(bootsrappers...),
-		dht.ProtocolPrefix(protocol.ID(fmt.Sprintf("/celestia/%s/%s", prefix, version))),
+		dht.ProtocolPrefix(protocol.ID(fmt.Sprintf("/celestia/%s", prefix))),
 		dht.Datastore(dataStore),
 		dht.RoutingTableRefreshPeriod(defaultRoutingRefreshPeriod),
 		dht.Mode(mode),

--- a/share/shwap/p2p/discovery/dht.go
+++ b/share/shwap/p2p/discovery/dht.go
@@ -1,0 +1,42 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ipfs/go-datastore"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+const (
+	defaultRoutingRefreshPeriod = time.Minute
+
+	// discovery version is a prefix for all tags used in discovery. It is bumped when
+	// there are protocol breaking changes.
+	version = "v1"
+)
+
+// PeerRouting provides constructor for PeerRouting over DHT.
+// Basically, this provides a way to discover peer addresses by respecting public keys.
+func NewDHT(
+	ctx context.Context,
+	prefix string,
+	bootsrappers []peer.AddrInfo,
+	host host.Host,
+	dataStore datastore.Batching,
+	mode dht.ModeOpt,
+) (*dht.IpfsDHT, error) {
+	opts := []dht.Option{
+		dht.BootstrapPeers(bootsrappers...),
+		dht.ProtocolPrefix(protocol.ID(fmt.Sprintf("/celestia/%s/%s", prefix, version))),
+		dht.Datastore(dataStore),
+		dht.RoutingTableRefreshPeriod(defaultRoutingRefreshPeriod),
+		dht.Mode(mode),
+	}
+
+	return dht.New(ctx, host, opts...)
+}

--- a/share/shwap/p2p/discovery/discovery.go
+++ b/share/shwap/p2p/discovery/discovery.go
@@ -34,10 +34,6 @@ const (
 	// logInterval defines the time interval at which a warning message will be logged
 	// if the desired number of nodes is not detected.
 	logInterval = 5 * time.Minute
-
-	// discovery version is a prefix for all tags used in discovery. It is bumped when
-	// there are protocol breaking changes.
-	version = "v1"
 )
 
 // discoveryRetryTimeout defines time interval between discovery attempts, needed for tests
@@ -85,6 +81,7 @@ func NewDiscovery(
 	params *Parameters,
 	h host.Host,
 	d discovery.Discovery,
+	prefix string,
 	tag string,
 	opts ...Option,
 ) (*Discovery, error) {
@@ -98,7 +95,7 @@ func NewDiscovery(
 	o := newOptions(opts...)
 	return &Discovery{
 		tag:            tag,
-		topic:          fmt.Sprintf("/%s/%s", version, tag),
+		topic:          fmt.Sprintf("/%s/%s", prefix, tag),
 		set:            newLimitedSet(params.PeersLimit),
 		host:           h,
 		disc:           d,

--- a/share/shwap/p2p/discovery/discovery.go
+++ b/share/shwap/p2p/discovery/discovery.go
@@ -34,10 +34,6 @@ const (
 	// logInterval defines the time interval at which a warning message will be logged
 	// if the desired number of nodes is not detected.
 	logInterval = 5 * time.Minute
-
-	// discovery version is a prefix for all tags used in discovery. It is bumped when
-	// there are protocol breaking changes.
-	version = "v1"
 )
 
 // discoveryRetryTimeout defines time interval between discovery attempts, needed for tests
@@ -46,11 +42,8 @@ var discoveryRetryTimeout = retryTimeout
 // Discovery combines advertise and discover services and allows to store discovered nodes.
 // TODO: The code here gets horribly hairy, so we should refactor this at some point
 type Discovery struct {
-	// tag is used to specify topic for discovery
-	tag string
-	// topic contains tag and current version of discovery protocol and is used as
-	// rendezvous point for discovery service
-	topic     string
+	// Tag is used as rendezvous point for discovery service
+	tag       string
 	set       *limitedSet
 	host      host.Host
 	disc      discovery.Discovery
@@ -98,7 +91,6 @@ func NewDiscovery(
 	o := newOptions(opts...)
 	return &Discovery{
 		tag:            tag,
-		topic:          fmt.Sprintf("%s/%s", version, tag),
 		set:            newLimitedSet(params.PeersLimit),
 		host:           h,
 		disc:           d,
@@ -124,11 +116,11 @@ func (d *Discovery) Start(context.Context) error {
 	go d.connector.GC(ctx)
 
 	if d.advertise {
-		log.Infow("advertising to topic", "topic", d.topic)
+		log.Infow("advertising to topic", "topic", d.tag)
 		go d.Advertise(ctx)
 	}
 
-	log.Infow("started discovery", "topic", d.topic)
+	log.Infow("started discovery", "topic", d.tag)
 	return nil
 }
 
@@ -155,7 +147,7 @@ func (d *Discovery) Discard(id peer.ID) bool {
 		return false
 	}
 
-	d.host.ConnManager().Unprotect(id, d.topic)
+	d.host.ConnManager().Unprotect(id, d.tag)
 	d.connector.Backoff(id)
 	d.set.Remove(id)
 	d.onUpdatedPeers(id, false)
@@ -178,14 +170,14 @@ func (d *Discovery) Advertise(ctx context.Context) {
 	timer := time.NewTimer(d.params.AdvertiseInterval)
 	defer timer.Stop()
 	for {
-		log.Infof("advertising to topic %s", d.topic)
-		_, err := d.disc.Advertise(ctx, d.topic)
+		log.Infof("advertising to topic %s", d.tag)
+		_, err := d.disc.Advertise(ctx, d.tag)
 		d.metrics.observeAdvertise(ctx, err)
 		if err != nil {
 			if ctx.Err() != nil {
 				return
 			}
-			log.Warnw("error advertising", "rendezvous", d.topic, "err", err)
+			log.Warnw("error advertising", "rendezvous", d.tag, "err", err)
 
 			// we don't want retry indefinitely in busy loop
 			// internal discovery mechanism may need some time before attempts
@@ -203,7 +195,7 @@ func (d *Discovery) Advertise(ctx context.Context) {
 			}
 		}
 
-		log.Infof("successfully advertised to topic %s", d.topic)
+		log.Infof("successfully advertised to topic %s", d.tag)
 		if !timer.Stop() {
 			<-timer.C
 		}
@@ -240,7 +232,7 @@ func (d *Discovery) discoveryLoop(ctx context.Context) {
 				log.Warnf(
 					"Potentially degraded connectivity, unable to discover the desired amount of %s peers in %v. "+
 						"Number of peers discovered: %d. Required: %d.",
-					d.topic, logInterval, d.set.Size(), d.set.Limit(),
+					d.tag, logInterval, d.set.Size(), d.set.Limit(),
 				)
 			}
 			// Do not break the loop; just continue
@@ -278,13 +270,13 @@ func (d *Discovery) discover(ctx context.Context) bool {
 	size := d.set.Size()
 	want := d.set.Limit() - size
 	if want == 0 {
-		log.Debugw("reached soft peer limit, skipping discovery", "topic", d.topic, "size", size)
+		log.Debugw("reached soft peer limit, skipping discovery", "topic", d.tag, "size", size)
 		return true
 	}
 	// TODO @renaynay: eventually, have a mechanism to catch if wanted amount of peers
 	//  has not been discovered in X amount of time so that users are warned of degraded
 	//  FN connectivity.
-	log.Debugw("discovering peers", "topic", d.topic, "want", want)
+	log.Debugw("discovering peers", "topic", d.tag, "want", want)
 
 	// we use errgroup as it provide limits
 	var wg errgroup.Group
@@ -298,9 +290,9 @@ func (d *Discovery) discover(ctx context.Context) bool {
 		findCancel()
 	}()
 
-	peers, err := d.disc.FindPeers(findCtx, d.topic)
+	peers, err := d.disc.FindPeers(findCtx, d.tag)
 	if err != nil {
-		log.Error("unable to start discovery", "topic", d.topic, "err", err)
+		log.Error("unable to start discovery", "topic", d.tag, "err", err)
 		return false
 	}
 
@@ -325,12 +317,12 @@ func (d *Discovery) discover(ctx context.Context) bool {
 				}
 
 				size := d.set.Size()
-				log.Debugw("found peer", "topic", d.topic, "peer", peer.ID.String(), "found_amount", size)
+				log.Debugw("found peer", "topic", d.tag, "peer", peer.ID.String(), "found_amount", size)
 				if size < d.set.Limit() {
 					return nil
 				}
 
-				log.Infow("discovered wanted peers", "topic", d.topic, "amount", size)
+				log.Infow("discovered wanted peers", "topic", d.tag, "amount", size)
 				findCancel() // stop discovery when we are done
 				return nil
 			})
@@ -341,7 +333,7 @@ func (d *Discovery) discover(ctx context.Context) bool {
 
 		isEnoughPeers := d.set.Size() >= d.set.Limit()
 		d.metrics.observeFindPeers(ctx, isEnoughPeers)
-		log.Debugw("discovery finished", "topic", d.topic, "discovered_wanted", isEnoughPeers)
+		log.Debugw("discovery finished", "topic", d.tag, "discovered_wanted", isEnoughPeers)
 		return isEnoughPeers
 	}
 }
@@ -393,7 +385,7 @@ func (d *Discovery) handleDiscoveredPeer(ctx context.Context, peer peer.AddrInfo
 	// NOTE: This is does not protect from remote killing the connection.
 	//  In the future, we should design a protocol that keeps bidirectional agreement on whether
 	//  connection should be kept or not, similar to mesh link in GossipSub.
-	d.host.ConnManager().Protect(peer.ID, d.topic)
+	d.host.ConnManager().Protect(peer.ID, d.tag)
 	return true
 }
 

--- a/share/shwap/p2p/discovery/discovery.go
+++ b/share/shwap/p2p/discovery/discovery.go
@@ -34,6 +34,10 @@ const (
 	// logInterval defines the time interval at which a warning message will be logged
 	// if the desired number of nodes is not detected.
 	logInterval = 5 * time.Minute
+
+	// discovery version is a prefix for all tags used in discovery. It is bumped when
+	// there are protocol breaking changes.
+	version = "v1"
 )
 
 // discoveryRetryTimeout defines time interval between discovery attempts, needed for tests
@@ -42,8 +46,11 @@ var discoveryRetryTimeout = retryTimeout
 // Discovery combines advertise and discover services and allows to store discovered nodes.
 // TODO: The code here gets horribly hairy, so we should refactor this at some point
 type Discovery struct {
-	// Tag is used as rendezvous point for discovery service
-	tag       string
+	// tag is used to specify topic for discovery
+	tag string
+	// topic contains tag and current version of discovery protocol and is used as
+	// rendezvous point for discovery service
+	topic     string
 	set       *limitedSet
 	host      host.Host
 	disc      discovery.Discovery
@@ -91,6 +98,7 @@ func NewDiscovery(
 	o := newOptions(opts...)
 	return &Discovery{
 		tag:            tag,
+		topic:          fmt.Sprintf("/%s/%s", version, tag),
 		set:            newLimitedSet(params.PeersLimit),
 		host:           h,
 		disc:           d,
@@ -116,11 +124,11 @@ func (d *Discovery) Start(context.Context) error {
 	go d.connector.GC(ctx)
 
 	if d.advertise {
-		log.Infow("advertising to topic", "topic", d.tag)
+		log.Infow("advertising to topic", "topic", d.topic)
 		go d.Advertise(ctx)
 	}
 
-	log.Infow("started discovery", "topic", d.tag)
+	log.Infow("started discovery", "topic", d.topic)
 	return nil
 }
 
@@ -147,7 +155,7 @@ func (d *Discovery) Discard(id peer.ID) bool {
 		return false
 	}
 
-	d.host.ConnManager().Unprotect(id, d.tag)
+	d.host.ConnManager().Unprotect(id, d.topic)
 	d.connector.Backoff(id)
 	d.set.Remove(id)
 	d.onUpdatedPeers(id, false)
@@ -170,14 +178,14 @@ func (d *Discovery) Advertise(ctx context.Context) {
 	timer := time.NewTimer(d.params.AdvertiseInterval)
 	defer timer.Stop()
 	for {
-		log.Infof("advertising to topic %s", d.tag)
-		_, err := d.disc.Advertise(ctx, d.tag)
+		log.Infof("advertising to topic %s", d.topic)
+		_, err := d.disc.Advertise(ctx, d.topic)
 		d.metrics.observeAdvertise(ctx, err)
 		if err != nil {
 			if ctx.Err() != nil {
 				return
 			}
-			log.Warnw("error advertising", "rendezvous", d.tag, "err", err)
+			log.Warnw("error advertising", "rendezvous", d.topic, "err", err)
 
 			// we don't want retry indefinitely in busy loop
 			// internal discovery mechanism may need some time before attempts
@@ -195,7 +203,7 @@ func (d *Discovery) Advertise(ctx context.Context) {
 			}
 		}
 
-		log.Infof("successfully advertised to topic %s", d.tag)
+		log.Infof("successfully advertised to topic %s", d.topic)
 		if !timer.Stop() {
 			<-timer.C
 		}
@@ -232,7 +240,7 @@ func (d *Discovery) discoveryLoop(ctx context.Context) {
 				log.Warnf(
 					"Potentially degraded connectivity, unable to discover the desired amount of %s peers in %v. "+
 						"Number of peers discovered: %d. Required: %d.",
-					d.tag, logInterval, d.set.Size(), d.set.Limit(),
+					d.topic, logInterval, d.set.Size(), d.set.Limit(),
 				)
 			}
 			// Do not break the loop; just continue
@@ -270,13 +278,13 @@ func (d *Discovery) discover(ctx context.Context) bool {
 	size := d.set.Size()
 	want := d.set.Limit() - size
 	if want == 0 {
-		log.Debugw("reached soft peer limit, skipping discovery", "topic", d.tag, "size", size)
+		log.Debugw("reached soft peer limit, skipping discovery", "topic", d.topic, "size", size)
 		return true
 	}
 	// TODO @renaynay: eventually, have a mechanism to catch if wanted amount of peers
 	//  has not been discovered in X amount of time so that users are warned of degraded
 	//  FN connectivity.
-	log.Debugw("discovering peers", "topic", d.tag, "want", want)
+	log.Debugw("discovering peers", "topic", d.topic, "want", want)
 
 	// we use errgroup as it provide limits
 	var wg errgroup.Group
@@ -290,9 +298,9 @@ func (d *Discovery) discover(ctx context.Context) bool {
 		findCancel()
 	}()
 
-	peers, err := d.disc.FindPeers(findCtx, d.tag)
+	peers, err := d.disc.FindPeers(findCtx, d.topic)
 	if err != nil {
-		log.Error("unable to start discovery", "topic", d.tag, "err", err)
+		log.Error("unable to start discovery", "topic", d.topic, "err", err)
 		return false
 	}
 
@@ -317,12 +325,12 @@ func (d *Discovery) discover(ctx context.Context) bool {
 				}
 
 				size := d.set.Size()
-				log.Debugw("found peer", "topic", d.tag, "peer", peer.ID.String(), "found_amount", size)
+				log.Debugw("found peer", "topic", d.topic, "peer", peer.ID.String(), "found_amount", size)
 				if size < d.set.Limit() {
 					return nil
 				}
 
-				log.Infow("discovered wanted peers", "topic", d.tag, "amount", size)
+				log.Infow("discovered wanted peers", "topic", d.topic, "amount", size)
 				findCancel() // stop discovery when we are done
 				return nil
 			})
@@ -333,7 +341,7 @@ func (d *Discovery) discover(ctx context.Context) bool {
 
 		isEnoughPeers := d.set.Size() >= d.set.Limit()
 		d.metrics.observeFindPeers(ctx, isEnoughPeers)
-		log.Debugw("discovery finished", "topic", d.tag, "discovered_wanted", isEnoughPeers)
+		log.Debugw("discovery finished", "topic", d.topic, "discovered_wanted", isEnoughPeers)
 		return isEnoughPeers
 	}
 }
@@ -385,7 +393,7 @@ func (d *Discovery) handleDiscoveredPeer(ctx context.Context, peer peer.AddrInfo
 	// NOTE: This is does not protect from remote killing the connection.
 	//  In the future, we should design a protocol that keeps bidirectional agreement on whether
 	//  connection should be kept or not, similar to mesh link in GossipSub.
-	d.host.ConnManager().Protect(peer.ID, d.tag)
+	d.host.ConnManager().Protect(peer.ID, d.topic)
 	return true
 }
 

--- a/share/shwap/p2p/discovery/discovery_test.go
+++ b/share/shwap/p2p/discovery/discovery_test.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	fullNodesTag = "full"
+	version      = "v1"
 )
 
 func TestDiscovery(t *testing.T) {
@@ -56,7 +57,7 @@ func TestDiscovery(t *testing.T) {
 	discs := make([]*Discovery, nodes)
 	for i := range discs {
 		host, routingDisc := tn.peer()
-		disc, err := NewDiscovery(params, host, routingDisc, fullNodesTag)
+		disc, err := NewDiscovery(params, host, routingDisc, version, fullNodesTag)
 		require.NoError(t, err)
 		go disc.Advertise(tn.ctx)
 		discs[i] = tn.startNewDiscovery(params, host, routingDisc, fullNodesTag)
@@ -166,7 +167,7 @@ func (t *testnet) startNewDiscovery(
 	tag string,
 	opts ...Option,
 ) *Discovery {
-	disc, err := NewDiscovery(params, hst, routingDisc, tag, opts...)
+	disc, err := NewDiscovery(params, hst, routingDisc, version, tag, opts...)
 	require.NoError(t.T, err)
 	err = disc.Start(t.ctx)
 	require.NoError(t.T, err)

--- a/share/shwap/p2p/shrex/peers/manager_test.go
+++ b/share/shwap/p2p/shrex/peers/manager_test.go
@@ -364,6 +364,7 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("get peer from discovery", func(t *testing.T) {
 		fullNodesTag := "fullNodes"
+		version := "v1"
 		nw, err := mocknet.FullMeshConnected(3)
 		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
@@ -399,6 +400,7 @@ func TestIntegration(t *testing.T) {
 			params,
 			bnHost,
 			routingdisc.NewRoutingDiscovery(bnRouter),
+			version,
 			fullNodesTag,
 		)
 		require.NoError(t, err)
@@ -435,6 +437,7 @@ func TestIntegration(t *testing.T) {
 			params,
 			fnHost,
 			routingdisc.NewRoutingDiscovery(fnRouter),
+			version,
 			fullNodesTag,
 			discovery.WithOnPeersUpdate(fnPeerManager.UpdateNodePool),
 			discovery.WithOnPeersUpdate(checkDiscoveredPeer),


### PR DESCRIPTION
Add versioning for discovery, so we can separate shwap network from older one. Metrics will still use tag instead of topic, so we can support multiple visions with same dashboard