### PR TITLE
fix: Correct branch name extraction in CI workflow

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Trim branch name
         id: trim_ref
         run: |
-          echo "branch=$(${${{ github.ref }}:11})" >> $GITHUB_OUTPUT
+          echo "branch=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Set debug output
         id: debug


### PR DESCRIPTION
### This PR fixes the branch name extraction in the CI workflow by:
- Replacing incorrect bash syntax `$(${${{ github.ref }}:11})` with proper GitHub Actions syntax
- Using standard GitHub environment variable `GITHUB_REF` with proper parameter expansion
- Implementing more reliable branch name extraction using `refs/*/` pattern

This change ensures proper branch name extraction for all GitHub event triggers.