### PR TITLE
feat(shwap): check ID equality

### DIFF
--- a/share/shwap/eds_id.go
+++ b/share/shwap/eds_id.go
@@ -39,6 +39,11 @@ func EdsIDFromBinary(data []byte) (EdsID, error) {
 	return eid, nil
 }
 
+// Equals checks equality of EdsIDs.
+func (eid *EdsID) Equals(other EdsID) bool {
+	return eid.Height == other.Height
+}
+
 // ReadFrom reads the binary form of EdsID from the provided reader.
 func (eid *EdsID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, EdsIDSize)

--- a/share/shwap/eds_id_test.go
+++ b/share/shwap/eds_id_test.go
@@ -21,6 +21,7 @@ func TestEdsID(t *testing.T) {
 
 	err = idOut.Validate()
 	require.NoError(t, err)
+	require.True(t, id.Equals(idOut))
 }
 
 func TestEdsIDReaderWriter(t *testing.T) {

--- a/share/shwap/namespace_data_id.go
+++ b/share/shwap/namespace_data_id.go
@@ -59,6 +59,11 @@ func NamespaceDataIDFromBinary(data []byte) (NamespaceDataID, error) {
 	return ndid, nil
 }
 
+// Equals checks equality of NamespaceDataID.
+func (ndid *NamespaceDataID) Equals(other NamespaceDataID) bool {
+	return ndid.EdsID.Equals(other.EdsID) && ndid.DataNamespace.Equals(other.DataNamespace)
+}
+
 // ReadFrom reads the binary form of NamespaceDataID from the provided reader.
 func (ndid *NamespaceDataID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, NamespaceDataIDSize)

--- a/share/shwap/namespace_data_id_test.go
+++ b/share/shwap/namespace_data_id_test.go
@@ -25,6 +25,7 @@ func TestNamespaceDataID(t *testing.T) {
 
 	err = sidOut.Validate()
 	require.NoError(t, err)
+	require.True(t, id.Equals(sidOut))
 }
 
 func TestNamespaceDataIDReaderWriter(t *testing.T) {

--- a/share/shwap/p2p/bitswap/block.go
+++ b/share/shwap/p2p/bitswap/block.go
@@ -34,5 +34,5 @@ type Block interface {
 }
 
 // UnmarshalFn is a closure produced by a Block that unmarshalls and validates
-// the given serialized bytes of a Shwap container and populates the Block with it on success.
-type UnmarshalFn func([]byte) error
+// the given serialized bytes of a Shwap container with ID and populates the Block with it on success.
+type UnmarshalFn func(container, id []byte) error

--- a/share/shwap/p2p/bitswap/block_fetch.go
+++ b/share/shwap/p2p/bitswap/block_fetch.go
@@ -142,9 +142,9 @@ func unmarshal(unmarshalFn UnmarshalFn, data []byte) error {
 		return err
 	}
 
-	id, err := extractCID(cid)
+	id, err := extractFromCID(cid)
 	if err != nil {
-		return fmt.Errorf("validating cid: %w", err)
+		return err
 	}
 
 	err = unmarshalFn(containerData, id)
@@ -201,12 +201,12 @@ func (h *hasher) write(data []byte) error {
 	}
 
 	// get ID out of CID while validating it
-	id, err := extractCID(cid)
+	id, err := extractFromCID(cid)
 	if err != nil {
-		return fmt.Errorf("validating cid: %w", err)
+		return err
 	}
 
-	// getBlock registered UnmarshalFn and use it to check data validity and
+	// get registered UnmarshalFn and use it to check data validity and
 	// pass it to Fetch caller
 	val, ok := unmarshalFns.Load(cid)
 	if !ok {

--- a/share/shwap/p2p/bitswap/block_test.go
+++ b/share/shwap/p2p/bitswap/block_test.go
@@ -104,7 +104,7 @@ func (t *testBlock) Marshal() ([]byte, error) {
 }
 
 func (t *testBlock) UnmarshalFn(*share.AxisRoots) UnmarshalFn {
-	return func(bytes []byte) error {
+	return func(bytes, _ []byte) error {
 		t.data = bytes
 		time.Sleep(time.Millisecond * 1)
 		return nil

--- a/share/shwap/p2p/bitswap/block_test.go
+++ b/share/shwap/p2p/bitswap/block_test.go
@@ -73,7 +73,7 @@ func newTestBlock(id int) *testBlock {
 }
 
 func newEmptyTestBlock(cid cid.Cid) (*testBlock, error) {
-	idData, err := extractCID(cid)
+	idData, err := extractFromCID(cid)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func newEmptyTestBlock(cid cid.Cid) (*testBlock, error) {
 }
 
 func (t *testBlock) CID() cid.Cid {
-	return encodeCID(t.id, testMultihashCode, testCodec)
+	return encodeToCID(t.id, testMultihashCode, testCodec)
 }
 
 func (t *testBlock) Height() uint64 {

--- a/share/shwap/p2p/bitswap/cid.go
+++ b/share/shwap/p2p/bitswap/cid.go
@@ -8,18 +8,18 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
-// extractCID retrieves Shwap ID out of the CID.
-func extractCID(cid cid.Cid) ([]byte, error) {
+// extractFromCID retrieves Shwap ID out of the CID.
+func extractFromCID(cid cid.Cid) ([]byte, error) {
 	if err := validateCID(cid); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid cid %s: %w", cid, err)
 	}
 	// mhPrefixSize is the size of the multihash prefix that used to cut it off.
 	const mhPrefixSize = 4
 	return cid.Hash()[mhPrefixSize:], nil
 }
 
-// encodeCID encodes Shwap ID into the CID.
-func encodeCID(bm encoding.BinaryMarshaler, mhcode, codec uint64) cid.Cid {
+// encodeToCID encodes Shwap ID into the CID.
+func encodeToCID(bm encoding.BinaryMarshaler, mhcode, codec uint64) cid.Cid {
 	data, err := bm.MarshalBinary()
 	if err != nil {
 		panic(fmt.Errorf("marshaling for CID: %w", err))

--- a/share/shwap/p2p/bitswap/row_block.go
+++ b/share/shwap/p2p/bitswap/row_block.go
@@ -52,7 +52,7 @@ func NewEmptyRowBlock(height uint64, rowIdx, edsSize int) (*RowBlock, error) {
 
 // EmptyRowBlockFromCID constructs an empty RowBlock out of the CID.
 func EmptyRowBlockFromCID(cid cid.Cid) (*RowBlock, error) {
-	ridData, err := extractCID(cid)
+	ridData, err := extractFromCID(cid)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func EmptyRowBlockFromCID(cid cid.Cid) (*RowBlock, error) {
 }
 
 func (rb *RowBlock) CID() cid.Cid {
-	return encodeCID(rb.ID, rowMultihashCode, rowCodec)
+	return encodeToCID(rb.ID, rowMultihashCode, rowCodec)
 }
 
 func (rb *RowBlock) Height() uint64 {

--- a/share/shwap/p2p/bitswap/row_namespace_data_block.go
+++ b/share/shwap/p2p/bitswap/row_namespace_data_block.go
@@ -55,7 +55,7 @@ func NewEmptyRowNamespaceDataBlock(
 
 // EmptyRowNamespaceDataBlockFromCID constructs an empty RowNamespaceDataBlock out of the CID.
 func EmptyRowNamespaceDataBlockFromCID(cid cid.Cid) (*RowNamespaceDataBlock, error) {
-	rndidData, err := extractCID(cid)
+	rndidData, err := extractFromCID(cid)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func EmptyRowNamespaceDataBlockFromCID(cid cid.Cid) (*RowNamespaceDataBlock, err
 }
 
 func (rndb *RowNamespaceDataBlock) CID() cid.Cid {
-	return encodeCID(rndb.ID, rowNamespaceDataMultihashCode, rowNamespaceDataCodec)
+	return encodeToCID(rndb.ID, rowNamespaceDataMultihashCode, rowNamespaceDataCodec)
 }
 
 func (rndb *RowNamespaceDataBlock) Height() uint64 {

--- a/share/shwap/p2p/bitswap/sample_block.go
+++ b/share/shwap/p2p/bitswap/sample_block.go
@@ -50,7 +50,7 @@ func NewEmptySampleBlock(height uint64, rowIdx, colIdx, edsSize int) (*SampleBlo
 
 // EmptySampleBlockFromCID constructs an empty SampleBlock out of the CID.
 func EmptySampleBlockFromCID(cid cid.Cid) (*SampleBlock, error) {
-	sidData, err := extractCID(cid)
+	sidData, err := extractFromCID(cid)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func EmptySampleBlockFromCID(cid cid.Cid) (*SampleBlock, error) {
 }
 
 func (sb *SampleBlock) CID() cid.Cid {
-	return encodeCID(sb.ID, sampleMultihashCode, sampleCodec)
+	return encodeToCID(sb.ID, sampleMultihashCode, sampleCodec)
 }
 
 func (sb *SampleBlock) Height() uint64 {

--- a/share/shwap/row_id.go
+++ b/share/shwap/row_id.go
@@ -56,6 +56,12 @@ func RowIDFromBinary(data []byte) (RowID, error) {
 	return rid, nil
 }
 
+// Equals checks equality of RowID.
+func (rid *RowID) Equals(other RowID) bool {
+	return rid.EdsID.Equals(other.EdsID) && rid.RowIndex == other.RowIndex
+}
+
+// ReadFrom reads the binary form of RowID from the provided reader.
 func (rid *RowID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, RowIDSize)
 	n, err := io.ReadFull(r, data)
@@ -79,6 +85,7 @@ func (rid RowID) MarshalBinary() ([]byte, error) {
 	return rid.appendTo(data), nil
 }
 
+// WriteTo writes the binary form of RowID to the provided writer.
 func (rid RowID) WriteTo(w io.Writer) (int64, error) {
 	data, err := rid.MarshalBinary()
 	if err != nil {

--- a/share/shwap/row_id_test.go
+++ b/share/shwap/row_id_test.go
@@ -23,6 +23,7 @@ func TestRowID(t *testing.T) {
 
 	err = idOut.Verify(edsSize)
 	require.NoError(t, err)
+	require.True(t, id.Equals(idOut))
 }
 
 func TestRowIDReaderWriter(t *testing.T) {

--- a/share/shwap/row_namespace_data_id.go
+++ b/share/shwap/row_namespace_data_id.go
@@ -66,8 +66,13 @@ func RowNamespaceDataIDFromBinary(data []byte) (RowNamespaceDataID, error) {
 	return rndid, nil
 }
 
+// Equals checks equality of RowNamespaceDataID.
+func (rndid *RowNamespaceDataID) Equals(other RowNamespaceDataID) bool {
+	return rndid.RowID.Equals(other.RowID) && rndid.DataNamespace.Equals(other.DataNamespace)
+}
+
 // ReadFrom reads the binary form of RowNamespaceDataID from the provided reader.
-func (s *RowNamespaceDataID) ReadFrom(r io.Reader) (int64, error) {
+func (rndid *RowNamespaceDataID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, RowNamespaceDataIDSize)
 	n, err := io.ReadFull(r, data)
 	if err != nil {
@@ -80,7 +85,7 @@ func (s *RowNamespaceDataID) ReadFrom(r io.Reader) (int64, error) {
 	if err != nil {
 		return int64(n), fmt.Errorf("RowNamespaceDataIDFromBinary: %w", err)
 	}
-	*s = id
+	*rndid = id
 	return int64(n), nil
 }
 
@@ -88,14 +93,14 @@ func (s *RowNamespaceDataID) ReadFrom(r io.Reader) (int64, error) {
 // NOTE: Proto is avoided because
 // * Its size is not deterministic which is required for IPLD.
 // * No support for uint16
-func (s RowNamespaceDataID) MarshalBinary() ([]byte, error) {
+func (rndid RowNamespaceDataID) MarshalBinary() ([]byte, error) {
 	data := make([]byte, 0, RowNamespaceDataIDSize)
-	return s.appendTo(data), nil
+	return rndid.appendTo(data), nil
 }
 
 // WriteTo writes the binary form of RowNamespaceDataID to the provided writer.
-func (s RowNamespaceDataID) WriteTo(w io.Writer) (int64, error) {
-	data, err := s.MarshalBinary()
+func (rndid RowNamespaceDataID) WriteTo(w io.Writer) (int64, error) {
+	data, err := rndid.MarshalBinary()
 	if err != nil {
 		return 0, err
 	}
@@ -104,20 +109,20 @@ func (s RowNamespaceDataID) WriteTo(w io.Writer) (int64, error) {
 }
 
 // Verify validates the RowNamespaceDataID and verifies the embedded RowID.
-func (s RowNamespaceDataID) Verify(edsSize int) error {
-	if err := s.RowID.Verify(edsSize); err != nil {
+func (rndid RowNamespaceDataID) Verify(edsSize int) error {
+	if err := rndid.RowID.Verify(edsSize); err != nil {
 		return fmt.Errorf("error verifying RowID: %w", err)
 	}
 
-	return s.Validate()
+	return rndid.Validate()
 }
 
 // Validate performs basic field validation.
-func (s RowNamespaceDataID) Validate() error {
-	if err := s.RowID.Validate(); err != nil {
+func (rndid RowNamespaceDataID) Validate() error {
+	if err := rndid.RowID.Validate(); err != nil {
 		return fmt.Errorf("validating RowID: %w", err)
 	}
-	if err := s.DataNamespace.ValidateForData(); err != nil {
+	if err := rndid.DataNamespace.ValidateForData(); err != nil {
 		return fmt.Errorf("%w: validating DataNamespace: %w", ErrInvalidID, err)
 	}
 
@@ -125,7 +130,7 @@ func (s RowNamespaceDataID) Validate() error {
 }
 
 // appendTo helps in appending the binary form of DataNamespace to the serialized RowID data.
-func (s RowNamespaceDataID) appendTo(data []byte) []byte {
-	data = s.RowID.appendTo(data)
-	return append(data, s.DataNamespace...)
+func (rndid RowNamespaceDataID) appendTo(data []byte) []byte {
+	data = rndid.RowID.appendTo(data)
+	return append(data, rndid.DataNamespace...)
 }

--- a/share/shwap/row_namespace_data_id_test.go
+++ b/share/shwap/row_namespace_data_id_test.go
@@ -26,6 +26,7 @@ func TestRowNamespaceDataID(t *testing.T) {
 
 	err = sidOut.Verify(edsSize)
 	require.NoError(t, err)
+	require.True(t, id.Equals(sidOut))
 }
 
 func TestRowNamespaceDataIDReaderWriter(t *testing.T) {

--- a/share/shwap/sample_id.go
+++ b/share/shwap/sample_id.go
@@ -58,6 +58,11 @@ func SampleIDFromBinary(data []byte) (SampleID, error) {
 	return sid, nil
 }
 
+// Equals checks equality of SampleID.
+func (sid *SampleID) Equals(other SampleID) bool {
+	return sid.RowID.Equals(other.RowID) && sid.ShareIndex == other.ShareIndex
+}
+
 // ReadFrom reads the binary form of SampleID from the provided reader.
 func (sid *SampleID) ReadFrom(r io.Reader) (int64, error) {
 	data := make([]byte, SampleIDSize)

--- a/share/shwap/sample_id_test.go
+++ b/share/shwap/sample_id_test.go
@@ -23,6 +23,7 @@ func TestSampleID(t *testing.T) {
 
 	err = idOut.Verify(edsSize)
 	require.NoError(t, err)
+	require.True(t, id.Equals(idOut))
 }
 
 func TestSampleIDReaderWriter(t *testing.T) {


### PR DESCRIPTION
We need to check that requested ID is equal to received ID.
This was the case, but implicitly in the Bitswap layer.
This change adds another explicit check for that, ensuring IDs are printed on error