### PR TITLE
ci(docker): bump version

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.5 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.5.0 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
       checkout_ref: ${{ github.event.inputs.ref }}


### PR DESCRIPTION
hello!

bumping version to: https://github.com/celestiaorg/.github/releases/tag/v0.5.0

best!