### PR TITLE
fix(share/shwap/p2p/bitswap): set archivalPool ctx

### DIFF
--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -67,7 +67,7 @@ func (g *Getter) Start() {
 	g.cancel = cancel
 
 	g.availablePool.ctx = ctx
-	g.availablePool.ctx = ctx
+	g.archivalPool.ctx = ctx
 }
 
 // Stop shuts down Getter's internal fetching getSession.


### PR DESCRIPTION
`archivalPool` ctx for bitswap session was never set, leading to a panic when tracing begins inside the bitswap session that is created for archival requests.




```
panic: cannot create context from nil parent

goroutine 3130 [running]:
context.WithValue({0x0?, 0x0?}, {0x103cbe2e0?, 0x103ad0f20?}, {0x1041e48a0?, 0x14004d89a40?})
        /opt/homebrew/opt/go/libexec/src/context/context.go:715 +0x140
go.opentelemetry.io/otel/trace.ContextWithSpan(...)
        /Users/rene/go/pkg/mod/go.opentelemetry.io/otel/trace@v1.31.0/context.go:14
go.opentelemetry.io/otel/internal/global.(*tracer).Start(0x14006998cd0, {0x0, 0x0}, {0x14004f9a558?, 0x102e7c26d?}, {0x0?, 0x102e7febf?, 0xa?})
        /Users/rene/go/pkg/mod/go.opentelemetry.io/otel@v1.31.0/internal/global/trace.go:143 +0x148
github.com/ipfs/boxo/bitswap/internal.startSpan({0x0, 0x0}, {0x14004f9a558, 0x12}, {0x0, 0x0, 0x0})
        /Users/rene/go/pkg/mod/github.com/celestiaorg/boxo@v0.0.0-20241118122411-70a650316c3b/bitswap/internal/tracing.go:16 +0x7c
github.com/ipfs/boxo/bitswap/internal.StartSpan(...)
        /Users/rene/go/pkg/mod/github.com/celestiaorg/boxo@v0.0.0-20241118122411-70a650316c3b/bitswap/internal/tracing.go:11
github.com/ipfs/boxo/bitswap/client.(*Client).NewSession(0x14002c232c0, {0x0, 0x0})
        /Users/rene/go/pkg/mod/github.com/celestiaorg/boxo@v0.0.0-20241118122411-70a650316c3b/bitswap/client/client.go:511 +0x74
github.com/celestiaorg/celestia-node/share/shwap/p2p/bitswap.(*pool).get(0x40?)
        /Users/rene/go/src/github.com/renaynay/celestia-node/share/shwap/p2p/bitswap/getter.go:339 +0xc4
github.com/celestiaorg/celestia-node/share/shwap/p2p/bitswap.(*Getter).getSession(0x14002d50140, 0x1)
        /Users/rene/go/src/github.com/renaynay/celestia-node/share/shwap/p2p/bitswap/getter.go:279 +0x44
github.com/celestiaorg/celestia-node/share/shwap/p2p/bitswap.(*Getter).GetEDS(0x14002d50140, {0x104307850?, 0x14006998be0?}, 0x140040ae480)
        /Users/rene/go/src/github.com/renaynay/celestia-node/share/shwap/p2p/bitswap/getter.go:190 +0x2d4
github.com/celestiaorg/celestia-node/share/shwap/getters.(*CascadeGetter).GetEDS.func1({0x104307850?, 0x14006998be0?}, {0x104307c40?, 0x14002d50140?})
        /Users/rene/go/src/github.com/renaynay/celestia-node/share/shwap/getters/cascade.go:68 +0x44
github.com/celestiaorg/celestia-node/share/shwap/getters.cascadeGetters[...]({0x104307818, 0x14006609f50}, {0x14002d501c0, 0x3, 0x0}, 0x14003f9d7f8?)
        /Users/rene/go/src/github.com/renaynay/celestia-node/share/shwap/getters/cascade.go:151 +0x530
github.com/celestiaorg/celestia-node/share/shwap/getters.(*CascadeGetter).GetEDS(0x140014c4cc0, {0x1043078c0?, 0x14003870d90?}, 0x140040ae480)
        /Users/rene/go/src/github.com/renaynay/celestia-node/share/shwap/getters/cascade.go:71 +0xd4
github.com/celestiaorg/celestia-node/share/availability/full.(*ShareAvailability).SharesAvailable(0x14002d4b1a0, {0x1043078c0, 0x14003870d90}, 0x140040ae480)
        /Users/rene/go/src/github.com/renaynay/celestia-node/share/availability/full/availability.go:85 +0x1a4
github.com/celestiaorg/celestia-node/das.(*DASer).sample(0x14002d4d930, {0x1043078c0, 0x14003870d90}, 0x140040ae480)
        /Users/rene/go/src/github.com/renaynay/celestia-node/das/daser.go:157 +0x40
github.com/celestiaorg/celestia-node/das.(*worker).sample(0x1400697e700, {0x104307850, 0x140035b65f0}, 0x1bf08eb000, 0x2?)
        /Users/rene/go/src/github.com/renaynay/celestia-node/das/worker.go:122 +0x94
github.com/celestiaorg/celestia-node/das.(*worker).run(0x1400697e700, {0x104307850, 0x140035b65f0}, 0x1bf08eb000, 0x14001451ce0)
        /Users/rene/go/src/github.com/renaynay/celestia-node/das/worker.go:82 +0x19c
github.com/celestiaorg/celestia-node/das.(*samplingCoordinator).runWorker.func1()
        /Users/rene/go/src/github.com/renaynay/celestia-node/das/coordinator.go:112 +0x64
created by github.com/celestiaorg/celestia-node/das.(*samplingCoordinator).runWorker in goroutine 981
        /Users/rene/go/src/github.com/renaynay/celestia-node/das/coordinator.go:110 +0x244
```