### PR TITLE
perf(share/shwap/p2p/shrex): Increase default concurrency limit for shrex server to 32

### DIFF
--- a/share/shwap/p2p/shrex/params.go
+++ b/share/shwap/p2p/shrex/params.go
@@ -34,7 +34,7 @@ func DefaultParameters() *Parameters {
 		ServerReadTimeout:    5 * time.Second,
 		ServerWriteTimeout:   time.Minute, // based on max observed sample time for 256 blocks (~50s)
 		HandleRequestTimeout: time.Minute,
-		ConcurrencyLimit:     10,
+		ConcurrencyLimit:     32,
 	}
 }
 


### PR DESCRIPTION
Will do some further testing on this first, so in draft mode for now, but this feels like a reasonable req limit.