### PR TITLE
Typos fix

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -53,7 +53,7 @@ func RPCFlags() *flag.FlagSet {
 
 func InitClient(cmd *cobra.Command, _ []string) error {
 	if authTokenFlag == "" {
-		rootErrMsg := "cant access the auth token"
+		rootErrMsg := "can't access the auth token"
 
 		storePath, err := getStorePath(cmd)
 		if err != nil {

--- a/nodebuilder/p2p/p2p_test.go
+++ b/nodebuilder/p2p/p2p_test.go
@@ -167,13 +167,13 @@ func TestP2PModule_Bandwidth(t *testing.T) {
 
 	peerStat, err := mgr.BandwidthForPeer(ctx, peer.ID())
 	require.NoError(t, err)
-	assert.NotZero(t, peerStat.TotalIn)
-	assert.Greater(t, int(peerStat.TotalIn), bufSize) // should be slightly more than buf size due negotiations, etc
+	assert.NotZero(t, peerStat.totaling, total in)
+	assert.Greater(t, int(peerStat.totaling, total in), bufSize) // should be slightly more than buf size due negotiations, etc
 
 	protoStat, err := mgr.BandwidthForProtocol(ctx, protoID)
 	require.NoError(t, err)
-	assert.NotZero(t, protoStat.TotalIn)
-	assert.Greater(t, int(protoStat.TotalIn), bufSize) // should be slightly more than buf size due negotiations, etc
+	assert.NotZero(t, protoStat.totaling, total in)
+	assert.Greater(t, int(protoStat.totaling, total in), bufSize) // should be slightly more than buf size due negotiations, etc
 }
 
 // TestP2PModule_Pubsub tests P2P Module methods on

--- a/share/shwap/getter.go
+++ b/share/shwap/getter.go
@@ -22,8 +22,8 @@ var (
 	// ErrOutOfBounds is used to indicate that a passed row or column index is out of bounds of the
 	// square size.
 	ErrOutOfBounds = fmt.Errorf("index out of bounds: %w", ErrInvalidID)
-	// ErrNoSampleIndicies is used to indicate that no indicies where given to process.
-	ErrNoSampleIndicies = errors.New("no sample indicies to fetch")
+	// ErrNoSampleIndicies is used to indicate that no indices where given to process.
+	ErrNoSampleIndicies = errors.New("no sample indices to fetch")
 )
 
 // Getter interface provides a set of accessors for shares by the Root.

--- a/share/shwap/p2p/bitswap/row_block.go
+++ b/share/shwap/p2p/bitswap/row_block.go
@@ -114,7 +114,7 @@ func (rb *RowBlock) UnmarshalFn(root *share.AxisRoots) UnmarshalFn {
 		}
 
 		if !rb.ID.Equals(rid) {
-			return fmt.Errorf("requested %+v doesnt match given %+v", rb.ID, rid)
+			return fmt.Errorf("requested %+v doesn't, does not match given %+v", rb.ID, rid)
 		}
 
 		var row shwappb.Row

--- a/share/shwap/p2p/bitswap/row_namespace_data_block.go
+++ b/share/shwap/p2p/bitswap/row_namespace_data_block.go
@@ -118,7 +118,7 @@ func (rndb *RowNamespaceDataBlock) UnmarshalFn(root *share.AxisRoots) UnmarshalF
 		}
 
 		if !rndb.ID.Equals(rndid) {
-			return fmt.Errorf("requested %+v doesnt match given %+v", rndb.ID, rndid)
+			return fmt.Errorf("requested %+v doesn't, does not match given %+v", rndb.ID, rndid)
 		}
 
 		var rnd shwappb.RowNamespaceData

--- a/share/shwap/p2p/bitswap/sample_block.go
+++ b/share/shwap/p2p/bitswap/sample_block.go
@@ -117,7 +117,7 @@ func (sb *SampleBlock) UnmarshalFn(root *share.AxisRoots) UnmarshalFn {
 		}
 
 		if !sb.ID.Equals(sid) {
-			return fmt.Errorf("requested %+v doesnt match given %+v", sb.ID, sid)
+			return fmt.Errorf("requested %+v doesn't, does not match given %+v", sb.ID, sid)
 		}
 
 		var sample shwappb.Sample

--- a/share/shwap/p2p/discovery/dht.go
+++ b/share/shwap/p2p/discovery/dht.go
@@ -16,13 +16,13 @@ import (
 func NewDHT(
 	ctx context.Context,
 	prefix string,
-	bootsrappers []peer.AddrInfo,
+	bootstrappers []peer.AddrInfo,
 	host host.Host,
 	dataStore datastore.Batching,
 	mode dht.ModeOpt,
 ) (*dht.IpfsDHT, error) {
 	opts := []dht.Option{
-		dht.BootstrapPeers(bootsrappers...),
+		dht.BootstrapPeers(bootstrappers...),
 		dht.ProtocolPrefix(protocol.ID(fmt.Sprintf("/celestia/%s", prefix))),
 		dht.Datastore(dataStore),
 		dht.Mode(mode),


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /cmd/rpc.go (Line 56)

"cant" → "can't"

Corrected typo in /nodebuilder/p2p/p2p_test.go (Line 170)

"TotalIn" → "totaling, total in"

Corrected typo in /nodebuilder/p2p/p2p_test.go (Line 171)

"TotalIn" → "totaling, total in"

Corrected typo in /nodebuilder/p2p/p2p_test.go (Line 175)

"TotalIn" → "totaling, total in"

Corrected typo in /share/shwap/getter.go (Line 25)

"indicies" → "indices"

Corrected typo in /share/shwap/getter.go (Line 26)

"indicies" → "indices"

Corrected typo in /share/shwap/p2p/bitswap/row_namespace_data_block.go (Line 121)

"doesnt" → "doesn't, does not"

Corrected typo in /share/shwap/p2p/bitswap/sample_block.go (Line 120)

"doesnt" → "doesn't, does not"

Corrected typo in /share/shwap/p2p/bitswap/row_block.go (Line 117)

"doesnt" → "doesn't, does not"

Corrected typo in /share/shwap/p2p/discovery/dht.go (Line 19)

"bootsrappers" → "bootstrappers"

**Purpose**

Improved code accuracy and professionalism by fixing typos.