### PR TITLE
fix(ci): Run pruning integration test separately in ci

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -128,3 +128,18 @@ jobs:
 
       - name: run sync tests
         run: make test-integration SHORT=true TAGS=sync
+
+  pruning_tests:
+    name: Integration Tests Sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: run sync tests
+        run: make test-integration SHORT=true TAGS=pruning

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -1,3 +1,5 @@
+//go:build pruning || integration
+
 package tests
 
 import (


### PR DESCRIPTION
Prunning test has been running with every other test in ci. This PR will separate running pruning test from other tests