### PR TITLE
ci: fix goreleaser check deprecation warning

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,7 +58,7 @@ signs:
         "${artifact}",
       ]
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
I expect your goreleaser-check CI workflow to start failing soon. See this [deprecation notice](https://goreleaser.com/deprecations/#snapshotname_template).

Related: https://github.com/celestiaorg/celestia-app/pull/3795