### PR TITLE
Revert "fix(p2p): disable quic (#3937)"

### DIFF
--- a/nodebuilder/p2p/addrs.go
+++ b/nodebuilder/p2p/addrs.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"fmt"
-	"slices"
 
 	p2pconfig "github.com/libp2p/go-libp2p/config"
 	hst "github.com/libp2p/go-libp2p/core/host"
@@ -12,22 +11,12 @@ import (
 // Listen returns invoke function that starts listening for inbound connections with libp2p.Host.
 func Listen(cfg *Config) func(h hst.Host) (err error) {
 	return func(h hst.Host) (err error) {
-		maListen := make([]ma.Multiaddr, 0, len(cfg.ListenAddresses))
-		for _, addr := range cfg.ListenAddresses {
-			maddr, err := ma.NewMultiaddr(addr)
+		maListen := make([]ma.Multiaddr, len(cfg.ListenAddresses))
+		for i, addr := range cfg.ListenAddresses {
+			maListen[i], err = ma.NewMultiaddr(addr)
 			if err != nil {
 				return fmt.Errorf("failure to parse config.P2P.ListenAddresses: %w", err)
 			}
-			if !enableQUIC {
-				// TODO(@walldiss): Remove this check when QUIC is stable
-				if slices.ContainsFunc(maddr.Protocols(), func(p ma.Protocol) bool {
-					return p.Code == ma.P_QUIC_V1 || p.Code == ma.P_WEBTRANSPORT
-				}) {
-					continue
-				}
-			}
-
-			maListen = append(maListen, maddr)
 		}
 		return h.Network().Listen(maListen...)
 	}

--- a/nodebuilder/p2p/host.go
+++ b/nodebuilder/p2p/host.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/libp2p/go-libp2p"
@@ -27,8 +26,6 @@ import (
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
-
-var enableQUIC = os.Getenv("CELESTIA_ENABLE_QUIC") == "1"
 
 // routedHost constructs a wrapped Host that may fallback to address discovery,
 // if any top-level operation on the Host is provided with PeerID(Hash(PbK)) only.
@@ -83,19 +80,6 @@ func host(params hostParams) (HostBase, error) {
 		params.Cfg.Upgrade()
 	}
 
-	transports := []libp2p.Option{
-		libp2p.Transport(tcp.NewTCPTransport),
-		libp2p.Transport(libp2pwebrtc.New),
-		wsTransport(tlsCfg),
-	}
-
-	// disable quic and webtransport client support until it is stable
-	if enableQUIC {
-		transports = append(transports,
-			libp2p.Transport(quic.NewTransport),
-			libp2p.Transport(webtransport.New))
-	}
-
 	opts := []libp2p.Option{
 		libp2p.NoListenAddrs, // do not listen automatically
 		libp2p.AddrsFactory(params.AddrF),
@@ -108,7 +92,13 @@ func host(params hostParams) (HostBase, error) {
 		libp2p.DisableRelay(),
 		libp2p.BandwidthReporter(params.Bandwidth),
 		libp2p.ResourceManager(params.ResourceManager),
-		libp2p.ChainOptions(transports...),
+		libp2p.ChainOptions(
+			libp2p.Transport(tcp.NewTCPTransport),
+			libp2p.Transport(quic.NewTransport),
+			libp2p.Transport(webtransport.New),
+			libp2p.Transport(libp2pwebrtc.New),
+			wsTransport(tlsCfg),
+		),
 		// to clearly define what defaults we rely upon
 		libp2p.DefaultSecurity,
 		libp2p.DefaultMuxers,


### PR DESCRIPTION
This reverts commit e6dbb54dd28462c2820ae455295acc856af92b64 as https://github.com/quic-go/quic-go/issues/4712 is solved and fixed. It's not yet released, but the bug is not critical to block on it.