### PR TITLE
fix(header): soft failure is only for not enough voting power

### DIFF
--- a/header/header.go
+++ b/header/header.go
@@ -201,7 +201,7 @@ func (eh *ExtendedHeader) Verify(untrst *ExtendedHeader) error {
 	if err := eh.ValidatorSet.VerifyCommitLightTrusting(eh.ChainID(), untrst.Commit, light.DefaultTrustLevel); err != nil {
 		return &libhead.VerifyError{
 			Reason:      fmt.Errorf("%w: %w", ErrVerifyCommitLightTrustingFailed, err),
-			SoftFailure: true,
+			SoftFailure: core.IsErrNotEnoughVotingPowerSigned(err),
 		}
 	}
 	return nil


### PR DESCRIPTION
We should set `libhead.VerifyError.SoftFailure` to true only when error is `core.ErrNotEnoughVotingPowerSigned`. In other words, this PR fixes a bug when we treat double vote and invalid signature as a soft failure (when it's not).

CC: @vgonkivs @Wondertan 