### PR TITLE
fix(p2p): disable quic

### DIFF
--- a/nodebuilder/p2p/addrs.go
+++ b/nodebuilder/p2p/addrs.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"fmt"
+	"slices"
 
 	p2pconfig "github.com/libp2p/go-libp2p/config"
 	hst "github.com/libp2p/go-libp2p/core/host"
@@ -11,12 +12,22 @@ import (
 // Listen returns invoke function that starts listening for inbound connections with libp2p.Host.
 func Listen(cfg *Config) func(h hst.Host) (err error) {
 	return func(h hst.Host) (err error) {
-		maListen := make([]ma.Multiaddr, len(cfg.ListenAddresses))
-		for i, addr := range cfg.ListenAddresses {
-			maListen[i], err = ma.NewMultiaddr(addr)
+		maListen := make([]ma.Multiaddr, 0, len(cfg.ListenAddresses))
+		for _, addr := range cfg.ListenAddresses {
+			maddr, err := ma.NewMultiaddr(addr)
 			if err != nil {
 				return fmt.Errorf("failure to parse config.P2P.ListenAddresses: %w", err)
 			}
+			if !enableQUIC {
+				// TODO(@walldiss): Remove this check when QUIC is stable
+				if slices.ContainsFunc(maddr.Protocols(), func(p ma.Protocol) bool {
+					return p.Code == ma.P_QUIC_V1 || p.Code == ma.P_WEBTRANSPORT
+				}) {
+					continue
+				}
+			}
+
+			maListen = append(maListen, maddr)
 		}
 		return h.Network().Listen(maListen...)
 	}


### PR DESCRIPTION
quic has been unstable lately as a transport. This PR disables quic and web transport support temporary until all related issues are resolved and tested. 