### PR TITLE
chore(lint): bump golang-ci lint to 1.60

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6.1.0
         with:
           args: --timeout 10m
-          version: v1.59
+          version: v1.60
           skip-cache: true
 
   go_mod_tidy_check:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     # - funlen
     # - gochecknoglobals
     # - gochecknoinits
-    - exportloopref
+    - copyloopvar
     - gocheckcompilerdirectives
     - goconst
     - gocritic
@@ -40,7 +40,6 @@ linters:
     - prealloc
     - protogetter
     # - scopelint - deprecated since v1.39. exportloopref will be used instead
-    - exportloopref
     - staticcheck
     - stylecheck
     - typecheck
@@ -68,6 +67,9 @@ issues:
   max-same-issues: 50
 
 linters-settings:
+  gosec:
+    excludes:
+      - G115 # integer overflow conversion
   dogsled:
     max-blank-identifiers: 3
   golint:

--- a/core/exchange.go
+++ b/core/exchange.go
@@ -104,7 +104,6 @@ func (ce *Exchange) getRangeByHeight(ctx context.Context, from, amount uint64) (
 	errGroup, ctx := errgroup.WithContext(ctx)
 	errGroup.SetLimit(concurrencyLimit)
 	for i := range headers {
-		i := i
 		errGroup.Go(func() error {
 			extHeader, err := ce.GetByHeight(ctx, from+uint64(i))
 			if err != nil {

--- a/nodebuilder/rpc/flags_test.go
+++ b/nodebuilder/rpc/flags_test.go
@@ -80,11 +80,11 @@ func TestParseFlags(t *testing.T) {
 
 			err := cmd.Flags().Set(addrFlag, test.addrFlag)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Errorf("error setting addrFlag: %s", err)
 			}
 			err = cmd.Flags().Set(portFlag, test.portFlag)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Errorf("error setting portFlag: %s", err)
 			}
 
 			ParseFlags(cmd, cfg)

--- a/share/eds/retriever_test.go
+++ b/share/eds/retriever_test.go
@@ -45,7 +45,6 @@ func TestRetriever_Retrieve(t *testing.T) {
 		{"128x128(max)", share.MaxSquareSize},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// generate EDS
 			shares := sharetest.RandShares(t, tc.squareSize*tc.squareSize)

--- a/share/eds/utils.go
+++ b/share/eds/utils.go
@@ -129,8 +129,6 @@ func CollectSharesByNamespace(
 	errGroup, ctx := errgroup.WithContext(ctx)
 	shares = make([]share.NamespacedRow, len(rootCIDs))
 	for i, rootCID := range rootCIDs {
-		// shadow loop variables, to ensure correct values are captured
-		i, rootCID := i, rootCID
 		errGroup.Go(func() error {
 			row, proof, err := ipld.GetSharesByNamespace(ctx, bg, rootCID, namespace, len(root.RowRoots))
 			shares[i] = share.NamespacedRow{

--- a/share/getters/getter_test.go
+++ b/share/getters/getter_test.go
@@ -301,7 +301,6 @@ func BenchmarkIPLDGetterOverBusyCache(b *testing.B) {
 	g := sync.WaitGroup{}
 	g.Add(blocks)
 	for _, h := range headers {
-		h := h
 		go func() {
 			defer g.Done()
 			_, err := getter.GetEDS(ctx, h)

--- a/share/ipld/get_shares_test.go
+++ b/share/ipld/get_shares_test.go
@@ -70,8 +70,6 @@ func TestBlockRecovery(t *testing.T) {
 		{"missing all but one shares", allShares, true, "failed to solve data square", extendedShareCount - 1},
 	}
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			squareSize := utils.SquareSize(len(tc.shares))
 


### PR DESCRIPTION
Bump linter and fix errors caused by upgrade.