### PR TITLE
chore(logs): increase verbosity for bitswap log

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -22,7 +22,7 @@ func SetAllLoggers(level logging.LogLevel) {
 	_ = logging.SetLogLevel("bitswap/network", "ERROR")
 	_ = logging.SetLogLevel("bitswap/session", "WARN")
 	_ = logging.SetLogLevel("bitswap/server", "WARN")
-	_ = logging.SetLogLevel("bitswap/server/decision", "WARN")
+	_ = logging.SetLogLevel("bitswap/server/decision", "INFO")
 	_ = logging.SetLogLevel("connmgr", "WARN")
 	_ = logging.SetLogLevel("nat", "INFO")
 	_ = logging.SetLogLevel("dht/RtRefreshManager", "FATAL")


### PR DESCRIPTION
Bitswap decision engine has certain important logs for us and node operators to keep in mind, thus the change.
Like https://github.com/ipfs/boxo/blob/ceb514cc23b0c60494ddac6579dae3829459cb93/bitswap/server/internal/decision/engine.go#L727
