### PR TITLE
fix(modshare): discovery leftover from #3777 

### DIFF
--- a/nodebuilder/share/p2p_constructors.go
+++ b/nodebuilder/share/p2p_constructors.go
@@ -133,8 +133,8 @@ func archivalDiscoveryAndPeerManager(tp node.Type, cfg *Config) fx.Option {
 				cfg.Discovery,
 				h,
 				disc,
-				protocolVersion,
 				archivalNodesTag,
+				protocolVersion,
 				discOpts...,
 			)
 			if err != nil {


### PR DESCRIPTION
I realized by seeing logs that the archival tag and version weren't rearranged in #3777 