### PR TITLE
refactor(share/eds): various accessor testing suite improvements

### DIFF
--- a/share/eds/testing.go
+++ b/share/eds/testing.go
@@ -70,20 +70,22 @@ func TestSuiteAccessor(
 	}
 }
 
-func testEDSes(t *testing.T, size int) map[string]*rsmt2d.ExtendedDataSquare {
-	fullEDS := edstest.RandEDS(t, size)
+func testEDSes(t *testing.T, sizes ...int) map[string]*rsmt2d.ExtendedDataSquare {
+	testEDSes := make(map[string]*rsmt2d.ExtendedDataSquare)
+	for _, size := range sizes {
+		fullEDS := edstest.RandEDS(t, size)
+		testEDSes[fmt.Sprintf("FullODS:%d", size)] = fullEDS
 
-	var padding int
-	for padding < 1 {
-		padding = rand.IntN(size * size) //nolint:gosec
+		var padding int
+		for padding < 1 {
+			padding = rand.IntN(size * size) //nolint:gosec
+		}
+		paddingEds := edstest.RandEDSWithTailPadding(t, size, padding)
+		testEDSes[fmt.Sprintf("PaddedODS:%d", size)] = paddingEds
 	}
 
-	paddingEds := edstest.RandEDSWithTailPadding(t, size, padding)
-
-	return map[string]*rsmt2d.ExtendedDataSquare{
-		fmt.Sprintf("FullODS:%d", size):   fullEDS,
-		fmt.Sprintf("PaddedODS:%d", size): paddingEds,
-	}
+	testEDSes["EmptyODS"] = share.EmptyEDS()
+	return testEDSes
 }
 
 func TestStreamer(

--- a/share/eds/testing.go
+++ b/share/eds/testing.go
@@ -170,6 +170,24 @@ func testAccessorSample(
 		}
 		wg.Wait()
 	})
+
+	t.Run("random", func(t *testing.T) {
+		t.Parallel()
+		acc := createAccessor(t, eds)
+		roots, err := share.NewAxisRoots(eds)
+		require.NoError(t, err)
+
+		wg := sync.WaitGroup{}
+		for range 1000 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				rowIdx, colIdx := rand.IntN(width), rand.IntN(width)
+				testSample(ctx, t, acc, roots, rowIdx, colIdx)
+			}()
+		}
+		wg.Wait()
+	})
 }
 
 func testSample(

--- a/share/eds/testing.go
+++ b/share/eds/testing.go
@@ -140,30 +140,31 @@ func testAccessorSample(
 	createAccessor createAccessor,
 	eds *rsmt2d.ExtendedDataSquare,
 ) {
-	fl := createAccessor(t, eds)
-
-	roots, err := share.NewAxisRoots(eds)
-	require.NoError(t, err)
-
 	width := int(eds.Width())
 	t.Run("single thread", func(t *testing.T) {
+		acc := createAccessor(t, eds)
+		roots, err := share.NewAxisRoots(eds)
+		require.NoError(t, err)
 		// t.Parallel() this fails the test for some reason
 		for rowIdx := 0; rowIdx < width; rowIdx++ {
 			for colIdx := 0; colIdx < width; colIdx++ {
-				testSample(ctx, t, fl, roots, colIdx, rowIdx)
+				testSample(ctx, t, acc, roots, colIdx, rowIdx)
 			}
 		}
 	})
 
 	t.Run("parallel", func(t *testing.T) {
 		t.Parallel()
+		acc := createAccessor(t, eds)
+		roots, err := share.NewAxisRoots(eds)
+		require.NoError(t, err)
 		wg := sync.WaitGroup{}
 		for rowIdx := 0; rowIdx < width; rowIdx++ {
 			for colIdx := 0; colIdx < width; colIdx++ {
 				wg.Add(1)
 				go func(rowIdx, colIdx int) {
 					defer wg.Done()
-					testSample(ctx, t, fl, roots, rowIdx, colIdx)
+					testSample(ctx, t, acc, roots, rowIdx, colIdx)
 				}(rowIdx, colIdx)
 			}
 		}

--- a/share/eds/testing.go
+++ b/share/eds/testing.go
@@ -317,12 +317,20 @@ func testAccessorShares(
 	createAccessor createAccessor,
 	eds *rsmt2d.ExtendedDataSquare,
 ) {
-	fl := createAccessor(t, eds)
+	acc := createAccessor(t, eds)
 
-	shares, err := fl.Shares(ctx)
-	require.NoError(t, err)
-	expected := eds.FlattenedODS()
-	require.Equal(t, expected, shares)
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			shares, err := acc.Shares(ctx)
+			require.NoError(t, err)
+			expected := eds.FlattenedODS()
+			require.Equal(t, expected, shares)
+		}()
+	}
+	wg.Wait()
 }
 
 func testAccessorReader(

--- a/share/eds/testing.go
+++ b/share/eds/testing.go
@@ -182,7 +182,7 @@ func testAccessorSample(
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				rowIdx, colIdx := rand.IntN(width), rand.IntN(width)
+				rowIdx, colIdx := rand.IntN(width), rand.IntN(width) //nolint:gosec
 				testSample(ctx, t, acc, roots, rowIdx, colIdx)
 			}()
 		}

--- a/store/file/ods_q4_test.go
+++ b/store/file/ods_q4_test.go
@@ -56,11 +56,7 @@ func BenchmarkAxisFromODSQ4File(b *testing.B) {
 	b.Cleanup(cancel)
 
 	minSize, maxSize := 32, 128
-	newFile := func(size int) eds.Accessor {
-		eds := edstest.RandEDS(b, size)
-		return createODSQ4File(b, eds)
-	}
-	eds.BenchGetHalfAxisFromAccessor(ctx, b, newFile, minSize, maxSize)
+	eds.BenchGetHalfAxisFromAccessor(ctx, b, createODSQ4Accessor, minSize, maxSize)
 }
 
 // BenchmarkSampleFromODSQ4File/Size:32/quadrant:1-16         	   14260	     82827 ns/op
@@ -80,11 +76,7 @@ func BenchmarkSampleFromODSQ4File(b *testing.B) {
 	b.Cleanup(cancel)
 
 	minSize, maxSize := 32, 128
-	newFile := func(size int) eds.Accessor {
-		eds := edstest.RandEDS(b, size)
-		return createODSQ4File(b, eds)
-	}
-	eds.BenchGetSampleFromAccessor(ctx, b, newFile, minSize, maxSize)
+	eds.BenchGetSampleFromAccessor(ctx, b, createODSQ4Accessor, minSize, maxSize)
 }
 
 func createODSQ4AccessorStreamer(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.AccessorStreamer {

--- a/store/file/ods_test.go
+++ b/store/file/ods_test.go
@@ -169,13 +169,7 @@ func createODSFile(t testing.TB, eds *rsmt2d.ExtendedDataSquare) *ODS {
 }
 
 func createODSFileDisabledCache(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.Accessor {
-	path := t.TempDir() + "/" + strconv.Itoa(rand.Intn(1000))
-	roots, err := share.NewAxisRoots(eds)
-	require.NoError(t, err)
-	err = CreateODS(path, roots, eds)
-	require.NoError(t, err)
-	ods, err := OpenODS(path)
-	require.NoError(t, err)
+	ods := createODSFile(t, eds)
 	ods.disableCache = true
 	return ods
 }

--- a/store/file/ods_test.go
+++ b/store/file/ods_test.go
@@ -78,11 +78,7 @@ func BenchmarkAxisFromODSFile(b *testing.B) {
 	b.Cleanup(cancel)
 
 	minSize, maxSize := 32, 128
-	newFile := func(size int) eds.Accessor {
-		eds := edstest.RandEDS(b, size)
-		return createODSFile(b, eds)
-	}
-	eds.BenchGetHalfAxisFromAccessor(ctx, b, newFile, minSize, maxSize)
+	eds.BenchGetHalfAxisFromAccessor(ctx, b, createODSAccessor, minSize, maxSize)
 }
 
 // BenchmarkAxisFromODSFileDisabledCache/Size:32/ProofType:row/squareHalf:0-16         	  378975	      3141 ns/op
@@ -102,11 +98,7 @@ func BenchmarkAxisFromODSFileDisabledCache(b *testing.B) {
 	b.Cleanup(cancel)
 
 	minSize, maxSize := 32, 128
-	newFile := func(size int) eds.Accessor {
-		eds := edstest.RandEDS(b, size)
-		return createODSFileDisabledCache(b, eds)
-	}
-	eds.BenchGetHalfAxisFromAccessor(ctx, b, newFile, minSize, maxSize)
+	eds.BenchGetHalfAxisFromAccessor(ctx, b, createODSFileDisabledCache, minSize, maxSize)
 }
 
 // BenchmarkSampleFromODSFile/Size:32/quadrant:1-16         	   13684	     87558 ns/op
@@ -126,11 +118,7 @@ func BenchmarkSampleFromODSFile(b *testing.B) {
 	b.Cleanup(cancel)
 
 	minSize, maxSize := 32, 128
-	newFile := func(size int) eds.Accessor {
-		eds := edstest.RandEDS(b, size)
-		return createODSFile(b, eds)
-	}
-	eds.BenchGetSampleFromAccessor(ctx, b, newFile, minSize, maxSize)
+	eds.BenchGetSampleFromAccessor(ctx, b, createODSAccessor, minSize, maxSize)
 }
 
 // BenchmarkSampleFromODSFileDisabledCache/Size:32/quadrant:1
@@ -151,11 +139,7 @@ func BenchmarkSampleFromODSFileDisabledCache(b *testing.B) {
 	b.Cleanup(cancel)
 
 	minSize, maxSize := 32, 128
-	newFile := func(size int) eds.Accessor {
-		eds := edstest.RandEDS(b, size)
-		return createODSFileDisabledCache(b, eds)
-	}
-	eds.BenchGetSampleFromAccessor(ctx, b, newFile, minSize, maxSize)
+	eds.BenchGetSampleFromAccessor(ctx, b, createODSFileDisabledCache, minSize, maxSize)
 }
 
 func createODSAccessorStreamer(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.AccessorStreamer {


### PR DESCRIPTION
Various accessor tests improvements:
- added empty file to test suite
- test Shares in parallel
- added randomised test for samples
- removed file references from tests
- add support for createAccessor func in benchmarks
