### PR TITLE
Typo fix adr-011-blocksync-overhaul-part-1.md

### DIFF
--- a/docs/adr/adr-011-blocksync-overhaul-part-1.md
+++ b/docs/adr/adr-011-blocksync-overhaul-part-1.md
@@ -343,7 +343,7 @@ To remove stored EDS `Remove` method is introduced. Internally it:
 - Destroys `Shard` via `DAGStore`
   - Internally removes its `Mount` as well
 - Removes CARv1 file from disk under `Store.Path/DataHash` path
-- Drops indecies
+- Drops indices
 
 ___NOTES:___
 


### PR DESCRIPTION
Corrected a typo in adr-011-blocksync-overhaul-part-1.md: "indecies" → "indices" 