### PR TITLE
Typos fix

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -653,7 +653,7 @@ func computeSubtreeRoots(shares []libshare.Share, ranges []nmt.LeafRange, offset
 		return nil, fmt.Errorf("cannot compute subtree roots for an empty ranges list")
 	}
 	if offset < 0 {
-		return nil, fmt.Errorf("the offset %d cannot be stricly negative", offset)
+		return nil, fmt.Errorf("the offset %d cannot be strictly negative", offset)
 	}
 
 	// create a tree containing the shares to generate their subtree roots

--- a/docs/adr/adr-011-blocksync-overhaul-part-1.md
+++ b/docs/adr/adr-011-blocksync-overhaul-part-1.md
@@ -343,7 +343,7 @@ To remove stored EDS `Remove` method is introduced. Internally it:
 - Destroys `Shard` via `DAGStore`
   - Internally removes its `Mount` as well
 - Removes CARv1 file from disk under `Store.Path/DataHash` path
-- Drops indecies
+- Drops indices
 
 ___NOTES:___
 


### PR DESCRIPTION
# Pull Request Typos fix

## Description
This pull request fixes typos in the following files:
1. `service.go`
2. `adr-011-blocksync-overhaul-part-1.md`

### Summary of Changes
#### 1. **`service.go`**
- Fixed typo in error message: "stricly" → "strictly".
  - **Original**: `the offset %d cannot be stricly negative`
  - **Updated**: `the offset %d cannot be strictly negative`

#### 2. **`adr-011-blocksync-overhaul-part-1.md`**
- Fixed typo in documentation: "indecies" → "indices".
  - **Original**: `Drops indecies`
  - **Updated**: `Drops indices`

---

## Files Changed
1. `blob/service.go`
2. `docs/adr/adr-011-blocksync-overhaul-part-1.md`


