### PR TITLE
fix: Add deterministic seed for random share removal in tests

### DIFF
--- a/share/ipld/get_shares_test.go
+++ b/share/ipld/get_shares_test.go
@@ -135,9 +135,11 @@ func Test_ConvertEDStoShares(t *testing.T) {
 // removes d shares from data
 func removeRandShares(data [][]byte, d int) [][]byte {
 	count := len(data)
+	// Initialize random number generator with current time as seed
+	r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
 	// remove shares randomly
 	for i := 0; i < d; {
-		ind := mrand.Intn(count)
+		ind := r.Intn(count)
 		if len(data[ind]) == 0 {
 			continue
 		}

--- a/share/ipld/get_shares_test.go
+++ b/share/ipld/get_shares_test.go
@@ -135,8 +135,8 @@ func Test_ConvertEDStoShares(t *testing.T) {
 // removes d shares from data
 func removeRandShares(data [][]byte, d int) [][]byte {
 	count := len(data)
-	// Initialize random number generator with current time as seed
-	r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	// Create deterministic random source using fixed seed
+	r := mrand.New(mrand.NewSource(123456))
 	// remove shares randomly
 	for i := 0; i < d; {
 		ind := r.Intn(count)


### PR DESCRIPTION
Initializes random number generator with time-based seed in removeRandShares() test helper to ensure proper randomization of test data and prevent potential test flakiness.