### PR TITLE
feat(shwap/ods_file): tail padding trim

### DIFF
--- a/share/eds/edstest/testing.go
+++ b/share/eds/edstest/testing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	appshares "github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -14,22 +15,44 @@ import (
 	"github.com/celestiaorg/celestia-node/share/sharetest"
 )
 
-func RandByzantineEDS(t testing.TB, size int, options ...nmt.Option) *rsmt2d.ExtendedDataSquare {
-	eds := RandEDS(t, size)
+func RandByzantineEDS(t testing.TB, odsSize int, options ...nmt.Option) *rsmt2d.ExtendedDataSquare {
+	eds := RandEDS(t, odsSize)
 	shares := eds.Flattened()
 	copy(share.GetData(shares[0]), share.GetData(shares[1])) // corrupting eds
-	eds, err := rsmt2d.ImportExtendedDataSquare(shares,
+	eds, err := rsmt2d.ImportExtendedDataSquare(
+		shares,
 		share.DefaultRSMT2DCodec(),
-		wrapper.NewConstructor(uint64(size),
-			options...))
+		wrapper.NewConstructor(uint64(odsSize), options...),
+	)
 	require.NoError(t, err, "failure to recompute the extended data square")
 	return eds
 }
 
 // RandEDS generates EDS filled with the random data with the given size for original square.
-func RandEDS(t testing.TB, size int) *rsmt2d.ExtendedDataSquare {
-	shares := sharetest.RandShares(t, size*size)
-	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), wrapper.NewConstructor(uint64(size)))
+func RandEDS(t testing.TB, odsSize int) *rsmt2d.ExtendedDataSquare {
+	shares := sharetest.RandShares(t, odsSize*odsSize)
+	eds, err := rsmt2d.ComputeExtendedDataSquare(
+		shares,
+		share.DefaultRSMT2DCodec(),
+		wrapper.NewConstructor(uint64(odsSize)),
+	)
+	require.NoError(t, err, "failure to recompute the extended data square")
+	return eds
+}
+
+// RandEDSWithTailPadding generates EDS of given ODS size filled with randomized and tail padding shares.
+func RandEDSWithTailPadding(t testing.TB, odsSize, padding int) *rsmt2d.ExtendedDataSquare {
+	shares := sharetest.RandShares(t, odsSize*odsSize)
+	for i := len(shares) - padding; i < len(shares); i++ {
+		paddingShare := appshares.TailPaddingShare()
+		shares[i] = paddingShare.ToBytes()
+	}
+
+	eds, err := rsmt2d.ComputeExtendedDataSquare(
+		shares,
+		share.DefaultRSMT2DCodec(),
+		wrapper.NewConstructor(uint64(odsSize)),
+	)
 	require.NoError(t, err, "failure to recompute the extended data square")
 	return eds
 }
@@ -39,10 +62,14 @@ func RandEDS(t testing.TB, size int) *rsmt2d.ExtendedDataSquare {
 func RandEDSWithNamespace(
 	t testing.TB,
 	namespace share.Namespace,
-	namespacedAmount, size int,
+	namespacedAmount, odsSize int,
 ) (*rsmt2d.ExtendedDataSquare, *share.AxisRoots) {
-	shares := sharetest.RandSharesWithNamespace(t, namespace, namespacedAmount, size*size)
-	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), wrapper.NewConstructor(uint64(size)))
+	shares := sharetest.RandSharesWithNamespace(t, namespace, namespacedAmount, odsSize*odsSize)
+	eds, err := rsmt2d.ComputeExtendedDataSquare(
+		shares,
+		share.DefaultRSMT2DCodec(),
+		wrapper.NewConstructor(uint64(odsSize)),
+	)
 	require.NoError(t, err, "failure to recompute the extended data square")
 	roots, err := share.NewAxisRoots(eds)
 	require.NoError(t, err)

--- a/share/new_eds/proofs_cache.go
+++ b/share/new_eds/proofs_cache.go
@@ -256,7 +256,7 @@ func (c *proofsCache) Shares(ctx context.Context) ([]share.Share, error) {
 
 func (c *proofsCache) Reader() (io.Reader, error) {
 	odsSize := c.Size(context.TODO()) / 2
-	reader := NewSharesReader(odsSize, c.getShare)
+	reader := NewShareReader(odsSize, c.getShare)
 	return reader, nil
 }
 

--- a/share/new_eds/read.go
+++ b/share/new_eds/read.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/celestiaorg/celestia-node/share"
 	"io"
+
+	"github.com/celestiaorg/celestia-node/share"
 )
 
 // ReadAccessor reads up EDS out of the io.Reader until io.EOF and provides.

--- a/share/new_eds/read.go
+++ b/share/new_eds/read.go
@@ -1,0 +1,56 @@
+package eds
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/celestiaorg/celestia-node/share"
+	"io"
+)
+
+// ReadAccessor reads up EDS out of the io.Reader until io.EOF and provides.
+func ReadAccessor(ctx context.Context, reader io.Reader, root *share.AxisRoots) (*Rsmt2D, error) {
+	odsSize := len(root.RowRoots) / 2
+	shares, err := ReadShares(reader, share.Size, odsSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read eds from ods bytes: %w", err)
+	}
+
+	// verify that the EDS hash matches the expected hash
+	rsmt2d, err := Rsmt2DFromShares(shares, odsSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rsmt2d from shares: %w", err)
+	}
+	datahash, err := rsmt2d.DataHash(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate data hash: %w", err)
+	}
+	if !bytes.Equal(datahash, root.Hash()) {
+		return nil, fmt.Errorf(
+			"content integrity mismatch: imported root %s doesn't match expected root %s",
+			datahash,
+			root.Hash(),
+		)
+	}
+	return rsmt2d, nil
+}
+
+// ReadShares reads shares from the provided io.Reader until EOF. If EOF is reached, the remaining shares
+// are populated as padding share. Provided reader must contain shares in row-major order.
+func ReadShares(r io.Reader, shareSize, odsSize int) ([]share.Share, error) {
+	shares := make([]share.Share, odsSize*odsSize)
+	var total int
+	for i := range shares {
+		shr := make(share.Share, shareSize)
+		n, err := io.ReadFull(r, shr)
+		if err != nil {
+			return nil, fmt.Errorf("reading share: %w, bytes read: %v", err, total+n)
+		}
+		if n != shareSize {
+			return nil, fmt.Errorf("share size mismatch: expected %v, got %v", shareSize, n)
+		}
+		shares[i] = shr
+		total += n
+	}
+	return shares, nil
+}

--- a/share/new_eds/rsmt2d.go
+++ b/share/new_eds/rsmt2d.go
@@ -122,19 +122,19 @@ func (eds *Rsmt2D) Reader() (io.Reader, error) {
 		return eds.GetCell(uint(rowIdx), uint(colIdx)), nil
 	}
 	odsSize := int(eds.Width() / 2)
-	reader := NewSharesReader(odsSize, getShare)
+	reader := NewShareReader(odsSize, getShare)
 	return reader, nil
 }
 
 // Rsmt2DFromShares constructs an Extended Data Square from shares.
-func Rsmt2DFromShares(shares []share.Share, odsSize int) (Rsmt2D, error) {
+func Rsmt2DFromShares(shares []share.Share, odsSize int) (*Rsmt2D, error) {
 	treeFn := wrapper.NewConstructor(uint64(odsSize))
 	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, share.DefaultRSMT2DCodec(), treeFn)
 	if err != nil {
-		return Rsmt2D{}, fmt.Errorf("computing extended data square: %w", err)
+		return &Rsmt2D{}, fmt.Errorf("computing extended data square: %w", err)
 	}
 
-	return Rsmt2D{eds}, nil
+	return &Rsmt2D{eds}, nil
 }
 
 func getAxis(eds *rsmt2d.ExtendedDataSquare, axisType rsmt2d.Axis, axisIdx int) []share.Share {

--- a/share/new_eds/share_reader_test.go
+++ b/share/new_eds/share_reader_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 )
 
-func TestSharesReader(t *testing.T) {
+func TestShareReader(t *testing.T) {
 	// create io.Writer that write random data
 	odsSize := 16
 	eds := edstest.RandEDS(t, odsSize)
@@ -20,7 +20,7 @@ func TestSharesReader(t *testing.T) {
 		return eds.GetCell(uint(rowIdx), uint(colIdx)), nil
 	}
 
-	reader := NewSharesReader(odsSize, getShare)
+	reader := NewShareReader(odsSize, getShare)
 	readBytes, err := readWithRandomBuffer(reader, 1024)
 	require.NoError(t, err)
 	expected := make([]byte, 0, odsSize*odsSize*share.Size)

--- a/share/share.go
+++ b/share/share.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	appshares "github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
 )
@@ -45,6 +46,11 @@ func ValidateShare(s Share) error {
 	return nil
 }
 
+// TailPadding is a constant tail padding share exported for reuse
+func TailPadding() Share {
+	return tailPadding
+}
+
 // ShareWithProof contains data with corresponding Merkle Proof
 type ShareWithProof struct { //nolint: revive
 	// Share is a full data including namespace
@@ -68,4 +74,11 @@ func (s *ShareWithProof) Validate(rootHash []byte, x, y, edsSize int) bool {
 		[][]byte{s.Share},
 		rootHash,
 	)
+}
+
+var tailPadding Share
+
+func init() {
+	shr := appshares.TailPaddingShare()
+	tailPadding = shr.ToBytes()
 }

--- a/share/shwap/p2p/shrex/shrexeds/client.go
+++ b/share/shwap/p2p/shrex/shrexeds/client.go
@@ -1,7 +1,6 @@
 package shrexeds
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -138,12 +137,12 @@ func (c *Client) doRequest(
 		// reset stream deadlines to original values, since read deadline was changed during status read
 		c.setStreamDeadlines(ctx, stream)
 		// use header and ODS bytes to construct EDS and verify it against dataHash
-		eds, err := readEds(ctx, stream, root)
+		eds, err := eds.ReadAccessor(ctx, stream, root)
 		if err != nil {
 			return nil, fmt.Errorf("read eds from stream: %w", err)
 		}
 		c.metrics.ObserveRequests(ctx, 1, shrex.StatusSuccess)
-		return eds, nil
+		return eds.ExtendedDataSquare, nil
 	case shrexpb.Status_NOT_FOUND:
 		c.metrics.ObserveRequests(ctx, 1, shrex.StatusNotFound)
 		return nil, shrex.ErrNotFound
@@ -156,32 +155,6 @@ func (c *Client) doRequest(
 		c.metrics.ObserveRequests(ctx, 1, shrex.StatusInternalErr)
 		return nil, shrex.ErrInvalidResponse
 	}
-}
-
-func readEds(ctx context.Context, stream network.Stream, root *share.AxisRoots) (*rsmt2d.ExtendedDataSquare, error) {
-	odsSize := len(root.RowRoots) / 2
-	shares, err := eds.ReadShares(stream, share.Size, odsSize)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read eds from ods bytes: %w", err)
-	}
-
-	// verify that the EDS hash matches the expected hash
-	rsmt2d, err := eds.Rsmt2DFromShares(shares, odsSize)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create rsmt2d from shares: %w", err)
-	}
-	datahash, err := rsmt2d.DataHash(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to calculate data hash: %w", err)
-	}
-	if !bytes.Equal(datahash, root.Hash()) {
-		return nil, fmt.Errorf(
-			"content integrity mismatch: imported root %s doesn't match expected root %s",
-			datahash,
-			root.Hash(),
-		)
-	}
-	return rsmt2d.ExtendedDataSquare, nil
 }
 
 func (c *Client) setStreamDeadlines(ctx context.Context, stream network.Stream) {

--- a/store/file/header.go
+++ b/store/file/header.go
@@ -79,6 +79,20 @@ func (h *headerV0) Size() int {
 	return headerVOSize + 1
 }
 
+func (h *headerV0) RootsSize() int {
+	// axis roots are stored in two parts: row roots and column roots, each part has size equal to
+	// the square size. Thus, the total amount of roots is equal to the square size * 2.
+	return share.AxisRootSize * h.SquareSize() * 2
+}
+
+func (h *headerV0) Offset() int {
+	return h.Size()
+}
+
+func (h *headerV0) OffsetWithRoots() int {
+	return h.RootsSize() + h.Offset()
+}
+
 func (h *headerV0) WriteTo(w io.Writer) (int64, error) {
 	buf := make([]byte, headerVOSize)
 	buf[0] = byte(h.fileVersion)

--- a/store/file/q4.go
+++ b/store/file/q4.go
@@ -130,7 +130,7 @@ func (q4 *Q4) AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (
 		return eds.AxisHalf{}, fmt.Errorf("invalid axis index for Q4: %d", axisIdx)
 	}
 
-	axisHalf, err := readAxisHalf(q4.file, axisType, q4.hdr.ShareSize(), size, q4.hdr.Size(), q4AxisIdx)
+	axisHalf, err := readAxisHalf(q4.file, axisType, axisIdx, q4.hdr, q4.hdr.Offset())
 	if err != nil {
 		return eds.AxisHalf{}, fmt.Errorf("reading axis half: %w", err)
 	}

--- a/store/file/square.go
+++ b/store/file/square.go
@@ -38,7 +38,7 @@ func (s square) reader() (io.Reader, error) {
 	getShare := func(rowIdx, colIdx int) ([]byte, error) {
 		return s[rowIdx][colIdx], nil
 	}
-	reader := eds.NewSharesReader(s.size(), getShare)
+	reader := eds.NewShareReader(s.size(), getShare)
 	return reader, nil
 }
 


### PR DESCRIPTION
Implements tail padding share trimming a.k.a. compression with supporting changes. The actual trimming logic turned out extremely simple and does not even require any form of indexing. (896bdd3211dc36ede3209a66b35888f996a5d8bc)

This PR is reviewable commit-by-commit and is supposed to merge as so.

Depends on #3643 