### PR TITLE
Corrected typos

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -653,7 +653,7 @@ func computeSubtreeRoots(shares []libshare.Share, ranges []nmt.LeafRange, offset
 		return nil, fmt.Errorf("cannot compute subtree roots for an empty ranges list")
 	}
 	if offset < 0 {
-		return nil, fmt.Errorf("the offset %d cannot be stricly negative", offset)
+		return nil, fmt.Errorf("the offset %d cannot be strictly negative", offset)
 	}
 
 	// create a tree containing the shares to generate their subtree roots

--- a/nodebuilder/p2p/p2p_test.go
+++ b/nodebuilder/p2p/p2p_test.go
@@ -167,13 +167,13 @@ func TestP2PModule_Bandwidth(t *testing.T) {
 
 	peerStat, err := mgr.BandwidthForPeer(ctx, peer.ID())
 	require.NoError(t, err)
-	assert.NotZero(t, peerStat.TotalIn)
-	assert.Greater(t, int(peerStat.TotalIn), bufSize) // should be slightly more than buf size due negotiations, etc
+	assert.NotZero(t, peerStat.totaling, total in)
+	assert.Greater(t, int(peerStat.totaling, total in), bufSize) // should be slightly more than buf size due negotiations, etc
 
 	protoStat, err := mgr.BandwidthForProtocol(ctx, protoID)
 	require.NoError(t, err)
-	assert.NotZero(t, protoStat.TotalIn)
-	assert.Greater(t, int(protoStat.TotalIn), bufSize) // should be slightly more than buf size due negotiations, etc
+	assert.NotZero(t, protoStat.totaling, total in)
+	assert.Greater(t, int(protoStat.totaling, total in), bufSize) // should be slightly more than buf size due negotiations, etc
 }
 
 // TestP2PModule_Pubsub tests P2P Module methods on

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -18,7 +18,7 @@ func newDHT(
 	lc fx.Lifecycle,
 	tp node.Type,
 	network Network,
-	bootsrappers Bootstrappers,
+	bootstrappers Bootstrappers,
 	host HostBase,
 	dataStore datastore.Batching,
 ) (*dht.IpfsDHT, error) {
@@ -35,10 +35,10 @@ func newDHT(
 	// no bootstrappers for a bootstrapper ¯\_(ツ)_/¯
 	// otherwise dht.Bootstrap(OnStart hook) will deadlock
 	if isBootstrapper() {
-		bootsrappers = nil
+		bootstrappers = nil
 	}
 
-	dht, err := discovery.NewDHT(ctx, network.String(), bootsrappers, host, dataStore, mode)
+	dht, err := discovery.NewDHT(ctx, network.String(), bootstrappers, host, dataStore, mode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Changes

1. **File:** `/nodebuilder/p2p/p2p_test.go`
    - Fixed `TotalIn` to `totaling, total in` (Line 170)
1. **File:** `/nodebuilder/p2p/routing.go`
    - Fixed `bootsrappers` to `bootstrappers` (Line 21)
1. **File:** `/blob/service.go`
    - Fixed `stricly` to `strictly` (Line 656)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.