### PR TITLE
fix(share/peer-manager): fix potential nil dereference in peer manager

### DIFF
--- a/share/shwap/p2p/shrex/peers/manager.go
+++ b/share/shwap/p2p/shrex/peers/manager.go
@@ -286,7 +286,12 @@ func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID, source peerS
 				m.nodes.putOnCooldown(peerID)
 				return
 			}
-			m.getPool(datahash.String()).putOnCooldown(peerID)
+			p := m.getPool(datahash.String())
+			if p == nil {
+				// pool was removed
+				return
+			}
+			p.putOnCooldown(peerID)
 		case ResultBlacklistPeer:
 			m.blacklistPeers(reasonMisbehave, peerID)
 		}


### PR DESCRIPTION
If pool was removed during request it could lead to unexpected panic in client.