### PR TITLE
fix(goreleaser): tag_sort

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,3 +71,4 @@ release:
   mode: keep-existing
 git:
   prerelease_suffix: "-rc*"
+  tag_sort: -version:creatordate


### PR DESCRIPTION
```
git:
  # What should be used to sort tags when gathering the current and previous
  # tags if there are more than one tag in the same commit.
  #
  # Default: '-version:refname'.
  tag_sort: -version:creatordate
```

https://goreleaser.com/customization/git/