### PR TITLE
feat(store/cache): add Has methods

### DIFF
--- a/store/cache/accessor_cache.go
+++ b/store/cache/accessor_cache.go
@@ -78,6 +78,15 @@ func (bc *AccessorCache) evictFn() func(uint64, *accessor) {
 	}
 }
 
+// Has checks if accessor for the height is present on the AccessorCache.
+func (bc *AccessorCache) Has(height uint64) bool {
+	lk := bc.getLock(height)
+	lk.RLock()
+	defer lk.RUnlock()
+
+	return bc.cache.Contains(height)
+}
+
 // Get retrieves the accessor for a given uint64 from the Cache. If the Accessor is not in
 // the Cache, it returns an ErrCacheMiss.
 func (bc *AccessorCache) Get(height uint64) (eds.AccessorStreamer, error) {

--- a/store/cache/accessor_cache_test.go
+++ b/store/cache/accessor_cache_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestAccessorCache(t *testing.T) {
-	t.Run("add / get item from cache", func(t *testing.T) {
+	t.Run("add / has / get item from cache", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		cache, err := NewAccessorCache("test", 1)
@@ -43,6 +43,8 @@ func TestAccessorCache(t *testing.T) {
 		require.NoError(t, err)
 
 		// check if item exists
+		has := cache.Has(height)
+		require.True(t, has)
 		got, err := cache.Get(height)
 		require.NoError(t, err)
 		reader, err = got.Reader()
@@ -100,6 +102,8 @@ func TestAccessorCache(t *testing.T) {
 		mock.checkClosed(t, true)
 
 		// check if item exists
+		has := cache.Has(height)
+		require.False(t, has)
 		_, err = cache.Get(height)
 		require.ErrorIs(t, err, ErrCacheMiss)
 	})
@@ -164,6 +168,8 @@ func TestAccessorCache(t *testing.T) {
 		mock.checkClosed(t, true)
 
 		// first item should be evicted from cache
+		has := cache.Has(height)
+		require.False(t, has)
 		_, err = cache.Get(height)
 		require.ErrorIs(t, err, ErrCacheMiss)
 	})

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -21,6 +21,9 @@ type OpenAccessorFn func(context.Context) (eds.AccessorStreamer, error)
 
 // Cache is an interface that defines the basic Cache operations.
 type Cache interface {
+	// Has checks if the Cache contains the eds.AccessorStreamer for the given height.
+	Has(height uint64) bool
+
 	// Get returns the eds.AccessorStreamer for the given height.
 	Get(height uint64) (eds.AccessorStreamer, error)
 

--- a/store/cache/doublecache.go
+++ b/store/cache/doublecache.go
@@ -21,6 +21,11 @@ func NewDoubleCache(first, second Cache) *DoubleCache {
 	}
 }
 
+// Has checks if accessor for the height is present on the AccessorCache.
+func (mc *DoubleCache) Has(height uint64) bool {
+	return mc.first.Has(height) || mc.second.Has(height)
+}
+
 // Get looks for an item in all the caches one by one and returns the Cache found item.
 func (mc *DoubleCache) Get(height uint64) (eds.AccessorStreamer, error) {
 	accessor, err := mc.first.Get(height)

--- a/store/cache/noop.go
+++ b/store/cache/noop.go
@@ -16,6 +16,10 @@ var _ Cache = (*NoopCache)(nil)
 // NoopCache implements noop version of Cache interface
 type NoopCache struct{}
 
+func (n NoopCache) Has(uint64) bool {
+	return false
+}
+
 func (n NoopCache) Get(uint64) (eds.AccessorStreamer, error) {
 	return nil, ErrCacheMiss
 }

--- a/store/store_cache.go
+++ b/store/store_cache.go
@@ -41,6 +41,15 @@ func (s *Store) WithCache(name string, size int) (*CachedStore, error) {
 	}, nil
 }
 
+// HasByHeight checks if accessor for the height is present.
+func (cs *CachedStore) HasByHeight(ctx context.Context, height uint64) (bool, error) {
+	if cs.combinedCache.Has(height) {
+		return true, nil
+	}
+
+	return cs.store.HasByHeight(ctx, height)
+}
+
 // GetByHeight returns accessor for given height and puts it into cache.
 func (cs *CachedStore) GetByHeight(ctx context.Context, height uint64) (eds.AccessorStreamer, error) {
 	acc, err := cs.combinedCache.First().Get(height)
@@ -52,7 +61,7 @@ func (cs *CachedStore) GetByHeight(ctx context.Context, height uint64) (eds.Acce
 
 func (cs *CachedStore) openFile(height uint64) cache.OpenAccessorFn {
 	return func(ctx context.Context) (eds.AccessorStreamer, error) {
-		// open file directly wihout calling GetByHeight of inner getter to
+		// open file directly without calling GetByHeight of inner getter to
 		// avoid hitting store cache second time
 		path := cs.store.heightToPath(height, odsFileExt)
 		return cs.store.openAccessor(ctx, path)


### PR DESCRIPTION
With Bitswap moving to using blockstore.Has soon, we need a way to check if the Accessor is present on the cache before reading the disk and this change does exactly that. 