### PR TITLE
chore(deps): upgrade to v2.2.0-mocha

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
 	github.com/benbjohnson/clock v1.3.5
-	github.com/celestiaorg/celestia-app/v2 v2.2.0-arabica
+	github.com/celestiaorg/celestia-app/v2 v2.2.0-mocha
 	github.com/celestiaorg/go-fraud v0.2.1
 	github.com/celestiaorg/go-header v0.6.2
 	github.com/celestiaorg/go-libp2p-messenger v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0 h1:h1Y4V3EMQ2mFmNtWt2sIhZIuyASInj1a9ExI8xOsTOw=
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0/go.mod h1:x4DKyfKOSv1ZJM9NwV+Pw01kH2CD7N5zTFclXIVJ6GQ=
-github.com/celestiaorg/celestia-app/v2 v2.2.0-arabica h1:EbcV7BVOs8oaN4DFO76B9dKOJtZu1DH8yLSGcwejIKU=
-github.com/celestiaorg/celestia-app/v2 v2.2.0-arabica/go.mod h1:+7xlXlBA3Tx9u1LxZF/4QAaAGfBIXv8JPrrFQAbLiWA=
+github.com/celestiaorg/celestia-app/v2 v2.2.0-mocha h1:8KZu4mnaf9xLpzGcNEozJFeW5gOlI2E894rIb9xW6xk=
+github.com/celestiaorg/celestia-app/v2 v2.2.0-mocha/go.mod h1:+7xlXlBA3Tx9u1LxZF/4QAaAGfBIXv8JPrrFQAbLiWA=
 github.com/celestiaorg/celestia-core v1.40.0-tm-v0.34.29 h1:J79TAjizxwIvm7/k+WI3PPH1aFj4AjOSjajoq5UzAwI=
 github.com/celestiaorg/celestia-core v1.40.0-tm-v0.34.29/go.mod h1:5jJ5magtH7gQOwSYfS/m5fliIS7irKunLV7kLNaD8o0=
 github.com/celestiaorg/cosmos-sdk v1.24.1-sdk-v0.46.16 h1:SeQ7Y/CyOcUMKo7mQiexaj/pZ/xIgyuZFIwYZwpSkWE=


### PR DESCRIPTION
Upgrade to https://github.com/celestiaorg/celestia-app/releases/tag/v2.2.0-mocha

v2.2.0-arabica has baked on Arabica since Thursday and no new issues reported.