### PR TITLE
fix(core): `storeEDS` respects window param

### DIFF
--- a/core/eds.go
+++ b/core/eds.go
@@ -71,7 +71,7 @@ func storeEDS(
 
 	var err error
 	// archival nodes should not store Q4 outside the availability window.
-	if availability.IsWithinWindow(eh.Time(), availability.StorageWindow) {
+	if availability.IsWithinWindow(eh.Time(), window) {
 		err = store.PutODSQ4(ctx, eh.DAH, eh.Height(), eds)
 	} else {
 		err = store.PutODS(ctx, eh.DAH, eh.Height(), eds)

--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -24,7 +24,7 @@ func TestCoreExchange_RequestHeaders(t *testing.T) {
 
 	cfg := DefaultTestConfig()
 	fetcher, cctx := createCoreFetcher(t, cfg)
-	generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx)
+	nonEmptyBlocks := generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx)
 
 	store, err := store.NewStore(store.DefaultParameters(), t.TempDir())
 	require.NoError(t, err)
@@ -39,12 +39,15 @@ func TestCoreExchange_RequestHeaders(t *testing.T) {
 	genHeader, err := ce.Get(ctx, genBlock.Header.Hash().Bytes())
 	require.NoError(t, err)
 
-	to := uint64(30)
+	to := nonEmptyBlocks[len(nonEmptyBlocks)-1].height
 	expectedFirstHeightInRange := genHeader.Height() + 1
 	expectedLastHeightInRange := to - 1
 	expectedLenHeaders := to - expectedFirstHeightInRange
 
-	// request headers from height 1 to 20 [2:30)
+	_, err = cctx.WaitForHeightWithTimeout(int64(to), 10*time.Second)
+	require.NoError(t, err)
+
+	// request headers from height 1 to last non-empty block height [2:to)
 	headers, err := ce.GetRangeByHeight(context.Background(), genHeader, to)
 	require.NoError(t, err)
 
@@ -71,7 +74,7 @@ func TestExchange_DoNotStoreHistoric(t *testing.T) {
 
 	cfg := DefaultTestConfig()
 	fetcher, cctx := createCoreFetcher(t, cfg)
-	generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx)
+	nonEmptyBlocks := generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx)
 
 	store, err := store.NewStore(store.DefaultParameters(), t.TempDir())
 	require.NoError(t, err)
@@ -91,7 +94,12 @@ func TestExchange_DoNotStoreHistoric(t *testing.T) {
 	genHeader, err := ce.Get(ctx, genBlock.Header.Hash().Bytes())
 	require.NoError(t, err)
 
-	headers, err := ce.GetRangeByHeight(ctx, genHeader, 30)
+	to := nonEmptyBlocks[len(nonEmptyBlocks)-1].height
+
+	err = cctx.WaitForBlocks(int64(to))
+	require.NoError(t, err)
+
+	headers, err := ce.GetRangeByHeight(ctx, genHeader, to)
 	require.NoError(t, err)
 
 	// ensure none of the "historic" EDSs were stored
@@ -118,7 +126,7 @@ func TestExchange_StoreHistoricIfArchival(t *testing.T) {
 
 	cfg := DefaultTestConfig()
 	fetcher, cctx := createCoreFetcher(t, cfg)
-	generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx)
+	nonEmptyBlocks := generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx)
 
 	store, err := store.NewStore(store.DefaultParameters(), t.TempDir())
 	require.NoError(t, err)
@@ -139,7 +147,12 @@ func TestExchange_StoreHistoricIfArchival(t *testing.T) {
 	genHeader, err := ce.Get(ctx, genBlock.Header.Hash().Bytes())
 	require.NoError(t, err)
 
-	headers, err := ce.GetRangeByHeight(ctx, genHeader, 30)
+	to := nonEmptyBlocks[len(nonEmptyBlocks)-1].height
+
+	_, err = cctx.WaitForHeight(int64(to))
+	require.NoError(t, err)
+
+	headers, err := ce.GetRangeByHeight(ctx, genHeader, to)
 	require.NoError(t, err)
 
 	// ensure all "historic" EDSs were stored but not the .q4 files
@@ -196,6 +209,11 @@ func fillBlocks(
 	}
 }
 
+type testBlocks struct {
+	height   uint64
+	datahash share.DataHash
+}
+
 // generateNonEmptyBlocks generates at least 20 non-empty blocks
 func generateNonEmptyBlocks(
 	t *testing.T,
@@ -203,7 +221,7 @@ func generateNonEmptyBlocks(
 	fetcher *BlockFetcher,
 	cfg *testnode.Config,
 	cctx testnode.Context,
-) []share.DataHash {
+) []testBlocks {
 	// generate several non-empty blocks
 	generateCtx, generateCtxCancel := context.WithCancel(context.Background())
 
@@ -212,7 +230,7 @@ func generateNonEmptyBlocks(
 
 	go fillBlocks(t, generateCtx, cfg, cctx)
 
-	hashes := make([]share.DataHash, 0, 20)
+	filledBlocks := make([]testBlocks, 0, 20)
 
 	i := 0
 	for i < 20 {
@@ -223,7 +241,10 @@ func generateNonEmptyBlocks(
 			if bytes.Equal(share.EmptyEDSDataHash(), b.Data.Hash()) {
 				continue
 			}
-			hashes = append(hashes, share.DataHash(b.Data.Hash()))
+			filledBlocks = append(filledBlocks, testBlocks{
+				height:   uint64(b.Header.Height),
+				datahash: share.DataHash(b.Data.Hash()),
+			})
 			i++
 		case <-ctx.Done():
 			t.Fatal("failed to fill blocks within timeout")
@@ -231,5 +252,5 @@ func generateNonEmptyBlocks(
 	}
 	generateCtxCancel()
 
-	return hashes
+	return filledBlocks
 }

--- a/core/listener_test.go
+++ b/core/listener_test.go
@@ -119,19 +119,19 @@ func TestListener_DoesNotStoreHistoric(t *testing.T) {
 	opt := WithAvailabilityWindow(time.Nanosecond)
 	cl := createListener(ctx, t, fetcher, ps0, eds, store, testChainID, opt)
 
-	dataRoots := generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx)
+	nonEmptyBlocks := generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx)
 
 	err = cl.Start(ctx)
 	require.NoError(t, err)
 
 	// ensure none of the EDSes were stored
-	for _, hash := range dataRoots {
-		has, err := store.HasByHash(ctx, hash)
+	for _, block := range nonEmptyBlocks {
+		has, err := store.HasByHash(ctx, block.datahash)
 		require.NoError(t, err)
 		assert.False(t, has)
 
 		// ensure .q4 file was not stored
-		has, err = store.HasQ4ByHash(ctx, hash)
+		has, err = store.HasQ4ByHash(ctx, block.datahash)
 		require.NoError(t, err)
 		assert.False(t, has)
 	}

--- a/core/option.go
+++ b/core/option.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	"github.com/celestiaorg/celestia-node/share/availability"
 )
 
 type Option func(*params)
@@ -17,7 +18,7 @@ type params struct {
 
 func defaultParams() params {
 	return params{
-		availabilityWindow: time.Duration(0),
+		availabilityWindow: availability.StorageWindow,
 		archival:           false,
 	}
 }


### PR DESCRIPTION
This fixes a bug where `storeEDS` would bypass the check to see if the node is a pruned node that it should not store historic blocks. While this isn't critical, because pruner would clean them up eventually anyway, this helps avoid unnecessary writes during the syncing process for pruned BNs.

Thanks to @chatton for unlocking this find!