### PR TITLE
fix(shwap/bitswap): update boxo and config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -362,4 +362,4 @@ replace (
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.43.0-tm-v0.34.35
 )
 
-replace github.com/ipfs/boxo => github.com/celestiaorg/boxo v0.0.0-20241114103253-16dd306892a7
+replace github.com/ipfs/boxo => github.com/celestiaorg/boxo v0.0.0-20241118020536-b0a7e7e3f8b6

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0 h1:h1Y4V3EMQ2mFmNtWt2sIhZIuyASInj1a9ExI8xOsTOw=
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0/go.mod h1:x4DKyfKOSv1ZJM9NwV+Pw01kH2CD7N5zTFclXIVJ6GQ=
-github.com/celestiaorg/boxo v0.0.0-20241114103253-16dd306892a7 h1:aPpDCIQeGcuLmZF1Yvq28awJdQCd+H/KWgjIq2X9dpc=
-github.com/celestiaorg/boxo v0.0.0-20241114103253-16dd306892a7/go.mod h1:OpUrJtGmZZktUqJvPOtmP8wSfEFcdF/55d3PNCcYLwc=
+github.com/celestiaorg/boxo v0.0.0-20241118020536-b0a7e7e3f8b6 h1:9UXP5vzlLmOu90A1cAb5FLqC66dvDgQy+3dlpLyrUe0=
+github.com/celestiaorg/boxo v0.0.0-20241118020536-b0a7e7e3f8b6/go.mod h1:OpUrJtGmZZktUqJvPOtmP8wSfEFcdF/55d3PNCcYLwc=
 github.com/celestiaorg/celestia-app/v3 v3.0.0-mocha h1:9tdQDaNgOfU56BueKq8i0Qte4FRmJJzG7woPTm6HHhk=
 github.com/celestiaorg/celestia-app/v3 v3.0.0-mocha/go.mod h1:K8U6TRHgofz0y5UcvlOL+CuNLbx4jeZrZF7HZdf+Rgs=
 github.com/celestiaorg/celestia-core v1.43.0-tm-v0.34.35 h1:L4GTm+JUXhB0a/nGPMq6jEqqe6THuYSQ8m2kUCtZYqw=

--- a/share/shwap/p2p/bitswap/bitswap.go
+++ b/share/shwap/p2p/bitswap/bitswap.go
@@ -56,7 +56,7 @@ const (
 	// client stuck for some time.
 	// This is relevant until https://github.com/ipfs/boxo/pull/629#discussion_r1653362485 is fixed.
 	// 1024 is 64 sampling requests of size 16 and 8 EDS requests with 8mb blocks
-	maxServerWantListsPerPeer = 1024
+	maxServerWantListsPerPeer = 4096
 	// targetResponseSize defines soft-limit of how much data server packs into a response.
 	// More data means more compute and time spend while serving a single peer under load, and thus increasing serving
 	// latency for other peers.
@@ -83,6 +83,8 @@ const (
 var simulateDontHaveConfig = &client.DontHaveTimeoutConfig{
 	// MaxTimeout is the limit cutoff time for the dynamic timeout estimation.
 	MaxTimeout: 30 * time.Second,
+	// MinTimeout is the minimum timeout for the dynamic timeout estimation.
+	MinTimeout: 1 * time.Second,
 	// MessageLatencyMultiplier is the multiplier for the message latency to account for errors
 	// THIS IS THE MOST IMPORTANT KNOB and is tricky to get right due to high variance in latency
 	// and particularly request processing time.


### PR DESCRIPTION
Yet another change to the bitswap configuration
* Adds `MinTimeout`. 
  * Robusta was having hard times with tail latency being too long, skewing timeout estimations, and causing cascade of simulated DONT_Haves that aren't real.
  * Basically only needed on low-latency envs like robusta.
* Reverts wantlist limit for peers to 4096
  * We observed limit overflow with FN syncing over bitswap. The overflow wasn't reached in any subsequent runs after the limit was raised back
