### PR TITLE
fix(.github/workflows): no automatic tagging of releases for CI

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -95,13 +95,6 @@ jobs:
         with:
           go-version: ${{ needs.setup.outputs.go-version }}
 
-      - name: Bump version and push tag
-        if: ${{ github.event_name == 'workflow_dispatch' }} && ${{ inputs.tag-as }} != ''
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ inputs.tag-as }}
-
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6


### PR DESCRIPTION
Do not allow goreleaser to automate tagging of releases - we always do this manually.