### PR TITLE
feat(share/shrex): add context cancellation to shrexeds and shrexnd clients

### DIFF
--- a/store/file/ods_test.go
+++ b/store/file/ods_test.go
@@ -46,7 +46,7 @@ func TestReadODSFromFile(t *testing.T) {
 	eds := edstest.RandEDS(t, 8)
 	f := createODSFile(t, eds)
 
-	ods, err := f.readODS()
+	ods, err := f.readODS(context.Background())
 	require.NoError(t, err)
 	for i, row := range ods {
 		original := eds.Row(uint(i))[:eds.Width()/2]
@@ -244,7 +244,7 @@ func createODSAccessor(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.Accesso
 
 func createCachedStreamer(t testing.TB, eds *rsmt2d.ExtendedDataSquare) eds.AccessorStreamer {
 	f := createODSFile(t, eds)
-	_, err := f.readODS()
+	_, err := f.readODS(context.Background())
 	require.NoError(t, err)
 	return f
 }

--- a/store/file/square.go
+++ b/store/file/square.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -17,10 +18,10 @@ type square [][]libshare.Share
 // readSquare reads Shares from the reader and returns a square. It assumes that the reader is
 // positioned at the beginning of the Shares. It knows the size of the Shares and the size of the
 // square, so reads from reader are limited to exactly the amount of data required.
-func readSquare(r io.Reader, shareSize, edsSize int) (square, error) {
+func readSquare(ctx context.Context, r io.Reader, shareSize, edsSize int) (square, error) {
 	odsLn := edsSize / 2
 
-	shares, err := eds.ReadShares(r, shareSize, odsLn)
+	shares, err := eds.ReadShares(ctx, r, shareSize, odsLn)
 	if err != nil {
 		return nil, fmt.Errorf("reading shares: %w", err)
 	}


### PR DESCRIPTION
  This PR implements context cancellation support for shrex clients to fix hanging requests when parent
  context is canceled.

  Closes #3480

  ## Changes

  - **shrexeds client**: Added `readEDSWithContext()` method with goroutine+channel pattern for context cancellation
  - **shrexnd client**: Added `readNamespaceDataWithContext()` method with similar cancellation support
  - **share/eds**: Updated `ReadShares()` to accept context and check for cancellation in reading loop
  - **store/file**: Added context propagation through ODS and square reading functions
  - **tests**: Added tests for quick server response cancellation and data reading cancellation cases
