### PR TITLE
fix(docker): set addr flags to 0.0.0.0 in entrypoint file

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ "$1" = 'celestia' ]; then
     echo "Initializing Celestia Node with command:"
-    COMMAND="celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}""
+    COMMAND="celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}" --rpc.addr="0.0.0.0" --gateway.addr="0.0.0.0""
     if [[ -n "$NODE_STORE" ]]; then
         COMMAND=${COMMAND}" --node.store "${NODE_STORE}""
         echo $COMMAND

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,13 +4,14 @@ set -e
 
 if [ "$1" = 'celestia' ]; then
     echo "Initializing Celestia Node with command:"
-
+    COMMAND="celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}""
     if [[ -n "$NODE_STORE" ]]; then
-        echo "celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}" --node.store "${NODE_STORE}""
-        celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}" --node.store "${NODE_STORE}"
+        COMMAND=${COMMAND}" --node.store "${NODE_STORE}""
+        echo $COMMAND
+        $COMMAND
     else
-        echo "celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}""
-        celestia "${NODE_TYPE}" init --p2p.network "${P2P_NETWORK}"
+        echo $COMMAND
+        $COMMAND
     fi
 
     echo ""


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

When using port forwarding in docker, you need to use the `any` address interface `0.0.0.0` otherwise you would be able to communicate to the server inside the container. 

This PR updates the `entrypoint.sh` file to set the RPC and Gateway addresses to `0.0.0.0` so that developers can properly communicate to the node when exposing ports, for example `-p 26658:26658`. 
