### PR TITLE
feat(nonce): Update core_access.go adjust network nonce

### DIFF
--- a/state/core_access.go
+++ b/state/core_access.go
@@ -276,8 +276,7 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 			numbers := regexpInt.FindAllString(err.Error(), -1)
 			log.Infof("Received nonce correction message from the network %w", err.Error())
 			if len(numbers) != 2 {
-				log.Infof("Could not parse acount sequence log")
-				continue
+				return nil, fmt.Errorf("unexpected wrong sequence error: %w", err)
 			}
 			nonce, _ := strconv.ParseUint(numbers[0], 10, 64)
 			log.Infof("Adjusting nonce to %d", nonce)


### PR DESCRIPTION
Continuation of the discussion here: https://github.com/celestiaorg/celestia-app/pull/4067

This PR adds the ability for self-adjusting flow when clients submit blobs and the message returned yells that the nonce is out of sync.

Caldera has been using this in mocha-4 and celestia network for months now and it would be beneficial for both to close the gaps on changes we've implemented.
