### PR TITLE
fix(eds/cache): Fix prealloc for proof nodes

### DIFF
--- a/share/ipld/nmt_adder.go
+++ b/share/ipld/nmt_adder.go
@@ -196,5 +196,5 @@ func (a *ProofsAdder) addProof(id cid.Cid, proof []byte) {
 
 // innerNodesAmount return amount of inner nodes in eds with given size
 func innerNodesAmount(squareSize int) int {
-	return 2 * (squareSize - 1) * squareSize
+	return 2*squareSize - 1
 }


### PR DESCRIPTION
Previous prealloc calc was incorrect resulting in higher allocation than needed. This is chart of amount of allocation we should have done and actually done:
```
eds size; needed alloc; real alloc
2 3 4
4 7 24
8 15 112
16 31 480
32 63 1984
64 127 8064
128 255 32512
256 511 130560
512 1023 523264
```

Fixes https://github.com/celestiaorg/celestia-node/issues/3858