### PR TITLE
refactor(share/availability/light | share/availability/full): Availability implementations are aware of sampling window, removed from DASer

### DIFF
--- a/core/eds.go
+++ b/core/eds.go
@@ -62,8 +62,9 @@ func storeEDS(
 	eds *rsmt2d.ExtendedDataSquare,
 	store *store.Store,
 	window time.Duration,
+	archival bool,
 ) error {
-	if !availability.IsWithinWindow(eh.Time(), window) {
+	if !archival && !availability.IsWithinWindow(eh.Time(), window) {
 		log.Debugw("skipping storage of historic block", "height", eh.Height())
 		return nil
 	}

--- a/core/exchange.go
+++ b/core/exchange.go
@@ -23,6 +23,7 @@ type Exchange struct {
 	construct header.ConstructFn
 
 	availabilityWindow time.Duration
+	archival           bool
 
 	metrics *exchangeMetrics
 }
@@ -54,6 +55,7 @@ func NewExchange(
 		store:              store,
 		construct:          construct,
 		availabilityWindow: p.availabilityWindow,
+		archival:           p.archival,
 		metrics:            metrics,
 	}, nil
 }
@@ -147,7 +149,7 @@ func (ce *Exchange) Get(ctx context.Context, hash libhead.Hash) (*header.Extende
 			&block.Height, hash, eh.Hash())
 	}
 
-	err = storeEDS(ctx, eh, eds, ce.store, ce.availabilityWindow)
+	err = storeEDS(ctx, eh, eds, ce.store, ce.availabilityWindow, ce.archival)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +189,7 @@ func (ce *Exchange) getExtendedHeaderByHeight(ctx context.Context, height *int64
 		panic(fmt.Errorf("constructing extended header for height %d: %w", b.Header.Height, err))
 	}
 
-	err = storeEDS(ctx, eh, eds, ce.store, ce.availabilityWindow)
+	err = storeEDS(ctx, eh, eds, ce.store, ce.availabilityWindow, ce.archival)
 	if err != nil {
 		return nil, err
 	}

--- a/core/listener.go
+++ b/core/listener.go
@@ -38,6 +38,7 @@ type Listener struct {
 	construct          header.ConstructFn
 	store              *store.Store
 	availabilityWindow time.Duration
+	archival           bool
 
 	headerBroadcaster libhead.Broadcaster[*header.ExtendedHeader]
 	hashBroadcaster   shrexsub.BroadcastFn
@@ -83,6 +84,7 @@ func NewListener(
 		construct:          construct,
 		store:              store,
 		availabilityWindow: p.availabilityWindow,
+		archival:           p.archival,
 		listenerTimeout:    5 * blocktime,
 		metrics:            metrics,
 		chainID:            p.chainID,
@@ -237,7 +239,7 @@ func (cl *Listener) handleNewSignedBlock(ctx context.Context, b types.EventDataS
 		panic(fmt.Errorf("making extended header: %w", err))
 	}
 
-	err = storeEDS(ctx, eh, eds, cl.store, cl.availabilityWindow)
+	err = storeEDS(ctx, eh, eds, cl.store, cl.availabilityWindow, cl.archival)
 	if err != nil {
 		return fmt.Errorf("storing EDS: %w", err)
 	}

--- a/core/option.go
+++ b/core/option.go
@@ -12,11 +12,13 @@ type params struct {
 	metrics            bool
 	chainID            string
 	availabilityWindow time.Duration
+	archival           bool
 }
 
 func defaultParams() params {
 	return params{
 		availabilityWindow: time.Duration(0),
+		archival:           false,
 	}
 }
 
@@ -37,5 +39,11 @@ func WithChainID(id p2p.Network) Option {
 func WithAvailabilityWindow(window time.Duration) Option {
 	return func(p *params) {
 		p.availabilityWindow = window
+	}
+}
+
+func WithArchivalMode() Option {
+	return func(p *params) {
+		p.archival = true
 	}
 }

--- a/das/daser.go
+++ b/das/daser.go
@@ -20,11 +20,6 @@ import (
 
 var log = logging.Logger("das")
 
-// errOutsideSamplingWindow is an error used to inform
-// the caller of Sample that the given header is outside
-// the sampling window.
-var errOutsideSamplingWindow = fmt.Errorf("skipping header outside of sampling window")
-
 // DASer continuously validates availability of data committed to headers.
 type DASer struct {
 	params Parameters

--- a/das/daser.go
+++ b/das/daser.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/share/availability"
 	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
 	"github.com/celestiaorg/celestia-node/share/shwap/p2p/shrex/shrexsub"
 )
@@ -160,14 +159,6 @@ func (d *DASer) Stop(ctx context.Context) error {
 }
 
 func (d *DASer) sample(ctx context.Context, h *header.ExtendedHeader) error {
-	// short-circuit if pruning is enabled and the header is outside the
-	// availability window
-	if !availability.IsWithinWindow(h.Time(), d.params.samplingWindow) {
-		log.Debugw("skipping header outside sampling window", "height", h.Height(),
-			"time", h.Time())
-		return errOutsideSamplingWindow
-	}
-
 	err := d.da.SharesAvailable(ctx, h)
 	if err != nil {
 		var byzantineErr *byzantine.ErrByzantine

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -3,7 +3,6 @@ package das
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/header/headertest"
 	"github.com/celestiaorg/celestia-node/share"
-	"github.com/celestiaorg/celestia-node/share/availability"
 	"github.com/celestiaorg/celestia-node/share/availability/mocks"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 )
@@ -240,45 +238,6 @@ func TestDASerSampleTimeout(t *testing.T) {
 	case <-doneCh:
 	case <-ctx.Done():
 		t.Fatal("call context didn't timeout in time")
-	}
-}
-
-// TestDASer_SamplingWindow tests the sampling window determination
-// for headers.
-func TestDASer_SamplingWindow(t *testing.T) {
-	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
-	sub := new(headertest.Subscriber)
-	fserv := &fraudtest.DummyService[*header.ExtendedHeader]{}
-	getter := getterStub{}
-	avail := mocks.NewMockAvailability(gomock.NewController(t))
-
-	// create and start DASer
-	daser, err := NewDASer(avail, sub, getter, ds, fserv, newBroadcastMock(1),
-		WithSamplingWindow(time.Second))
-	require.NoError(t, err)
-
-	tests := []struct {
-		timestamp    time.Time
-		withinWindow bool
-	}{
-		{timestamp: time.Now().Add(-(time.Second * 5)), withinWindow: false},
-		{timestamp: time.Now().Add(-(time.Millisecond * 800)), withinWindow: true},
-		{timestamp: time.Now().Add(-(time.Hour)), withinWindow: false},
-		{timestamp: time.Now().Add(-(time.Hour * 24 * 30)), withinWindow: false},
-		{timestamp: time.Now(), withinWindow: true},
-	}
-
-	for i, tt := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			eh := headertest.RandExtendedHeader(t)
-			eh.RawHeader.Time = tt.timestamp
-
-			assert.Equal(
-				t,
-				tt.withinWindow,
-				availability.IsWithinWindow(eh.Time(), daser.params.samplingWindow),
-			)
-		})
 	}
 }
 

--- a/das/options.go
+++ b/das/options.go
@@ -41,11 +41,6 @@ type Parameters struct {
 	// divided between parallel workers. SampleTimeout should be adjusted proportionally to
 	// ConcurrencyLimit.
 	SampleTimeout time.Duration
-
-	// samplingWindow determines the time window that headers should fall into
-	// in order to be sampled. If set to 0, the sampling window will include
-	// all headers.
-	samplingWindow time.Duration
 }
 
 // DefaultParameters returns the default configuration values for the daser parameters
@@ -159,13 +154,5 @@ func WithSampleFrom(sampleFrom uint64) Option {
 func WithSampleTimeout(sampleTimeout time.Duration) Option {
 	return func(d *DASer) {
 		d.params.SampleTimeout = sampleTimeout
-	}
-}
-
-// WithSamplingWindow is a functional option to configure the DASer's
-// `samplingWindow` parameter.
-func WithSamplingWindow(samplingWindow time.Duration) Option {
-	return func(d *DASer) {
-		d.params.samplingWindow = samplingWindow
 	}
 }

--- a/das/worker.go
+++ b/das/worker.go
@@ -10,6 +10,7 @@ import (
 	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share/availability"
 	"github.com/celestiaorg/celestia-node/share/shwap/p2p/shrex/shrexsub"
 )
 
@@ -83,7 +84,7 @@ func (w *worker) run(ctx context.Context, timeout time.Duration, resultCh chan<-
 			// sampling worker will resume upon restart
 			return
 		}
-		if errors.Is(err, errOutsideSamplingWindow) {
+		if errors.Is(err, availability.ErrOutsideSamplingWindow) {
 			skipped++
 			err = nil
 		}
@@ -119,7 +120,7 @@ func (w *worker) sample(ctx context.Context, timeout time.Duration, height uint6
 	defer cancel()
 
 	err = w.sampleFn(ctx, h)
-	if errors.Is(err, errOutsideSamplingWindow) {
+	if errors.Is(err, availability.ErrOutsideSamplingWindow) {
 		// if header is outside sampling window, do not log
 		// or record it.
 		return err

--- a/nodebuilder/das/constructors.go
+++ b/nodebuilder/das/constructors.go
@@ -12,7 +12,6 @@ import (
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/header"
 	modfraud "github.com/celestiaorg/celestia-node/nodebuilder/fraud"
-	modshare "github.com/celestiaorg/celestia-node/nodebuilder/share"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/byzantine"
 	"github.com/celestiaorg/celestia-node/share/shwap/p2p/shrex/shrexsub"
@@ -45,11 +44,8 @@ func newDASer(
 	batching datastore.Batching,
 	fraudServ fraud.Service[*header.ExtendedHeader],
 	bFn shrexsub.BroadcastFn,
-	availWindow modshare.Window,
 	options ...das.Option,
 ) (*das.DASer, *modfraud.ServiceBreaker[*das.DASer, *header.ExtendedHeader], error) {
-	options = append(options, das.WithSamplingWindow(availWindow.Duration()))
-
 	ds, err := das.NewDASer(da, hsub, store, batching, fraudServ, bFn, options...)
 	if err != nil {
 		return nil, nil, err

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	logging "github.com/ipfs/go-log/v2"
 
@@ -23,16 +24,27 @@ var log = logging.Logger("share/full")
 type ShareAvailability struct {
 	store  *store.Store
 	getter shwap.Getter
+
+	storageWindow time.Duration
+	archival      bool
 }
 
 // NewShareAvailability creates a new full ShareAvailability.
 func NewShareAvailability(
 	store *store.Store,
 	getter shwap.Getter,
+	opts ...Option,
 ) *ShareAvailability {
+	p := defaultParams()
+	for _, opt := range opts {
+		opt(p)
+	}
+
 	return &ShareAvailability{
-		store:  store,
-		getter: getter,
+		store:         store,
+		getter:        getter,
+		storageWindow: p.storageWindow,
+		archival:      p.archival,
 	}
 }
 
@@ -40,6 +52,16 @@ func NewShareAvailability(
 // enough Shares from the network.
 func (fa *ShareAvailability) SharesAvailable(ctx context.Context, header *header.ExtendedHeader) error {
 	dah := header.DAH
+
+	if !fa.archival {
+		// do not sync blocks outside of sampling window if not archival
+		if !availability.IsWithinWindow(header.Time(), fa.storageWindow) {
+			log.Debugw("skipping availability check for block outside sampling"+
+				" window", "height", header.Height(), "data hash", dah.String())
+			return availability.ErrOutsideSamplingWindow
+		}
+	}
+
 	// if the data square is empty, we can safely link the header height in the store to an empty EDS.
 	if share.DataHash(dah.Hash()).IsEmptyEDS() {
 		err := fa.store.PutODSQ4(ctx, dah, header.Height(), share.EmptyEDS())
@@ -68,7 +90,7 @@ func (fa *ShareAvailability) SharesAvailable(ctx context.Context, header *header
 	}
 
 	// archival nodes should not store Q4 outside the availability window.
-	if availability.IsWithinWindow(header.Time(), availability.StorageWindow) {
+	if availability.IsWithinWindow(header.Time(), fa.storageWindow) {
 		err = fa.store.PutODSQ4(ctx, dah, header.Height(), eds)
 	} else {
 		err = fa.store.PutODS(ctx, dah, header.Height(), eds)

--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -43,7 +43,7 @@ func NewShareAvailability(
 	return &ShareAvailability{
 		store:         store,
 		getter:        getter,
-		storageWindow: p.storageWindow,
+		storageWindow: availability.StorageWindow,
 		archival:      p.archival,
 	}
 }

--- a/share/availability/full/availability_test.go
+++ b/share/availability/full/availability_test.go
@@ -114,8 +114,8 @@ func TestSharesAvailable_OutsideSamplingWindow_NonArchival(t *testing.T) {
 	suite := headertest.NewTestSuite(t, 3, time.Nanosecond)
 	headers := suite.GenExtendedHeaders(10)
 
-	storageWindow := time.Nanosecond // make all headers outside sampling window
-	avail := NewShareAvailability(store, getter, WithStorageWindow(storageWindow))
+	avail := NewShareAvailability(store, getter)
+	avail.storageWindow = time.Nanosecond // make all headers outside sampling window
 
 	for _, h := range headers {
 		err := avail.SharesAvailable(ctx, h)
@@ -140,8 +140,8 @@ func TestSharesAvailable_OutsideSamplingWindow_Archival(t *testing.T) {
 
 	getter.EXPECT().GetEDS(gomock.Any(), gomock.Any()).Times(1).Return(eds, nil)
 
-	storageWindow := time.Nanosecond // make all headers outside sampling window
-	avail := NewShareAvailability(store, getter, WithStorageWindow(storageWindow), WithArchivalMode())
+	avail := NewShareAvailability(store, getter, WithArchivalMode())
+	avail.storageWindow = time.Nanosecond // make all headers outside sampling window
 
 	err = avail.SharesAvailable(ctx, eh)
 	require.NoError(t, err)

--- a/share/availability/full/availability_test.go
+++ b/share/availability/full/availability_test.go
@@ -2,6 +2,7 @@ package full
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/header/headertest"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/availability"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 	"github.com/celestiaorg/celestia-node/share/shwap"
 	"github.com/celestiaorg/celestia-node/share/shwap/getters/mock"
@@ -96,4 +98,54 @@ func TestSharesAvailable_ErrNotAvailable(t *testing.T) {
 		err := avail.SharesAvailable(ctx, eh)
 		require.ErrorIs(t, err, share.ErrNotAvailable)
 	}
+}
+
+// TestSharesAvailable_OutsideSamplingWindow_NonArchival tests to make sure
+// blocks are skipped that are outside sampling window.
+func TestSharesAvailable_OutsideSamplingWindow_NonArchival(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	getter := mock.NewMockGetter(gomock.NewController(t))
+	getter.EXPECT().GetEDS(gomock.Any(), gomock.Any()).Times(0)
+	store, err := store.NewStore(store.DefaultParameters(), t.TempDir())
+	require.NoError(t, err)
+
+	suite := headertest.NewTestSuite(t, 3, time.Nanosecond)
+	headers := suite.GenExtendedHeaders(10)
+
+	storageWindow := time.Nanosecond // make all headers outside sampling window
+	avail := NewShareAvailability(store, getter, WithStorageWindow(storageWindow))
+
+	for _, h := range headers {
+		err := avail.SharesAvailable(ctx, h)
+		assert.ErrorIs(t, err, availability.ErrOutsideSamplingWindow)
+	}
+}
+
+// TestSharesAvailable_OutsideSamplingWindow_Archival tests to make sure
+// blocks are still synced that are outside sampling window.
+func TestSharesAvailable_OutsideSamplingWindow_Archival(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	getter := mock.NewMockGetter(gomock.NewController(t))
+	store, err := store.NewStore(store.DefaultParameters(), t.TempDir())
+	require.NoError(t, err)
+
+	eds := edstest.RandEDS(t, 4)
+	roots, err := share.NewAxisRoots(eds)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
+	require.NoError(t, err)
+
+	getter.EXPECT().GetEDS(gomock.Any(), gomock.Any()).Times(1).Return(eds, nil)
+
+	storageWindow := time.Nanosecond // make all headers outside sampling window
+	avail := NewShareAvailability(store, getter, WithStorageWindow(storageWindow), WithArchivalMode())
+
+	err = avail.SharesAvailable(ctx, eh)
+	require.NoError(t, err)
+	has, err := store.HasByHash(ctx, roots.Hash())
+	require.NoError(t, err)
+	assert.True(t, has)
 }

--- a/share/availability/full/availability_test.go
+++ b/share/availability/full/availability_test.go
@@ -2,11 +2,11 @@ package full
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-node/header/headertest"

--- a/share/availability/full/options.go
+++ b/share/availability/full/options.go
@@ -1,14 +1,7 @@
 package full
 
-import (
-	"time"
-
-	"github.com/celestiaorg/celestia-node/share/availability"
-)
-
 type params struct {
-	storageWindow time.Duration
-	archival      bool
+	archival bool
 }
 
 // Option is a function that configures light availability Parameters
@@ -18,8 +11,7 @@ type Option func(*params)
 // for the light availability implementation
 func defaultParams() *params {
 	return &params{
-		storageWindow: availability.StorageWindow,
-		archival:      false,
+		archival: false,
 	}
 }
 
@@ -29,13 +21,5 @@ func defaultParams() *params {
 func WithArchivalMode() Option {
 	return func(p *params) {
 		p.archival = true
-	}
-}
-
-// WithStorageWindow is a functional option to set the storage window
-// to something other than the default for the full availability implementation
-func WithStorageWindow(window time.Duration) Option {
-	return func(p *params) {
-		p.storageWindow = window
 	}
 }

--- a/share/availability/full/options.go
+++ b/share/availability/full/options.go
@@ -1,0 +1,38 @@
+package full
+
+import (
+	"time"
+
+	"github.com/celestiaorg/celestia-node/share/availability"
+)
+
+type params struct {
+	storageWindow time.Duration
+	archival      bool
+}
+
+// Option is a function that configures light availability Parameters
+type Option func(*params)
+
+// DefaultParameters returns the default Parameters' configuration values
+// for the light availability implementation
+func defaultParams() *params {
+	return &params{
+		storageWindow: availability.StorageWindow,
+		archival:      false,
+	}
+}
+
+func WithArchivalMode() Option {
+	return func(p *params) {
+		p.archival = true
+	}
+}
+
+// WithStorageWindow is a functional option to set the storage window
+// to something other than the default for the full availability implementation
+func WithStorageWindow(window time.Duration) Option {
+	return func(p *params) {
+		p.storageWindow = window
+	}
+}

--- a/share/availability/full/options.go
+++ b/share/availability/full/options.go
@@ -23,6 +23,9 @@ func defaultParams() *params {
 	}
 }
 
+// WithArchivalMode is a functional option to tell the full availability
+// implementation that the node wants to sync *all* blocks, not just those
+// within the sampling window.
 func WithArchivalMode() Option {
 	return func(p *params) {
 		p.archival = true

--- a/share/availability/light/availability.go
+++ b/share/availability/light/availability.go
@@ -17,6 +17,7 @@ import (
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/libs/utils"
 	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/availability"
 	"github.com/celestiaorg/celestia-node/share/ipld"
 	"github.com/celestiaorg/celestia-node/share/shwap"
 	"github.com/celestiaorg/celestia-node/share/shwap/p2p/bitswap"
@@ -74,6 +75,11 @@ func (la *ShareAvailability) SharesAvailable(ctx context.Context, header *header
 	// short-circuit if the given root is an empty data square
 	if share.DataHash(dah.Hash()).IsEmptyEDS() {
 		return nil
+	}
+
+	// short-circuit if outside sampling window
+	if !availability.IsWithinWindow(header.Time(), la.params.storageWindow) {
+		return availability.ErrOutsideSamplingWindow
 	}
 
 	// Prevent multiple sampling and pruning sessions for the same header height

--- a/share/availability/light/availability.go
+++ b/share/availability/light/availability.go
@@ -78,7 +78,7 @@ func (la *ShareAvailability) SharesAvailable(ctx context.Context, header *header
 	}
 
 	// short-circuit if outside sampling window
-	if !availability.IsWithinWindow(header.Time(), la.params.storageWindow) {
+	if !availability.IsWithinWindow(header.Time(), la.params.StorageWindow) {
 		return availability.ErrOutsideSamplingWindow
 	}
 

--- a/share/availability/light/availability.go
+++ b/share/availability/light/availability.go
@@ -38,6 +38,8 @@ type ShareAvailability struct {
 	bs     blockstore.Blockstore
 	params Parameters
 
+	storageWindow time.Duration
+
 	activeHeights *utils.Sessions
 	dsLk          sync.RWMutex
 	ds            *autobatch.Datastore
@@ -62,6 +64,7 @@ func NewShareAvailability(
 		getter:        getter,
 		bs:            bs,
 		params:        params,
+		storageWindow: availability.StorageWindow,
 		activeHeights: utils.NewSessions(),
 		ds:            autoDS,
 	}
@@ -78,7 +81,7 @@ func (la *ShareAvailability) SharesAvailable(ctx context.Context, header *header
 	}
 
 	// short-circuit if outside sampling window
-	if !availability.IsWithinWindow(header.Time(), la.params.StorageWindow) {
+	if !availability.IsWithinWindow(header.Time(), la.storageWindow) {
 		return availability.ErrOutsideSamplingWindow
 	}
 

--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -517,6 +517,7 @@ func randEdsAndHeader(t *testing.T, size int) (*rsmt2d.ExtendedDataSquare, *head
 	h := &header.ExtendedHeader{
 		RawHeader: header.RawHeader{
 			Height: int64(height),
+			Time:   time.Now(),
 		},
 		DAH: roots,
 	}

--- a/share/availability/light/options.go
+++ b/share/availability/light/options.go
@@ -2,6 +2,9 @@ package light
 
 import (
 	"fmt"
+	"time"
+
+	"github.com/celestiaorg/celestia-node/share/availability"
 )
 
 // SampleAmount specifies the minimum required amount of samples a light node must perform
@@ -14,6 +17,8 @@ var (
 // availability implementation
 type Parameters struct {
 	SampleAmount uint // The minimum required amount of samples to perform
+
+	storageWindow time.Duration
 }
 
 // Option is a function that configures light availability Parameters
@@ -23,7 +28,8 @@ type Option func(*Parameters)
 // for the light availability implementation
 func DefaultParameters() *Parameters {
 	return &Parameters{
-		SampleAmount: DefaultSampleAmount,
+		SampleAmount:  DefaultSampleAmount,
+		storageWindow: availability.StorageWindow,
 	}
 }
 

--- a/share/availability/light/options.go
+++ b/share/availability/light/options.go
@@ -7,7 +7,7 @@ import (
 	"github.com/celestiaorg/celestia-node/share/availability"
 )
 
-// SampleAmount specifies the minimum required amount of samples a light node must perform
+// DefaultSampleAmount specifies the minimum required amount of samples a light node must perform
 // before declaring that a block is available
 var (
 	DefaultSampleAmount uint = 16
@@ -18,7 +18,7 @@ var (
 type Parameters struct {
 	SampleAmount uint // The minimum required amount of samples to perform
 
-	storageWindow time.Duration
+	StorageWindow time.Duration
 }
 
 // Option is a function that configures light availability Parameters
@@ -29,7 +29,7 @@ type Option func(*Parameters)
 func DefaultParameters() *Parameters {
 	return &Parameters{
 		SampleAmount:  DefaultSampleAmount,
-		storageWindow: availability.StorageWindow,
+		StorageWindow: availability.StorageWindow,
 	}
 }
 

--- a/share/availability/light/options.go
+++ b/share/availability/light/options.go
@@ -2,9 +2,6 @@ package light
 
 import (
 	"fmt"
-	"time"
-
-	"github.com/celestiaorg/celestia-node/share/availability"
 )
 
 // DefaultSampleAmount specifies the minimum required amount of samples a light node must perform
@@ -17,8 +14,6 @@ var (
 // availability implementation
 type Parameters struct {
 	SampleAmount uint // The minimum required amount of samples to perform
-
-	StorageWindow time.Duration
 }
 
 // Option is a function that configures light availability Parameters
@@ -28,8 +23,7 @@ type Option func(*Parameters)
 // for the light availability implementation
 func DefaultParameters() *Parameters {
 	return &Parameters{
-		SampleAmount:  DefaultSampleAmount,
-		StorageWindow: availability.StorageWindow,
+		SampleAmount: DefaultSampleAmount,
 	}
 }
 

--- a/share/availability/window.go
+++ b/share/availability/window.go
@@ -1,6 +1,7 @@
 package availability
 
 import (
+	"errors"
 	"os"
 	"time"
 )
@@ -9,6 +10,8 @@ const (
 	RequestWindow = 30 * 24 * time.Hour
 	StorageWindow = RequestWindow + time.Hour
 )
+
+var ErrOutsideSamplingWindow = errors.New("timestamp outside sampling window")
 
 // IsWithinWindow checks whether the given timestamp is within the
 // given AvailabilityWindow. If the window is disabled (0), it returns true for


### PR DESCRIPTION
This PR makes the concept of `archival` node explicit, splitting it away from sampling window. Now, both the node's pruning status (archival or not) and the sampling window will have to be provided to availability implementations for them to determine what to sync + what to store. This also applies to `core` package for BNs as that's their "availability implementation" technically.