### PR TITLE
fix(libs/utils): rely on DNS for rpc/grpc requests to core

### DIFF
--- a/libs/utils/address.go
+++ b/libs/utils/address.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 )
 
@@ -27,30 +28,21 @@ func SanitizeAddr(addr string) (string, error) {
 // ValidateAddr sanitizes the given address and verifies that it
 // is a valid IP or hostname. The sanitized address is returned.
 func ValidateAddr(addr string) (string, error) {
-	addr, err := ValidateAddrPreservingHostname(addr)
-	if err != nil {
-		return addr, err
-	}
-
-	resolved, err := net.ResolveIPAddr("ip4", addr)
-	if err != nil {
-		return addr, err
-	}
-	return resolved.String(), nil
-}
-
-// ValidateAddr sanitizes the given address and verifies that it
-// is a valid IP or hostname. The sanitized address is returned.
-func ValidateAddrPreservingHostname(addr string) (string, error) {
 	addr, err := SanitizeAddr(addr)
 	if err != nil {
 		return addr, err
 	}
 
-	ip := net.ParseIP(addr)
-	if ip != nil {
-		return addr, nil
+	// if the address is a valid IP, return it
+	ip, err := netip.ParseAddr(addr)
+	if err == nil {
+		return ip.String(), nil
 	}
 
-	return addr, nil
+	// if the address is not a valid IP, resolve it
+	resolved, err := net.ResolveIPAddr("ip4", addr)
+	if err != nil {
+		return addr, err
+	}
+	return resolved.String(), nil
 }

--- a/libs/utils/address.go
+++ b/libs/utils/address.go
@@ -24,9 +24,24 @@ func SanitizeAddr(addr string) (string, error) {
 	return addr, nil
 }
 
-// ValidateAddr sanitizes the given address and verifies that it is a valid IP or hostname. The
-// sanitized address is returned.
+// ValidateAddr sanitizes the given address and verifies that it
+// is a valid IP or hostname. The sanitized address is returned.
 func ValidateAddr(addr string) (string, error) {
+	addr, err := ValidateAddrPreservingHostname(addr)
+	if err != nil {
+		return addr, err
+	}
+
+	resolved, err := net.ResolveIPAddr("ip4", addr)
+	if err != nil {
+		return addr, err
+	}
+	return resolved.String(), nil
+}
+
+// ValidateAddr sanitizes the given address and verifies that it
+// is a valid IP or hostname. The sanitized address is returned.
+func ValidateAddrPreservingHostname(addr string) (string, error) {
 	addr, err := SanitizeAddr(addr)
 	if err != nil {
 		return addr, err
@@ -37,9 +52,5 @@ func ValidateAddr(addr string) (string, error) {
 		return addr, nil
 	}
 
-	resolved, err := net.ResolveIPAddr("ip4", addr)
-	if err != nil {
-		return addr, err
-	}
-	return resolved.String(), nil
+	return addr, nil
 }

--- a/libs/utils/address_test.go
+++ b/libs/utils/address_test.go
@@ -53,6 +53,8 @@ func TestValidateAddr(t *testing.T) {
 		{addr: "https://celestia.org", want: want{unresolved: true}},
 		// Testcase: hostname is valid, but no schema
 		{addr: "celestia.org", want: want{unresolved: true}},
+		// Testcase: localhost
+		{addr: "localhost", want: want{addr: "127.0.0.1"}},
 	}
 
 	for _, tt := range tests {

--- a/nodebuilder/core/config.go
+++ b/nodebuilder/core/config.go
@@ -44,7 +44,7 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("nodebuilder/core: grpc port is not set")
 	}
 
-	ip, err := utils.ValidateAddr(cfg.IP)
+	ip, err := utils.ValidateAddrPreservingHostname(cfg.IP)
 	if err != nil {
 		return err
 	}

--- a/nodebuilder/core/config.go
+++ b/nodebuilder/core/config.go
@@ -44,7 +44,7 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("nodebuilder/core: grpc port is not set")
 	}
 
-	ip, err := utils.ValidateAddrPreservingHostname(cfg.IP)
+	ip, err := utils.SanitizeAddr(cfg.IP)
 	if err != nil {
 		return err
 	}

--- a/nodebuilder/core/config_test.go
+++ b/nodebuilder/core/config_test.go
@@ -27,6 +27,15 @@ func TestValidate(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "hostname preserved",
+			cfg: Config{
+				IP:       "celestia.org",
+				RPCPort:  DefaultRPCPort,
+				GRPCPort: DefaultGRPCPort,
+			},
+			expectErr: false,
+		},
+		{
 			name: "missing RPC port",
 			cfg: Config{
 				IP:       "127.0.0.1",
@@ -43,13 +52,13 @@ func TestValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "invalid IP",
+			name: "invalid IP, but will be accepted as host and not raise an error",
 			cfg: Config{
 				IP:       "invalid-ip",
 				RPCPort:  DefaultRPCPort,
 				GRPCPort: DefaultGRPCPort,
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			name: "invalid RPC port",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

Refs #3570 and I believe solves the issue well enough

previously, on start, node would resolve DNS hostnames to IP when validating. This is somewhat legitimate and necessary when building multiaddr format, but the same code was being used for configuring http clients for RPC/gRPC connections. 

This meant, that in the event of some server administration or an incident, if DNS was updated for a "core" node (as configured via `--core.ip`) this meant a long running node would suddenly lose it's destination and get stuck failing and retrying. 

Instead, this seeks to separate validation, for validating --core.ip for rpc/grpc clients do NOT resolve to IP on start/validate, then should make requests over the DNS using hostname, meaning a core node moving, should eventually resolve again properly, preventing need for a restart.

We had to take care NOT to accidentally cause multiaddr to remain hostnames. The original issue suggests wanting to update all p2p networking to be host based, I feel that is probably unnecessary