### PR TITLE
!refactor(api/share): use height in share module

### DIFF
--- a/api/gateway/availability.go
+++ b/api/gateway/availability.go
@@ -27,13 +27,7 @@ func (h *Handler) handleHeightAvailabilityRequest(w http.ResponseWriter, r *http
 		return
 	}
 
-	header, err := h.header.GetByHeight(r.Context(), uint64(height))
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, heightAvailabilityEndpoint, err)
-		return
-	}
-
-	err = h.share.SharesAvailable(r.Context(), header)
+	err = h.share.SharesAvailable(r.Context(), uint64(height))
 	switch {
 	case err == nil:
 		resp, err := json.Marshal(&AvailabilityResponse{Available: true})

--- a/api/gateway/share.go
+++ b/api/gateway/share.go
@@ -93,12 +93,7 @@ func (h *Handler) getShares(
 	height uint64,
 	namespace libshare.Namespace,
 ) ([]libshare.Share, error) {
-	header, err := h.header.GetByHeight(ctx, height)
-	if err != nil {
-		return nil, err
-	}
-
-	shares, err := h.share.GetSharesByNamespace(ctx, header, namespace)
+	shares, err := h.share.GetSharesByNamespace(ctx, height, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/nodebuilder/node_test.go
+++ b/nodebuilder/node_test.go
@@ -15,9 +15,7 @@ import (
 	collectormetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/celestiaorg/celestia-node/header/headertest"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
-	"github.com/celestiaorg/celestia-node/share"
 )
 
 func TestLifecycle(t *testing.T) {
@@ -124,35 +122,4 @@ func StartMockOtelCollectorHTTPServer(t *testing.T) (string, func()) {
 
 	server.EnableHTTP2 = true
 	return server.URL, server.Close
-}
-
-func TestEmptyBlockExists(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	test := []struct {
-		tp node.Type
-	}{
-		{tp: node.Bridge},
-		{tp: node.Full},
-		// technically doesn't need to be tested as a SharesAvailable call to
-		// light node short circuits on an empty EDS
-		{tp: node.Light},
-	}
-	for i, tt := range test {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			node := TestNode(t, tt.tp)
-			err := node.Start(ctx)
-			require.NoError(t, err)
-
-			// ensure an empty block exists in store
-
-			eh := headertest.RandExtendedHeaderWithRoot(t, share.EmptyEDSRoots())
-			err = node.ShareServ.SharesAvailable(ctx, eh)
-			require.NoError(t, err)
-
-			err = node.Stop(ctx)
-			require.NoError(t, err)
-		})
-	}
 }

--- a/nodebuilder/share/cmd/share.go
+++ b/nodebuilder/share/cmd/share.go
@@ -8,9 +8,7 @@ import (
 
 	libshare "github.com/celestiaorg/go-square/v2/share"
 
-	rpc "github.com/celestiaorg/celestia-node/api/rpc/client"
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
-	"github.com/celestiaorg/celestia-node/header"
 )
 
 func init() {

--- a/nodebuilder/share/cmd/share.go
+++ b/nodebuilder/share/cmd/share.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"encoding/hex"
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -42,12 +40,12 @@ var sharesAvailableCmd = &cobra.Command{
 		}
 		defer client.Close()
 
-		eh, err := getExtendedHeaderFromCmdArg(cmd.Context(), client, args[0])
+		height, err := strconv.ParseUint(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
 
-		err = client.Share.SharesAvailable(cmd.Context(), eh)
+		err = client.Share.SharesAvailable(cmd.Context(), height)
 		formatter := func(data interface{}) interface{} {
 			err, ok := data.(error)
 			available := false
@@ -79,7 +77,7 @@ var getSharesByNamespaceCmd = &cobra.Command{
 		}
 		defer client.Close()
 
-		eh, err := getExtendedHeaderFromCmdArg(cmd.Context(), client, args[0])
+		height, err := strconv.ParseUint(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
@@ -89,7 +87,7 @@ var getSharesByNamespaceCmd = &cobra.Command{
 			return err
 		}
 
-		shares, err := client.Share.GetSharesByNamespace(cmd.Context(), eh, ns)
+		shares, err := client.Share.GetSharesByNamespace(cmd.Context(), height, ns)
 		return cmdnode.PrintOutput(shares, err, nil)
 	},
 }
@@ -105,7 +103,7 @@ var getShare = &cobra.Command{
 		}
 		defer client.Close()
 
-		eh, err := getExtendedHeaderFromCmdArg(cmd.Context(), client, args[0])
+		height, err := strconv.ParseUint(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
@@ -120,7 +118,7 @@ var getShare = &cobra.Command{
 			return err
 		}
 
-		s, err := client.Share.GetShare(cmd.Context(), eh, int(row), int(col))
+		s, err := client.Share.GetShare(cmd.Context(), height, int(row), int(col))
 
 		formatter := func(data interface{}) interface{} {
 			sh, ok := data.(libshare.Share)
@@ -153,26 +151,12 @@ var getEDS = &cobra.Command{
 		}
 		defer client.Close()
 
-		eh, err := getExtendedHeaderFromCmdArg(cmd.Context(), client, args[0])
+		height, err := strconv.ParseUint(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
 
-		shares, err := client.Share.GetEDS(cmd.Context(), eh)
+		shares, err := client.Share.GetEDS(cmd.Context(), height)
 		return cmdnode.PrintOutput(shares, err, nil)
 	},
-}
-
-func getExtendedHeaderFromCmdArg(ctx context.Context, client *rpc.Client, arg string) (*header.ExtendedHeader, error) {
-	height, err := strconv.ParseUint(arg, 10, 64)
-	if err == nil {
-		return client.Header.GetByHeight(ctx, height)
-	}
-
-	hash, err := hex.DecodeString(arg)
-	if err != nil {
-		return nil, fmt.Errorf("can't parse the height/hash argument: %w", err)
-	}
-
-	return client.Header.GetByHash(ctx, hash)
 }

--- a/nodebuilder/share/mocks/api.go
+++ b/nodebuilder/share/mocks/api.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	header "github.com/celestiaorg/celestia-node/header"
 	share "github.com/celestiaorg/celestia-node/nodebuilder/share"
 	shwap "github.com/celestiaorg/celestia-node/share/shwap"
 	share0 "github.com/celestiaorg/go-square/v2/share"
@@ -40,7 +39,7 @@ func (m *MockModule) EXPECT() *MockModuleMockRecorder {
 }
 
 // GetEDS mocks base method.
-func (m *MockModule) GetEDS(arg0 context.Context, arg1 *header.ExtendedHeader) (*rsmt2d.ExtendedDataSquare, error) {
+func (m *MockModule) GetEDS(arg0 context.Context, arg1 uint64) (*rsmt2d.ExtendedDataSquare, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEDS", arg0, arg1)
 	ret0, _ := ret[0].(*rsmt2d.ExtendedDataSquare)
@@ -70,7 +69,7 @@ func (mr *MockModuleMockRecorder) GetRange(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // GetShare mocks base method.
-func (m *MockModule) GetShare(arg0 context.Context, arg1 *header.ExtendedHeader, arg2, arg3 int) (share0.Share, error) {
+func (m *MockModule) GetShare(arg0 context.Context, arg1 uint64, arg2, arg3 int) (share0.Share, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetShare", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(share0.Share)
@@ -85,7 +84,7 @@ func (mr *MockModuleMockRecorder) GetShare(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // GetSharesByNamespace mocks base method.
-func (m *MockModule) GetSharesByNamespace(arg0 context.Context, arg1 *header.ExtendedHeader, arg2 share0.Namespace) (shwap.NamespaceData, error) {
+func (m *MockModule) GetSharesByNamespace(arg0 context.Context, arg1 uint64, arg2 share0.Namespace) (shwap.NamespaceData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSharesByNamespace", arg0, arg1, arg2)
 	ret0, _ := ret[0].(shwap.NamespaceData)
@@ -100,7 +99,7 @@ func (mr *MockModuleMockRecorder) GetSharesByNamespace(arg0, arg1, arg2 interfac
 }
 
 // SharesAvailable mocks base method.
-func (m *MockModule) SharesAvailable(arg0 context.Context, arg1 *header.ExtendedHeader) error {
+func (m *MockModule) SharesAvailable(arg0 context.Context, arg1 uint64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SharesAvailable", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/nodebuilder/share/share.go
+++ b/nodebuilder/share/share.go
@@ -112,10 +112,10 @@ type module struct {
 	hs     headerServ.Module
 }
 
-func (m module) GetShare(ctx context.Context, height uint64, row, col int) (share.Share, error) {
+func (m module) GetShare(ctx context.Context, height uint64, row, col int) (libshare.Share, error) {
 	header, err := m.hs.GetByHeight(ctx, height)
 	if err != nil {
-		return nil, err
+		return libshare.Share{}, err
 	}
 	return m.getter.GetShare(ctx, header, row, col)
 }
@@ -159,8 +159,12 @@ func (m module) GetRange(ctx context.Context, height uint64, start, end int) (*G
 
 func (m module) GetSharesByNamespace(
 	ctx context.Context,
-	header *header.ExtendedHeader,
+	height uint64,
 	namespace libshare.Namespace,
 ) (shwap.NamespaceData, error) {
-	return m.Getter.GetSharesByNamespace(ctx, header, namespace)
+	header, err := m.hs.GetByHeight(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+	return m.getter.GetSharesByNamespace(ctx, header, namespace)
 }

--- a/nodebuilder/tests/nd_test.go
+++ b/nodebuilder/tests/nd_test.go
@@ -72,9 +72,10 @@ func TestShrexNDFromLights(t *testing.T) {
 		ns, err := libshare.NewNamespaceFromBytes(namespace)
 		require.NoError(t, err)
 
-		expected, err := bridgeClient.Share.GetSharesByNamespace(reqCtx, h, ns)
+		height := h.Height()
+		expected, err := bridgeClient.Share.GetSharesByNamespace(reqCtx, height, ns)
 		require.NoError(t, err)
-		got, err := lightClient.Share.GetSharesByNamespace(reqCtx, h, ns)
+		got, err := lightClient.Share.GetSharesByNamespace(reqCtx, height, ns)
 		require.NoError(t, err)
 
 		require.True(t, len(got[0].Shares) > 0)
@@ -147,18 +148,18 @@ func TestShrexNDFromLightsWithBadFulls(t *testing.T) {
 		namespace := h.DAH.RowRoots[1][:libshare.NamespaceSize]
 		ns, err := libshare.NewNamespaceFromBytes(namespace)
 		require.NoError(t, err)
-		expected, err := bridgeClient.Share.GetSharesByNamespace(reqCtx, h, ns)
+		expected, err := bridgeClient.Share.GetSharesByNamespace(reqCtx, h.Height(), ns)
 		require.NoError(t, err)
 		require.True(t, len(expected[0].Shares) > 0)
 
 		// choose a random full to test
 		fN := fulls[len(fulls)/2]
 		fnClient := getAdminClient(ctx, fN, t)
-		gotFull, err := fnClient.Share.GetSharesByNamespace(reqCtx, h, ns)
+		gotFull, err := fnClient.Share.GetSharesByNamespace(reqCtx, height, ns)
 		require.NoError(t, err)
 		require.True(t, len(gotFull[0].Shares) > 0)
 
-		gotLight, err := lightClient.Share.GetSharesByNamespace(reqCtx, h, ns)
+		gotLight, err := lightClient.Share.GetSharesByNamespace(reqCtx, height, ns)
 		require.NoError(t, err)
 		require.True(t, len(gotLight[0].Shares) > 0)
 

--- a/nodebuilder/tests/nd_test.go
+++ b/nodebuilder/tests/nd_test.go
@@ -146,9 +146,10 @@ func TestShrexNDFromLightsWithBadFulls(t *testing.T) {
 
 		// ensure to fetch random namespace (not the reserved namespace)
 		namespace := h.DAH.RowRoots[1][:libshare.NamespaceSize]
+		height := h.Height()
 		ns, err := libshare.NewNamespaceFromBytes(namespace)
 		require.NoError(t, err)
-		expected, err := bridgeClient.Share.GetSharesByNamespace(reqCtx, h.Height(), ns)
+		expected, err := bridgeClient.Share.GetSharesByNamespace(reqCtx, height, ns)
 		require.NoError(t, err)
 		require.True(t, len(expected[0].Shares) > 0)
 

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -135,12 +135,12 @@ func TestArchivalBlobSync(t *testing.T) {
 		shr, err := archivalFN.ShareServ.GetShare(ctx, eh, 2, 2)
 		require.NoError(t, err)
 
-		blobs, err := archivalFN.BlobServ.GetAll(ctx, uint64(i), []libshare.Namespace{shr.Namespace()})
+		blobs, err := archivalFN.BlobServ.GetAll(ctx,eh.Height(), []libshare.Namespace{shr.Namespace()})
 		require.NoError(t, err)
 
 		archivalBlobs = append(archivalBlobs, &archivalBlob{
 			blob:   blobs[0],
-			height: uint64(i),
+			height: eh.Height(),
 			root:   eh.DAH.Hash(),
 		})
 

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -132,10 +132,10 @@ func TestArchivalBlobSync(t *testing.T) {
 			continue
 		}
 
-		shr, err := archivalFN.ShareServ.GetShare(ctx, eh, 2, 2)
+		shr, err := archivalFN.ShareServ.GetShare(ctx, eh.Height(), 2, 2)
 		require.NoError(t, err)
 
-		blobs, err := archivalFN.BlobServ.GetAll(ctx,eh.Height(), []libshare.Namespace{shr.Namespace()})
+		blobs, err := archivalFN.BlobServ.GetAll(ctx, eh.Height(), []libshare.Namespace{shr.Namespace()})
 		require.NoError(t, err)
 
 		archivalBlobs = append(archivalBlobs, &archivalBlob{

--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -75,7 +75,7 @@ func TestFullReconstructFromBridge(t *testing.T) {
 				return err
 			}
 
-			return fullClient.Share.SharesAvailable(bctx, h)
+			return fullClient.Share.SharesAvailable(bctx, h.Height())
 		})
 	}
 	require.NoError(t, <-fillDn)
@@ -214,10 +214,10 @@ func TestFullReconstructFromFulls(t *testing.T) {
 	ctxErr, cancelErr := context.WithTimeout(ctx, time.Second*30)
 	errg, errCtx = errgroup.WithContext(ctxErr)
 	errg.Go(func() error {
-		return fullClient1.Share.SharesAvailable(errCtx, h)
+		return fullClient1.Share.SharesAvailable(errCtx, h.Height())
 	})
 	errg.Go(func() error {
-		return fullClient1.Share.SharesAvailable(errCtx, h)
+		return fullClient1.Share.SharesAvailable(errCtx, h.Height())
 	})
 	require.Error(t, errg.Wait())
 	cancelErr()
@@ -230,10 +230,10 @@ func TestFullReconstructFromFulls(t *testing.T) {
 		h, err := fullClient1.Header.WaitForHeight(bctx, uint64(i))
 		require.NoError(t, err)
 		errg.Go(func() error {
-			return fullClient1.Share.SharesAvailable(bctx, h)
+			return fullClient1.Share.SharesAvailable(bctx, h.Height())
 		})
 		errg.Go(func() error {
-			return fullClient2.Share.SharesAvailable(bctx, h)
+			return fullClient2.Share.SharesAvailable(bctx, h.Height())
 		})
 	}
 
@@ -352,7 +352,7 @@ func TestFullReconstructFromLights(t *testing.T) {
 				return err
 			}
 
-			return fullClient.Share.SharesAvailable(bctx, h)
+			return fullClient.Share.SharesAvailable(bctx, h.Height())
 		})
 	}
 	require.NoError(t, <-fillDn)

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -77,7 +77,7 @@ func TestSyncAgainstBridge_NonEmptyChain(t *testing.T) {
 		assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
 		// check that the light node has also sampled over the block at height 20
-		err = lightClient.Share.SharesAvailable(ctx, h)
+		err = lightClient.Share.SharesAvailable(ctx, h.Height())
 		assert.NoError(t, err)
 
 		// wait until the entire chain (up to network head) has been sampled
@@ -97,7 +97,7 @@ func TestSyncAgainstBridge_NonEmptyChain(t *testing.T) {
 		assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
 		// check to ensure the full node can sync the 20th block's data
-		err = fullClient.Share.SharesAvailable(ctx, h)
+		err = fullClient.Share.SharesAvailable(ctx, h.Height())
 		assert.NoError(t, err)
 
 		// wait for full node to sync up the blocks from genesis -> network head.
@@ -167,7 +167,7 @@ func TestSyncAgainstBridge_EmptyChain(t *testing.T) {
 		assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
 		// check that the light node has also sampled over the block at height 20
-		err = lightClient.Share.SharesAvailable(ctx, h)
+		err = lightClient.Share.SharesAvailable(ctx, h.Height())
 		assert.NoError(t, err)
 
 		// wait until the entire chain (up to network head) has been sampled
@@ -187,7 +187,7 @@ func TestSyncAgainstBridge_EmptyChain(t *testing.T) {
 		assert.EqualValues(t, h.Commit.BlockID.Hash, sw.GetCoreBlockHashByHeight(ctx, numBlocks))
 
 		// check to ensure the full node can sync the 20th block's data
-		err = fullClient.Share.SharesAvailable(ctx, h)
+		err = fullClient.Share.SharesAvailable(ctx, h.Height())
 		assert.NoError(t, err)
 
 		// wait for full node to sync up the blocks from genesis -> network head.


### PR DESCRIPTION
Use height instead of header in share module API