### PR TITLE
chore(ci): add lint imports ci action

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   lint-imports:
     needs: [setup]
-    name: Sort Imports
+    name: Lint Imports
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -47,6 +47,24 @@ jobs:
           version: v1.59
           skip-cache: true
 
+  lint-imports:
+    needs: [setup]
+    name: Sort Imports
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: install goimports-reviser
+        run: go install -v github.com/incu6us/goimports-reviser/v3@latest
+
+      - name: lint imports
+        run: make lint-imports
+
   go_mod_tidy_check:
     needs: [setup]
     name: Go Mod Tidy Check

--- a/share/eds/blockstore.go
+++ b/share/eds/blockstore.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	share_ipld "github.com/celestiaorg/celestia-node/share/ipld"
-
 	bstore "github.com/ipfs/boxo/blockstore"
 	"github.com/ipfs/boxo/datastore/dshelp"
 	blocks "github.com/ipfs/go-block-format"
@@ -15,6 +13,8 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	ipld "github.com/ipfs/go-ipld-format"
+
+	share_ipld "github.com/celestiaorg/celestia-node/share/ipld"
 )
 
 var enableFixedDataSize = os.Getenv("CELESTIA_CONST_DATA_SIZE") == "1"


### PR DESCRIPTION
Adds lint imports check to CI to ensure imports order is correct. Found by failed lint locally, that was green in ci.