### PR TITLE
feat: Add node type selector and Go version field to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,6 +15,24 @@ body:
         from source code
     validations:
       required: true
+  - type: dropdown
+    id: node_type
+    attributes:
+      label: Node Type
+      description: What type of Celestia node are you running?
+      options:
+        - Light Node
+        - Full Node
+        - Bridge Node
+    validations:
+      required: true
+  - type: input
+    id: go_version
+    attributes:
+      label: Go Version
+      description: Output of 'go version' if built from source
+    validations:
+      required: false
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
Enhance bug report template by adding:
- Required dropdown for node type selection (Light/Full/Bridge)
- Optional field for Go version information

This will help maintainers identify node-specific issues faster and assist with build-related troubleshooting.