### PR TITLE
chore: fix formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ install-key:
 fmt: sort-imports
 	@find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s
 	@go mod tidy -compat=1.20
-	@cfmt -w -m=100 ./...
+	@cfmt -w -m=120 ./...
 	@gofumpt -w -extra .
 	@markdownlint --fix --quiet --config .markdownlint.yaml .
 .PHONY: fmt

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -111,7 +111,6 @@ func TestBlobModule(t *testing.T) {
 				assert.Equal(t, v1[0].Commitment, blobV1.Commitment)
 				assert.NotNil(t, blobV1.Signer())
 				assert.Equal(t, blobV1.Signer(), v1[0].Signer())
-
 			},
 		},
 		{


### PR DESCRIPTION
I noticed that some files are not formatted with `make fmt`.