### PR TITLE
fix(swamp): collect submitted heights in FillBlocks

### DIFF
--- a/nodebuilder/tests/fraud_test.go
+++ b/nodebuilder/tests/fraud_test.go
@@ -57,7 +57,7 @@ func TestFraudProofHandling(t *testing.T) {
 	)
 
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(blockTime))
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], blockSize, blocks)
+	_, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], blockSize, blocks)
 	set, val := sw.Validators(t)
 	fMaker := headerfraud.NewFraudMaker(t, 10, []types.PrivValidator{val}, set)
 

--- a/nodebuilder/tests/nd_test.go
+++ b/nodebuilder/tests/nd_test.go
@@ -57,7 +57,7 @@ func TestShrexNDFromLights(t *testing.T) {
 	require.NoError(t, <-fillDn)
 
 	for i := range heightsCh {
-		h, err := bridgeClient.Header.GetByHeight(ctx, uint64(i))
+		h, err := bridgeClient.Header.GetByHeight(ctx, i)
 		require.NoError(t, err)
 
 		var ns libshare.Namespace
@@ -134,7 +134,7 @@ func TestShrexNDFromLightsWithBadFulls(t *testing.T) {
 	require.NoError(t, <-fillDn)
 
 	for i := range heightsCh {
-		h, err := bridgeClient.Header.GetByHeight(ctx, uint64(i))
+		h, err := bridgeClient.Header.GetByHeight(ctx, i)
 		require.NoError(t, err)
 
 		var ns libshare.Namespace

--- a/nodebuilder/tests/nd_test.go
+++ b/nodebuilder/tests/nd_test.go
@@ -36,7 +36,7 @@ func TestShrexNDFromLights(t *testing.T) {
 	t.Cleanup(cancel)
 
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	heights, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
+	heightsCh, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
 
 	bridge := sw.NewBridgeNode()
 	sw.SetBootstrapper(t, bridge)
@@ -56,7 +56,7 @@ func TestShrexNDFromLights(t *testing.T) {
 	// wait for chain to be filled
 	require.NoError(t, <-fillDn)
 
-	for i := range heights {
+	for i := range heightsCh {
 		h, err := bridgeClient.Header.GetByHeight(ctx, uint64(i))
 		require.NoError(t, err)
 
@@ -101,7 +101,7 @@ func TestShrexNDFromLightsWithBadFulls(t *testing.T) {
 	t.Cleanup(cancel)
 
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	heights, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
+	heightsCh, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
 
 	bridge := sw.NewBridgeNode()
 	sw.SetBootstrapper(t, bridge)
@@ -133,7 +133,7 @@ func TestShrexNDFromLightsWithBadFulls(t *testing.T) {
 	// wait for chain to fill up
 	require.NoError(t, <-fillDn)
 
-	for i := range heights {
+	for i := range heightsCh {
 		h, err := bridgeClient.Header.GetByHeight(ctx, uint64(i))
 		require.NoError(t, err)
 

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -141,6 +141,10 @@ func TestArchivalBlobSync(t *testing.T) {
 			}
 		}
 
+		if ns.ID() == nil {
+			t.Fatal("usable namespace was not found")
+		}
+
 		blobs, err := archivalFN.BlobServ.GetAll(ctx, eh.Height(), []libshare.Namespace{ns})
 		require.NoError(t, err)
 

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -67,7 +67,7 @@ func TestArchivalBlobSync(t *testing.T) {
 
 	require.NoError(t, <-fillDn)
 
-	heights := make([]int64, 0, blocks)
+	heights := make([]uint64, 0, blocks)
 	// drain channel to get all heights
 	for height := range heightsCh {
 		heights = append(heights, height)
@@ -95,7 +95,7 @@ func TestArchivalBlobSync(t *testing.T) {
 	)
 
 	// wait until bn syncs to the latest submitted height
-	_, err = archivalFN.HeaderServ.WaitForHeight(ctx, uint64(heights[len(heights)-1]))
+	_, err = archivalFN.HeaderServ.WaitForHeight(ctx, heights[len(heights)-1])
 	require.NoError(t, err)
 	err = archivalBN.Stop(ctx)
 	require.NoError(t, err)

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -3,7 +3,6 @@
 package tests
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"net"
@@ -20,7 +19,6 @@ import (
 	libshare "github.com/celestiaorg/go-square/v2/share"
 
 	"github.com/celestiaorg/celestia-node/blob"
-	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -46,7 +44,7 @@ import (
 // spin up 1 LN that syncs historic blobs
 func TestArchivalBlobSync(t *testing.T) {
 	const (
-		blocks = 50
+		blocks = 10
 		btime  = time.Millisecond * 300
 		bsize  = 16
 	)
@@ -55,7 +53,7 @@ func TestArchivalBlobSync(t *testing.T) {
 	t.Cleanup(cancel)
 
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
+	heightsCh, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
 
 	archivalBN := sw.NewBridgeNode()
 	sw.SetBootstrapper(t, archivalBN)
@@ -69,13 +67,19 @@ func TestArchivalBlobSync(t *testing.T) {
 
 	require.NoError(t, <-fillDn)
 
+	heights := make([]int64, 0, blocks)
+	// drain channel to get all heights
+	for height := range heightsCh {
+		heights = append(heights, height)
+	}
+
 	pruningCfg := nodebuilder.DefaultConfig(node.Bridge)
 	pruningCfg.Pruner.EnableService = true
 
 	testAvailWindow := time.Millisecond
 	prunerOpts := fx.Options(
 		fx.Replace(testAvailWindow),
-		fxutil.ReplaceAs(func(
+		fx.Decorate(func(
 			edsClient *shrexeds.Client,
 			ndClient *shrexnd.Client,
 			managers map[string]*peers.Manager,
@@ -87,11 +91,12 @@ func TestArchivalBlobSync(t *testing.T) {
 				managers["archival"],
 				testAvailWindow,
 			)
-		}, new(shrex_getter.Getter)),
+		}),
 	)
 
-	// stop the archival BN to force LN to have to discover
-	// the archival FN later
+	// wait until bn syncs to the latest submitted height
+	_, err = archivalFN.HeaderServ.WaitForHeight(ctx, uint64(heights[len(heights)-1]))
+	require.NoError(t, err)
 	err = archivalBN.Stop(ctx)
 	require.NoError(t, err)
 
@@ -120,21 +125,23 @@ func TestArchivalBlobSync(t *testing.T) {
 		root   share.DataHash
 	}
 
-	archivalBlobs := make([]*archivalBlob, 0)
-	i := 1
-	for {
-		eh, err := archivalFN.HeaderServ.GetByHeight(ctx, uint64(i))
+	archivalBlobs := make([]*archivalBlob, 0, blocks)
+	for _, height := range heights {
+		eh, err := archivalFN.HeaderServ.GetByHeight(ctx, uint64(height))
 		require.NoError(t, err)
-
-		if bytes.Equal(eh.DataHash, share.EmptyEDSRoots().Hash()) {
-			i++
-			continue
+		var ns libshare.Namespace
+		for _, roots := range eh.DAH.RowRoots {
+			namespace := roots[:libshare.NamespaceSize]
+			ns, err = libshare.NewNamespaceFromBytes(namespace)
+			require.NoError(t, err)
+			// Ideally we should check for `ValidateForBlob` here,
+			// but it throws an error every time.
+			if ns.IsUsableNamespace() {
+				break
+			}
 		}
 
-		shr, err := archivalFN.ShareServ.GetShare(ctx, eh.Height(), 2, 2)
-		require.NoError(t, err)
-
-		blobs, err := archivalFN.BlobServ.GetAll(ctx, eh.Height(), []libshare.Namespace{shr.Namespace()})
+		blobs, err := archivalFN.BlobServ.GetAll(ctx, eh.Height(), []libshare.Namespace{ns})
 		require.NoError(t, err)
 
 		archivalBlobs = append(archivalBlobs, &archivalBlob{
@@ -142,11 +149,6 @@ func TestArchivalBlobSync(t *testing.T) {
 			height: eh.Height(),
 			root:   eh.DAH.Hash(),
 		})
-
-		if len(archivalBlobs) > 10 {
-			break
-		}
-		i++
 	}
 
 	// ensure pruned FNs don't have the blocks associated

--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -46,7 +46,7 @@ func TestFullReconstructFromBridge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
+	_, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
 
 	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
@@ -104,7 +104,7 @@ func TestFullReconstructFromFulls(t *testing.T) {
 	t.Cleanup(cancel)
 
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
+	_, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
 
 	const defaultTimeInterval = time.Second * 5
 	bridge := sw.NewBridgeNode()
@@ -276,7 +276,7 @@ func TestFullReconstructFromLights(t *testing.T) {
 
 	t.Cleanup(cancel)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(btime))
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
+	_, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, blocks)
 
 	const defaultTimeInterval = time.Second * 5
 	cfg := nodebuilder.DefaultConfig(node.Full)

--- a/nodebuilder/tests/swamp/swamp_tx.go
+++ b/nodebuilder/tests/swamp/swamp_tx.go
@@ -19,7 +19,7 @@ func FillBlocks(
 ) (
 	<-chan uint64, <-chan error,
 ) {
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	heightCh := make(chan uint64, blocks)
 	go func() {
 		defer close(errCh)

--- a/nodebuilder/tests/swamp/swamp_tx.go
+++ b/nodebuilder/tests/swamp/swamp_tx.go
@@ -17,11 +17,12 @@ func FillBlocks(
 	account string,
 	bsize, blocks int,
 ) (
-	<-chan int64, <-chan error,
+	<-chan uint64, <-chan error,
 ) {
 	errCh := make(chan error)
-	heightCh := make(chan int64, blocks)
+	heightCh := make(chan uint64, blocks)
 	go func() {
+		defer close(errCh)
 		defer close(heightCh)
 		// TODO: FillBlock must respect the context
 		// fill blocks is not working correctly without sleep rn.
@@ -32,7 +33,7 @@ func FillBlocks(
 			if err != nil {
 				break
 			}
-			heightCh <- txResp.Height
+			heightCh <- uint64(txResp.Height)
 		}
 
 		select {

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -49,7 +49,7 @@ func TestSyncAgainstBridge_NonEmptyChain(t *testing.T) {
 
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(sbtime))
 	// wait for core network to fill 20 blocks
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, numBlocks)
+	_, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, numBlocks)
 	sw.WaitTillHeight(ctx, numBlocks)
 
 	// create a bridge node and set it as the bootstrapper for the suite
@@ -222,7 +222,7 @@ func TestSyncStartStopLightWithBridge(t *testing.T) {
 
 	sw := swamp.NewSwamp(t)
 	// wait for core network to fill 20 blocks
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, numBlocks)
+	_, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, numBlocks)
 	sw.WaitTillHeight(ctx, numBlocks)
 
 	// create bridge and set it as a bootstrapper
@@ -290,7 +290,7 @@ func TestSyncLightAgainstFull(t *testing.T) {
 
 	sw := swamp.NewSwamp(t)
 	// wait for the core network to fill up 20 blocks
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, numBlocks)
+	_, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, numBlocks)
 	sw.WaitTillHeight(ctx, numBlocks)
 
 	// create bridge and set it as a bootstrapper
@@ -368,7 +368,7 @@ func TestSyncLightWithTrustedPeers(t *testing.T) {
 	t.Cleanup(cancel)
 
 	sw := swamp.NewSwamp(t)
-	fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, numBlocks)
+	_, fillDn := swamp.FillBlocks(ctx, sw.ClientContext, sw.Accounts[0], bsize, numBlocks)
 	sw.WaitTillHeight(ctx, numBlocks)
 
 	// create a BN and set as a bootstrapper


### PR DESCRIPTION
Collect and return all submitted heights. 
Some tests were broken at all, so I had to refactor them to make them work. `TestArchivalBlobSync` is still flakey(stuck on `ln.HeaderServ.WaitForHeight` step) and the root cause is not clear rn.