### PR TITLE
chore: fix incorrect logging in `updateHead`

### DIFF
--- a/das/state.go
+++ b/das/state.go
@@ -146,8 +146,10 @@ func (s *coordinatorState) updateHead(newHead uint64) {
 		log.Infow("found first header, starting sampling")
 	}
 
+	oldHead := s.networkHead
 	s.networkHead = newHead
-	log.Debugw("updated head", "from_height", s.networkHead, "to_height", newHead)
+	
+	log.Debugw("updated head", "from_height", oldHead, "to_height", newHead)
 	s.checkDone()
 }
 


### PR DESCRIPTION
I noticed that `s.networkHead` was being updated **after** the log statement, causing `"from_height"` to always match `"to_height"`.
Now, the old value is stored before updating, ensuring the log accurately reflects the height change.