### PR TITLE
fxi(nodebuilder/swamp): ignore leveldb panic in swamp tests

### DIFF
--- a/nodebuilder/tests/api_test.go
+++ b/nodebuilder/tests/api_test.go
@@ -26,6 +26,7 @@ const (
 )
 
 func TestNodeModule(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
@@ -66,6 +67,7 @@ func TestNodeModule(t *testing.T) {
 }
 
 func TestGetByHeight(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
@@ -95,6 +97,7 @@ func TestGetByHeight(t *testing.T) {
 
 // TestBlobRPC ensures that blobs can be submitted via rpc
 func TestBlobRPC(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
@@ -125,6 +128,7 @@ func TestBlobRPC(t *testing.T) {
 // TestHeaderSubscription ensures that the header subscription over RPC works
 // as intended and gets canceled successfully after rpc context cancellation.
 func TestHeaderSubscription(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestBlobModule(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	t.Cleanup(cancel)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second*1))

--- a/nodebuilder/tests/da_test.go
+++ b/nodebuilder/tests/da_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestDaModule(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	t.Cleanup(cancel)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second))

--- a/nodebuilder/tests/nd_test.go
+++ b/nodebuilder/tests/nd_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestShrexNDFromLights(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	const (
 		blocks = 10
 		btime  = time.Millisecond * 300
@@ -82,6 +83,7 @@ func TestShrexNDFromLights(t *testing.T) {
 }
 
 func TestShrexNDFromLightsWithBadFulls(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	const (
 		blocks        = 10
 		btime         = time.Millisecond * 300

--- a/nodebuilder/tests/p2p_test.go
+++ b/nodebuilder/tests/p2p_test.go
@@ -28,6 +28,7 @@ Steps:
 5. Check that nodes are connected to bridge
 */
 func TestBridgeNodeAsBootstrapper(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
@@ -67,6 +68,7 @@ Steps:
  7. Check that full and light nodes are connected to each other
 */
 func TestFullDiscoveryViaBootstrapper(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
@@ -141,6 +143,7 @@ Steps:
 *NOTE*: this test will take some time because it relies on several cycles of peer discovery
 */
 func TestRestartNodeDiscovery(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -39,6 +39,7 @@ import (
 // spin up 3 pruning FNs, connect
 // spin up 1 LN that syncs historic blobs
 func TestArchivalBlobSync(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	const (
 		blocks = 50
 		btime  = time.Millisecond * 300
@@ -172,6 +173,7 @@ func TestArchivalBlobSync(t *testing.T) {
 }
 
 func TestConvertFromPrunedToArchival(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	t.Cleanup(cancel)

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -367,4 +368,16 @@ func (s *Swamp) Validators(t *testing.T) (*types.ValidatorSet, types.PrivValidat
 	validator := types.NewValidator(key, 100)
 	set := types.NewValidatorSet([]*types.Validator{validator})
 	return set, priv
+}
+
+// leveldb is closed after the test, but before node is stopped. Ignore this panic.
+func IgnoreLevelDBPanic(t *testing.T) {
+	if r := recover(); r != nil {
+		// convert to string
+		err := r.(error)
+		if strings.Contains(err.Error(), "leveldb: closed") {
+			return
+		}
+		t.Fatalf("unexpected panic: %v", r)
+	}
 }

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -137,6 +137,7 @@ Full node:
 8. Wait for FN DASer to catch up to network head
 */
 func TestSyncAgainstBridge_EmptyChain(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
@@ -213,6 +214,7 @@ Steps:
 9. Check LN is synced to height 40
 */
 func TestSyncStartStopLightWithBridge(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	if testing.Short() {
 		t.Skip("skipping TestSyncStartStopLightWithBridge test in short mode.")
 	}
@@ -284,6 +286,7 @@ Steps:
 10. Check LN is synced to network head
 */
 func TestSyncLightAgainstFull(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 
@@ -363,6 +366,7 @@ Steps:
 9. Check LN is synced to network head.
 */
 func TestSyncLightWithTrustedPeers(t *testing.T) {
+	defer swamp.IgnoreLevelDBPanic(t)
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
LevelDB may panic after test is over. This happens due to leveldb being closed before node client is closed. This is temporary fix to make swamp tests more stable until swamp tests shutdown order is fixed.