### PR TITLE
fix(shwap/bitswap): correct protocol id

### DIFF
--- a/share/shwap/p2p/bitswap/bitswap.go
+++ b/share/shwap/p2p/bitswap/bitswap.go
@@ -159,5 +159,5 @@ func shwapProtocolID(network protocol.ID) protocol.ID {
 	if network == "" {
 		return ""
 	}
-	return protocol.ID(fmt.Sprintf("/%s/shwap", network))
+	return protocol.ID(fmt.Sprintf("%s/shwap", network))
 }


### PR DESCRIPTION
Otherwise, it has additional `/` e.g. `//celestia/private/shwap/ipfs/bitswap/1.2.0`