### PR TITLE
chore(scripts): single-node.sh

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# This script can be used in conjunction with
+# https://github.com/celestiaorg/celestia-app/blob/main/scripts/single-node.sh
+# to start a local devnet with one celestia-app validator and one celestia
+# bridge node.
+
+# Stop script execution if an error is encountered
+set -o errexit
+# Stop script execution if an undefined variable is used
+set -o nounset
+
+if ! [ -x "$(command -v celestia)" ]
+then
+    echo "celestia could not be found. Please install the celestia binary using 'make install' and make sure the PATH contains the directory where the binary exists. By default, go will install the binary under '~/go/bin'"
+    exit 1
+fi
+
+CHAIN_ID="test"
+KEY_NAME="validator"
+APP_PATH="${HOME}/.celestia-app"
+NODE_PATH="${HOME}/.celestia-bridge-test/"
+CELESTIA_VERSION=$(celestia version 2>&1)
+
+echo "celestia path: ${NODE_PATH}"
+echo "celestia version: ${CELESTIA_VERSION}"
+echo ""
+
+echo "Deleting $NODE_PATH..."
+rm -r "$NODE_PATH"
+
+echo "Creating $NODE_PATH/keys..."
+mkdir -p $NODE_PATH/keys
+
+echo "Copying keys..."
+cp -r $APP_PATH/keyring-test/ $NODE_PATH/keys/keyring-test/
+
+# Try to get the genesis hash. Usually first request returns an empty string (port is not open, curl fails), later attempts
+# returns "null" if block was not yet produced.
+GENESIS=
+CNT=0
+MAX=30
+while [ "${#GENESIS}" -le 4 -a $CNT -ne $MAX ]; do
+	GENESIS=$(curl -s http://127.0.0.1:26657/block?height=1 | jq '.result.block_id.hash' | tr -d '"')
+	((CNT++))
+	sleep 1
+done
+
+export CELESTIA_CUSTOM=test:$GENESIS
+echo "celestia custom: $CELESTIA_CUSTOM"
+
+echo "Initializing celestia bridge..."
+celestia bridge init --node.store $NODE_PATH
+
+echo "Starting celestia bridge..."
+celestia bridge start \
+  --node.store $NODE_PATH \
+  --gateway \
+  --core.ip 127.0.0.1 \
+  --keyring.keyname $KEY_NAME \
+  --gateway.addr 0.0.0.0 \
+  --rpc.addr 0.0.0.0


### PR DESCRIPTION
Extremely optional PR to add a script used for testing to this repo. Maintainers feel free to close if ya'll don't want this.

## Context

Rene and I wanted to verify that celestia-node v0.16.0-rc0 works with celestia-app v2.0.0. I tested locally with this script. They are indeed compatible:

```logs
2024-08-12T13:59:52.133-0400	INFO	header/store	store/store.go:367	new head	{"height": 2, "hash": "A214AB65F7EED8A181195CB34D9290F1919FFF625872535A00FE0F6528007670"}
2024-08-12T14:00:03.166-0400	INFO	header/store	store/store.go:367	new head	{"height": 3, "hash": "F94E1206A77A5EFEE261627D83572237FC392AA02EC82F9421B71717BCD6D4E7"}
2024-08-12T14:00:14.192-0400	INFO	header/store	store/store.go:367	new head	{"height": 4, "hash": "D7DD8224D297CA0592660D4A2BB63F6731A35CE615AF53A69FD095B67EA58E62"}
```
