### PR TITLE
fix(p2p): improve error handling

### DIFF
--- a/nodebuilder/p2p/resources.go
+++ b/nodebuilder/p2p/resources.go
@@ -59,11 +59,7 @@ func allowList(ctx context.Context, cfg *Config, bootstrappers Bootstrappers) (r
 }
 
 func traceReporter() rcmgr.Option {
-	str, err := rcmgr.NewStatsTraceReporter()
-	if err != nil {
-		panic(err) // err is always nil as per sources
-	}
-
+	str := rcmgr.NewStatsTraceReporter()
 	return rcmgr.WithTraceReporter(str)
 }
 


### PR DESCRIPTION
Remove redundant error handling in p2p/resources.go:
   - Remove unnecessary error check and panic() call in traceReporter
   - NewStatsTraceReporter() never returns an error, making the check redundant
   - Makes the code cleaner and more maintainable