### PR TITLE
feat(modp2p): Ping and ConnectionState APIs

### DIFF
--- a/nodebuilder/p2p/cmd/p2p.go
+++ b/nodebuilder/p2p/cmd/p2p.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/libp2p/go-libp2p/core/metrics"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -9,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdnode "github.com/celestiaorg/celestia-node/cmd"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 type peerInfo struct {
@@ -35,6 +38,8 @@ func init() {
 		bandwidthForProtocolCmd,
 		pubsubPeersCmd,
 		pubsubTopicsCmd,
+		connectionInfoCmd,
+		pingCmd,
 	)
 }
 
@@ -597,5 +602,74 @@ var pubsubTopicsCmd = &cobra.Command{
 			}
 		}
 		return cmdnode.PrintOutput(topics, err, formatter)
+	},
+}
+
+var connectionInfoCmd = &cobra.Command{
+	Use:   "connection-state [peerID]",
+	Short: "Gets connection info for a given peer ID",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+
+		pid, err := peer.Decode(args[0])
+		if err != nil {
+			return err
+		}
+
+		infos, err := client.P2P.ConnectionState(cmd.Context(), pid)
+		return cmdnode.PrintOutput(infos, err, func(i interface{}) interface{} {
+			type state struct {
+				Info       network.ConnectionState
+				NumStreams int
+				Direction  string
+				Opened     string
+				Limited    bool
+			}
+
+			states := i.([]p2p.ConnectionState)
+			infos := make([]state, len(states))
+			for i, s := range states {
+				infos[i] = state{
+					Info:       s.Info,
+					NumStreams: s.NumStreams,
+					Direction:  s.Direction.String(),
+					Opened:     s.Opened.Format("2006-01-02 15:04:05"),
+					Limited:    s.Limited,
+				}
+			}
+
+			if len(infos) == 1 {
+				return infos[0]
+			}
+			return infos
+		})
+	},
+}
+
+var pingCmd = &cobra.Command{
+	Use:   "ping [peerID]",
+	Short: "Pings given peer and tell how much time that took or errors",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+
+		pid, err := peer.Decode(args[0])
+		if err != nil {
+			return err
+		}
+
+		pingDuration, err := client.P2P.Ping(cmd.Context(), pid)
+		return cmdnode.PrintOutput(pingDuration, err, func(i interface{}) interface{} {
+			return i.(time.Duration).String()
+		})
 	},
 }

--- a/nodebuilder/p2p/mocks/api.go
+++ b/nodebuilder/p2p/mocks/api.go
@@ -7,7 +7,9 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
+	p2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/libp2p/go-libp2p/core/metrics"
 	network "github.com/libp2p/go-libp2p/core/network"
@@ -141,6 +143,21 @@ func (mr *MockModuleMockRecorder) Connectedness(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connectedness", reflect.TypeOf((*MockModule)(nil).Connectedness), arg0, arg1)
 }
 
+// ConnectionState mocks base method.
+func (m *MockModule) ConnectionState(arg0 context.Context, arg1 peer.ID) ([]p2p.ConnectionState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnectionState", arg0, arg1)
+	ret0, _ := ret[0].([]p2p.ConnectionState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ConnectionState indicates an expected call of ConnectionState.
+func (mr *MockModuleMockRecorder) ConnectionState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectionState", reflect.TypeOf((*MockModule)(nil).ConnectionState), arg0, arg1)
+}
+
 // Info mocks base method.
 func (m *MockModule) Info(arg0 context.Context) (peer.AddrInfo, error) {
 	m.ctrl.T.Helper()
@@ -229,6 +246,21 @@ func (m *MockModule) Peers(arg0 context.Context) ([]peer.ID, error) {
 func (mr *MockModuleMockRecorder) Peers(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peers", reflect.TypeOf((*MockModule)(nil).Peers), arg0)
+}
+
+// Ping mocks base method.
+func (m *MockModule) Ping(arg0 context.Context, arg1 peer.ID) (time.Duration, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping", arg0, arg1)
+	ret0, _ := ret[0].(time.Duration)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Ping indicates an expected call of Ping.
+func (mr *MockModuleMockRecorder) Ping(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockModule)(nil).Ping), arg0, arg1)
 }
 
 // Protect mocks base method.

--- a/nodebuilder/p2p/p2p_test.go
+++ b/nodebuilder/p2p/p2p_test.go
@@ -41,6 +41,11 @@ func TestP2PModule_Host(t *testing.T) {
 
 	connectedness, err := mgr.Connectedness(ctx, peer.ID())
 	require.NoError(t, err)
+
+	infos, err := mgr.ConnectionState(ctx, peer.ID())
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(infos), 1)
+
 	assert.Equal(t, host.Network().Connectedness(peer.ID()), connectedness)
 	// now disconnect using manager and check for connectedness match again
 	assert.NoError(t, mgr.ClosePeer(ctx, peer.ID()))


### PR DESCRIPTION
Yet another helpful p2p debugging endpoints with respective commands:
* Ping tries to reach a peer by its peer id
* ConnectionState provides information about active connection for a peer by its ID