### PR TITLE
fix(store/file): wait for q4 to be written before returning

### DIFF
--- a/store/file/ods_q4.go
+++ b/store/file/ods_q4.go
@@ -43,23 +43,21 @@ func CreateODSQ4(
 	go func() {
 		// doing this async shaves off ~27% of time for 128 ODS
 		// for bigger ODSes the discrepancy is even bigger
-		err := createQ4(pathQ4, eds)
-		if err != nil {
-			err = fmt.Errorf("сreating Q4 file: %w", err)
-		}
-
-		errCh <- err
+		errCh <- createQ4(pathQ4, eds)
 	}()
 
-	if err := CreateODS(pathODS, roots, eds); err != nil {
+	err := CreateODS(pathODS, roots, eds)
+	q4Err := <-errCh
+
+	if err != nil && q4Err != nil {
+		return fmt.Errorf("creating ODS and Q4 files: %w", errors.Join(err, q4Err))
+	}
+	if err != nil {
 		return fmt.Errorf("creating ODS file: %w", err)
 	}
-
-	err := <-errCh
-	if err != nil {
-		return err
+	if q4Err != nil {
+		return fmt.Errorf("creating Q4 file: %w", q4Err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
TLDR: It was possible to return with error before reading from channel. Which could lead to leak of q4 writing go-routine.

Fixed a race condition when writing/removing the Q4 file. The main go-routine wasn’t waiting for the Q4 write to finish, causing the file to be removed before the write completed. This could leave unpredictable data on disk after the removal. These changes ensure the write operation finishes before any removal is attempted.