### PR TITLE
fix(test): check error before deferring file.Close in TestGenerateJSO…

### DIFF
--- a/state/integration_test.go
+++ b/state/integration_test.go
@@ -141,8 +141,8 @@ func (s *IntegrationTestSuite) TestGenerateJSONBlock() {
 	require.NoError(err)
 
 	file, err := os.OpenFile("sample-block.json", os.O_CREATE|os.O_RDWR, os.ModePerm)
-	defer file.Close() //nolint: staticcheck
 	require.NoError(err)
+	defer file.Close()
 
 	err = json.NewEncoder(file).Encode(pBlock)
 	require.NoError(err)


### PR DESCRIPTION
…NBlock

- Moved the defer file.Close() statement after the error check for opening the file in the TestGenerateJSONBlock test to prevent potential panic if the file fails to open.
- Removed the //nolint: staticcheck comment since the underlying issue has been resolved.
- This makes the code safer and cleaner, and aligns with static analysis best practices.
