### PR TITLE
!refactor: rename GetSharesByNamespace to GetNamespaceData

### DIFF
--- a/api/gateway/share.go
+++ b/api/gateway/share.go
@@ -93,7 +93,7 @@ func (h *Handler) getShares(
 	height uint64,
 	namespace libshare.Namespace,
 ) ([]libshare.Share, error) {
-	shares, err := h.share.GetSharesByNamespace(ctx, height, namespace)
+	shares, err := h.share.GetNamespaceData(ctx, height, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/blob/service.go
+++ b/blob/service.go
@@ -368,7 +368,7 @@ func (s *Service) retrieve(
 	getCtx, getSharesSpan := tracer.Start(ctx, "get-shares-by-namespace")
 
 	// collect shares for the requested namespace
-	namespacedShares, err := s.shareGetter.GetSharesByNamespace(getCtx, header, namespace)
+	namespacedShares, err := s.shareGetter.GetNamespaceData(getCtx, header, namespace)
 	if err != nil {
 		if errors.Is(err, shwap.ErrNotFound) {
 			err = ErrBlobNotFound

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -412,7 +412,7 @@ func TestBlobService_Get(t *testing.T) {
 				innerGetter := service.shareGetter
 				getterWrapper := mock.NewMockGetter(ctrl)
 				getterWrapper.EXPECT().
-					GetSharesByNamespace(gomock.Any(), gomock.Any(), gomock.Any()).
+					GetNamespaceData(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(
 						func(
 							ctx context.Context, h *header.ExtendedHeader, ns libshare.Namespace,
@@ -420,7 +420,7 @@ func TestBlobService_Get(t *testing.T) {
 							if ns.Equals(blobsWithDiffNamespaces[0].Namespace()) {
 								return nil, errors.New("internal error")
 							}
-							return innerGetter.GetSharesByNamespace(ctx, h, ns)
+							return innerGetter.GetNamespaceData(ctx, h, ns)
 						}).AnyTimes()
 
 				service.shareGetter = getterWrapper
@@ -876,7 +876,7 @@ func createServiceWithSub(ctx context.Context, t testing.TB, blobs []*Blob) *Ser
 	ctrl := gomock.NewController(t)
 	shareGetter := mock.NewMockGetter(ctrl)
 
-	shareGetter.EXPECT().GetSharesByNamespace(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+	shareGetter.EXPECT().GetNamespaceData(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		DoAndReturn(func(ctx context.Context, h *header.ExtendedHeader, ns libshare.Namespace) (shwap.NamespaceData, error) {
 			idx := int(h.Height()) - 1
 			accessor := &eds.Rsmt2D{ExtendedDataSquare: edsses[idx]}
@@ -897,7 +897,7 @@ func createService(ctx context.Context, t testing.TB, shares []libshare.Share) *
 	accessor := &eds.Rsmt2D{ExtendedDataSquare: square}
 	ctrl := gomock.NewController(t)
 	shareGetter := mock.NewMockGetter(ctrl)
-	shareGetter.EXPECT().GetSharesByNamespace(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+	shareGetter.EXPECT().GetNamespaceData(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		DoAndReturn(func(ctx context.Context, h *header.ExtendedHeader, ns libshare.Namespace) (shwap.NamespaceData, error) {
 			nd, err := eds.NamespaceData(ctx, accessor, ns)
 			return nd, err

--- a/nodebuilder/da/mocks/api.go
+++ b/nodebuilder/da/mocks/api.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	da "github.com/rollkit/go-da"
 )
 
 // MockModule is a mock of Module interface.
@@ -65,10 +66,10 @@ func (mr *MockModuleMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call
 }
 
 // GetIDs mocks base method.
-func (m *MockModule) GetIDs(arg0 context.Context, arg1 uint64, arg2 []byte) ([][]byte, error) {
+func (m *MockModule) GetIDs(arg0 context.Context, arg1 uint64, arg2 []byte) (*da.GetIDsResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIDs", arg0, arg1, arg2)
-	ret0, _ := ret[0].([][]byte)
+	ret0, _ := ret[0].(*da.GetIDsResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -122,6 +123,21 @@ func (m *MockModule) Submit(arg0 context.Context, arg1 [][]byte, arg2 float64, a
 func (mr *MockModuleMockRecorder) Submit(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Submit", reflect.TypeOf((*MockModule)(nil).Submit), arg0, arg1, arg2, arg3)
+}
+
+// SubmitWithOptions mocks base method.
+func (m *MockModule) SubmitWithOptions(arg0 context.Context, arg1 [][]byte, arg2 float64, arg3, arg4 []byte) ([][]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubmitWithOptions", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].([][]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubmitWithOptions indicates an expected call of SubmitWithOptions.
+func (mr *MockModuleMockRecorder) SubmitWithOptions(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitWithOptions", reflect.TypeOf((*MockModule)(nil).SubmitWithOptions), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Validate mocks base method.

--- a/nodebuilder/share/cmd/share.go
+++ b/nodebuilder/share/cmd/share.go
@@ -85,7 +85,7 @@ var getSharesByNamespaceCmd = &cobra.Command{
 			return err
 		}
 
-		shares, err := client.Share.GetSharesByNamespace(cmd.Context(), height, ns)
+		shares, err := client.Share.GetNamespaceData(cmd.Context(), height, ns)
 		return cmdnode.PrintOutput(shares, err, nil)
 	},
 }

--- a/nodebuilder/share/share.go
+++ b/nodebuilder/share/share.go
@@ -47,9 +47,9 @@ type Module interface {
 	GetShare(ctx context.Context, height uint64, row, col int) (libshare.Share, error)
 	// GetEDS gets the full EDS identified by the given extended header.
 	GetEDS(ctx context.Context, height uint64) (*rsmt2d.ExtendedDataSquare, error)
-	// GetSharesByNamespace gets all shares from an EDS within the given namespace.
+	// GetNamespaceData gets all shares from an EDS within the given namespace.
 	// Shares are returned in a row-by-row order if the namespace spans multiple rows.
-	GetSharesByNamespace(
+	GetNamespaceData(
 		ctx context.Context, height uint64, namespace libshare.Namespace,
 	) (shwap.NamespaceData, error)
 	// GetRange gets a list of shares and their corresponding proof.
@@ -69,7 +69,7 @@ type API struct {
 			ctx context.Context,
 			height uint64,
 		) (*rsmt2d.ExtendedDataSquare, error) `perm:"read"`
-		GetSharesByNamespace func(
+		GetNamespaceData func(
 			ctx context.Context,
 			height uint64,
 			namespace libshare.Namespace,
@@ -98,12 +98,12 @@ func (api *API) GetRange(ctx context.Context, height uint64, start, end int) (*G
 	return api.Internal.GetRange(ctx, height, start, end)
 }
 
-func (api *API) GetSharesByNamespace(
+func (api *API) GetNamespaceData(
 	ctx context.Context,
 	height uint64,
 	namespace libshare.Namespace,
 ) (shwap.NamespaceData, error) {
-	return api.Internal.GetSharesByNamespace(ctx, height, namespace)
+	return api.Internal.GetNamespaceData(ctx, height, namespace)
 }
 
 type module struct {
@@ -157,7 +157,7 @@ func (m module) GetRange(ctx context.Context, height uint64, start, end int) (*G
 	}, nil
 }
 
-func (m module) GetSharesByNamespace(
+func (m module) GetNamespaceData(
 	ctx context.Context,
 	height uint64,
 	namespace libshare.Namespace,

--- a/nodebuilder/share/share.go
+++ b/nodebuilder/share/share.go
@@ -166,5 +166,5 @@ func (m module) GetSharesByNamespace(
 	if err != nil {
 		return nil, err
 	}
-	return m.getter.GetSharesByNamespace(ctx, header, namespace)
+	return m.getter.GetNamespaceData(ctx, header, namespace)
 }

--- a/nodebuilder/tests/nd_test.go
+++ b/nodebuilder/tests/nd_test.go
@@ -73,9 +73,9 @@ func TestShrexNDFromLights(t *testing.T) {
 		require.NoError(t, err)
 
 		height := h.Height()
-		expected, err := bridgeClient.Share.GetSharesByNamespace(reqCtx, height, ns)
+		expected, err := bridgeClient.Share.GetNamespaceData(reqCtx, height, ns)
 		require.NoError(t, err)
-		got, err := lightClient.Share.GetSharesByNamespace(reqCtx, height, ns)
+		got, err := lightClient.Share.GetNamespaceData(reqCtx, height, ns)
 		require.NoError(t, err)
 
 		require.True(t, len(got[0].Shares) > 0)
@@ -149,18 +149,18 @@ func TestShrexNDFromLightsWithBadFulls(t *testing.T) {
 		height := h.Height()
 		ns, err := libshare.NewNamespaceFromBytes(namespace)
 		require.NoError(t, err)
-		expected, err := bridgeClient.Share.GetSharesByNamespace(reqCtx, height, ns)
+		expected, err := bridgeClient.Share.GetNamespaceData(reqCtx, height, ns)
 		require.NoError(t, err)
 		require.True(t, len(expected[0].Shares) > 0)
 
 		// choose a random full to test
 		fN := fulls[len(fulls)/2]
 		fnClient := getAdminClient(ctx, fN, t)
-		gotFull, err := fnClient.Share.GetSharesByNamespace(reqCtx, height, ns)
+		gotFull, err := fnClient.Share.GetNamespaceData(reqCtx, height, ns)
 		require.NoError(t, err)
 		require.True(t, len(gotFull[0].Shares) > 0)
 
-		gotLight, err := lightClient.Share.GetSharesByNamespace(reqCtx, height, ns)
+		gotLight, err := lightClient.Share.GetNamespaceData(reqCtx, height, ns)
 		require.NoError(t, err)
 		require.True(t, len(gotLight[0].Shares) > 0)
 

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -271,7 +271,7 @@ func (g onceGetter) GetEDS(_ context.Context, _ *header.ExtendedHeader) (*rsmt2d
 	panic("not implemented")
 }
 
-func (m onceGetter) GetNamespaceData(
+func (g onceGetter) GetNamespaceData(
 	_ context.Context,
 	_ *header.ExtendedHeader,
 	_ libshare.Namespace,

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -271,7 +271,7 @@ func (g onceGetter) GetEDS(_ context.Context, _ *header.ExtendedHeader) (*rsmt2d
 	panic("not implemented")
 }
 
-func (g onceGetter) GetSharesByNamespace(
+func (m onceGetter) GetNamespaceData(
 	_ context.Context,
 	_ *header.ExtendedHeader,
 	_ libshare.Namespace,

--- a/share/shwap/getter.go
+++ b/share/shwap/getter.go
@@ -35,10 +35,10 @@ type Getter interface {
 	// GetEDS gets the full EDS identified by the given extended header.
 	GetEDS(context.Context, *header.ExtendedHeader) (*rsmt2d.ExtendedDataSquare, error)
 
-	// GetSharesByNamespace gets all shares from an EDS within the given namespace.
+	// GetNamespaceData gets all shares from an EDS within the given namespace.
 	// Shares are returned in a row-by-row order if the namespace spans multiple rows.
 	// Inclusion of returned data could be verified using Verify method on NamespacedShares.
 	// If no shares are found for target namespace non-inclusion could be also verified by calling
 	// Verify method.
-	GetSharesByNamespace(context.Context, *header.ExtendedHeader, libshare.Namespace) (NamespaceData, error)
+	GetNamespaceData(context.Context, *header.ExtendedHeader, libshare.Namespace) (NamespaceData, error)
 }

--- a/share/shwap/getters/cascade.go
+++ b/share/shwap/getters/cascade.go
@@ -78,9 +78,9 @@ func (cg *CascadeGetter) GetEDS(
 	return cascadeGetters(ctx, cg.getters, get)
 }
 
-// GetSharesByNamespace gets NamespacedShares from any of registered shwap.Getters in cascading
+// GetNamespaceData gets NamespacedShares from any of registered shwap.Getters in cascading
 // order.
-func (cg *CascadeGetter) GetSharesByNamespace(
+func (cg *CascadeGetter) GetNamespaceData(
 	ctx context.Context,
 	header *header.ExtendedHeader,
 	namespace libshare.Namespace,
@@ -91,7 +91,7 @@ func (cg *CascadeGetter) GetSharesByNamespace(
 	defer span.End()
 
 	get := func(ctx context.Context, get shwap.Getter) (shwap.NamespaceData, error) {
-		return get.GetSharesByNamespace(ctx, header, namespace)
+		return get.GetNamespaceData(ctx, header, namespace)
 	}
 
 	return cascadeGetters(ctx, cg.getters, get)

--- a/share/shwap/getters/mock/getter.go
+++ b/share/shwap/getters/mock/getter.go
@@ -53,6 +53,21 @@ func (mr *MockGetterMockRecorder) GetEDS(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEDS", reflect.TypeOf((*MockGetter)(nil).GetEDS), arg0, arg1)
 }
 
+// GetNamespaceData mocks base method.
+func (m *MockGetter) GetNamespaceData(arg0 context.Context, arg1 *header.ExtendedHeader, arg2 share.Namespace) (shwap.NamespaceData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespaceData", arg0, arg1, arg2)
+	ret0, _ := ret[0].(shwap.NamespaceData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNamespaceData indicates an expected call of GetNamespaceData.
+func (mr *MockGetterMockRecorder) GetNamespaceData(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceData", reflect.TypeOf((*MockGetter)(nil).GetNamespaceData), arg0, arg1, arg2)
+}
+
 // GetShare mocks base method.
 func (m *MockGetter) GetShare(arg0 context.Context, arg1 *header.ExtendedHeader, arg2, arg3 int) (share.Share, error) {
 	m.ctrl.T.Helper()
@@ -66,19 +81,4 @@ func (m *MockGetter) GetShare(arg0 context.Context, arg1 *header.ExtendedHeader,
 func (mr *MockGetterMockRecorder) GetShare(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShare", reflect.TypeOf((*MockGetter)(nil).GetShare), arg0, arg1, arg2, arg3)
-}
-
-// GetSharesByNamespace mocks base method.
-func (m *MockGetter) GetSharesByNamespace(arg0 context.Context, arg1 *header.ExtendedHeader, arg2 share.Namespace) (shwap.NamespaceData, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSharesByNamespace", arg0, arg1, arg2)
-	ret0, _ := ret[0].(shwap.NamespaceData)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSharesByNamespace indicates an expected call of GetSharesByNamespace.
-func (mr *MockGetterMockRecorder) GetSharesByNamespace(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSharesByNamespace", reflect.TypeOf((*MockGetter)(nil).GetSharesByNamespace), arg0, arg1, arg2)
 }

--- a/share/shwap/getters/testing.go
+++ b/share/shwap/getters/testing.go
@@ -30,7 +30,7 @@ func TestGetter(t *testing.T) (shwap.Getter, *header.ExtendedHeader) {
 }
 
 // SingleEDSGetter contains a single EDS where data is retrieved from.
-// Its primary use is testing, and GetSharesByNamespace is not supported.
+// Its primary use is testing, and GetNamespaceData is not supported.
 type SingleEDSGetter struct {
 	EDS *rsmt2d.ExtendedDataSquare
 }
@@ -65,10 +65,10 @@ func (seg *SingleEDSGetter) GetEDS(
 	return seg.EDS, nil
 }
 
-// GetSharesByNamespace returns NamespacedShares from a kept EDS if the correct root is given.
-func (seg *SingleEDSGetter) GetSharesByNamespace(context.Context, *header.ExtendedHeader, libshare.Namespace,
+// GetNamespaceData returns NamespacedShares from a kept EDS if the correct root is given.
+func (seg *SingleEDSGetter) GetNamespaceData(context.Context, *header.ExtendedHeader, libshare.Namespace,
 ) (shwap.NamespaceData, error) {
-	panic("SingleEDSGetter: GetSharesByNamespace is not implemented")
+	panic("SingleEDSGetter: GetNamespaceData is not implemented")
 }
 
 func (seg *SingleEDSGetter) checkRoots(roots *share.AxisRoots) error {

--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -179,10 +179,10 @@ func (g *Getter) GetEDS(
 	return square, nil
 }
 
-// GetSharesByNamespace uses [RowNamespaceDataBlock] and [Fetch] to get all the data
+// GetNamespaceData uses [RowNamespaceDataBlock] and [Fetch] to get all the data
 // by the given namespace. If data spans over multiple rows, the request is split into
 // parallel RowNamespaceDataID requests per each row and then assembled back into NamespaceData.
-func (g *Getter) GetSharesByNamespace(
+func (g *Getter) GetNamespaceData(
 	ctx context.Context,
 	hdr *header.ExtendedHeader,
 	ns libshare.Namespace,

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -214,7 +214,7 @@ func (sg *Getter) GetEDS(ctx context.Context, header *header.ExtendedHeader) (*r
 	}
 }
 
-func (sg *Getter) GetSharesByNamespace(
+func (sg *Getter) GetNamespaceData(
 	ctx context.Context,
 	header *header.ExtendedHeader,
 	namespace libshare.Namespace,

--- a/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
@@ -82,7 +82,7 @@ func TestShrexGetter(t *testing.T) {
 			Height:   height,
 		})
 
-		got, err := getter.GetSharesByNamespace(ctx, eh, namespace)
+		got, err := getter.GetNamespaceData(ctx, eh, namespace)
 		require.NoError(t, err)
 		require.NoError(t, got.Verify(roots, namespace))
 	})
@@ -102,7 +102,7 @@ func TestShrexGetter(t *testing.T) {
 			Height:   height,
 		})
 
-		_, err := getter.GetSharesByNamespace(ctx, eh, namespace)
+		_, err := getter.GetNamespaceData(ctx, eh, namespace)
 		require.ErrorIs(t, err, shwap.ErrNotFound)
 	})
 
@@ -131,7 +131,7 @@ func TestShrexGetter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, rows, 1)
 
-		emptyShares, err := getter.GetSharesByNamespace(ctx, eh, nID)
+		emptyShares, err := getter.GetNamespaceData(ctx, eh, nID)
 		require.NoError(t, err)
 		// no shares should be returned
 		require.Nil(t, emptyShares.Flatten())
@@ -145,7 +145,7 @@ func TestShrexGetter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, rows, 0)
 
-		emptyShares, err = getter.GetSharesByNamespace(ctx, eh, nID)
+		emptyShares, err = getter.GetNamespaceData(ctx, eh, nID)
 		require.NoError(t, err)
 		// no shares should be returned
 		require.Nil(t, emptyShares.Flatten())
@@ -176,7 +176,7 @@ func TestShrexGetter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, rows, 0)
 
-		emptyShares, err := getter.GetSharesByNamespace(ctx, eh, namespace)
+		emptyShares, err := getter.GetNamespaceData(ctx, eh, namespace)
 		require.NoError(t, err)
 		// no shares should be returned
 		require.Empty(t, emptyShares.Flatten())

--- a/store/getter.go
+++ b/store/getter.go
@@ -68,7 +68,7 @@ func (g *Getter) GetEDS(ctx context.Context, h *header.ExtendedHeader) (*rsmt2d.
 	return rsmt2d.ExtendedDataSquare, nil
 }
 
-func (g *Getter) GetSharesByNamespace(
+func (g *Getter) GetNamespaceData(
 	ctx context.Context,
 	h *header.ExtendedHeader,
 	ns libshare.Namespace,

--- a/store/getter_test.go
+++ b/store/getter_test.go
@@ -66,7 +66,7 @@ func TestStoreGetter(t *testing.T) {
 		require.ErrorIs(t, err, shwap.ErrNotFound)
 	})
 
-	t.Run("GetSharesByNamespace", func(t *testing.T) {
+	t.Run("GetNamespaceData", func(t *testing.T) {
 		ns := libshare.RandomNamespace()
 		eds, roots := edstest.RandEDSWithNamespace(t, ns, 8, 16)
 		eh := headertest.RandExtendedHeaderWithRoot(t, roots)
@@ -75,19 +75,19 @@ func TestStoreGetter(t *testing.T) {
 		err := edsStore.PutODSQ4(ctx, eh.DAH, height, eds)
 		require.NoError(t, err)
 
-		shares, err := sg.GetSharesByNamespace(ctx, eh, ns)
+		shares, err := sg.GetNamespaceData(ctx, eh, ns)
 		require.NoError(t, err)
 		require.NoError(t, shares.Verify(eh.DAH, ns))
 
 		// namespace not found
 		randNamespace := libshare.RandomNamespace()
-		emptyShares, err := sg.GetSharesByNamespace(ctx, eh, randNamespace)
+		emptyShares, err := sg.GetNamespaceData(ctx, eh, randNamespace)
 		require.NoError(t, err)
 		require.Empty(t, emptyShares.Flatten())
 
 		// root not found
 		eh.RawHeader.Height = 666
-		_, err = sg.GetSharesByNamespace(ctx, eh, ns)
+		_, err = sg.GetNamespaceData(ctx, eh, ns)
 		require.ErrorIs(t, err, shwap.ErrNotFound)
 	})
 }


### PR DESCRIPTION
Fixes #3892 