### PR TITLE
chore(go.mod): use toolchain version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/celestia-node
 
-go 1.23
+go 1.23.0
 
 require (
 	cosmossdk.io/math v1.3.0


### PR DESCRIPTION
Use toolchain version instead of golang version in go.mod. It will allow auto-upgrade of toolchain by compiler.