### PR TITLE
Fixed typos

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -53,7 +53,7 @@ func RPCFlags() *flag.FlagSet {
 
 func InitClient(cmd *cobra.Command, _ []string) error {
 	if authTokenFlag == "" {
-		rootErrMsg := "cant access the auth token"
+		rootErrMsg := "can't access the auth token"
 
 		storePath, err := getStorePath(cmd)
 		if err != nil {

--- a/nodebuilder/p2p/p2p_test.go
+++ b/nodebuilder/p2p/p2p_test.go
@@ -167,13 +167,13 @@ func TestP2PModule_Bandwidth(t *testing.T) {
 
 	peerStat, err := mgr.BandwidthForPeer(ctx, peer.ID())
 	require.NoError(t, err)
-	assert.NotZero(t, peerStat.TotalIn)
-	assert.Greater(t, int(peerStat.TotalIn), bufSize) // should be slightly more than buf size due negotiations, etc
+	assert.NotZero(t, peerStat.totaling, total in)
+	assert.Greater(t, int(peerStat.totaling, total in), bufSize) // should be slightly more than buf size due negotiations, etc
 
 	protoStat, err := mgr.BandwidthForProtocol(ctx, protoID)
 	require.NoError(t, err)
-	assert.NotZero(t, protoStat.TotalIn)
-	assert.Greater(t, int(protoStat.TotalIn), bufSize) // should be slightly more than buf size due negotiations, etc
+	assert.NotZero(t, protoStat.totaling, total in)
+	assert.Greater(t, int(protoStat.totaling, total in), bufSize) // should be slightly more than buf size due negotiations, etc
 }
 
 // TestP2PModule_Pubsub tests P2P Module methods on

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -18,7 +18,7 @@ func newDHT(
 	lc fx.Lifecycle,
 	tp node.Type,
 	network Network,
-	bootsrappers Bootstrappers,
+	bootstrappers Bootstrappers,
 	host HostBase,
 	dataStore datastore.Batching,
 ) (*dht.IpfsDHT, error) {
@@ -35,10 +35,10 @@ func newDHT(
 	// no bootstrappers for a bootstrapper ¯\_(ツ)_/¯
 	// otherwise dht.Bootstrap(OnStart hook) will deadlock
 	if isBootstrapper() {
-		bootsrappers = nil
+		bootstrappers = nil
 	}
 
-	dht, err := discovery.NewDHT(ctx, network.String(), bootsrappers, host, dataStore, mode)
+	dht, err := discovery.NewDHT(ctx, network.String(), bootstrappers, host, dataStore, mode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Changes

1. **File:** `/cmd/rpc.go`
    - Fixed `cant` to `can't` (Line 56)
1. **File:** `/nodebuilder/p2p/p2p_test.go`
    - Fixed `TotalIn` to `totaling, total in` (Line 175)
1. **File:** `/nodebuilder/p2p/routing.go`
    - Fixed `bootsrappers` to `bootstrappers` (Line 41)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.