### PR TITLE
params(share/shwap/p2p/shrex/shrexnd): Increase concurrency limit for shrexnd middleware

### DIFF
--- a/share/shwap/p2p/shrex/shrexnd/params.go
+++ b/share/shwap/p2p/shrex/shrexnd/params.go
@@ -17,7 +17,9 @@ var log = logging.Logger("shrex/nd")
 type Parameters = shrex.Parameters
 
 func DefaultParameters() *Parameters {
-	return shrex.DefaultParameters()
+	defaultParams := shrex.DefaultParameters()
+	defaultParams.ConcurrencyLimit = 32
+	return defaultParams
 }
 
 func (c *Client) WithMetrics() error {


### PR DESCRIPTION
I changed it specifically for shrexnd server (which is a bit ugly) but I don't want to increase shrex-eds server limit even though we deprecated FNs because users are likely still running FNs and I don't want them to bombard BNs.