### PR TITLE
Typos fix

### DIFF
--- a/docs/adr/adr-011-blocksync-overhaul-part-1.md
+++ b/docs/adr/adr-011-blocksync-overhaul-part-1.md
@@ -343,7 +343,7 @@ To remove stored EDS `Remove` method is introduced. Internally it:
 - Destroys `Shard` via `DAGStore`
   - Internally removes its `Mount` as well
 - Removes CARv1 file from disk under `Store.Path/DataHash` path
-- Drops indecies
+- Drops indices
 
 ___NOTES:___
 

--- a/nodebuilder/p2p/p2p_test.go
+++ b/nodebuilder/p2p/p2p_test.go
@@ -167,13 +167,13 @@ func TestP2PModule_Bandwidth(t *testing.T) {
 
 	peerStat, err := mgr.BandwidthForPeer(ctx, peer.ID())
 	require.NoError(t, err)
-	assert.NotZero(t, peerStat.TotalIn)
-	assert.Greater(t, int(peerStat.TotalIn), bufSize) // should be slightly more than buf size due negotiations, etc
+	assert.NotZero(t, peerStat.totaling, total in)
+	assert.Greater(t, int(peerStat.totaling, total in), bufSize) // should be slightly more than buf size due negotiations, etc
 
 	protoStat, err := mgr.BandwidthForProtocol(ctx, protoID)
 	require.NoError(t, err)
-	assert.NotZero(t, protoStat.TotalIn)
-	assert.Greater(t, int(protoStat.TotalIn), bufSize) // should be slightly more than buf size due negotiations, etc
+	assert.NotZero(t, protoStat.totaling, total in)
+	assert.Greater(t, int(protoStat.totaling, total in), bufSize) // should be slightly more than buf size due negotiations, etc
 }
 
 // TestP2PModule_Pubsub tests P2P Module methods on

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -18,7 +18,7 @@ func newDHT(
 	lc fx.Lifecycle,
 	tp node.Type,
 	network Network,
-	bootsrappers Bootstrappers,
+	bootstrappers Bootstrappers,
 	host HostBase,
 	dataStore datastore.Batching,
 ) (*dht.IpfsDHT, error) {
@@ -35,10 +35,10 @@ func newDHT(
 	// no bootstrappers for a bootstrapper ¯\_(ツ)_/¯
 	// otherwise dht.Bootstrap(OnStart hook) will deadlock
 	if isBootstrapper() {
-		bootsrappers = nil
+		bootstrappers = nil
 	}
 
-	dht, err := discovery.NewDHT(ctx, network.String(), bootsrappers, host, dataStore, mode)
+	dht, err := discovery.NewDHT(ctx, network.String(), bootstrappers, host, dataStore, mode)
 	if err != nil {
 		return nil, err
 	}

--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -129,7 +129,7 @@ func writeAxisRoots(w io.Writer, roots *share.AxisRoots) error {
 
 	for _, root := range roots.ColumnRoots {
 		if _, err := w.Write(root); err != nil {
-			return fmt.Errorf("writing columm roots: %w", err)
+			return fmt.Errorf("writing column roots: %w", err)
 		}
 	}
 


### PR DESCRIPTION
### Changes

1. **File:** `/docs/adr/adr-011-blocksync-overhaul-part-1.md`
    - Fixed `indecies` to `indices` (Line 346)
1. **File:** `/nodebuilder/p2p/p2p_test.go`
    - Fixed `TotalIn` to `totaling, total in` (Line 171)
1. **File:** `/nodebuilder/p2p/routing.go`
    - Fixed `bootsrappers` to `bootstrappers` (Line 38)
1. **File:** `/store/file/ods.go`
    - Fixed `columm` to `column` (Line 132)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.