### PR TITLE
perf(shwap/bitswap): add session pools inside Getter

### DIFF
--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -3,6 +3,8 @@ package bitswap
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/boxo/blockstore"
@@ -10,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/celestiaorg/celestia-app/v3/pkg/wrapper"
 	libshare "github.com/celestiaorg/go-square/v2/share"
@@ -30,8 +31,8 @@ type Getter struct {
 	bstore    blockstore.Blockstore
 	availWndw time.Duration
 
-	availableSession exchange.Fetcher
-	archivalSession  exchange.Fetcher
+	availablePool sync.Pool
+	archivalPool  sync.Pool
 
 	cancel context.CancelFunc
 }
@@ -57,9 +58,21 @@ func NewGetter(
 // with regular full node peers.
 func (g *Getter) Start() {
 	ctx, cancel := context.WithCancel(context.Background())
-	g.availableSession = g.exchange.NewSession(ctx)
-	g.archivalSession = g.exchange.NewSession(ctx)
 	g.cancel = cancel
+
+	var availableID atomic.Uint64
+	g.availablePool.New = func() interface{} {
+		log.Debugw("creating new available window session", "id", availableID.Load())
+		defer availableID.Add(1)
+		return g.exchange.NewSession(ctx)
+	}
+
+	var archivalID atomic.Uint64
+	g.archivalPool.New = func() interface{} {
+		log.Debugw("creating new archival session", "id", archivalID.Load())
+		defer archivalID.Add(1)
+		return g.exchange.NewSession(ctx)
+	}
 }
 
 // Stop shuts down Getter's internal fetching session.
@@ -97,7 +110,12 @@ func (g *Getter) GetShares(
 		blks[i] = sid
 	}
 
-	ses := g.session(ctx, hdr)
+	isArchival := g.isArchival(hdr)
+	span.SetAttributes(attribute.Bool("is_archival", isArchival))
+
+	ses := g.session(isArchival)
+	defer g.poolSession(ses, isArchival)
+
 	err := Fetch(ctx, g.exchange, hdr.DAH, blks, WithStore(g.bstore), WithFetcher(ses))
 	if err != nil {
 		span.RecordError(err)
@@ -156,7 +174,12 @@ func (g *Getter) GetEDS(
 		blks[i] = blk
 	}
 
-	ses := g.session(ctx, hdr)
+	isArchival := g.isArchival(hdr)
+	span.SetAttributes(attribute.Bool("is_archival", isArchival))
+
+	ses := g.session(isArchival)
+	defer g.poolSession(ses, isArchival)
+
 	err := Fetch(ctx, g.exchange, hdr.DAH, blks, WithFetcher(ses))
 	if err != nil {
 		span.RecordError(err)
@@ -210,7 +233,12 @@ func (g *Getter) GetNamespaceData(
 		blks[i] = rndblk
 	}
 
-	ses := g.session(ctx, hdr)
+	isArchival := g.isArchival(hdr)
+	span.SetAttributes(attribute.Bool("is_archival", isArchival))
+
+	ses := g.session(isArchival)
+	defer g.poolSession(ses, isArchival)
+
 	if err = Fetch(ctx, g.exchange, hdr.DAH, blks, WithFetcher(ses)); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Fetch")
@@ -230,17 +258,37 @@ func (g *Getter) GetNamespaceData(
 	return nsShrs, nil
 }
 
-// session decides which fetching session to use for the given header.
-func (g *Getter) session(ctx context.Context, hdr *header.ExtendedHeader) exchange.Fetcher {
-	session := g.archivalSession
+// isArchival reports whether the header is for archival data
+func (g *Getter) isArchival(hdr *header.ExtendedHeader) bool {
+	return !availability.IsWithinWindow(hdr.Time(), g.availWndw)
+}
 
-	isWithinAvailability := availability.IsWithinWindow(hdr.Time(), g.availWndw)
-	if isWithinAvailability {
-		session = g.availableSession
+// session takes a session out of the respective session pool
+func (g *Getter) session(isArchival bool) exchange.Fetcher {
+	if isArchival {
+		v := g.archivalPool.Get()
+		if v == nil {
+			panic("Getter must be started")
+		}
+
+		return v.(exchange.Fetcher)
 	}
 
-	trace.SpanFromContext(ctx).SetAttributes(attribute.Bool("within_availability", isWithinAvailability))
-	return session
+	v := g.availablePool.Get()
+	if v == nil {
+		panic("Getter must be started")
+	}
+
+	return v.(exchange.Fetcher)
+}
+
+// poolSession puts session back into the respective session pool
+func (g *Getter) poolSession(session exchange.Fetcher, isArchival bool) {
+	if isArchival {
+		g.archivalPool.Put(session)
+	} else {
+		g.availablePool.Put(session)
+	}
 }
 
 // edsFromRows imports given Rows and computes EDS out of them, assuming enough Rows were provided.

--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -63,19 +63,19 @@ func (g *Getter) Start() {
 	var availableID atomic.Uint64
 	g.availablePool.New = func() interface{} {
 		log.Debugw("creating new available window session", "id", availableID.Load())
-		defer availableID.Add(1)
+		availableID.Add(1)
 		return g.exchange.NewSession(ctx)
 	}
 
 	var archivalID atomic.Uint64
 	g.archivalPool.New = func() interface{} {
 		log.Debugw("creating new archival session", "id", archivalID.Load())
-		defer archivalID.Add(1)
+		archivalID.Add(1)
 		return g.exchange.NewSession(ctx)
 	}
 }
 
-// Stop shuts down Getter's internal fetching session.
+// Stop shuts down Getter's internal fetching getSession.
 func (g *Getter) Stop() {
 	g.cancel()
 }
@@ -113,8 +113,8 @@ func (g *Getter) GetShares(
 	isArchival := g.isArchival(hdr)
 	span.SetAttributes(attribute.Bool("is_archival", isArchival))
 
-	ses := g.session(isArchival)
-	defer g.poolSession(ses, isArchival)
+	ses := g.getSession(isArchival)
+	defer g.putSession(ses, isArchival)
 
 	err := Fetch(ctx, g.exchange, hdr.DAH, blks, WithStore(g.bstore), WithFetcher(ses))
 	if err != nil {
@@ -177,8 +177,8 @@ func (g *Getter) GetEDS(
 	isArchival := g.isArchival(hdr)
 	span.SetAttributes(attribute.Bool("is_archival", isArchival))
 
-	ses := g.session(isArchival)
-	defer g.poolSession(ses, isArchival)
+	ses := g.getSession(isArchival)
+	defer g.putSession(ses, isArchival)
 
 	err := Fetch(ctx, g.exchange, hdr.DAH, blks, WithFetcher(ses))
 	if err != nil {
@@ -236,8 +236,8 @@ func (g *Getter) GetNamespaceData(
 	isArchival := g.isArchival(hdr)
 	span.SetAttributes(attribute.Bool("is_archival", isArchival))
 
-	ses := g.session(isArchival)
-	defer g.poolSession(ses, isArchival)
+	ses := g.getSession(isArchival)
+	defer g.putSession(ses, isArchival)
 
 	if err = Fetch(ctx, g.exchange, hdr.DAH, blks, WithFetcher(ses)); err != nil {
 		span.RecordError(err)
@@ -263,8 +263,8 @@ func (g *Getter) isArchival(hdr *header.ExtendedHeader) bool {
 	return !availability.IsWithinWindow(hdr.Time(), g.availWndw)
 }
 
-// session takes a session out of the respective session pool
-func (g *Getter) session(isArchival bool) exchange.Fetcher {
+// getSession takes a session out of the respective session pool
+func (g *Getter) getSession(isArchival bool) exchange.Fetcher {
 	if isArchival {
 		v := g.archivalPool.Get()
 		if v == nil {
@@ -282,8 +282,8 @@ func (g *Getter) session(isArchival bool) exchange.Fetcher {
 	return v.(exchange.Fetcher)
 }
 
-// poolSession puts session back into the respective session pool
-func (g *Getter) poolSession(session exchange.Fetcher, isArchival bool) {
+// putSession puts session back into the respective session pool
+func (g *Getter) putSession(session exchange.Fetcher, isArchival bool) {
 	if isArchival {
 		g.archivalPool.Put(session)
 	} else {

--- a/share/shwap/p2p/bitswap/getter_test.go
+++ b/share/shwap/p2p/bitswap/getter_test.go
@@ -1,8 +1,11 @@
 package bitswap
 
 import (
+	"context"
+	"sync"
 	"testing"
 
+	"github.com/ipfs/boxo/exchange"
 	"github.com/stretchr/testify/require"
 
 	libshare "github.com/celestiaorg/go-square/v2/share"
@@ -27,4 +30,86 @@ func TestEDSFromRows(t *testing.T) {
 	edsOut, err := edsFromRows(roots, rows)
 	require.NoError(t, err)
 	require.True(t, edsIn.Equals(edsOut))
+}
+
+// mockSessionExchange is a mock implementation of exchange.SessionExchange
+type mockSessionExchange struct {
+	exchange.SessionExchange
+	sessionCount int
+	mu           sync.Mutex
+}
+
+func (m *mockSessionExchange) NewSession(ctx context.Context) exchange.Fetcher {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessionCount++
+	return &mockFetcher{id: m.sessionCount}
+}
+
+// mockFetcher is a mock implementation of exchange.Fetcher
+type mockFetcher struct {
+	exchange.Fetcher
+	id int
+}
+
+func TestPoolGetFromEmptyPool(t *testing.T) {
+	ex := &mockSessionExchange{}
+	p := newPool(ex)
+	ctx := context.Background()
+	p.ctx = ctx
+
+	ses := p.get().(*mockFetcher)
+	require.NotNil(t, ses)
+	require.Equal(t, 1, ses.id)
+}
+
+func TestPoolPutAndGet(t *testing.T) {
+	ex := &mockSessionExchange{}
+	p := newPool(ex)
+	ctx := context.Background()
+	p.ctx = ctx
+
+	// Get a session
+	ses := p.get().(*mockFetcher)
+
+	// Put it back
+	p.put(ses)
+
+	// Get again
+	ses2 := p.get().(*mockFetcher)
+
+	require.Equal(t, ses.id, ses2.id)
+}
+
+func TestPoolConcurrency(t *testing.T) {
+	ex := &mockSessionExchange{}
+	p := newPool(ex)
+	ctx := context.Background()
+	p.ctx = ctx
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+
+	sessionIDSet := make(map[int]struct{})
+	lock := sync.Mutex{}
+
+	// Start multiple goroutines to get sessions
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ses := p.get()
+			mockSes := ses.(*mockFetcher)
+			p.put(ses)
+			lock.Lock()
+			sessionIDSet[mockSes.id] = struct{}{}
+			lock.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Since the pool reuses sessions, the number of unique session IDs should be less than or equal to numGoroutines
+	if len(sessionIDSet) > numGoroutines {
+		t.Fatalf("expected number of unique sessions to be less than or equal to %d, got %d", numGoroutines, len(sessionIDSet))
+	}
 }

--- a/share/shwap/p2p/bitswap/getter_test.go
+++ b/share/shwap/p2p/bitswap/getter_test.go
@@ -110,6 +110,7 @@ func TestPoolConcurrency(t *testing.T) {
 
 	// Since the pool reuses sessions, the number of unique session IDs should be less than or equal to numGoroutines
 	if len(sessionIDSet) > numGoroutines {
-		t.Fatalf("expected number of unique sessions to be less than or equal to %d, got %d", numGoroutines, len(sessionIDSet))
+		t.Fatalf("expected number of unique sessions to be less than or equal to %d, got %d",
+			numGoroutines, len(sessionIDSet))
 	}
 }


### PR DESCRIPTION
In the Robusta environment this change:
* Improved load distribution across BN/FNs
* Sped up sampling

Originally, I was testing Bitswap with this change but decided against including it in the patch, as it is solely an optimization. However, without this change on the rc tag, load distribution was rather strange. One LN sampled at 180/s, while all 4 others at 4/s. Adding pooling fixed the issue and resulted in all 5 LNs at about 100/s.
