### PR TITLE
fix(p2p/discovery,core/listener): fix timer deadlock

### DIFF
--- a/core/listener.go
+++ b/core/listener.go
@@ -156,10 +156,6 @@ func (cl *Listener) listen(ctx context.Context, sub <-chan types.EventDataSigned
 					"hash", b.Header.Hash().String(),
 					"err", err)
 			}
-
-			if !timeout.Stop() {
-				<-timeout.C
-			}
 		case <-timeout.C:
 			cl.metrics.subscriptionStuck(ctx)
 			log.Error("underlying subscription is stuck")

--- a/share/shwap/p2p/discovery/discovery.go
+++ b/share/shwap/p2p/discovery/discovery.go
@@ -189,24 +189,16 @@ func (d *Discovery) Advertise(ctx context.Context) {
 
 			// we don't want retry indefinitely in busy loop
 			// internal discovery mechanism may need some time before attempts
-			errTimer := time.NewTimer(retryTimeout)
+			errTimer := time.After(retryTimeout)
 			select {
-			case <-errTimer.C:
-				errTimer.Stop()
-				if !timer.Stop() {
-					<-timer.C
-				}
+			case <-errTimer:
 				continue
 			case <-ctx.Done():
-				errTimer.Stop()
 				return
 			}
 		}
 
 		log.Infof("successfully advertised to topic %s", d.topic)
-		if !timer.Stop() {
-			<-timer.C
-		}
 		timer.Reset(d.params.AdvertiseInterval)
 		select {
 		case <-timer.C:


### PR DESCRIPTION
**Go 1.23 Timer Behavior Change**

Go 1.23 introduced changes to the behavior of `Timer` that affect how channels should be handled:

1. **No need to drain the channel before `Reset`**  
   ```go
   // For a chan-based timer created with NewTimer, as of Go 1.23,
   // any receive from t.C after Reset has returned is guaranteed not
   // to receive a time value corresponding to the previous timer settings;
   // if the program has not received from t.C already and the timer is
   // running, Reset is guaranteed to return true.
   // Before Go 1.23, the only safe way to use Reset was to [Stop] and
   // explicitly drain the timer first.
   ```

2. **Draining after `Stop` will never read a value**  
   ```go
   // For a chan-based timer created with NewTimer(d), as of Go 1.23,
   // any receive from t.C after Stop has returned is guaranteed to block
   // rather than receive a stale time value from before the Stop;
   // if the program has not received from t.C already and the timer is
   // running, Stop is guaranteed to return true.
   // Before Go 1.23, the only safe way to use Stop was to insert an extra
   // <-t.C if Stop returned false to drain a potential stale value.
   // See the [NewTimer] documentation for more details.
   ```

These changes caused our code to enter a deadlock state when reading from the channel, which in turn prevented the discovery module from continuing announcements. The same issue also affected the core listener, which could potentially deadlock under similar circumstances.

In particular, If `Timer.Stop` is called after the `Timer` expires, we deadlock. This can happen if advertisement call or new block handling takes _longer_ then the set deadline on the `Timer`, both are rare but possible case in production environment.

Fixes #4228
Fixes #4045
