### PR TITLE
Fix Typo in Comments and Variable Name

### DIFF
--- a/state/core_access.go
+++ b/state/core_access.go
@@ -71,7 +71,7 @@ type CoreAccessor struct {
 	estimatorServiceTLS  bool
 	estimatorConn        *grpc.ClientConn
 
-	// these fields are mutatable and thus need to be protected by a mutex
+	// these fields are mutable and thus need to be protected by a mutex
 	lock            sync.Mutex
 	lastPayForBlob  int64
 	payForBlobCount int64

--- a/store/getter_test.go
+++ b/store/getter_test.go
@@ -81,11 +81,11 @@ func TestStoreGetter(t *testing.T) {
 		for i := range eh.DAH.RowRoots {
 			row, err := sg.GetRow(ctx, eh, i)
 			require.NoError(t, err)
-			retreivedShrs, err := row.Shares()
+			retrievedShrs, err := row.Shares()
 			require.NoError(t, err)
 			edsShrs, err := libshare.FromBytes(eds.Row(uint(i)))
 			require.NoError(t, err)
-			require.Equal(t, edsShrs, retreivedShrs)
+			require.Equal(t, edsShrs, retrievedShrs)
 		}
 	})
 


### PR DESCRIPTION


**Description:**  
- Corrected a typo in the comment in `core_access.go` ("mutable" instead of "mutatble").
- Fixed the variable name from `retreivedShrs` to `retrievedShrs` in `getter_test.go` for clarity and consistency.  
