### PR TITLE
share!(shwap): implement GetRange over Shwap

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -395,7 +395,7 @@ func (s *Service) retrieve(
 		}
 
 		appShares = row.Shares
-		proofs = append(proofs, row.Proof)
+		proofs = append(proofs, row.Proof.SharesProof())
 		index := row.Proof.Start()
 
 		for {

--- a/nodebuilder/share/mocks/api.go
+++ b/nodebuilder/share/mocks/api.go
@@ -9,9 +9,8 @@ import (
 	reflect "reflect"
 
 	header "github.com/celestiaorg/celestia-node/header"
-	share "github.com/celestiaorg/celestia-node/nodebuilder/share"
 	shwap "github.com/celestiaorg/celestia-node/share/shwap"
-	share0 "github.com/celestiaorg/go-square/v2/share"
+	share "github.com/celestiaorg/go-square/v2/share"
 	rsmt2d "github.com/celestiaorg/rsmt2d"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -55,7 +54,7 @@ func (mr *MockModuleMockRecorder) GetEDS(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // GetNamespaceData mocks base method.
-func (m *MockModule) GetNamespaceData(arg0 context.Context, arg1 uint64, arg2 share0.Namespace) (shwap.NamespaceData, error) {
+func (m *MockModule) GetNamespaceData(arg0 context.Context, arg1 uint64, arg2 share.Namespace) (shwap.NamespaceData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNamespaceData", arg0, arg1, arg2)
 	ret0, _ := ret[0].(shwap.NamespaceData)
@@ -70,18 +69,18 @@ func (mr *MockModuleMockRecorder) GetNamespaceData(arg0, arg1, arg2 interface{})
 }
 
 // GetRange mocks base method.
-func (m *MockModule) GetRange(arg0 context.Context, arg1 uint64, arg2, arg3 int) (*share.GetRangeResult, error) {
+func (m *MockModule) GetRange(arg0 context.Context, arg1 share.Namespace, arg2 uint64, arg3, arg4 shwap.SampleCoords, arg5 bool) (shwap.RangeNamespaceData, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRange", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*share.GetRangeResult)
+	ret := m.ctrl.Call(m, "GetRange", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(shwap.RangeNamespaceData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRange indicates an expected call of GetRange.
-func (mr *MockModuleMockRecorder) GetRange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRange", reflect.TypeOf((*MockModule)(nil).GetRange), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRange", reflect.TypeOf((*MockModule)(nil).GetRange), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // GetRow mocks base method.
@@ -115,10 +114,10 @@ func (mr *MockModuleMockRecorder) GetSamples(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // GetShare mocks base method.
-func (m *MockModule) GetShare(arg0 context.Context, arg1 uint64, arg2, arg3 int) (share0.Share, error) {
+func (m *MockModule) GetShare(arg0 context.Context, arg1 uint64, arg2, arg3 int) (share.Share, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetShare", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(share0.Share)
+	ret0, _ := ret[0].(share.Share)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/nodebuilder/tests/share_test.go
+++ b/nodebuilder/tests/share_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestShareModule(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
 	t.Cleanup(cancel)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second*1))
 	blobSize := 128
@@ -44,6 +44,7 @@ func TestShareModule(t *testing.T) {
 	require.NoError(t, fullNode.Start(ctx))
 
 	addrsFull, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(fullNode.Host))
+
 	require.NoError(t, err)
 
 	lightCfg := sw.DefaultTestConfig(node.Light)
@@ -207,7 +208,30 @@ func TestShareModule(t *testing.T) {
 					require.NoError(t, err)
 					// compare commitments
 					require.Equal(t, nodeBlob[0].Commitment, blb[0].Commitment)
+				}
+			},
+		},
+		{
+			name: "GetRangeNamespaceData",
+			doFn: func(t *testing.T) {
+				dah := hdr.DAH
+				blobLength, err := sampledBlob.Length()
+				require.NoError(t, err)
+				from, to, err := shwap.RangeCoordsFromIdx(sampledBlob.Index(), blobLength, len(dah.RowRoots))
+				require.NoError(t, err)
+				for _, client := range clients {
+					rng, err := client.Share.GetRange(ctx, nodeBlob[0].Namespace(), height, from, to, false)
+					require.NoError(t, err)
+					err = rng.Verify(nodeBlob[0].Namespace(), from, to, dah.Hash())
+					require.NoError(t, err)
 
+					shrs := rng.Flatten()
+					blbs, err := libshare.ParseBlobs(shrs)
+					require.NoError(t, err)
+
+					parsedBlob, err := blob.ToNodeBlobs(blbs...)
+					require.NoError(t, err)
+					require.Equal(t, nodeBlob[0].Commitment, parsedBlob[0].Commitment)
 				}
 			},
 		},

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -321,6 +321,16 @@ func (g successGetter) GetNamespaceData(
 	panic("not implemented")
 }
 
+func (g successGetter) GetRangeNamespaceData(
+	_ context.Context,
+	_ *header.ExtendedHeader,
+	_ libshare.Namespace,
+	_, _ shwap.SampleCoords,
+	_ bool,
+) (shwap.RangeNamespaceData, error) {
+	panic("not implemented")
+}
+
 func TestPruneAll(t *testing.T) {
 	const size = 8
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)

--- a/share/eds/accessor.go
+++ b/share/eds/accessor.go
@@ -33,6 +33,13 @@ type Accessor interface {
 	RowNamespaceData(ctx context.Context, namespace libshare.Namespace, rowIdx int) (shwap.RowNamespaceData, error)
 	// Shares returns data (ODS) shares extracted from the Accessor.
 	Shares(ctx context.Context) ([]libshare.Share, error)
+	// RangeNamespaceData returns data(ODS) shares along with their proofs from the requested range
+	// from the Accessor. Response might have only proofs.
+	RangeNamespaceData(
+		ctx context.Context,
+		ns libshare.Namespace,
+		from, to shwap.SampleCoords,
+	) (shwap.RangeNamespaceData, error)
 }
 
 // AccessorStreamer is an interface that groups Accessor and Streamer interfaces.

--- a/share/eds/close_once.go
+++ b/share/eds/close_once.go
@@ -93,6 +93,17 @@ func (c *closeOnce) Shares(ctx context.Context) ([]libshare.Share, error) {
 	return c.f.Shares(ctx)
 }
 
+func (c *closeOnce) RangeNamespaceData(
+	ctx context.Context,
+	ns libshare.Namespace,
+	from, to shwap.SampleCoords,
+) (shwap.RangeNamespaceData, error) {
+	if c.closed.Load() {
+		return shwap.RangeNamespaceData{}, errAccessorClosed
+	}
+	return c.f.RangeNamespaceData(ctx, ns, from, to)
+}
+
 func (c *closeOnce) Reader() (io.Reader, error) {
 	if c.closed.Load() {
 		return nil, errAccessorClosed

--- a/share/eds/close_once_test.go
+++ b/share/eds/close_once_test.go
@@ -75,6 +75,14 @@ func (s *stubEdsAccessorCloser) RowNamespaceData(
 	return shwap.RowNamespaceData{}, nil
 }
 
+func (s *stubEdsAccessorCloser) RangeNamespaceData(
+	_ context.Context,
+	_ libshare.Namespace,
+	_, _ shwap.SampleCoords,
+) (shwap.RangeNamespaceData, error) {
+	return shwap.RangeNamespaceData{}, nil
+}
+
 func (s *stubEdsAccessorCloser) Shares(context.Context) ([]libshare.Share, error) {
 	return nil, nil
 }

--- a/share/eds/proofs_cache.go
+++ b/share/eds/proofs_cache.go
@@ -320,7 +320,7 @@ func (c *proofsCache) RangeNamespaceData(
 		}
 		nd = append(nd, rngData.NamespaceData...)
 	}
-	return shwap.RangeNamespaceData{Start: fromRow, NamespaceData: nd}, nil
+	return shwap.RangeNamespaceData{Start: from.Row, NamespaceData: nd}, nil
 }
 
 func (c *proofsCache) Reader() (io.Reader, error) {

--- a/share/eds/proofs_cache_test.go
+++ b/share/eds/proofs_cache_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCache(t *testing.T) {
 	ODSSize := 16
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
 	t.Cleanup(cancel)
 
 	newAccessor := func(tb testing.TB, inner *rsmt2d.ExtendedDataSquare) Accessor {

--- a/share/eds/proofs_cache_test.go
+++ b/share/eds/proofs_cache_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCache(t *testing.T) {
 	ODSSize := 16
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	t.Cleanup(cancel)
 
 	newAccessor := func(tb testing.TB, inner *rsmt2d.ExtendedDataSquare) Accessor {

--- a/share/eds/rsmt2d.go
+++ b/share/eds/rsmt2d.go
@@ -104,7 +104,7 @@ func (eds *Rsmt2D) HalfRow(idx int, side shwap.RowSide) (shwap.Row, error) {
 
 // RowNamespaceData returns data for the given namespace and row index.
 func (eds *Rsmt2D) RowNamespaceData(
-	_ context.Context,
+	ctx context.Context,
 	namespace libshare.Namespace,
 	rowIdx int,
 ) (shwap.RowNamespaceData, error) {
@@ -113,7 +113,35 @@ func (eds *Rsmt2D) RowNamespaceData(
 	if err != nil {
 		return shwap.RowNamespaceData{}, fmt.Errorf("while converting shares from bytes: %w", err)
 	}
-	return shwap.RowNamespaceDataFromShares(sh, namespace, rowIdx)
+
+	roots, err := eds.AxisRoots(ctx)
+	if err != nil {
+		return shwap.RowNamespaceData{}, fmt.Errorf("while axis roots: %w", err)
+	}
+	return shwap.RowNamespaceDataFromShares(sh, namespace, rowIdx, roots)
+}
+
+// RangeNamespaceData builds a namespace range from the given coordinates and the length of the
+// range.
+func (eds *Rsmt2D) RangeNamespaceData(
+	ctx context.Context,
+	ns libshare.Namespace,
+	from, to shwap.SampleCoords,
+) (shwap.RangeNamespaceData, error) {
+	rawShares := make([][]libshare.Share, 0, to.Row-from.Row+1)
+	for row := from.Row; row <= to.Row; row++ {
+		rawShare := eds.Row(uint(row))
+		sh, err := libshare.FromBytes(rawShare)
+		if err != nil {
+			return shwap.RangeNamespaceData{}, err
+		}
+		rawShares = append(rawShares, sh)
+	}
+	roots, err := eds.AxisRoots(ctx)
+	if err != nil {
+		return shwap.RangeNamespaceData{}, err
+	}
+	return shwap.RangedNamespaceDataFromShares(rawShares, ns, roots, from, to)
 }
 
 // Shares returns data (ODS) shares extracted from the EDS. It returns new copy of the shares each

--- a/share/eds/testing.go
+++ b/share/eds/testing.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/celestia-app/v3/pkg/da"
 	libshare "github.com/celestiaorg/go-square/v2/share"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
@@ -65,6 +66,11 @@ func TestSuiteAccessor(
 			t.Run(fmt.Sprintf("Shares:%s", name), func(t *testing.T) {
 				t.Parallel()
 				testAccessorShares(ctx, t, createAccessor, eds)
+			})
+
+			t.Run(fmt.Sprintf("RangeNamespaceData:%s", name), func(t *testing.T) {
+				t.Parallel()
+				testRangeNamespaceData(ctx, t, createAccessor, size)
 			})
 		}
 	}
@@ -242,7 +248,7 @@ func testAccessorRowNamespaceData(
 				actualSharesAmount += len(rowData.Shares)
 				require.NoError(t, err)
 				require.True(t, len(rowData.Shares) > 0)
-				err = rowData.Verify(roots, namespace, i)
+				err = rowData.Verify(roots.Hash(), namespace, i)
 				require.NoError(t, err)
 			}
 
@@ -277,10 +283,53 @@ func testAccessorRowNamespaceData(
 			require.Len(t, rowData.Shares, 0)
 			require.True(t, rowData.Proof.IsOfAbsence())
 
-			err = rowData.Verify(roots, absentNs, i)
+			err = rowData.Verify(roots.Hash(), absentNs, i)
 			require.NoError(t, err)
 		}
 	})
+}
+
+func testRangeNamespaceData(
+	ctx context.Context,
+	t *testing.T,
+	createAccessor createAccessor,
+	odsSize int,
+) {
+	sharesAmount := odsSize * odsSize
+	namespace := libshare.RandomNamespace()
+	eds, _ := edstest.RandEDSWithNamespace(t, namespace, sharesAmount, odsSize)
+	acc := createAccessor(t, eds)
+	dah, err := da.NewDataAvailabilityHeader(eds)
+	require.NoError(t, err)
+
+	// request all possible ranges
+	for startRow := 0; startRow < odsSize; startRow++ {
+		for endRow := startRow; endRow < odsSize; endRow++ {
+			multiplier := (endRow - startRow) * odsSize
+			for startCol := 0; startCol < odsSize; startCol++ {
+				for endCol := startCol; endCol < odsSize; endCol++ {
+					actualSharesAmount := endCol - startCol + multiplier + 1
+					rngData, err := acc.RangeNamespaceData(
+						ctx,
+						namespace,
+						shwap.SampleCoords{Row: startRow, Col: startCol},
+						shwap.SampleCoords{Row: endRow, Col: endCol},
+					)
+					require.NoError(t, err)
+					shares := rngData.Flatten()
+					require.Equal(t, actualSharesAmount, len(shares))
+					require.NoError(t, err)
+					err = rngData.Verify(
+						namespace,
+						shwap.SampleCoords{Row: startRow, Col: startCol},
+						shwap.SampleCoords{Row: endRow, Col: endCol},
+						dah.Hash(),
+					)
+					require.NoError(t, err)
+				}
+			}
+		}
+	}
 }
 
 func testAccessorAxisHalf(

--- a/share/eds/validation.go
+++ b/share/eds/validation.go
@@ -61,3 +61,29 @@ func (f validation) RowNamespaceData(
 	}
 	return f.Accessor.RowNamespaceData(ctx, namespace, rowIdx)
 }
+
+func (f validation) RangeNamespaceData(
+	ctx context.Context,
+	ns libshare.Namespace,
+	from, to shwap.SampleCoords,
+) (shwap.RangeNamespaceData, error) {
+	if from.Row > to.Row {
+		return shwap.RangeNamespaceData{}, fmt.Errorf(
+			"range validation: from row %d is > then to row %d", from.Row, to.Row,
+		)
+	}
+	odsSize := f.Size(ctx) / 2
+	if from.Row > odsSize-1 || from.Col > odsSize {
+		return shwap.RangeNamespaceData{}, fmt.Errorf(
+			"range validation: invalid start coordinates of the range:{%d;%d}. ODS size %d",
+			from.Row, from.Col, odsSize,
+		)
+	}
+	if to.Row > odsSize-1 || to.Col > odsSize {
+		return shwap.RangeNamespaceData{}, fmt.Errorf(
+			"range validation: invalid end coordinates of the range:{%d;%d}. ODS size %d",
+			to.Row, to.Col, odsSize,
+		)
+	}
+	return f.Accessor.RangeNamespaceData(ctx, ns, from, to)
+}

--- a/share/eds/validation.go
+++ b/share/eds/validation.go
@@ -73,13 +73,13 @@ func (f validation) RangeNamespaceData(
 		)
 	}
 	odsSize := f.Size(ctx) / 2
-	if from.Row > odsSize-1 || from.Col > odsSize {
+	if from.Row > odsSize-1 || from.Col > odsSize-1 {
 		return shwap.RangeNamespaceData{}, fmt.Errorf(
 			"range validation: invalid start coordinates of the range:{%d;%d}. ODS size %d",
 			from.Row, from.Col, odsSize,
 		)
 	}
-	if to.Row > odsSize-1 || to.Col > odsSize {
+	if to.Row > odsSize-1 || to.Col > odsSize-1 {
 		return shwap.RangeNamespaceData{}, fmt.Errorf(
 			"range validation: invalid end coordinates of the range:{%d;%d}. ODS size %d",
 			to.Row, to.Col, odsSize,

--- a/share/shwap/getter.go
+++ b/share/shwap/getter.go
@@ -47,4 +47,13 @@ type Getter interface {
 	// If no shares are found for target namespace non-inclusion could be also verified by calling
 	// Verify method.
 	GetNamespaceData(context.Context, *header.ExtendedHeader, libshare.Namespace) (NamespaceData, error)
+	// GetNamespaceData gets all namespaced shares from an EDS within a given range.
+	// Shares are returned in a row-by-row order if the range spans multiple rows.
+	GetRangeNamespaceData(
+		_ context.Context,
+		_ *header.ExtendedHeader,
+		_ libshare.Namespace,
+		from, to SampleCoords,
+		_ bool,
+	) (RangeNamespaceData, error)
 }

--- a/share/shwap/getters/cascade.go
+++ b/share/shwap/getters/cascade.go
@@ -110,7 +110,7 @@ func (cg *CascadeGetter) GetRangeNamespaceData(
 	from, to shwap.SampleCoords,
 	proofsOnly bool,
 ) (shwap.RangeNamespaceData, error) {
-	ctx, span := tracer.Start(ctx, "cascade/get-shares-range", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "cascade/get-range-namespace-date", trace.WithAttributes(
 		attribute.String("namespace", namespace.String()),
 	))
 	defer span.End()

--- a/share/shwap/getters/cascade.go
+++ b/share/shwap/getters/cascade.go
@@ -3,6 +3,7 @@ package getters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -97,6 +98,30 @@ func (cg *CascadeGetter) GetNamespaceData(
 
 	get := func(ctx context.Context, get shwap.Getter) (shwap.NamespaceData, error) {
 		return get.GetNamespaceData(ctx, header, namespace)
+	}
+
+	return cascadeGetters(ctx, cg.getters, get)
+}
+
+func (cg *CascadeGetter) GetRangeNamespaceData(
+	ctx context.Context,
+	header *header.ExtendedHeader,
+	namespace libshare.Namespace,
+	from, to shwap.SampleCoords,
+	proofsOnly bool,
+) (shwap.RangeNamespaceData, error) {
+	ctx, span := tracer.Start(ctx, "cascade/get-shares-range", trace.WithAttributes(
+		attribute.String("namespace", namespace.String()),
+	))
+	defer span.End()
+
+	if from.Row > to.Row {
+		return shwap.RangeNamespaceData{},
+			fmt.Errorf("start row must not be bigger to end row: %d-%d", from.Row, to.Row)
+	}
+
+	get := func(ctx context.Context, get shwap.Getter) (shwap.RangeNamespaceData, error) {
+		return get.GetRangeNamespaceData(ctx, header, namespace, from, to, proofsOnly)
 	}
 
 	return cascadeGetters(ctx, cg.getters, get)

--- a/share/shwap/getters/mock/getter.go
+++ b/share/shwap/getters/mock/getter.go
@@ -68,6 +68,21 @@ func (mr *MockGetterMockRecorder) GetNamespaceData(arg0, arg1, arg2 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceData", reflect.TypeOf((*MockGetter)(nil).GetNamespaceData), arg0, arg1, arg2)
 }
 
+// GetRangeNamespaceData mocks base method.
+func (m *MockGetter) GetRangeNamespaceData(arg0 context.Context, arg1 *header.ExtendedHeader, arg2 share.Namespace, arg3, arg4 shwap.SampleCoords, arg5 bool) (shwap.RangeNamespaceData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRangeNamespaceData", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(shwap.RangeNamespaceData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRangeNamespaceData indicates an expected call of GetRangeNamespaceData.
+func (mr *MockGetterMockRecorder) GetRangeNamespaceData(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeNamespaceData", reflect.TypeOf((*MockGetter)(nil).GetRangeNamespaceData), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
 // GetRow mocks base method.
 func (m *MockGetter) GetRow(arg0 context.Context, arg1 *header.ExtendedHeader, arg2 int) (shwap.Row, error) {
 	m.ctrl.T.Helper()

--- a/share/shwap/getters/testing.go
+++ b/share/shwap/getters/testing.go
@@ -93,6 +93,16 @@ func (seg *SingleEDSGetter) GetNamespaceData(context.Context, *header.ExtendedHe
 	panic("SingleEDSGetter: GetNamespaceData is not implemented")
 }
 
+func (seg *SingleEDSGetter) GetRangeNamespaceData(
+	_ context.Context,
+	_ *header.ExtendedHeader,
+	_ libshare.Namespace,
+	_, _ shwap.SampleCoords,
+	_ bool,
+) (shwap.RangeNamespaceData, error) {
+	panic("SingleEDSGetter: GetRangeNamespaceData is not implemented")
+}
+
 func (seg *SingleEDSGetter) checkRoots(roots *share.AxisRoots) error {
 	dah, err := da.NewDataAvailabilityHeader(seg.EDS.ExtendedDataSquare)
 	if err != nil {

--- a/share/shwap/p2p/bitswap/range_namespace_data_block.go
+++ b/share/shwap/p2p/bitswap/range_namespace_data_block.go
@@ -1,0 +1,149 @@
+package bitswap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+
+	libshare "github.com/celestiaorg/go-square/v2/share"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/celestia-node/share/shwap"
+	shwappb "github.com/celestiaorg/celestia-node/share/shwap/pb"
+)
+
+const (
+	// rangeNamespaceDataCodec is a CID codec used for data Bitswap requests over Namespaced Merkle Tree.
+	rangeNamespaceDataCodec = 0x7830
+
+	// rangeNamespaceDataMultihashCode is the multihash code for data multihash function.
+	rangeNamespaceDataMultihashCode = 0x7831
+)
+
+// maxRangeSize is the maximum size of the RangeNamespaceDataBlock.
+// It is calculated as a maxRoxSize multiplied by the half of the square size.
+var maxRangeSize = maxRowSize * share.MaxSquareSize / 2
+
+func init() {
+	registerBlock(
+		rangeNamespaceDataMultihashCode,
+		rangeNamespaceDataCodec,
+		maxRangeSize,
+		shwap.RangeNamespaceDataIDSize,
+		func(cid cid.Cid) (Block, error) {
+			return EmptyRangeNamespaceDataBlockFromCID(cid)
+		},
+	)
+}
+
+// RangeNamespaceDataBlock is a Bitswap compatible block for Shwap's RangeNamespaceData container.
+type RangeNamespaceDataBlock struct {
+	ID shwap.RangeNamespaceDataID
+
+	Container shwap.RangeNamespaceData
+}
+
+// NewEmptyRangeNamespaceDataBlock constructs a new empty RangeNamespaceDataBlock.
+func NewEmptyRangeNamespaceDataBlock(
+	height uint64,
+	namespace libshare.Namespace,
+	from shwap.SampleCoords,
+	to shwap.SampleCoords,
+	edsSize int,
+	proofsOnly bool,
+) (*RangeNamespaceDataBlock, error) {
+	id, err := shwap.NewRangeNamespaceDataID(shwap.EdsID{Height: height}, namespace, from, to, edsSize, proofsOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RangeNamespaceDataBlock{ID: id}, nil
+}
+
+// EmptyRangeNamespaceDataBlockFromCID constructs an empty RangeNamespaceDataBlock out of the CID.
+func EmptyRangeNamespaceDataBlockFromCID(cid cid.Cid) (*RangeNamespaceDataBlock, error) {
+	rngidData, err := extractFromCID(cid)
+	if err != nil {
+		return nil, err
+	}
+
+	rndid, err := shwap.RangeNamespaceDataIDFromBinary(rngidData)
+	if err != nil {
+		return nil, fmt.Errorf("unmarhalling RangeNamespaceDataBlock: %w", err)
+	}
+	return &RangeNamespaceDataBlock{ID: rndid}, nil
+}
+
+func (rndb *RangeNamespaceDataBlock) CID() cid.Cid {
+	return encodeToCID(rndb.ID, rangeNamespaceDataMultihashCode, rangeNamespaceDataCodec)
+}
+
+func (rndb *RangeNamespaceDataBlock) Height() uint64 {
+	return rndb.ID.Height
+}
+
+func (rndb *RangeNamespaceDataBlock) Marshal() ([]byte, error) {
+	if empty := rndb.Container.IsEmpty(); empty {
+		return nil, fmt.Errorf("cannot marshal empty RangeNamespaceDataBlock")
+	}
+	container := rndb.Container.ToProto()
+	containerData, err := container.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RangeNamespaceDataBlock container: %w", err)
+	}
+	return containerData, nil
+}
+
+func (rndb *RangeNamespaceDataBlock) Populate(ctx context.Context, eds eds.Accessor) error {
+	rnd, err := eds.RangeNamespaceData(
+		ctx,
+		rndb.ID.DataNamespace,
+		rndb.ID.From,
+		rndb.ID.To,
+	)
+	if err != nil {
+		return fmt.Errorf("accessing RangeNamespaceData: %w", err)
+	}
+
+	if rndb.ID.ProofsOnly {
+		rnd.CleanupData()
+	}
+	rndb.Container = rnd
+	return nil
+}
+
+func (rndb *RangeNamespaceDataBlock) UnmarshalFn(root *share.AxisRoots) UnmarshalFn {
+	return func(cntrData, idData []byte) error {
+		if empty := rndb.Container.IsEmpty(); !empty {
+			return nil
+		}
+
+		rndid, err := shwap.RangeNamespaceDataIDFromBinary(idData)
+		if err != nil {
+			return fmt.Errorf("unmarhaling RangeNamespaceDataID: %w", err)
+		}
+
+		if !rndb.ID.Equals(rndid) {
+			return fmt.Errorf("requested %+v doesnt match given %+v", rndb.ID, rndid)
+		}
+
+		var rnd shwappb.RangeNamespaceData
+		if err := rnd.Unmarshal(cntrData); err != nil {
+			return fmt.Errorf("unmarshaling RangeNamespaceData for %+v: %w", rndb.ID, err)
+		}
+
+		rangeNsData, err := shwap.RangeNamespaceDataFromProto(&rnd)
+		if err != nil {
+			return fmt.Errorf("unmarshaling RangeNamespaceData for %+v: %w", rndb.ID, err)
+		}
+		if !rndb.ID.ProofsOnly {
+			if err := rangeNsData.Verify(rndid.DataNamespace, rndid.From, rndid.To, root.Hash()); err != nil {
+				return fmt.Errorf("validating RangeNamespaceData for %+v: %w", rndb.ID, err)
+			}
+		}
+		rndb.Container = *rangeNsData
+		return nil
+	}
+}

--- a/share/shwap/p2p/bitswap/range_namespace_data_block_test.go
+++ b/share/shwap/p2p/bitswap/range_namespace_data_block_test.go
@@ -1,0 +1,41 @@
+package bitswap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v2/share"
+
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+func TestRangeNamespaceData_FetchRoundtrip(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	namespace := libshare.RandomNamespace()
+	eds, root := edstest.RandEDSWithNamespace(t, namespace, 64, 8)
+	exchange := newExchangeOverEDS(ctx, t, eds)
+	blk, err := NewEmptyRangeNamespaceDataBlock(1, namespace,
+		shwap.SampleCoords{Row: 0, Col: 0},
+		shwap.SampleCoords{Row: 2, Col: 2},
+		16,
+		false,
+	)
+	require.NoError(t, err)
+
+	err = Fetch(ctx, exchange, root, []Block{blk})
+	require.NoError(t, err)
+
+	err = blk.Container.Verify(
+		namespace,
+		shwap.SampleCoords{Row: 0, Col: 0},
+		shwap.SampleCoords{Row: 2, Col: 2},
+		root.Hash(),
+	)
+	require.NoError(t, err)
+}

--- a/share/shwap/p2p/bitswap/range_namespace_data_block_test.go
+++ b/share/shwap/p2p/bitswap/range_namespace_data_block_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRangeNamespaceData_FetchRoundtrip(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
 	namespace := libshare.RandomNamespace()

--- a/share/shwap/p2p/bitswap/row_namespace_data_block.go
+++ b/share/shwap/p2p/bitswap/row_namespace_data_block.go
@@ -130,7 +130,7 @@ func (rndb *RowNamespaceDataBlock) UnmarshalFn(root *share.AxisRoots) UnmarshalF
 		if err != nil {
 			return fmt.Errorf("unmarshaling RowNamespaceData for %+v: %w", rndb.ID, err)
 		}
-		if err := cntr.Verify(root, rndb.ID.DataNamespace, rndb.ID.RowIndex); err != nil {
+		if err := cntr.Verify(root.Hash(), rndb.ID.DataNamespace, rndb.ID.RowIndex); err != nil {
 			return fmt.Errorf("validating RowNamespaceData for %+v: %w", rndb.ID, err)
 		}
 

--- a/share/shwap/p2p/bitswap/row_namespace_data_block_test.go
+++ b/share/shwap/p2p/bitswap/row_namespace_data_block_test.go
@@ -35,7 +35,7 @@ func TestRowNamespaceData_FetchRoundtrip(t *testing.T) {
 
 	for _, blk := range blks {
 		rnd := blk.(*RowNamespaceDataBlock)
-		err = rnd.Container.Verify(root, rnd.ID.DataNamespace, rnd.ID.RowIndex)
+		err = rnd.Container.Verify(root.Hash(), rnd.ID.DataNamespace, rnd.ID.RowIndex)
 		require.NoError(t, err)
 	}
 }

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -306,6 +306,16 @@ func (sg *Getter) GetNamespaceData(
 	}
 }
 
+func (sg *Getter) GetRangeNamespaceData(
+	_ context.Context,
+	_ *header.ExtendedHeader,
+	_ libshare.Namespace,
+	_, _ shwap.SampleCoords,
+	_ bool,
+) (shwap.RangeNamespaceData, error) {
+	return shwap.RangeNamespaceData{}, errors.New("not supported")
+}
+
 func (sg *Getter) getPeer(
 	ctx context.Context,
 	header *header.ExtendedHeader,

--- a/share/shwap/pb/shwap.pb.go
+++ b/share/shwap/pb/shwap.pb.go
@@ -186,8 +186,8 @@ func (m *Sample) GetProofType() AxisType {
 }
 
 type RowNamespaceData struct {
-	Shares []*Share  `protobuf:"bytes,1,rep,name=shares,proto3" json:"shares,omitempty"`
-	Proof  *pb.Proof `protobuf:"bytes,2,opt,name=proof,proto3" json:"proof,omitempty"`
+	Shares []*Share `protobuf:"bytes,1,rep,name=shares,proto3" json:"shares,omitempty"`
+	Proof  *Proof   `protobuf:"bytes,2,opt,name=proof,proto3" json:"proof,omitempty"`
 }
 
 func (m *RowNamespaceData) Reset()         { *m = RowNamespaceData{} }
@@ -230,9 +230,105 @@ func (m *RowNamespaceData) GetShares() []*Share {
 	return nil
 }
 
-func (m *RowNamespaceData) GetProof() *pb.Proof {
+func (m *RowNamespaceData) GetProof() *Proof {
 	if m != nil {
 		return m.Proof
+	}
+	return nil
+}
+
+type NamespaceData struct {
+	NamespaceData []*RowNamespaceData `protobuf:"bytes,1,rep,name=namespaceData,proto3" json:"namespaceData,omitempty"`
+}
+
+func (m *NamespaceData) Reset()         { *m = NamespaceData{} }
+func (m *NamespaceData) String() string { return proto.CompactTextString(m) }
+func (*NamespaceData) ProtoMessage()    {}
+func (*NamespaceData) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9431653f3c9f0bcb, []int{3}
+}
+func (m *NamespaceData) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *NamespaceData) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_NamespaceData.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *NamespaceData) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NamespaceData.Merge(m, src)
+}
+func (m *NamespaceData) XXX_Size() int {
+	return m.Size()
+}
+func (m *NamespaceData) XXX_DiscardUnknown() {
+	xxx_messageInfo_NamespaceData.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_NamespaceData proto.InternalMessageInfo
+
+func (m *NamespaceData) GetNamespaceData() []*RowNamespaceData {
+	if m != nil {
+		return m.NamespaceData
+	}
+	return nil
+}
+
+type RangeNamespaceData struct {
+	Start              int32          `protobuf:"varint,1,opt,name=start,proto3" json:"start,omitempty"`
+	RangeNamespaceData *NamespaceData `protobuf:"bytes,3,opt,name=rangeNamespaceData,proto3" json:"rangeNamespaceData,omitempty"`
+}
+
+func (m *RangeNamespaceData) Reset()         { *m = RangeNamespaceData{} }
+func (m *RangeNamespaceData) String() string { return proto.CompactTextString(m) }
+func (*RangeNamespaceData) ProtoMessage()    {}
+func (*RangeNamespaceData) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9431653f3c9f0bcb, []int{4}
+}
+func (m *RangeNamespaceData) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RangeNamespaceData) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RangeNamespaceData.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RangeNamespaceData) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RangeNamespaceData.Merge(m, src)
+}
+func (m *RangeNamespaceData) XXX_Size() int {
+	return m.Size()
+}
+func (m *RangeNamespaceData) XXX_DiscardUnknown() {
+	xxx_messageInfo_RangeNamespaceData.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RangeNamespaceData proto.InternalMessageInfo
+
+func (m *RangeNamespaceData) GetStart() int32 {
+	if m != nil {
+		return m.Start
+	}
+	return 0
+}
+
+func (m *RangeNamespaceData) GetRangeNamespaceData() *NamespaceData {
+	if m != nil {
+		return m.RangeNamespaceData
 	}
 	return nil
 }
@@ -245,7 +341,7 @@ func (m *Share) Reset()         { *m = Share{} }
 func (m *Share) String() string { return proto.CompactTextString(m) }
 func (*Share) ProtoMessage()    {}
 func (*Share) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9431653f3c9f0bcb, []int{3}
+	return fileDescriptor_9431653f3c9f0bcb, []int{5}
 }
 func (m *Share) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -281,43 +377,185 @@ func (m *Share) GetData() []byte {
 	return nil
 }
 
+type RowRootProof struct {
+	Total    int64    `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
+	Index    int64    `protobuf:"varint,2,opt,name=index,proto3" json:"index,omitempty"`
+	LeafHash []byte   `protobuf:"bytes,3,opt,name=leafHash,proto3" json:"leafHash,omitempty"`
+	Aunts    [][]byte `protobuf:"bytes,4,rep,name=aunts,proto3" json:"aunts,omitempty"`
+}
+
+func (m *RowRootProof) Reset()         { *m = RowRootProof{} }
+func (m *RowRootProof) String() string { return proto.CompactTextString(m) }
+func (*RowRootProof) ProtoMessage()    {}
+func (*RowRootProof) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9431653f3c9f0bcb, []int{6}
+}
+func (m *RowRootProof) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RowRootProof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RowRootProof.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RowRootProof) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RowRootProof.Merge(m, src)
+}
+func (m *RowRootProof) XXX_Size() int {
+	return m.Size()
+}
+func (m *RowRootProof) XXX_DiscardUnknown() {
+	xxx_messageInfo_RowRootProof.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RowRootProof proto.InternalMessageInfo
+
+func (m *RowRootProof) GetTotal() int64 {
+	if m != nil {
+		return m.Total
+	}
+	return 0
+}
+
+func (m *RowRootProof) GetIndex() int64 {
+	if m != nil {
+		return m.Index
+	}
+	return 0
+}
+
+func (m *RowRootProof) GetLeafHash() []byte {
+	if m != nil {
+		return m.LeafHash
+	}
+	return nil
+}
+
+func (m *RowRootProof) GetAunts() [][]byte {
+	if m != nil {
+		return m.Aunts
+	}
+	return nil
+}
+
+type Proof struct {
+	SharesProof  *pb.Proof     `protobuf:"bytes,1,opt,name=sharesProof,proto3" json:"sharesProof,omitempty"`
+	RowRootProof *RowRootProof `protobuf:"bytes,2,opt,name=rowRootProof,proto3" json:"rowRootProof,omitempty"`
+	Root         []byte        `protobuf:"bytes,3,opt,name=root,proto3" json:"root,omitempty"`
+}
+
+func (m *Proof) Reset()         { *m = Proof{} }
+func (m *Proof) String() string { return proto.CompactTextString(m) }
+func (*Proof) ProtoMessage()    {}
+func (*Proof) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9431653f3c9f0bcb, []int{7}
+}
+func (m *Proof) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Proof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Proof.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Proof) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Proof.Merge(m, src)
+}
+func (m *Proof) XXX_Size() int {
+	return m.Size()
+}
+func (m *Proof) XXX_DiscardUnknown() {
+	xxx_messageInfo_Proof.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Proof proto.InternalMessageInfo
+
+func (m *Proof) GetSharesProof() *pb.Proof {
+	if m != nil {
+		return m.SharesProof
+	}
+	return nil
+}
+
+func (m *Proof) GetRowRootProof() *RowRootProof {
+	if m != nil {
+		return m.RowRootProof
+	}
+	return nil
+}
+
+func (m *Proof) GetRoot() []byte {
+	if m != nil {
+		return m.Root
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterEnum("shwap.AxisType", AxisType_name, AxisType_value)
 	proto.RegisterEnum("shwap.Row_HalfSide", Row_HalfSide_name, Row_HalfSide_value)
 	proto.RegisterType((*Row)(nil), "shwap.Row")
 	proto.RegisterType((*Sample)(nil), "shwap.Sample")
 	proto.RegisterType((*RowNamespaceData)(nil), "shwap.RowNamespaceData")
+	proto.RegisterType((*NamespaceData)(nil), "shwap.NamespaceData")
+	proto.RegisterType((*RangeNamespaceData)(nil), "shwap.RangeNamespaceData")
 	proto.RegisterType((*Share)(nil), "shwap.Share")
+	proto.RegisterType((*RowRootProof)(nil), "shwap.RowRootProof")
+	proto.RegisterType((*Proof)(nil), "shwap.Proof")
 }
 
 func init() { proto.RegisterFile("share/shwap/pb/shwap.proto", fileDescriptor_9431653f3c9f0bcb) }
 
 var fileDescriptor_9431653f3c9f0bcb = []byte{
-	// 381 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x92, 0x4f, 0x6b, 0xe2, 0x40,
-	0x18, 0xc6, 0x33, 0x1b, 0xe3, 0xc6, 0x57, 0xd1, 0x30, 0x7b, 0x09, 0xee, 0x92, 0x95, 0xb0, 0x0b,
-	0xb2, 0x60, 0xb2, 0xe8, 0x27, 0xd8, 0xbf, 0xb5, 0x60, 0x6b, 0x19, 0x85, 0x42, 0x2f, 0x61, 0x62,
-	0x46, 0x13, 0x88, 0x9d, 0x21, 0x49, 0x49, 0x3d, 0xf7, 0xd0, 0x6b, 0x3f, 0x56, 0x8f, 0x1e, 0x7b,
-	0x2c, 0xfa, 0x45, 0x4a, 0x26, 0xb1, 0x14, 0xda, 0x43, 0x6f, 0xbf, 0xcc, 0xf3, 0xcc, 0xbc, 0xcf,
-	0x13, 0x5e, 0xe8, 0xa6, 0x21, 0x4d, 0x98, 0x9b, 0x86, 0x39, 0x15, 0xae, 0xf0, 0x4b, 0x70, 0x44,
-	0xc2, 0x33, 0x8e, 0x35, 0xf9, 0xd1, 0x6d, 0x0b, 0xdf, 0x15, 0x09, 0xe7, 0xcb, 0xf2, 0xd8, 0xbe,
-	0x45, 0xa0, 0x12, 0x9e, 0xe3, 0x01, 0x34, 0xe5, 0xe5, 0xd4, 0x0b, 0x69, 0xbc, 0x34, 0x51, 0x4f,
-	0xed, 0x37, 0x87, 0x2d, 0xa7, 0x7c, 0x61, 0x56, 0x28, 0x04, 0x4a, 0xc3, 0x98, 0xc6, 0x4b, 0xfc,
-	0x13, 0x1a, 0x85, 0xcf, 0x4b, 0xa3, 0x80, 0x99, 0x1f, 0x7a, 0xa8, 0xdf, 0x1e, 0x7e, 0xaa, 0xcc,
-	0x84, 0xe7, 0x4e, 0xe1, 0x99, 0x45, 0x01, 0x23, 0x7a, 0x58, 0x91, 0xfd, 0x15, 0xf4, 0xc3, 0x29,
-	0xd6, 0xa1, 0x36, 0xf9, 0xf7, 0x7f, 0x6e, 0x28, 0xb8, 0x01, 0x1a, 0x39, 0x3e, 0x1a, 0xcf, 0x0d,
-	0x64, 0xdf, 0x20, 0xa8, 0xcf, 0xe8, 0x5a, 0xc4, 0x0c, 0xdb, 0xa0, 0xc9, 0x59, 0x26, 0xea, 0xa1,
-	0x57, 0x31, 0x4a, 0x09, 0x7f, 0x07, 0x4d, 0xf6, 0x90, 0xd3, 0x9b, 0xc3, 0x8e, 0x53, 0xb5, 0xf2,
-	0x9d, 0xb3, 0x02, 0x48, 0xa9, 0x62, 0x07, 0x40, 0x82, 0x97, 0x6d, 0x04, 0x33, 0x55, 0x99, 0xb4,
-	0x53, 0xbd, 0xf7, 0xeb, 0x3a, 0x4a, 0xe7, 0x1b, 0xc1, 0x48, 0x43, 0x5a, 0x0a, 0xb4, 0x3d, 0x30,
-	0x08, 0xcf, 0x4f, 0xe9, 0x9a, 0xa5, 0x82, 0x2e, 0xd8, 0x5f, 0x9a, 0x51, 0xfc, 0x0d, 0xea, 0x65,
-	0xf5, 0x37, 0x7f, 0x4b, 0xa5, 0xbd, 0x33, 0x90, 0xfd, 0x19, 0x34, 0x79, 0x0f, 0x63, 0xa8, 0x05,
-	0x34, 0xa3, 0xb2, 0x63, 0x8b, 0x48, 0xfe, 0xf1, 0x05, 0xf4, 0x43, 0x28, 0xfc, 0x11, 0x54, 0x32,
-	0x3d, 0x37, 0x94, 0x02, 0xfe, 0x4c, 0x27, 0x06, 0xfa, 0x7d, 0x72, 0xbf, 0xb3, 0xd0, 0x76, 0x67,
-	0xa1, 0xc7, 0x9d, 0x85, 0xee, 0xf6, 0x96, 0xb2, 0xdd, 0x5b, 0xca, 0xc3, 0xde, 0x52, 0x2e, 0x46,
-	0xab, 0x28, 0x0b, 0xaf, 0x7c, 0x67, 0xc1, 0xd7, 0xee, 0x82, 0xc5, 0x2c, 0xcd, 0x22, 0xca, 0x93,
-	0xd5, 0x33, 0x0f, 0x2e, 0x79, 0x50, 0xec, 0xc5, 0xcb, 0xed, 0xf0, 0xeb, 0x72, 0x03, 0x46, 0x4f,
-	0x01, 0x00, 0x00, 0xff, 0xff, 0x67, 0xb6, 0xc0, 0x8b, 0x36, 0x02, 0x00, 0x00,
+	// 541 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x53, 0x41, 0x8f, 0xd2, 0x40,
+	0x14, 0x66, 0x2c, 0x45, 0x78, 0x74, 0x77, 0xc9, 0xb8, 0x89, 0x04, 0x4d, 0x25, 0x8d, 0x26, 0xc4,
+	0x64, 0x8b, 0xb2, 0x07, 0x4f, 0x1e, 0xd4, 0x55, 0x31, 0x59, 0x77, 0xcd, 0x83, 0xc4, 0xc4, 0x98,
+	0x90, 0x01, 0x06, 0xda, 0xa4, 0x30, 0x4d, 0x3b, 0x1b, 0x76, 0xcf, 0x1e, 0xbc, 0xfa, 0xb3, 0x3c,
+	0xee, 0xd1, 0xa3, 0x81, 0x3f, 0x62, 0x66, 0xa6, 0x60, 0x1b, 0xf6, 0xf6, 0x7d, 0xef, 0x7d, 0x7d,
+	0xef, 0x7b, 0xaf, 0x6f, 0xa0, 0x95, 0x06, 0x2c, 0xe1, 0xdd, 0x34, 0x58, 0xb1, 0xb8, 0x1b, 0x8f,
+	0x0d, 0xf0, 0xe3, 0x44, 0x48, 0x41, 0x6d, 0x4d, 0x5a, 0x87, 0xf1, 0xb8, 0x1b, 0x27, 0x42, 0xcc,
+	0x4c, 0xd8, 0xfb, 0x49, 0xc0, 0x42, 0xb1, 0xa2, 0x27, 0x50, 0xd7, 0x1f, 0xa7, 0xa3, 0x80, 0x45,
+	0xb3, 0x26, 0x69, 0x5b, 0x9d, 0x7a, 0xcf, 0xf1, 0x4d, 0x85, 0x81, 0xca, 0x20, 0x18, 0x41, 0x9f,
+	0x45, 0x33, 0xfa, 0x02, 0x6a, 0x4a, 0x37, 0x4a, 0xc3, 0x29, 0x6f, 0xde, 0x6b, 0x93, 0xce, 0x61,
+	0xef, 0x41, 0x26, 0x46, 0xb1, 0xf2, 0x95, 0x66, 0x10, 0x4e, 0x39, 0x56, 0x83, 0x0c, 0x79, 0x4f,
+	0xa0, 0xba, 0x8d, 0xd2, 0x2a, 0x94, 0xcf, 0xdf, 0x7f, 0x18, 0x36, 0x4a, 0xb4, 0x06, 0x36, 0x7e,
+	0xfa, 0xd8, 0x1f, 0x36, 0x88, 0xf7, 0x83, 0x40, 0x65, 0xc0, 0x16, 0x71, 0xc4, 0xa9, 0x07, 0xb6,
+	0xee, 0xd5, 0x24, 0x6d, 0xb2, 0x67, 0xc3, 0xa4, 0xe8, 0x33, 0xb0, 0xf5, 0x1c, 0xba, 0x7b, 0xbd,
+	0x77, 0xe4, 0x67, 0x53, 0x8d, 0xfd, 0x2f, 0x0a, 0xa0, 0xc9, 0x52, 0x1f, 0x40, 0x83, 0x91, 0xbc,
+	0x89, 0x79, 0xd3, 0xd2, 0x4e, 0x8f, 0xb2, 0x7a, 0x6f, 0xae, 0xc3, 0x74, 0x78, 0x13, 0x73, 0xac,
+	0x69, 0x89, 0x82, 0xde, 0x77, 0x68, 0xa0, 0x58, 0x5d, 0xb0, 0x05, 0x4f, 0x63, 0x36, 0xe1, 0x67,
+	0x4c, 0x32, 0xfa, 0x14, 0x2a, 0x66, 0xf4, 0x3b, 0xd7, 0x92, 0xe5, 0x94, 0xe9, 0xbc, 0xa1, 0xad,
+	0x28, 0xef, 0xc6, 0xbb, 0x80, 0x83, 0x62, 0xe9, 0xd7, 0x70, 0xb0, 0xcc, 0x07, 0xb2, 0x0e, 0x0f,
+	0xff, 0xef, 0xb2, 0xa0, 0xc7, 0xa2, 0xda, 0x8b, 0x81, 0x22, 0x5b, 0xce, 0x79, 0xb1, 0xe8, 0x31,
+	0xd8, 0xa9, 0x64, 0x89, 0xd4, 0xeb, 0xb3, 0xd1, 0x10, 0x7a, 0x06, 0x34, 0xd9, 0xd3, 0xea, 0x8d,
+	0xd4, 0x7b, 0xc7, 0x59, 0xbf, 0x62, 0xb3, 0x3b, 0xf4, 0xde, 0x23, 0xb0, 0xf5, 0xd8, 0x94, 0x42,
+	0x79, 0x6a, 0x0c, 0x93, 0x8e, 0x83, 0x1a, 0x7b, 0x11, 0x38, 0x28, 0x56, 0x28, 0x84, 0xd4, 0x53,
+	0x2b, 0x23, 0x52, 0x48, 0x16, 0x69, 0x91, 0x85, 0x86, 0xa8, 0x68, 0xb8, 0x9c, 0xf2, 0x6b, 0xbd,
+	0x28, 0x0b, 0x0d, 0xa1, 0x2d, 0xa8, 0x46, 0x9c, 0xcd, 0xfa, 0x2c, 0x0d, 0xb4, 0x29, 0x07, 0x77,
+	0x5c, 0x7d, 0xc1, 0xae, 0x96, 0x32, 0x6d, 0x96, 0xdb, 0x56, 0xc7, 0x41, 0x43, 0xd4, 0xe9, 0xda,
+	0xa6, 0xcf, 0xcb, 0xed, 0xf1, 0x6a, 0x9a, 0x5d, 0xcd, 0xde, 0x45, 0xe4, 0x35, 0xf4, 0x15, 0x38,
+	0x49, 0xce, 0x6a, 0xf6, 0xd3, 0x72, 0x37, 0xbc, 0x4b, 0x61, 0x41, 0xa8, 0xe6, 0x4e, 0x84, 0x90,
+	0x99, 0x47, 0x8d, 0x9f, 0x3f, 0x86, 0xea, 0xf6, 0x96, 0xe8, 0x7d, 0xb0, 0xf0, 0xf2, 0x6b, 0xa3,
+	0xa4, 0xc0, 0xbb, 0xcb, 0xf3, 0x06, 0x79, 0xfb, 0xf9, 0xf7, 0xda, 0x25, 0xb7, 0x6b, 0x97, 0xfc,
+	0x5d, 0xbb, 0xe4, 0xd7, 0xc6, 0x2d, 0xdd, 0x6e, 0xdc, 0xd2, 0x9f, 0x8d, 0x5b, 0xfa, 0x76, 0x3a,
+	0x0f, 0x65, 0x70, 0x35, 0xf6, 0x27, 0x62, 0xd1, 0x9d, 0xf0, 0x88, 0xa7, 0x32, 0x64, 0x22, 0x99,
+	0xef, 0xf0, 0xc9, 0x52, 0x4c, 0xd5, 0x73, 0xce, 0x3f, 0xea, 0x71, 0x45, 0x3f, 0xdc, 0xd3, 0x7f,
+	0x01, 0x00, 0x00, 0xff, 0xff, 0xc7, 0xd2, 0x0a, 0xe0, 0xed, 0x03, 0x00, 0x00,
 }
 
 func (m *Row) Marshal() (dAtA []byte, err error) {
@@ -463,6 +701,83 @@ func (m *RowNamespaceData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *NamespaceData) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NamespaceData) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *NamespaceData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.NamespaceData) > 0 {
+		for iNdEx := len(m.NamespaceData) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.NamespaceData[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintShwap(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *RangeNamespaceData) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RangeNamespaceData) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RangeNamespaceData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.RangeNamespaceData != nil {
+		{
+			size, err := m.RangeNamespaceData.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintShwap(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Start != 0 {
+		i = encodeVarintShwap(dAtA, i, uint64(m.Start))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Share) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -487,6 +802,109 @@ func (m *Share) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i -= len(m.Data)
 		copy(dAtA[i:], m.Data)
 		i = encodeVarintShwap(dAtA, i, uint64(len(m.Data)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *RowRootProof) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RowRootProof) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RowRootProof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Aunts) > 0 {
+		for iNdEx := len(m.Aunts) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Aunts[iNdEx])
+			copy(dAtA[i:], m.Aunts[iNdEx])
+			i = encodeVarintShwap(dAtA, i, uint64(len(m.Aunts[iNdEx])))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.LeafHash) > 0 {
+		i -= len(m.LeafHash)
+		copy(dAtA[i:], m.LeafHash)
+		i = encodeVarintShwap(dAtA, i, uint64(len(m.LeafHash)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Index != 0 {
+		i = encodeVarintShwap(dAtA, i, uint64(m.Index))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Total != 0 {
+		i = encodeVarintShwap(dAtA, i, uint64(m.Total))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Proof) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Proof) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Proof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Root) > 0 {
+		i -= len(m.Root)
+		copy(dAtA[i:], m.Root)
+		i = encodeVarintShwap(dAtA, i, uint64(len(m.Root)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.RowRootProof != nil {
+		{
+			size, err := m.RowRootProof.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintShwap(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.SharesProof != nil {
+		{
+			size, err := m.SharesProof.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintShwap(dAtA, i, uint64(size))
+		}
 		i--
 		dAtA[i] = 0xa
 	}
@@ -561,6 +979,37 @@ func (m *RowNamespaceData) Size() (n int) {
 	return n
 }
 
+func (m *NamespaceData) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.NamespaceData) > 0 {
+		for _, e := range m.NamespaceData {
+			l = e.Size()
+			n += 1 + l + sovShwap(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *RangeNamespaceData) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Start != 0 {
+		n += 1 + sovShwap(uint64(m.Start))
+	}
+	if m.RangeNamespaceData != nil {
+		l = m.RangeNamespaceData.Size()
+		n += 1 + l + sovShwap(uint64(l))
+	}
+	return n
+}
+
 func (m *Share) Size() (n int) {
 	if m == nil {
 		return 0
@@ -568,6 +1017,52 @@ func (m *Share) Size() (n int) {
 	var l int
 	_ = l
 	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovShwap(uint64(l))
+	}
+	return n
+}
+
+func (m *RowRootProof) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Total != 0 {
+		n += 1 + sovShwap(uint64(m.Total))
+	}
+	if m.Index != 0 {
+		n += 1 + sovShwap(uint64(m.Index))
+	}
+	l = len(m.LeafHash)
+	if l > 0 {
+		n += 1 + l + sovShwap(uint64(l))
+	}
+	if len(m.Aunts) > 0 {
+		for _, b := range m.Aunts {
+			l = len(b)
+			n += 1 + l + sovShwap(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *Proof) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.SharesProof != nil {
+		l = m.SharesProof.Size()
+		n += 1 + l + sovShwap(uint64(l))
+	}
+	if m.RowRootProof != nil {
+		l = m.RowRootProof.Size()
+		n += 1 + l + sovShwap(uint64(l))
+	}
+	l = len(m.Root)
 	if l > 0 {
 		n += 1 + l + sovShwap(uint64(l))
 	}
@@ -917,9 +1412,198 @@ func (m *RowNamespaceData) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Proof == nil {
-				m.Proof = &pb.Proof{}
+				m.Proof = &Proof{}
 			}
 			if err := m.Proof.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipShwap(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NamespaceData) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowShwap
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NamespaceData: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NamespaceData: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NamespaceData", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthShwap
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NamespaceData = append(m.NamespaceData, &RowNamespaceData{})
+			if err := m.NamespaceData[len(m.NamespaceData)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipShwap(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RangeNamespaceData) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowShwap
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RangeNamespaceData: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RangeNamespaceData: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Start", wireType)
+			}
+			m.Start = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Start |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RangeNamespaceData", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthShwap
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RangeNamespaceData == nil {
+				m.RangeNamespaceData = &NamespaceData{}
+			}
+			if err := m.RangeNamespaceData.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1005,6 +1689,316 @@ func (m *Share) Unmarshal(dAtA []byte) error {
 			m.Data = append(m.Data[:0], dAtA[iNdEx:postIndex]...)
 			if m.Data == nil {
 				m.Data = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipShwap(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RowRootProof) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowShwap
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RowRootProof: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RowRootProof: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Total", wireType)
+			}
+			m.Total = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Total |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Index", wireType)
+			}
+			m.Index = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Index |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LeafHash", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthShwap
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.LeafHash = append(m.LeafHash[:0], dAtA[iNdEx:postIndex]...)
+			if m.LeafHash == nil {
+				m.LeafHash = []byte{}
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Aunts", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthShwap
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Aunts = append(m.Aunts, make([]byte, postIndex-iNdEx))
+			copy(m.Aunts[len(m.Aunts)-1], dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipShwap(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Proof) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowShwap
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Proof: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Proof: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SharesProof", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthShwap
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SharesProof == nil {
+				m.SharesProof = &pb.Proof{}
+			}
+			if err := m.SharesProof.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RowRootProof", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthShwap
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RowRootProof == nil {
+				m.RowRootProof = &RowRootProof{}
+			}
+			if err := m.RowRootProof.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Root", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShwap
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthShwap
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthShwap
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Root = append(m.Root[:0], dAtA[iNdEx:postIndex]...)
+			if m.Root == nil {
+				m.Root = []byte{}
 			}
 			iNdEx = postIndex
 		default:

--- a/share/shwap/pb/shwap.proto
+++ b/share/shwap/pb/shwap.proto
@@ -23,7 +23,16 @@ message Sample {
 
 message RowNamespaceData {
     repeated Share shares = 1;
-    proof.pb.Proof proof = 2;
+    Proof proof = 2;
+}
+
+message NamespaceData {
+    repeated RowNamespaceData namespaceData = 1;
+}
+
+message RangeNamespaceData {
+    int32 start = 1;
+    NamespaceData rangeNamespaceData = 3;
 }
 
 message Share {
@@ -33,4 +42,17 @@ message Share {
 enum AxisType {
     ROW = 0;
     COL = 1;
+}
+
+message RowRootProof {
+    int64 total = 1;
+    int64 index = 2;
+    bytes leafHash = 3;
+    repeated bytes aunts = 4;
+}
+
+message Proof {
+    proof.pb.Proof sharesProof = 1;
+    RowRootProof rowRootProof = 2;
+    bytes root = 3;
 }

--- a/share/shwap/proof.go
+++ b/share/shwap/proof.go
@@ -1,0 +1,220 @@
+package shwap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/tendermint/tendermint/crypto/merkle"
+
+	libshare "github.com/celestiaorg/go-square/v2/share"
+	"github.com/celestiaorg/nmt"
+	nmt_pb "github.com/celestiaorg/nmt/pb"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/shwap/pb"
+)
+
+// Proof represents a proof that a data share is included in a
+// committed data root.
+// It consists of multiple components to support verification:
+// * shareProof: A nmt proof that verifies the inclusion of a specific data share within a row of the datasquare.
+// * rowRootProof: A Merkle proof that verifies the inclusion of the row root within the final data root.
+// * root: The row root against which the proof is verified
+type Proof struct {
+	shareProof   *nmt.Proof
+	rowRootProof *merkle.Proof
+	root         []byte
+}
+
+func NewProof(rowIndex int, sharesProofs *nmt.Proof, root *share.AxisRoots) *Proof {
+	proof := &Proof{shareProof: sharesProofs}
+	roots := append(root.RowRoots, root.ColumnRoots...) //nolint: gocritic
+	_, proofs := merkle.ProofsFromByteSlices(roots)
+
+	proof.rowRootProof = proofs[rowIndex]
+	proof.root = roots[rowIndex]
+	return proof
+}
+
+// SharesProof returns a shares inclusion proof.
+func (p *Proof) SharesProof() *nmt.Proof {
+	return p.shareProof
+}
+
+// RowRootProof returns a merkle proof of the row root to the data root.
+func (p *Proof) RowRootProof() *merkle.Proof {
+	return p.rowRootProof
+}
+
+// VerifyInclusion verifies the inclusion of the shares to the data root.
+func (p *Proof) VerifyInclusion(shares []libshare.Share, namespace libshare.Namespace, dataRoot []byte) error {
+	outside, err := share.IsOutsideRange(namespace, p.root, p.root)
+	if err != nil {
+		return err
+	}
+	if outside {
+		return fmt.Errorf("namespace out of range")
+	}
+
+	isValid := p.shareProof.VerifyInclusion(
+		share.NewSHA256Hasher(),
+		namespace.Bytes(),
+		libshare.ToBytes(shares),
+		p.root,
+	)
+	if !isValid {
+		return errors.New("failed to verify nmt proof")
+	}
+
+	err = p.rowRootProof.Verify(dataRoot, p.root)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// VerifyNamespace verifies the whole namespace of the shares to the data root.
+func (p *Proof) VerifyNamespace(shrs []libshare.Share, namespace libshare.Namespace, dataRoot []byte) error {
+	outside, err := share.IsOutsideRange(namespace, p.root, p.root)
+	if err != nil {
+		return err
+	}
+	if outside {
+		return fmt.Errorf("namespace out of range")
+	}
+
+	leaves := make([][]byte, 0, len(shrs))
+	for _, sh := range shrs {
+		namespaceBytes := sh.Namespace().Bytes()
+		leave := make([]byte, len(sh.ToBytes())+len(namespaceBytes))
+		copy(leave, namespaceBytes)
+		copy(leave[len(namespaceBytes):], sh.ToBytes())
+		leaves = append(leaves, leave)
+	}
+
+	valid := p.shareProof.VerifyNamespace(
+		share.NewSHA256Hasher(),
+		namespace.Bytes(),
+		leaves,
+		p.root,
+	)
+	if !valid {
+		return fmt.Errorf("failed to verify namespace for the shares in row")
+	}
+
+	err = p.rowRootProof.Verify(dataRoot, p.root)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Start returns that start index of the proof
+func (p *Proof) Start() int {
+	return p.shareProof.Start()
+}
+
+// End returns an *inclusive* end index of the proof.
+func (p *Proof) End() int {
+	return p.shareProof.End() - 1
+}
+
+func (p *Proof) IsOfAbsence() bool {
+	return p.shareProof.IsOfAbsence()
+}
+
+func (p *Proof) MarshalJSON() ([]byte, error) {
+	temp := struct {
+		ShareProof   *nmt.Proof    `json:"share_proof"`
+		RowRootProof *merkle.Proof `json:"row_root_proof"`
+		Roots        []byte        `json:"root"`
+	}{
+		ShareProof:   p.shareProof,
+		RowRootProof: p.rowRootProof,
+		Roots:        p.root,
+	}
+	return json.Marshal(temp)
+}
+
+func (p *Proof) UnmarshalJSON(data []byte) error {
+	temp := struct {
+		ShareProof   *nmt.Proof    `json:"share_proof"`
+		RowRootProof *merkle.Proof `json:"row_root_proof"`
+		Root         []byte        `json:"root"`
+	}{}
+	err := json.Unmarshal(data, &temp)
+	if err != nil {
+		return err
+	}
+	p.shareProof = temp.ShareProof
+	p.rowRootProof = temp.RowRootProof
+	p.root = temp.Root
+	return nil
+}
+
+func (p *Proof) ToProto() *pb.Proof {
+	nmtProof := &nmt_pb.Proof{
+		Start:                 int64(p.shareProof.Start()),
+		End:                   int64(p.shareProof.End()),
+		Nodes:                 p.shareProof.Nodes(),
+		LeafHash:              p.shareProof.LeafHash(),
+		IsMaxNamespaceIgnored: p.shareProof.IsMaxNamespaceIDIgnored(),
+	}
+
+	rowRootProofs := &pb.RowRootProof{
+		Total:    p.rowRootProof.Total,
+		Index:    p.rowRootProof.Index,
+		LeafHash: p.rowRootProof.LeafHash,
+		Aunts:    p.rowRootProof.Aunts,
+	}
+
+	return &pb.Proof{
+		SharesProof:  nmtProof,
+		RowRootProof: rowRootProofs,
+		Root:         p.root,
+	}
+}
+
+func ProofFromProto(p *pb.Proof) (*Proof, error) {
+	var proof nmt.Proof
+	if p.GetSharesProof().GetLeafHash() != nil {
+		proof = nmt.NewAbsenceProof(
+			int(p.GetSharesProof().GetStart()),
+			int(p.GetSharesProof().GetEnd()),
+			p.GetSharesProof().GetNodes(),
+			p.GetSharesProof().GetLeafHash(),
+			p.GetSharesProof().GetIsMaxNamespaceIgnored(),
+		)
+	} else {
+		proof = nmt.NewInclusionProof(
+			int(p.GetSharesProof().GetStart()),
+			int(p.GetSharesProof().GetEnd()),
+			p.GetSharesProof().GetNodes(),
+			p.GetSharesProof().GetIsMaxNamespaceIgnored(),
+		)
+	}
+
+	rowRootProof := &merkle.Proof{
+		Total:    p.GetRowRootProof().GetTotal(),
+		Index:    p.GetRowRootProof().GetIndex(),
+		LeafHash: p.GetRowRootProof().GetLeafHash(),
+		Aunts:    p.GetRowRootProof().GetAunts(),
+	}
+
+	return &Proof{
+		shareProof:   &proof,
+		rowRootProof: rowRootProof,
+		root:         p.GetRoot(),
+	}, nil
+}
+
+// IsEmptyProof checks if the proof is empty or not. It returns *false*
+// if at least one of the condition is not met.
+func (p *Proof) IsEmptyProof() bool {
+	return p == nil ||
+		p.shareProof == nil ||
+		p.shareProof.IsEmptyProof() ||
+		p.rowRootProof == nil ||
+		p.root == nil
+}

--- a/share/shwap/range_namespace_data.go
+++ b/share/shwap/range_namespace_data.go
@@ -1,0 +1,188 @@
+package shwap
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+
+	"github.com/celestiaorg/celestia-app/v3/pkg/wrapper"
+	libshare "github.com/celestiaorg/go-square/v2/share"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/shwap/pb"
+)
+
+// RangeNamespaceData embeds `NamespaceData` and contains a contiguous range of shares
+// along with proofs for these shares.
+type RangeNamespaceData struct {
+	Start         int `json:"start"`
+	NamespaceData `json:"namespace_data"`
+}
+
+// RangedNamespaceDataFromShares builds a range of namespaced data for the given coordinates:
+// shares is a list of shares (grouped by the rows) relative to the data square and
+// needed to build the range;
+// namespace is the target namespace for the built range;
+// from is the coordinates of the first share of the range within the EDS.
+// to is the coordinates of the last inclusive share of the range within the EDS.
+func RangedNamespaceDataFromShares(
+	shares [][]libshare.Share,
+	namespace libshare.Namespace,
+	roots *share.AxisRoots,
+	from, to SampleCoords,
+) (RangeNamespaceData, error) {
+	if len(shares) == 0 {
+		return RangeNamespaceData{}, fmt.Errorf("empty share list")
+	}
+
+	odsSize := len(shares[0]) / 2
+	nsData := make([]RowNamespaceData, 0, len(shares))
+	rngData := RangeNamespaceData{Start: from.Row}
+	for i, row := 0, from.Row; i < len(shares); i++ {
+		rowShares := shares[i]
+		// end index will be explicitly set only for the last row in range.
+		// in other cases, it will be equal to the odsSize.
+		exclusiveEnd := odsSize
+		if i == len(shares)-1 {
+			// `to.Col` is an inclusive index
+			exclusiveEnd = to.Col + 1
+		}
+
+		// ensure that all shares from the range belong to the requested namespace
+		for offset := range rowShares[from.Col:exclusiveEnd] {
+			if !namespace.Equals(rowShares[from.Col+offset].Namespace()) {
+				return RangeNamespaceData{},
+					fmt.Errorf("targeted namespace was not found in share at {Row: %d, Col: %d}",
+						row, from.Col+offset,
+					)
+			}
+		}
+
+		tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(odsSize), uint(row))
+
+		for _, shr := range rowShares {
+			if err := tree.Push(shr.ToBytes()); err != nil {
+				return RangeNamespaceData{}, fmt.Errorf("failed to build tree for row %d: %w", row, err)
+			}
+		}
+
+		root, err := tree.Root()
+		if err != nil {
+			return RangeNamespaceData{}, fmt.Errorf("failed to get root for row %d: %w", row, err)
+		}
+
+		outside, err := share.IsOutsideRange(namespace, root, root)
+		if err != nil {
+			return RangeNamespaceData{}, err
+		}
+		if outside {
+			return RangeNamespaceData{}, ErrNamespaceOutsideRange
+		}
+
+		proof, err := tree.ProveRange(from.Col, exclusiveEnd)
+		if err != nil {
+			return RangeNamespaceData{}, err
+		}
+		dataRootProof := NewProof(row, &proof, roots)
+		nsData = append(nsData,
+			RowNamespaceData{Shares: rowShares[from.Col:exclusiveEnd], Proof: dataRootProof},
+		)
+
+		// reset from.Col as we are moving to the next row.
+		from.Col = 0
+		row++
+	}
+
+	rngData.NamespaceData = nsData
+	return rngData, nil
+}
+
+// Verify performs a basic validation of the incoming data. It ensures that the response data
+// correspond to the request.
+func (rngdata *RangeNamespaceData) Verify(
+	namespace libshare.Namespace,
+	from SampleCoords,
+	to SampleCoords,
+	dataHash []byte,
+) error {
+	if rngdata.IsEmpty() {
+		return errors.New("empty data")
+	}
+	if rngdata.NamespaceData[0].Proof.IsEmptyProof() {
+		return errors.New("empty proof")
+	}
+
+	if from.Row != rngdata.Start {
+		return fmt.Errorf("mismatched row: wanted: %d, got: %d", rngdata.Start, from.Row)
+	}
+	if from.Col != rngdata.NamespaceData[0].Proof.Start() {
+		return fmt.Errorf("mismatched col: wanted: %d, got: %d", rngdata.NamespaceData[0].Proof.Start(), from.Col)
+	}
+	if to.Col != rngdata.NamespaceData[len(rngdata.NamespaceData)-1].Proof.End() {
+		return fmt.Errorf(
+			"mismatched col: wanted: %d, got: %d",
+			rngdata.NamespaceData[len(rngdata.NamespaceData)-1].Proof.End(), to.Col,
+		)
+	}
+
+	for i, nsData := range rngdata.NamespaceData {
+		if nsData.Proof.IsEmptyProof() {
+			return fmt.Errorf("nil proof for row: %d", rngdata.Start+i)
+		}
+		if nsData.Proof.shareProof.IsOfAbsence() {
+			return fmt.Errorf("absence proof for row: %d", rngdata.Start+i)
+		}
+
+		err := nsData.Proof.VerifyInclusion(nsData.Shares, namespace, dataHash)
+		if err != nil {
+			return fmt.Errorf("%w for row: %d, %w", ErrFailedVerification, rngdata.Start+i, err)
+		}
+	}
+	return nil
+}
+
+func (rngdata *RangeNamespaceData) IsEmpty() bool {
+	return len(rngdata.NamespaceData) == 0
+}
+
+func (rngdata *RangeNamespaceData) ToProto() *pb.RangeNamespaceData {
+	return &pb.RangeNamespaceData{
+		Start:              int32(rngdata.Start),
+		RangeNamespaceData: rngdata.NamespaceData.ToProto(),
+	}
+}
+
+func (rngdata *RangeNamespaceData) CleanupData() {
+	for i := range rngdata.NamespaceData {
+		rngdata.NamespaceData[i].Shares = nil
+	}
+}
+
+func RangeNamespaceDataFromProto(nd *pb.RangeNamespaceData) (*RangeNamespaceData, error) {
+	data, err := NamespaceDataFromProto(nd.RangeNamespaceData)
+	if err != nil {
+		return nil, err
+	}
+	return &RangeNamespaceData{Start: int(nd.Start), NamespaceData: data}, nil
+}
+
+// RangeCoordsFromIdx accepts the start index and the length of the range and
+// computes `shwap.SampleCoords` of the first and the last sample of this range.
+// * edsIndex is the index of the first sample inside the eds;
+// * length is the amount of *ORIGINAL* samples that are expected to get(including the first sample);
+func RangeCoordsFromIdx(edsIndex, length, edsSize int) (SampleCoords, SampleCoords, error) {
+	from, err := SampleCoordsFrom1DIndex(edsIndex, edsSize)
+	if err != nil {
+		return SampleCoords{}, SampleCoords{}, err
+	}
+	odsIndex, err := SampleCoordsAs1DIndex(from, edsSize/2)
+	if err != nil {
+		return SampleCoords{}, SampleCoords{}, err
+	}
+
+	toInclusive := odsIndex + length - 1
+	toCoords, err := SampleCoordsFrom1DIndex(toInclusive, edsSize/2)
+	if err != nil {
+		return SampleCoords{}, SampleCoords{}, err
+	}
+	return from, toCoords, nil
+}

--- a/share/shwap/range_namespace_data.go
+++ b/share/shwap/range_namespace_data.go
@@ -92,6 +92,7 @@ func RangedNamespaceDataFromShares(
 		row++
 	}
 
+	rngData.Start = from.Row
 	rngData.NamespaceData = nsData
 	return rngData, nil
 }

--- a/share/shwap/range_namespace_data.go
+++ b/share/shwap/range_namespace_data.go
@@ -1,8 +1,8 @@
 package shwap
 
 import (
+	"errors"
 	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/celestiaorg/celestia-app/v3/pkg/wrapper"
 	libshare "github.com/celestiaorg/go-square/v2/share"

--- a/share/shwap/range_namespace_data_id.go
+++ b/share/shwap/range_namespace_data_id.go
@@ -1,0 +1,179 @@
+package shwap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	libshare "github.com/celestiaorg/go-square/v2/share"
+)
+
+// RangeNamespaceDataIDSize defines the size of the RangeNamespaceDataIDSize in bytes,
+// combining SampleID size, Namespace size, 4 additional bytes
+// for the end coordinates of share of the range and uint representation of bool flag.
+const RangeNamespaceDataIDSize = EdsIDSize + libshare.NamespaceSize + 10
+
+// RangeNamespaceDataID identifies the continuous range of shares in the DataSquare(EDS),
+// starting from the given `SampleID` and contains `Length` number of shares.
+type RangeNamespaceDataID struct {
+	EdsID
+	// coordinates from the first share of the range
+	From SampleCoords
+	// coordinates from the last share of the range
+	To SampleCoords
+	//  DataNamespace is a string representation of the namespace of the requested range.
+	DataNamespace libshare.Namespace
+
+	ProofsOnly bool
+}
+
+func NewRangeNamespaceDataID(
+	edsID EdsID,
+	namespace libshare.Namespace,
+	from SampleCoords,
+	to SampleCoords,
+	edsSize int,
+	proofsOnly bool,
+) (RangeNamespaceDataID, error) {
+	rngid := RangeNamespaceDataID{
+		EdsID:         edsID,
+		From:          from,
+		DataNamespace: namespace,
+		To:            to,
+		ProofsOnly:    proofsOnly,
+	}
+
+	err := rngid.Verify(edsSize)
+	if err != nil {
+		return RangeNamespaceDataID{}, fmt.Errorf("verifying range id: %w", err)
+	}
+	return rngid, nil
+}
+
+// Verify validates the RangeNamespaceDataID fields and verifies that number of the requested shares
+// does not exceed the number of shares inside the ODS.
+func (rngid RangeNamespaceDataID) Verify(edsSize int) error {
+	err := rngid.EdsID.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid EdsID: %w", err)
+	}
+	err = rngid.DataNamespace.ValidateForData()
+	if err != nil {
+		return err
+	}
+	_, err = SampleCoordsAs1DIndex(rngid.From, edsSize)
+	if err != nil {
+		return err
+	}
+	// verify that to is not exceed that edsSize
+	_, err = SampleCoordsAs1DIndex(rngid.To, edsSize)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate performs basic fields validation.
+func (rngid RangeNamespaceDataID) Validate() error {
+	return rngid.DataNamespace.ValidateForData()
+}
+
+// ReadFrom reads the binary form of RangeNamespaceDataID from the provided reader.
+func (rngid *RangeNamespaceDataID) ReadFrom(r io.Reader) (int64, error) {
+	data := make([]byte, RangeNamespaceDataIDSize)
+	n, err := io.ReadFull(r, data)
+	if err != nil {
+		return int64(n), err
+	}
+	if n != RangeNamespaceDataIDSize {
+		return int64(n), fmt.Errorf("RangeNamespaceDataID: expected %d bytes, got %d", RangeNamespaceDataIDSize, n)
+	}
+
+	id, err := RangeNamespaceDataIDFromBinary(data)
+	if err != nil {
+		return int64(n), fmt.Errorf("RangeNamespaceDataIDFromBinary: %w", err)
+	}
+	*rngid = id
+	return int64(n), nil
+}
+
+// WriteTo writes the binary form of RangeNamespaceDataID to the provided writer.
+func (rngid RangeNamespaceDataID) WriteTo(w io.Writer) (int64, error) {
+	data, err := rngid.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	n, err := w.Write(data)
+	return int64(n), err
+}
+
+// Equals checks equality of RangeNamespaceDataID.
+func (rngid *RangeNamespaceDataID) Equals(other RangeNamespaceDataID) bool {
+	return rngid.DataNamespace.Equals(other.DataNamespace) && rngid.From == other.From &&
+		rngid.To == other.To
+}
+
+// RangeNamespaceDataIDFromBinary deserializes a RangeNamespaceDataID from its binary form.
+func RangeNamespaceDataIDFromBinary(data []byte) (RangeNamespaceDataID, error) {
+	if len(data) != RangeNamespaceDataIDSize {
+		return RangeNamespaceDataID{}, fmt.Errorf(
+			"invalid RangeNamespaceDataID data length: expected %d, got %d", RangeNamespaceDataIDSize, len(data),
+		)
+	}
+
+	edsID, err := EdsIDFromBinary(data[:EdsIDSize])
+	if err != nil {
+		return RangeNamespaceDataID{}, err
+	}
+
+	fromCoords := SampleCoords{
+		Row: int(binary.BigEndian.Uint16(data[EdsIDSize : EdsIDSize+2])),
+		Col: int(binary.BigEndian.Uint16(data[EdsIDSize+2 : EdsIDSize+4])),
+	}
+	toCoords := SampleCoords{
+		Row: int(binary.BigEndian.Uint16(data[EdsIDSize+4 : EdsIDSize+6])),
+		Col: int(binary.BigEndian.Uint16(data[EdsIDSize+6 : EdsIDSize+8])),
+	}
+
+	ns, err := libshare.NewNamespaceFromBytes(data[EdsIDSize+8 : EdsIDSize+8+libshare.NamespaceSize])
+	if err != nil {
+		return RangeNamespaceDataID{}, fmt.Errorf("converting namespace from binary: %w", err)
+	}
+
+	var proofsOnly bool
+	if data[RangeNamespaceDataIDSize-1] == 1 {
+		proofsOnly = true
+	}
+
+	rngID := RangeNamespaceDataID{
+		EdsID:         edsID,
+		From:          fromCoords,
+		DataNamespace: ns,
+		To:            toCoords,
+		ProofsOnly:    proofsOnly,
+	}
+	return rngID, rngID.Validate()
+}
+
+// MarshalBinary encodes RangeNamespaceDataID into binary form.
+func (rngid RangeNamespaceDataID) MarshalBinary() ([]byte, error) {
+	data := make([]byte, 0, RangeNamespaceDataIDSize)
+	return rngid.appendTo(data), nil
+}
+
+// appendTo helps in constructing the binary representation  of RangeNamespaceDataID
+// by appending all encoded fields.
+func (rngid RangeNamespaceDataID) appendTo(data []byte) []byte {
+	data = rngid.EdsID.appendTo(data)
+	data = binary.BigEndian.AppendUint16(data, uint16(rngid.From.Row))
+	data = binary.BigEndian.AppendUint16(data, uint16(rngid.From.Col))
+	data = binary.BigEndian.AppendUint16(data, uint16(rngid.To.Row))
+	data = binary.BigEndian.AppendUint16(data, uint16(rngid.To.Col))
+	data = append(data, rngid.DataNamespace.Bytes()...)
+	if rngid.ProofsOnly {
+		data = binary.BigEndian.AppendUint16(data, 1)
+	} else {
+		data = binary.BigEndian.AppendUint16(data, 0)
+	}
+	return data
+}

--- a/share/shwap/range_namespace_data_id_test.go
+++ b/share/shwap/range_namespace_data_id_test.go
@@ -1,0 +1,59 @@
+package shwap
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v2/share"
+)
+
+func TestNewRangeNamespaceDataID(t *testing.T) {
+	edsSize := 16
+	ns := libshare.RandomNamespace()
+
+	rngid, err := NewRangeNamespaceDataID(
+		EdsID{1},
+		ns,
+		SampleCoords{Row: 5, Col: 10},
+		SampleCoords{7, 12},
+		edsSize,
+		true,
+	)
+	require.NoError(t, err)
+
+	bin, err := rngid.MarshalBinary()
+	require.NoError(t, err)
+
+	rngidOut, err := RangeNamespaceDataIDFromBinary(bin)
+	require.NoError(t, err)
+	assert.EqualValues(t, rngid, rngidOut)
+
+	err = rngid.Validate()
+	require.NoError(t, err)
+}
+
+func TestRangeNamespaceDataIDReaderWriter(t *testing.T) {
+	edsSize := 32
+	ns := libshare.RandomNamespace()
+	to, err := SampleCoordsFrom1DIndex(10, edsSize)
+	require.NoError(t, err)
+	rngid, err := NewRangeNamespaceDataID(EdsID{1}, ns, SampleCoords{Row: 0, Col: 1}, to, edsSize, false)
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(nil)
+	n, err := rngid.WriteTo(buf)
+	require.NoError(t, err)
+	require.Equal(t, int64(RangeNamespaceDataIDSize), n)
+
+	rngidOut := RangeNamespaceDataID{}
+	n, err = rngidOut.ReadFrom(buf)
+	require.NoError(t, err)
+	require.Equal(t, int64(RangeNamespaceDataIDSize), n)
+	require.EqualValues(t, rngid, rngidOut)
+
+	err = rngidOut.Validate()
+	require.NoError(t, err)
+}

--- a/share/shwap/range_namespace_data_test.go
+++ b/share/shwap/range_namespace_data_test.go
@@ -1,0 +1,154 @@
+package shwap_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v2/share"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+func TestRangeNamespaceData(t *testing.T) {
+	const (
+		odsSize      = 16
+		sharesAmount = odsSize * odsSize
+	)
+
+	ns := libshare.RandomNamespace()
+	square, root := edstest.RandEDSWithNamespace(t, ns, odsSize, odsSize)
+
+	nsRowStart := -1
+	for i, row := range root.RowRoots {
+		outside, err := share.IsOutsideRange(ns, row, row)
+		require.NoError(t, err)
+		if !outside {
+			nsRowStart = i
+			break
+		}
+	}
+	assert.Greater(t, nsRowStart, -1)
+
+	extended := &eds.Rsmt2D{ExtendedDataSquare: square}
+
+	nsData, err := extended.RowNamespaceData(context.Background(), ns, nsRowStart)
+	require.NoError(t, err)
+	col := nsData.Proof.Start()
+
+	for i := 1; i <= odsSize; i++ {
+		t.Run(fmt.Sprintf("range of %d shares", i), func(t *testing.T) {
+			toRow, toCol := nsRowStart, col+i-1
+			for toCol >= odsSize {
+				toRow++
+				toCol -= odsSize
+			}
+
+			to := shwap.SampleCoords{Row: toRow, Col: toCol}
+			dataID, err := shwap.NewRangeNamespaceDataID(
+				shwap.EdsID{Height: 1},
+				ns,
+				shwap.SampleCoords{Row: nsRowStart, Col: col},
+				to,
+				sharesAmount,
+				false,
+			)
+			require.NoError(t, err)
+
+			rngdata, err := extended.RangeNamespaceData(
+				context.Background(),
+				dataID.DataNamespace,
+				shwap.SampleCoords{Row: dataID.From.Row, Col: dataID.From.Col},
+				to,
+			)
+			require.NoError(t, err)
+			err = rngdata.Verify(ns, dataID.From, dataID.To, root.Hash())
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRangeCoordsFromIdx(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+	const (
+		odsSize = 4
+		edsSize = odsSize * 2
+	)
+
+	ns := libshare.RandomNamespace()
+	square, _ := edstest.RandEDSWithNamespace(t, ns, odsSize*odsSize, odsSize)
+	rngLengths := []int{2, 7, 11, 15}
+	extended := &eds.Rsmt2D{ExtendedDataSquare: square}
+	for _, length := range rngLengths {
+		from, to, err := shwap.RangeCoordsFromIdx(0, length, edsSize)
+		require.NoError(t, err)
+		rngData, err := extended.RangeNamespaceData(ctx, ns, from, to)
+		require.NoError(t, err)
+		require.Equal(t, length, len(rngData.Flatten()))
+	}
+}
+
+func FuzzRangeCoordsFromIdx(f *testing.F) {
+	if testing.Short() {
+		f.Skip()
+	}
+
+	const (
+		odsSize = 16
+		edsSize = odsSize * 2
+	)
+
+	square := edstest.RandEDS(f, odsSize)
+	shrs := square.FlattenedODS()
+	assert.Equal(f, len(shrs), odsSize*odsSize)
+
+	f.Add(0, 3, edsSize)
+	f.Add(10, 14, edsSize)
+	f.Add(23, 30, edsSize)
+	f.Add(62, 3, edsSize)
+
+	f.Fuzz(func(t *testing.T, edsIndex, length, size int) {
+		if edsIndex < 0 || edsIndex >= edsSize*edsSize {
+			return
+		}
+
+		coords, err := shwap.SampleCoordsFrom1DIndex(edsIndex, edsSize)
+		require.NoError(t, err)
+		if coords.Row >= odsSize || coords.Col >= odsSize {
+			return
+		}
+
+		odsIndexStart := coords.Row*odsSize + coords.Col
+		if odsIndexStart+length >= odsSize*odsSize {
+			return
+		}
+
+		if length <= 0 || length >= odsSize*odsSize {
+			return
+		}
+		if size != edsSize {
+			return
+		}
+
+		from, to, err := shwap.RangeCoordsFromIdx(edsIndex, length, size)
+		require.NoError(t, err)
+		edsStartShare := square.GetCell(uint(from.Row), uint(from.Col))
+		edsEndShare := square.GetCell(uint(to.Row), uint(to.Col))
+
+		odsIndexStart = from.Row*odsSize + from.Col
+		odsIndexEnd := to.Row*odsSize + to.Col
+
+		odsStartShare := shrs[odsIndexStart]
+		odsEndShare := shrs[odsIndexEnd]
+		require.Equal(t, edsStartShare, odsStartShare)
+		require.Equal(t, edsEndShare, odsEndShare)
+	})
+}

--- a/share/shwap/row_namespace_data_test.go
+++ b/share/shwap/row_namespace_data_test.go
@@ -1,9 +1,7 @@
 package shwap_test
 
 import (
-	"bytes"
 	"context"
-	"slices"
 	"testing"
 	"time"
 
@@ -16,29 +14,6 @@ import (
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 	"github.com/celestiaorg/celestia-node/share/shwap"
 )
-
-func TestNamespacedRowFromShares(t *testing.T) {
-	const odsSize = 8
-
-	minNamespace, err := libshare.NewV0Namespace(slices.Concat(bytes.Repeat([]byte{0}, 8), []byte{1, 0}))
-	require.NoError(t, err)
-	require.NoError(t, minNamespace.ValidateForData())
-
-	for namespacedAmount := 1; namespacedAmount < odsSize; namespacedAmount++ {
-		shares, err := libshare.RandSharesWithNamespace(minNamespace, namespacedAmount, odsSize)
-		require.NoError(t, err)
-		parity, err := share.DefaultRSMT2DCodec().Encode(libshare.ToBytes(shares))
-		require.NoError(t, err)
-
-		paritySh, err := libshare.FromBytes(parity)
-		require.NoError(t, err)
-		extended := slices.Concat(shares, paritySh)
-
-		nr, err := shwap.RowNamespaceDataFromShares(extended, minNamespace, 0)
-		require.NoError(t, err)
-		require.Equal(t, namespacedAmount, len(nr.Shares))
-	}
-}
 
 // func TestNamespacedRowFromSharesNonIncluded(t *testing.T) {
 // //TODO: this will fail until absence proof support is added
@@ -83,7 +58,7 @@ func TestValidateNamespacedRow(t *testing.T) {
 		require.Len(t, nd, len(rowIdxs))
 
 		for i, rowIdx := range rowIdxs {
-			err = nd[i].Verify(root, namespace, rowIdx)
+			err = nd[i].Verify(root.Hash(), namespace, rowIdx)
 			require.NoError(t, err)
 		}
 	}

--- a/store/cache/accessor_cache_test.go
+++ b/store/cache/accessor_cache_test.go
@@ -327,6 +327,14 @@ func (m *mockAccessor) RowNamespaceData(context.Context, libshare.Namespace, int
 	panic("implement me")
 }
 
+func (m *mockAccessor) RangeNamespaceData(
+	context.Context,
+	libshare.Namespace,
+	shwap.SampleCoords, shwap.SampleCoords,
+) (shwap.RangeNamespaceData, error) {
+	panic("implement me")
+}
+
 func (m *mockAccessor) Shares(context.Context) ([]libshare.Share, error) {
 	panic("implement me")
 }

--- a/store/cache/noop.go
+++ b/store/cache/noop.go
@@ -71,6 +71,14 @@ func (n NoopFile) RowNamespaceData(context.Context, libshare.Namespace, int) (sh
 	return shwap.RowNamespaceData{}, nil
 }
 
+func (n NoopFile) RangeNamespaceData(
+	_ context.Context,
+	_ libshare.Namespace,
+	_, _ shwap.SampleCoords,
+) (shwap.RangeNamespaceData, error) {
+	return shwap.RangeNamespaceData{}, nil
+}
+
 func (n NoopFile) Shares(context.Context) ([]libshare.Share, error) {
 	return []libshare.Share{}, nil
 }

--- a/store/file/ods_q4.go
+++ b/store/file/ods_q4.go
@@ -161,7 +161,11 @@ func (odsq4 *ODSQ4) RowNamespaceData(ctx context.Context,
 	if err != nil {
 		return shwap.RowNamespaceData{}, fmt.Errorf("extending shares: %w", err)
 	}
-	return shwap.RowNamespaceDataFromShares(shares, namespace, rowIdx)
+	roots, err := odsq4.AxisRoots(ctx)
+	if err != nil {
+		return shwap.RowNamespaceData{}, fmt.Errorf("getting axis roots %w", err)
+	}
+	return shwap.RowNamespaceDataFromShares(shares, namespace, rowIdx, roots)
 }
 
 func (odsq4 *ODSQ4) Shares(ctx context.Context) ([]libshare.Share, error) {
@@ -188,4 +192,12 @@ func (odsq4 *ODSQ4) Close() error {
 		}
 	}
 	return err
+}
+
+func (odsq4 *ODSQ4) RangeNamespaceData(
+	ctx context.Context,
+	ns libshare.Namespace,
+	from, to shwap.SampleCoords,
+) (shwap.RangeNamespaceData, error) {
+	return odsq4.ods.RangeNamespaceData(ctx, ns, from, to)
 }

--- a/store/getter.go
+++ b/store/getter.go
@@ -110,3 +110,27 @@ func (g *Getter) GetNamespaceData(
 	}
 	return nd, nil
 }
+
+func (g *Getter) GetRangeNamespaceData(
+	ctx context.Context,
+	h *header.ExtendedHeader,
+	ns libshare.Namespace,
+	from, to shwap.SampleCoords,
+	proofsOnly bool,
+) (shwap.RangeNamespaceData, error) {
+	acc, err := g.store.GetByHeight(ctx, h.Height())
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return shwap.RangeNamespaceData{}, shwap.ErrNotFound
+		}
+		return shwap.RangeNamespaceData{}, fmt.Errorf("getting accessor from store:%w", err)
+	}
+	rngData, err := acc.RangeNamespaceData(ctx, ns, from, to)
+	if err != nil {
+		return shwap.RangeNamespaceData{}, fmt.Errorf("getting range from accessor:%w", err)
+	}
+	if proofsOnly {
+		rngData.CleanupData()
+	}
+	return rngData, nil
+}


### PR DESCRIPTION
This PR enables GetRangeRequests over the shwap by introducing the GetRangeNamespaceData container. It allows users to retrieve namespace data using ODS coordinates [from; to]. The user must specify the type of response they want:
* Data + Proofs;
* ProofsOnly;
The returned proof can be verified against the data root. Additionally, GetRow and GetNamespaceData now return proofs that can also be verified against the data root.