### PR TITLE
fix(nodebuilder): flag parsing for --node.type needs lowercase string, list network aliases for --p2p.network

### DIFF
--- a/nodebuilder/node/type.go
+++ b/nodebuilder/node/type.go
@@ -1,5 +1,9 @@
 package node
 
+import (
+	"strings"
+)
+
 // Type defines the Node type (e.g. `light`, `bridge`) for identity purposes.
 // The zero value for Type is invalid.
 type Type uint8
@@ -36,7 +40,7 @@ func (t Type) IsValid() bool {
 
 // ParseType converts string in a type if possible.
 func ParseType(str string) Type {
-	tp, ok := stringToType[str]
+	tp, ok := stringToType[strings.ToLower(str)]
 	if !ok {
 		return 0
 	}
@@ -53,9 +57,9 @@ var typeToString = map[Type]string{
 
 // typeToString maps strings representations of all valid Types.
 var stringToType = map[string]Type{
-	"Bridge": Bridge,
-	"Light":  Light,
-	"Full":   Full,
+	"bridge": Bridge,
+	"light":  Light,
+	"full":   Full,
 }
 
 // orderedTypes is a slice of all valid types in order of priority.

--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -83,13 +83,19 @@ func GetNetworks() []Network {
 }
 
 // listAvailableNetworks provides a string listing all known long-standing networks for things
-// like CLI hints.
+// like CLI hints. It also lists the network aliases as valid arguments.
 func listAvailableNetworks() string {
 	var networks []string
+
 	for _, net := range orderedNetworks {
 		// "private" networks are configured via env vars, so skip
 		if net != Private {
 			networks = append(networks, net.String())
+		}
+	}
+	for net := range networkAliases {
+		if net != "private" {
+			networks = append(networks, net)
 		}
 	}
 


### PR DESCRIPTION
Fixes #3825 

Also lists all network aliases as well in `--p2p.network` description string.