### PR TITLE
Fixed typos in documentation

### DIFF
--- a/blob/commitment_proof.go
+++ b/blob/commitment_proof.go
@@ -103,7 +103,7 @@ func (commitmentProof *CommitmentProof) Verify(root []byte, subtreeRootThreshold
 	}
 
 	if subtreeRootThreshold <= 0 {
-		return false, errors.New("subtreeRootThreshould must be > 0")
+		return false, errors.New("subtreeRootThreshold must be > 0")
 	}
 
 	// use the computed total number of shares to calculate the subtree roots

--- a/das/options.go
+++ b/das/options.go
@@ -11,7 +11,7 @@ import (
 // This error will also be returned by NewDASer if supplied with an invalid option
 var ErrInvalidOption = errors.New("das: invalid option")
 
-// errInvalidOptionValue is a utility function to dedup code for error-returning
+// errInvalidOptionValue is a utility function to deduplicate code for error-returning
 // when dealing with invalid parameter values
 func errInvalidOptionValue(optionName, value string) error {
 	return fmt.Errorf("%w: value %s cannot be %s", ErrInvalidOption, optionName, value)

--- a/docs/adr/adr-001-predevnet-celestia-node.md
+++ b/docs/adr/adr-001-predevnet-celestia-node.md
@@ -20,7 +20,7 @@ This ADR describes a basic pre-devnet design for a "Celestia Node" that was deci
 
 The goal of this design is to get a basic structure of "Celestia Node" interoperating with a "Celestia Core" consensus node by November 2021 (devnet).
 
-After basic interoperability on devnet, there will be an effort to merge consensus functionality into the "Celestia Node" design as a modulor service that can be added on top of the basic functions of a "Celestia Node".
+After basic interoperability on devnet, there will be an effort to merge consensus functionality into the "Celestia Node" design as a modular service that can be added on top of the basic functions of a "Celestia Node".
 
 ## Decision
 


### PR DESCRIPTION
This pull request addresses and corrects the following errors in the documentation:

"subtreeRootThreshould" -> "subtreeRootThreshold"
"dedup" -> "deduplicate"
"modulor" -> "modular"

Thank you for your work, and I hope my pull request proves useful!