### PR TITLE
chore(ci): add workflow dispath to docker ci to manually trigger

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -14,13 +14,20 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-arabica"
       - "v[0-9]+.[0-9]+.[0-9]+-mocha"
   pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The checkout reference (ie tag, branch, sha)"
+        required: true
+        type: string
 
 jobs:
   docker-security-build:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.3 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@checkout_ref # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
+      checkout_ref: ${{ github.event.inputs.ref }}
     secrets: inherit

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@checkout_ref # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.4 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
       checkout_ref: ${{ github.event.inputs.ref }}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

This PRs shows how to use the new input for the docker ci workflow added in https://github.com/celestiaorg/.github/pull/112

This would allow triggering the docker workflow on a tag that (such as the new arabica and mocha tags) that didn't trigger the workflow originally. 

