### PR TITLE
feat(availability): env var to disable pruning

### DIFF
--- a/share/availability/window.go
+++ b/share/availability/window.go
@@ -17,6 +17,9 @@ func IsWithinWindow(t time.Time, window time.Duration) bool {
 	if alwaysAvailable {
 		return true
 	}
+	if windowOverride != time.Duration(0) {
+		window = windowOverride
+	}
 	if window == time.Duration(0) {
 		return true
 	}
@@ -25,3 +28,14 @@ func IsWithinWindow(t time.Time, window time.Duration) bool {
 
 // alwaysAvailable is a flag that disables the availability window.
 var alwaysAvailable = os.Getenv("CELESTIA_PRUNING_DISABLED") == "true"
+
+var windowOverride time.Duration
+
+func init() {
+	durationRaw := os.Getenv("CELESTIA_OVERRIDE_AVAILABILITY_WINDOW")
+	duration, err := time.ParseDuration(durationRaw)
+	if err != nil {
+		panic("failed to parse CELESTIA_OVERRIDE_AVAILABILITY_WINDOW: " + err.Error())
+	}
+	windowOverride = duration
+}

--- a/share/availability/window.go
+++ b/share/availability/window.go
@@ -14,11 +14,8 @@ const (
 // given AvailabilityWindow. If the window is disabled (0), it returns true for
 // every timestamp.
 func IsWithinWindow(t time.Time, window time.Duration) bool {
-	if alwaysAvailable {
-		return true
-	}
-	if windowOverride != time.Duration(0) {
-		window = windowOverride
+	if windowOverride {
+		window = windowOverrideDur
 	}
 	if window == time.Duration(0) {
 		return true
@@ -26,19 +23,24 @@ func IsWithinWindow(t time.Time, window time.Duration) bool {
 	return time.Since(t) <= window
 }
 
-// alwaysAvailable is a flag that disables the availability window. This flag is intended for
-// testing purposes only.
-var alwaysAvailable = os.Getenv("CELESTIA_PRUNING_DISABLED") == "true"
-
 // windowOverride is a flag that overrides the availability window. This flag is intended for
 // testing purposes only.
-var windowOverride time.Duration
+var (
+	windowOverride    bool
+	windowOverrideDur time.Duration
+)
 
 func init() {
-	durationRaw := os.Getenv("CELESTIA_OVERRIDE_AVAILABILITY_WINDOW")
+	durationRaw, ok := os.LookupEnv("CELESTIA_OVERRIDE_AVAILABILITY_WINDOW")
+	if !ok {
+		return
+	}
+
 	duration, err := time.ParseDuration(durationRaw)
 	if err != nil {
 		panic("failed to parse CELESTIA_OVERRIDE_AVAILABILITY_WINDOW: " + err.Error())
 	}
-	windowOverride = duration
+
+	windowOverride = true
+	windowOverrideDur = duration
 }

--- a/share/availability/window.go
+++ b/share/availability/window.go
@@ -26,9 +26,12 @@ func IsWithinWindow(t time.Time, window time.Duration) bool {
 	return time.Since(t) <= window
 }
 
-// alwaysAvailable is a flag that disables the availability window.
+// alwaysAvailable is a flag that disables the availability window. This flag is intended for
+// testing purposes only.
 var alwaysAvailable = os.Getenv("CELESTIA_PRUNING_DISABLED") == "true"
 
+// windowOverride is a flag that overrides the availability window. This flag is intended for
+// testing purposes only.
 var windowOverride time.Duration
 
 func init() {

--- a/share/availability/window.go
+++ b/share/availability/window.go
@@ -1,6 +1,9 @@
 package availability
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
 const (
 	RequestWindow = 30 * 24 * time.Hour
@@ -11,8 +14,14 @@ const (
 // given AvailabilityWindow. If the window is disabled (0), it returns true for
 // every timestamp.
 func IsWithinWindow(t time.Time, window time.Duration) bool {
+	if alwaysAvailable {
+		return true
+	}
 	if window == time.Duration(0) {
 		return true
 	}
 	return time.Since(t) <= window
 }
+
+// alwaysAvailable is a flag that disables the availability window.
+var alwaysAvailable = os.Getenv("CELESTIA_PRUNING_DISABLED") == "true"


### PR DESCRIPTION
This trick allowed me to reuse an old 8mb snapshot, even though it is already far beyond the availability window. I think it is helpful to add it to main.