### PR TITLE
chore: bump go version to match the go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.23-alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.23.5-alpine3.21 AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
helloo team! 👋 

small one, just bumping the docker versions to match the [go.mod](https://github.com/celestiaorg/celestia-node/blob/main/go.mod#L3)

best! 