### PR TITLE
fix(ci): Add fetch-depth:0 to upload-docs checkout action

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -135,6 +135,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fix potential issues with git tags during release process by adding fetch-depth:0 to actions/checkout in upload-docs job.