### PR TITLE
refactor(nodebuilder): Deprecation of Full Node Support

### DIFF
--- a/cmd/node.go
+++ b/cmd/node.go
@@ -84,8 +84,8 @@ func NewFull(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			log.Error(
 				"DEPRECATION NOTICE: FULL NODE MODE WILL BE DEPRECATED SOON." +
-				" NODE OPERATORS SHOULD CONSIDER RUNNING A BRIDGE NODE INSTEAD IF THEY REQUIRE FULL DATA STORAGE FUNCTIONALITY."
-				)
+					" NODE OPERATORS SHOULD CONSIDER RUNNING A BRIDGE NODE INSTEAD IF THEY REQUIRE FULL DATA STORAGE FUNCTIONALITY.",
+			)
 			return PersistentPreRunEnv(cmd, node.Full, args)
 		},
 	}

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -82,6 +82,10 @@ func NewFull(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Manage your Full node",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			log.Error(
+				"DEPRECATION NOTICE: FULL NODE MODE WILL BE DEPRECATED SOON." +
+				" NODE OPERATORS SHOULD CONSIDER RUNNING A BRIDGE NODE INSTEAD IF THEY REQUIRE FULL DATA STORAGE FUNCTIONALITY."
+				)
 			return PersistentPreRunEnv(cmd, node.Full, args)
 		},
 	}


### PR DESCRIPTION
This PR introduces a deprecation notice for Full Nodes.  
Full Nodes are no longer actively supported and will be deprecated in upcoming releases. Testing and maintenance of Full Nodes will cease in future updates.


### Migration Instructions for Node Operators:

Since the storage backend for Full Nodes and Bridge Nodes is the same, migrating from a Full Node to a Bridge Node is straightforward:

1. **Initialize a New Bridge Node**  
   Run `celestia bridge init` (or equivalent) to create a new bridge node directory.

2. **Copy Existing Data from Full Node**  
   - Replace the `blocks/`, `data/`, and `keys/` directories/files in the newly created Bridge Node folder with the corresponding ones from your Full Node setup.
   - Ensure permissions and ownership remain correct after copying.

This method preserves your existing blockchain data and keys, avoiding the need to re-sync from scratch.

---

### Important Notice:
- Full Nodes currently deployed **should be replaced with Bridge Nodes** as soon as possible.
- After deprecation, Full Nodes will no longer receive bug fixes, updates, or official support.
- Operators continuing to run Full Nodes post-deprecation may encounter incompatibilities without assistance.