### PR TITLE
Fix

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -653,7 +653,7 @@ func computeSubtreeRoots(shares []libshare.Share, ranges []nmt.LeafRange, offset
 		return nil, fmt.Errorf("cannot compute subtree roots for an empty ranges list")
 	}
 	if offset < 0 {
-		return nil, fmt.Errorf("the offset %d cannot be stricly negative", offset)
+		return nil, fmt.Errorf("the offset %d cannot be strictly negative", offset)
 	}
 
 	// create a tree containing the shares to generate their subtree roots

--- a/docs/adr/adr-011-blocksync-overhaul-part-1.md
+++ b/docs/adr/adr-011-blocksync-overhaul-part-1.md
@@ -343,7 +343,7 @@ To remove stored EDS `Remove` method is introduced. Internally it:
 - Destroys `Shard` via `DAGStore`
   - Internally removes its `Mount` as well
 - Removes CARv1 file from disk under `Store.Path/DataHash` path
-- Drops indecies
+- Drops indices
 
 ___NOTES:___
 


### PR DESCRIPTION
# Fix: Corrected typo errors and improved clarity in documentation and code

## What was changed
1. **Corrected typos**:
   - Replaced `indecies` with `indices` in `adr-011-blocksync-overhaul-part-1.md`.
   - Replaced `stricly` with `strictly` in `service.go`.

## Why these changes were made
- **Fixing typos** enhances the readability and professionalism of both the documentation and the codebase.
- Accurate terminology ensures clarity and reduces potential confusion for developers and readers.

## Additional Notes
- These changes focus solely on correcting typographical errors and do not impact the application's functionality.

