### PR TITLE
fix(makefile): ensure correct semantic version is shown for branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 SHELL=/usr/bin/env bash
 PROJECTNAME=$(shell basename "$(PWD)")
 DIR_FULLPATH=$(shell pwd)
-versioningPath := "github.com/celestiaorg/celestia-node/nodebuilder/node"
+versioningPath := github.com/celestiaorg/celestia-node/nodebuilder/node
 OS := $(shell uname -s)
-LDFLAGS=-ldflags="-X '$(versioningPath).buildTime=$(shell date)' -X '$(versioningPath).lastCommit=$(shell git rev-parse HEAD)' -X '$(versioningPath).semanticVersion=$(shell git describe --tags --dirty=-dev 2>/dev/null || git rev-parse --abbrev-ref HEAD)'"
+LDFLAGS = -ldflags="-X $(versioningPath).buildTime=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
+                    -X $(versioningPath).lastCommit=$(shell git rev-parse HEAD) \
+                    -X $(versioningPath).semanticVersion=$(shell \
+                      git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || \
+                      git describe --tags --dirty=-dev 2>/dev/null || \
+                      git rev-parse --short HEAD)"
 TAGS=integration
 SHORT=
 ifeq (${PREFIX},)


### PR DESCRIPTION
## Summary

Closes #4171 
Related https://github.com/celestiaorg/celestia-node/issues/3820#issue-2569998484
This PR fixes the long-standing issue where the `celestia version` command would report an incorrect semantic version when building from certain branches or lightweight tags — such as `v0.21.7-mocha` or `v0.22.1-arabica`.

The problem originated from the use of `git describe`, which only returns annotated tags. As a result, lightweight tags or branch names would fall back to unrelated previous tags (e.g., `v0.21.7-arabica`) or even commit hashes, leading to confusion in development and CI environments.

## Before
```make
$ git checkout v0.21.7-mocha
$ make install
$ celestia version
Semantic version: v0.21.7-arabica
Commit: 9c1d27a9c41cf16f7b20e96a556d9601b29b5b3a
Build Date: Thu Mar 13 14:22:07 EDT 2025
System version: arm64/darwin
Golang version: go1.24.0
```
## After Fix
```make
$ git checkout v0.21.7-mocha
$ make install
$ celestia version
Semantic version: v0.21.7-mocha
Commit: 9c1d27a9c41cf16f7b20e96a556d9601b29b5b3a
Build Date: 2025-04-22T00:04:00Z
System version: arm64/darwin
Golang version: go1.24.1
```

## Screenshot

![Pasted Graphic 4](https://github.com/user-attachments/assets/e847cb8c-bcf4-4ad6-a453-afdbff7ce816)


## Result
Now, when building from:

`v0.21.7-mocha` → shows `v0.21.7-mocha`

`v0.22.1-arabica` → shows `v0.22.1-arabica`

main or other branches → shows correct branch name

any detached state → still resolves the proper tag/branch

