### PR TITLE
WIP: fix(share): type in assert

### DIFF
--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -428,7 +428,7 @@ func TestPruneWithCancelledContext(t *testing.T) {
 	avail.Close(ctx)
 
 	preDeleteCount := countKeys(ctx, t, clientBs)
-	require.EqualValues(t, sampleAmount, preDeleteCount)
+	require.EqualValues(t, sampleAmount, uint(preDeleteCount))
 
 	// prune the samples
 	err = avail.Prune(ctx, h)


### PR DESCRIPTION
Have noticed the following failure in another PR:

```
--- FAIL: TestPruneWithCancelledContext (0.11s)
    availability_test.go:431: 
        	Error Trace:	/Users/runner/work/celestia-node/celestia-node/share/availability/light/availability_test.go:431
        	Error:      	Not equal: 
        	            	expected: uint(0x14)
        	            	actual  : int(0)
        	Test:       	TestPruneWithCancelledContext
FAIL
```