### PR TITLE
fix(header)!: use tmjson encoding for Commit field as well

### DIFF
--- a/api/docgen/exampledata/extendedHeader.json
+++ b/api/docgen/exampledata/extendedHeader.json
@@ -46,7 +46,7 @@
     }
   },
   "commit": {
-    "height": 67374,
+    "height": "67374",
     "round": 0,
     "block_id": {
       "hash": "A7F6B1CF33313121539206754A73FDC22ADA48C4AA8C4BB4F707ED2E089E59D3",

--- a/header/header.go
+++ b/header/header.go
@@ -239,13 +239,19 @@ func (eh *ExtendedHeader) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	commit, err := tmjson.Marshal(eh.Commit)
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(&struct {
 		RawHeader    json.RawMessage `json:"header"`
 		ValidatorSet json.RawMessage `json:"validator_set"`
+		Commit       json.RawMessage `json:"commit"`
 		*Alias
 	}{
 		ValidatorSet: validatorSet,
 		RawHeader:    rawHeader,
+		Commit:       commit,
 		Alias:        (*Alias)(eh),
 	})
 }
@@ -257,6 +263,7 @@ func (eh *ExtendedHeader) UnmarshalJSON(data []byte) error {
 	aux := &struct {
 		RawHeader    json.RawMessage `json:"header"`
 		ValidatorSet json.RawMessage `json:"validator_set"`
+		Commit       json.RawMessage `json:"commit"`
 		*Alias
 	}{
 		Alias: (*Alias)(eh),
@@ -273,9 +280,14 @@ func (eh *ExtendedHeader) UnmarshalJSON(data []byte) error {
 	if err := tmjson.Unmarshal(aux.RawHeader, rawHeader); err != nil {
 		return err
 	}
+	commit := new(core.Commit)
+	if err := tmjson.Unmarshal(aux.Commit, commit); err != nil {
+		return err
+	}
 
 	eh.ValidatorSet = valSet
 	eh.RawHeader = *rawHeader
+	eh.Commit = commit
 	return nil
 }
 


### PR DESCRIPTION
Fixes #3918 

**Please note: this PR is _BREAKING_** as header encoding has changed.

I don't see a reason we weren't doing this to begin with as we tmjson encode the other "tendermint" fields. 