### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -101,7 +101,7 @@ type SubscriptionResponse struct {
 // Additionally, not reading from the returned channel will cause the stream to close after 16 messages.
 func (s *Service) Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan *SubscriptionResponse, error) {
 	if s.ctx == nil {
-		return nil, fmt.Errorf("service has not been started")
+		return nil, errors.New("service has not been started")
 	}
 
 	headerCh, err := s.headerSub(ctx)
@@ -503,7 +503,7 @@ func (s *Service) GetCommitmentProof(
 ) (*CommitmentProof, error) {
 	log.Debugw("proving share commitment", "height", height, "commitment", shareCommitment, "namespace", namespace)
 	if height == 0 {
-		return nil, fmt.Errorf("height cannot be equal to 0")
+		return nil, errors.New("height cannot be equal to 0")
 	}
 
 	// get the blob to compute the subtree roots
@@ -571,7 +571,7 @@ func ProveCommitment(
 		}
 	}
 	if blobSharesStartIndex < 0 {
-		return nil, fmt.Errorf("couldn't find the blob shares in the ODS")
+		return nil, errors.New("couldn't find the blob shares in the ODS")
 	}
 
 	log.Debugw(
@@ -647,10 +647,10 @@ func ProveCommitment(
 // the offset is the number of shares that are before the subtree roots we're calculating.
 func computeSubtreeRoots(shares []libshare.Share, ranges []nmt.LeafRange, offset int) ([][]byte, error) {
 	if len(shares) == 0 {
-		return nil, fmt.Errorf("cannot compute subtree roots for an empty shares list")
+		return nil, errors.New("cannot compute subtree roots for an empty shares list")
 	}
 	if len(ranges) == 0 {
-		return nil, fmt.Errorf("cannot compute subtree roots for an empty ranges list")
+		return nil, errors.New("cannot compute subtree roots for an empty ranges list")
 	}
 	if offset < 0 {
 		return nil, fmt.Errorf("the offset %d cannot be strictly negative", offset)

--- a/cmd/cel-shed/p2p.go
+++ b/cmd/cel-shed/p2p.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -98,7 +99,7 @@ var p2pConnectBootstrappersCmd = &cobra.Command{
 	Short: "Connect to bootstrappers of a certain network",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if errorOnAnyFailure && errorOnAllFailure {
-			return fmt.Errorf("only one of --err-any and --err-all can be specified")
+			return errors.New("only one of --err-any and --err-all can be specified")
 		}
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), connectionTimeout)

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -77,7 +78,7 @@ func (f *BlockFetcher) GetBlock(ctx context.Context, height int64) (*SignedBlock
 
 func (f *BlockFetcher) GetBlockByHash(ctx context.Context, hash libhead.Hash) (*types.Block, error) {
 	if hash == nil {
-		return nil, fmt.Errorf("cannot get block with nil hash")
+		return nil, errors.New("cannot get block with nil hash")
 	}
 	stream, err := f.client.BlockByHash(ctx, &coregrpc.BlockByHashRequest{Hash: hash})
 	if err != nil {

--- a/core/listener.go
+++ b/core/listener.go
@@ -89,7 +89,7 @@ func NewListener(
 // Start kicks off the Listener listener loop.
 func (cl *Listener) Start(context.Context) error {
 	if cl.cancel != nil {
-		return fmt.Errorf("listener: already started")
+		return errors.New("listener: already started")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/share/eds/axis_half.go
+++ b/share/eds/axis_half.go
@@ -1,6 +1,7 @@
 package eds
 
 import (
+	"errors"
 	"fmt"
 
 	libshare "github.com/celestiaorg/go-square/v2/share"
@@ -38,7 +39,7 @@ func (a AxisHalf) Extended() ([]libshare.Share, error) {
 // extendShares constructs full axis shares from original half axis shares.
 func extendShares(original []libshare.Share) ([]libshare.Share, error) {
 	if len(original) == 0 {
-		return nil, fmt.Errorf("original shares are empty")
+		return nil, errors.New("original shares are empty")
 	}
 
 	parity, err := codec.Encode(libshare.ToBytes(original))
@@ -60,7 +61,7 @@ func extendShares(original []libshare.Share) ([]libshare.Share, error) {
 
 func reconstructShares(parity []libshare.Share) ([]libshare.Share, error) {
 	if len(parity) == 0 {
-		return nil, fmt.Errorf("parity shares are empty")
+		return nil, errors.New("parity shares are empty")
 	}
 
 	sqLen := len(parity) * 2

--- a/share/eds/byzantine/byzantine.go
+++ b/share/eds/byzantine/byzantine.go
@@ -2,6 +2,7 @@ package byzantine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ipfs/boxo/blockstore"
@@ -65,7 +66,7 @@ func NewErrByzantine(
 	}
 
 	if count < len(roots.RowRoots)/2 {
-		return fmt.Errorf("failed to collect proof")
+		return errors.New("failed to collect proof")
 	}
 
 	return &ErrByzantine{


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.