### PR TITLE
fix: increase receive size limit for grpc

### DIFF
--- a/nodebuilder/core/constructors.go
+++ b/nodebuilder/core/constructors.go
@@ -63,6 +63,7 @@ func grpcClient(lc fx.Lifecycle, cfg Config) (*grpc.ClientConn, error) {
 	opts = append(opts,
 		grpc.WithUnaryInterceptor(retryInterceptor),
 		grpc.WithStreamInterceptor(retryStreamInterceptor),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(128*1024*1024)),
 	)
 
 	if cfg.XTokenPath != "" {


### PR DESCRIPTION
I'm not sure where this actually needs to be added or which branch for mamo, but I think in order to download 128MiB blocks we need this so figured I'd open. Please feel free to edit the target branch, this branch, close merge etc
