### PR TITLE
fix(shwap): ReadFull for read helpers

### DIFF
--- a/share/shwap/eds_id.go
+++ b/share/shwap/eds_id.go
@@ -42,7 +42,7 @@ func EdsIDFromBinary(data []byte) (EdsID, error) {
 // ReadFrom reads the binary form of EdsID from the provided reader.
 func (eid *EdsID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, EdsIDSize)
-	n, err := r.Read(data)
+	n, err := io.ReadFull(r, data)
 	if err != nil {
 		return int64(n), err
 	}

--- a/share/shwap/row_id.go
+++ b/share/shwap/row_id.go
@@ -58,7 +58,7 @@ func RowIDFromBinary(data []byte) (RowID, error) {
 
 func (rid *RowID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, RowIDSize)
-	n, err := r.Read(data)
+	n, err := io.ReadFull(r, data)
 	if err != nil {
 		return int64(n), err
 	}

--- a/share/shwap/row_namespace_data_id.go
+++ b/share/shwap/row_namespace_data_id.go
@@ -69,7 +69,7 @@ func RowNamespaceDataIDFromBinary(data []byte) (RowNamespaceDataID, error) {
 // ReadFrom reads the binary form of RowNamespaceDataID from the provided reader.
 func (s *RowNamespaceDataID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, RowNamespaceDataIDSize)
-	n, err := r.Read(data)
+	n, err := io.ReadFull(r, data)
 	if err != nil {
 		return int64(n), err
 	}

--- a/share/shwap/sample_id.go
+++ b/share/shwap/sample_id.go
@@ -61,7 +61,7 @@ func SampleIDFromBinary(data []byte) (SampleID, error) {
 // ReadFrom reads the binary form of SampleID from the provided reader.
 func (sid *SampleID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, SampleIDSize)
-	n, err := r.Read(data)
+	n, err := io.ReadFull(r, data)
 	if err != nil {
 		return int64(n), err
 	}


### PR DESCRIPTION
This ensures we catch EOF as an UnexepectedEOF when not enough data given.
