### PR TITLE
fix: wrong network error

### DIFF
--- a/state/core_access.go
+++ b/state/core_access.go
@@ -153,7 +153,7 @@ func (ca *CoreAccessor) Start(ctx context.Context) error {
 
 	defaultNetwork := resp.GetDefaultNodeInfo().GetNetwork()
 	if defaultNetwork != ca.network {
-		return fmt.Errorf("wrong network in core.ip endpoint, expected %s, got %s", defaultNetwork, ca.network)
+		return fmt.Errorf("wrong network in core.ip endpoint, expected %s, got %s", ca.network, defaultNetwork)
 	}
 
 	// set up signer to handle tx submission


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

This resolves #3884, reversing order of variables in error message.

Tested, and it works as expected now:

```bash
./build/celestia light start --core.ip rpc-mocha.pops.one

Error: node: failed to start: wrong network in core.ip endpoint, expected celestia, got mocha-4
```

