### PR TITLE
fix(node): fixup CELESTIA_HOME

### DIFF
--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -42,7 +42,7 @@ func ParseNodeFlags(ctx context.Context, cmd *cobra.Command, network p2p.Network
 	if store == "" {
 		tp := NodeType(ctx)
 		var err error
-		store, err = nodebuilder.DefaultNodeStorePath(tp.String(), network.String())
+		store, err = nodebuilder.DefaultNodeStorePath(tp, network)
 		if err != nil {
 			return ctx, err
 		}

--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -168,7 +168,7 @@ func DiscoverOpened() (string, error) {
 
 	for _, n := range defaultNetwork {
 		for _, tp := range nodeTypes {
-			path, err := DefaultNodeStorePath(tp.String(), n.String())
+			path, err := DefaultNodeStorePath(tp, n)
 			if err != nil {
 				return "", err
 			}
@@ -185,25 +185,26 @@ func DiscoverOpened() (string, error) {
 
 // DefaultNodeStorePath constructs the default node store path using the given
 // node type and network.
-var DefaultNodeStorePath = func(tp, network string) (string, error) {
+var DefaultNodeStorePath = func(tp nodemod.Type, network p2p.Network) (string, error) {
 	home := os.Getenv("CELESTIA_HOME")
-
-	if home == "" {
-		var err error
-		home, err = os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
+	if home != "" {
+		return home, nil
 	}
-	if network == p2p.Mainnet.String() {
-		return fmt.Sprintf("%s/.celestia-%s", home, strings.ToLower(tp)), nil
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	if network == p2p.Mainnet {
+		return fmt.Sprintf("%s/.celestia-%s", home, strings.ToLower(tp.String())), nil
 	}
 	// only include network name in path for testnets and custom networks
 	return fmt.Sprintf(
 		"%s/.celestia-%s-%s",
 		home,
-		strings.ToLower(tp),
-		strings.ToLower(network),
+		strings.ToLower(tp.String()),
+		strings.ToLower(network.String()),
 	), nil
 }
 

--- a/nodebuilder/store_test.go
+++ b/nodebuilder/store_test.go
@@ -167,7 +167,7 @@ func TestDiscoverOpened(t *testing.T) {
 	t.Run("single open store", func(t *testing.T) {
 		_, dir := initAndOpenStore(t, node.Full)
 
-		mockDefaultNodeStorePath := func(t, n string) (string, error) {
+		mockDefaultNodeStorePath := func(t node.Type, n p2p.Network) (string, error) {
 			return dir, nil
 		}
 		DefaultNodeStorePath = mockDefaultNodeStorePath
@@ -193,8 +193,8 @@ func TestDiscoverOpened(t *testing.T) {
 			}
 		}
 
-		mockDefaultNodeStorePath := func(tp, n string) (string, error) {
-			key := n + "_" + tp
+		mockDefaultNodeStorePath := func(tp node.Type, n p2p.Network) (string, error) {
+			key := n.String() + "_" + tp.String()
 			if dir, ok := dirMap[key]; ok {
 				return dir, nil
 			}
@@ -218,7 +218,7 @@ func TestDiscoverOpened(t *testing.T) {
 
 	t.Run("no opened store", func(t *testing.T) {
 		dir := t.TempDir()
-		mockDefaultNodeStorePath := func(t, n string) (string, error) {
+		mockDefaultNodeStorePath := func(t node.Type, n p2p.Network) (string, error) {
 			return dir, nil
 		}
 		DefaultNodeStorePath = mockDefaultNodeStorePath


### PR DESCRIPTION
This mainly fixes the usage of `CELESTIA_HOME` env var. Previously, it worked like `XDG_HOME` in the form of `$CELESTIA_HOME/.celestia-<network>-<type>`. This change makes `$CELESTIA_HOME` the actual path to which node data goes.

This is promoted by me logging into the pods on Robusta and being tired of constantly passing the `--node.store` flag while `CELESTIA_HOME` is already set. 

---

Besides, it contains a minor refactor to use respective types for node and network instead of strings.