### PR TITLE
chore(Dockerfile): bump go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.23-alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.23.2-alpine3.20 AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
We removed `godebug asynctimerchan=1` in https://github.com/celestiaorg/celestia-node/pull/3790 and forgot to update the Dockerfile to the latest version of Go, resulting in images being built with go1.23.0 reproducing the original bug.