### PR TITLE
refactor: use `time.DateTime` constant from standard library

### DIFF
--- a/nodebuilder/p2p/cmd/p2p.go
+++ b/nodebuilder/p2p/cmd/p2p.go
@@ -638,7 +638,7 @@ var connectionInfoCmd = &cobra.Command{
 					Info:       s.Info,
 					NumStreams: s.NumStreams,
 					Direction:  s.Direction.String(),
-					Opened:     s.Opened.Format("2006-01-02 15:04:05"),
+					Opened:     s.Opened.Format(time.DateTime),
 					Limited:    s.Limited,
 				}
 			}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->


The new [time.DateTime]((https://pkg.go.dev/time@go1.20#pkg-constants) ) constant added in Go 1.20 can improve code readability.
