### PR TITLE
chore(node/tests): fix and cleanup swamp tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,10 @@ linters:
       - linters:
           - lll
         source: https://
+      - linters:
+          - revive
+        text: "var-naming: avoid meaningless package names"
+        path: "libs/utils"
     paths:
       - third_party$
       - builtin$

--- a/nodebuilder/tests/api_test.go
+++ b/nodebuilder/tests/api_test.go
@@ -32,6 +32,8 @@ const (
 )
 
 func TestNodeModule(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -16,7 +16,7 @@ import (
 	libshare "github.com/celestiaorg/go-square/v2/share"
 
 	"github.com/celestiaorg/celestia-node/blob"
-	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
 	"github.com/celestiaorg/celestia-node/state"
 )
@@ -36,20 +36,13 @@ func TestBlobModule(t *testing.T) {
 
 	bridge := sw.NewBridgeNode()
 	require.NoError(t, bridge.Start(ctx))
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
-	require.NoError(t, err)
+	sw.SetBootstrapper(t, bridge)
 
-	fullCfg := sw.DefaultTestConfig(node.Full)
-	fullCfg.Header.TrustedPeers = append(fullCfg.Header.TrustedPeers, addrs[0].String())
-	fullNode := sw.NewNodeWithConfig(node.Full, fullCfg)
+	fullNode := sw.NewFullNode()
 	require.NoError(t, fullNode.Start(ctx))
+	addrFn := host.InfoFromHost(fullNode.Host)
 
-	addrsFull, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(fullNode.Host))
-	require.NoError(t, err)
-
-	lightCfg := sw.DefaultTestConfig(node.Light)
-	lightCfg.Header.TrustedPeers = append(lightCfg.Header.TrustedPeers, addrsFull[0].String())
-	lightNode := sw.NewNodeWithConfig(node.Light, lightCfg)
+	lightNode := sw.NewLightNode(nodebuilder.WithBootstrappers([]peer.AddrInfo{*addrFn}))
 	require.NoError(t, lightNode.Start(ctx))
 
 	fullClient := getAdminClient(ctx, fullNode, t)

--- a/nodebuilder/tests/blob_test.go
+++ b/nodebuilder/tests/blob_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestBlobModule(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	t.Cleanup(cancel)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second*1))

--- a/nodebuilder/tests/da_test.go
+++ b/nodebuilder/tests/da_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestDaModule(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	t.Cleanup(cancel)
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second))

--- a/nodebuilder/tests/da_test.go
+++ b/nodebuilder/tests/da_test.go
@@ -16,8 +16,8 @@ import (
 	libshare "github.com/celestiaorg/go-square/v2/share"
 
 	"github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/da"
-	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
 )
 
@@ -52,21 +52,13 @@ func TestDaModule(t *testing.T) {
 	require.NoError(t, err)
 	bridge := sw.NewBridgeNode()
 	require.NoError(t, bridge.Start(ctx))
+	sw.SetBootstrapper(t, bridge)
 
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
-	require.NoError(t, err)
-
-	fullCfg := sw.DefaultTestConfig(node.Full)
-	fullCfg.Header.TrustedPeers = append(fullCfg.Header.TrustedPeers, addrs[0].String())
-	fullNode := sw.NewNodeWithConfig(node.Full, fullCfg)
+	fullNode := sw.NewFullNode()
 	require.NoError(t, fullNode.Start(ctx))
+	addrFn := host.InfoFromHost(fullNode.Host)
 
-	addrsFull, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(fullNode.Host))
-	require.NoError(t, err)
-
-	lightCfg := sw.DefaultTestConfig(node.Light)
-	lightCfg.Header.TrustedPeers = append(lightCfg.Header.TrustedPeers, addrsFull[0].String())
-	lightNode := sw.NewNodeWithConfig(node.Light, lightCfg)
+	lightNode := sw.NewLightNode(nodebuilder.WithBootstrappers([]peer.AddrInfo{*addrFn}))
 	require.NoError(t, lightNode.Start(ctx))
 
 	fullClient := getAdminClient(ctx, fullNode, t)

--- a/nodebuilder/tests/fraud_test.go
+++ b/nodebuilder/tests/fraud_test.go
@@ -4,13 +4,10 @@ package tests
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
 	"github.com/cometbft/cometbft/types"
-	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
@@ -68,25 +65,17 @@ func TestFraudProofHandling(t *testing.T) {
 		_ = edsStore.Stop(ctx)
 	})
 
-	cfg := nodebuilder.DefaultConfig(node.Bridge)
-	cfg.Core.IP, cfg.Core.Port, err = net.SplitHostPort(sw.ClientContext.GRPCClient.Target())
-	require.NoError(t, err)
 	// 1.
-	bridge := sw.NewNodeWithConfig(
-		node.Bridge,
-		cfg,
+	bridge := sw.NewBridgeNode(
 		core.WithHeaderConstructFn(fMaker.MakeExtendedHeader(16, edsStore)),
 		fx.Replace(edsStore),
 	)
 	// 2.
 	err = bridge.Start(ctx)
 	require.NoError(t, err)
-
+	sw.SetBootstrapper(t, bridge)
 	// 3.
-	cfg = nodebuilder.DefaultConfig(node.Full)
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(bridge.Host))
-	require.NoError(t, err)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
+	cfg := sw.DefaultTestConfig(node.Full)
 	cfg.Share.UseShareExchange = false
 	store := nodebuilder.MockStore(t, cfg)
 	full := sw.MustNewNodeWithStore(node.Full, store)
@@ -145,10 +134,7 @@ func TestFraudProofHandling(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
 	// 7.
-	cfg = nodebuilder.DefaultConfig(node.Light)
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, addrs[0].String())
-	lnStore := nodebuilder.MockStore(t, cfg)
-	light := sw.MustNewNodeWithStore(node.Light, lnStore)
+	light := sw.NewLightNode()
 	require.NoError(t, light.Start(ctx))
 	lightClient := getAdminClient(ctx, light, t)
 

--- a/nodebuilder/tests/helpers_test.go
+++ b/nodebuilder/tests/helpers_test.go
@@ -1,3 +1,6 @@
+// this directive needs to be here and i wanted to remove but couldn't
+// its too long to explain so just trust me or try removing yourself :)
+//
 //nolint:unused
 package tests
 

--- a/nodebuilder/tests/nd_test.go
+++ b/nodebuilder/tests/nd_test.go
@@ -41,7 +41,7 @@ func TestShrexNDFromLights(t *testing.T) {
 	bridge := sw.NewBridgeNode()
 	sw.SetBootstrapper(t, bridge)
 
-	cfg := nodebuilder.DefaultConfig(node.Light)
+	cfg := sw.DefaultTestConfig(node.Light)
 	cfg.Share.Discovery.PeersLimit = 1
 	light := sw.NewNodeWithConfig(node.Light, cfg)
 
@@ -112,13 +112,13 @@ func TestShrexNDFromLightsWithBadFulls(t *testing.T) {
 	}
 	fulls := make([]*nodebuilder.Node, 0, amountOfFulls)
 	for i := 0; i < amountOfFulls; i++ {
-		cfg := nodebuilder.DefaultConfig(node.Full)
+		cfg := sw.DefaultTestConfig(node.Full)
 		setTimeInterval(cfg, testTimeout)
 		full := sw.NewNodeWithConfig(node.Full, cfg, replaceNDServer(cfg, ndHandler), replaceShareGetter())
 		fulls = append(fulls, full)
 	}
 
-	lnConfig := nodebuilder.DefaultConfig(node.Light)
+	lnConfig := sw.DefaultTestConfig(node.Light)
 	lnConfig.Share.Discovery.PeersLimit = uint(amountOfFulls)
 	light := sw.NewNodeWithConfig(node.Light, lnConfig)
 

--- a/nodebuilder/tests/nd_test.go
+++ b/nodebuilder/tests/nd_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestShrexNDFromLights(t *testing.T) {
+	t.Parallel()
 	const (
 		blocks = 10
 		btime  = time.Millisecond * 300

--- a/nodebuilder/tests/p2p_test.go
+++ b/nodebuilder/tests/p2p_test.go
@@ -28,6 +28,7 @@ Steps:
 5. Check that nodes are connected to bridge
 */
 func TestBridgeNodeAsBootstrapper(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 

--- a/nodebuilder/tests/prune_test.go
+++ b/nodebuilder/tests/prune_test.go
@@ -41,6 +41,8 @@ import (
 // spin up 3 pruning FNs, connect
 // spin up 1 LN that syncs historic blobs
 func TestArchivalBlobSync(t *testing.T) {
+	t.Parallel()
+
 	const (
 		blocks = 10
 		btime  = time.Millisecond * 300
@@ -189,6 +191,7 @@ func TestArchivalBlobSync(t *testing.T) {
 }
 
 func TestDisallowConvertFromPrunedToArchival(t *testing.T) {
+	t.Parallel()
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	t.Cleanup(cancel)
@@ -219,6 +222,7 @@ func TestDisallowConvertFromPrunedToArchival(t *testing.T) {
 }
 
 func TestDisallowConvertToArchivalViaLastPrunedCheck(t *testing.T) {
+	t.Parallel()
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	t.Cleanup(cancel)
@@ -251,6 +255,7 @@ func TestDisallowConvertToArchivalViaLastPrunedCheck(t *testing.T) {
 }
 
 func TestConvertFromArchivalToPruned(t *testing.T) {
+	t.Parallel()
 	sw := swamp.NewSwamp(t, swamp.WithBlockTime(time.Second))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	t.Cleanup(cancel)

--- a/nodebuilder/tests/reconstruct_test.go
+++ b/nodebuilder/tests/reconstruct_test.go
@@ -51,6 +51,7 @@ func TestFullReconstructFromBridge(t *testing.T) {
 	bridge := sw.NewBridgeNode()
 	err := bridge.Start(ctx)
 	require.NoError(t, err)
+	sw.SetBootstrapper(t, bridge)
 	bridgeClient := getAdminClient(ctx, bridge, t)
 
 	// TODO: This is required to avoid flakes coming from unfinished retry
@@ -58,9 +59,8 @@ func TestFullReconstructFromBridge(t *testing.T) {
 	_, err = bridgeClient.Header.WaitForHeight(ctx, uint64(blocks))
 	require.NoError(t, err)
 
-	cfg := nodebuilder.DefaultConfig(node.Full)
+	cfg := sw.DefaultTestConfig(node.Full)
 	cfg.Share.UseShareExchange = false
-	cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, getMultiAddr(t, bridge.Host))
 	full := sw.NewNodeWithConfig(node.Full, cfg)
 	err = full.Start(ctx)
 	require.NoError(t, err)
@@ -123,9 +123,8 @@ func TestFullReconstructFromFulls(t *testing.T) {
 	subs := make([]event.Subscription, lnodes)
 	errg, errCtx := errgroup.WithContext(ctx)
 	for i := 0; i < lnodes/2; i++ {
-		i := i
 		errg.Go(func() error {
-			lnConfig := nodebuilder.DefaultConfig(node.Light)
+			lnConfig := sw.DefaultTestConfig(node.Light)
 			setTimeInterval(lnConfig, defaultTimeInterval)
 			light := sw.NewNodeWithConfig(node.Light, lnConfig)
 			sub, err := light.Host.EventBus().Subscribe(&event.EvtPeerIdentificationCompleted{})
@@ -137,7 +136,7 @@ func TestFullReconstructFromFulls(t *testing.T) {
 			return light.Start(errCtx)
 		})
 		errg.Go(func() error {
-			lnConfig := nodebuilder.DefaultConfig(node.Light)
+			lnConfig := sw.DefaultTestConfig(node.Light)
 			setTimeInterval(lnConfig, defaultTimeInterval)
 			light := sw.NewNodeWithConfig(node.Light, lnConfig)
 			sub, err := light.Host.EventBus().Subscribe(&event.EvtPeerIdentificationCompleted{})
@@ -314,7 +313,6 @@ func TestFullReconstructFromLights(t *testing.T) {
 	subs := make([]event.Subscription, lnodes)
 	errg, errCtx := errgroup.WithContext(ctx)
 	for i := 0; i < lnodes; i++ {
-		i := i
 		errg.Go(func() error {
 			lnConfig := nodebuilder.DefaultConfig(node.Light)
 			setTimeInterval(lnConfig, defaultTimeInterval)
@@ -345,7 +343,6 @@ func TestFullReconstructFromLights(t *testing.T) {
 	}
 	errg, bctx := errgroup.WithContext(ctx)
 	for i := 1; i <= blocks+1; i++ {
-		i := i
 		errg.Go(func() error {
 			h, err := fullClient.Header.WaitForHeight(bctx, uint64(i))
 			if err != nil {
@@ -357,10 +354,4 @@ func TestFullReconstructFromLights(t *testing.T) {
 	}
 	require.NoError(t, <-fillDn)
 	require.NoError(t, errg.Wait())
-}
-
-func getMultiAddr(t *testing.T, h host.Host) string {
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(h))
-	require.NoError(t, err)
-	return addrs[0].String()
 }

--- a/nodebuilder/tests/share_test.go
+++ b/nodebuilder/tests/share_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestShareModule(t *testing.T) {
+	t.Parallel()
 	logs.SetDebugLogging()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)

--- a/nodebuilder/tests/share_test.go
+++ b/nodebuilder/tests/share_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/celestiaorg/celestia-node/api/rpc/client"
 	"github.com/celestiaorg/celestia-node/blob"
-	"github.com/celestiaorg/celestia-node/logs"
 	"github.com/celestiaorg/celestia-node/nodebuilder/tests/swamp"
 	"github.com/celestiaorg/celestia-node/share/shwap"
 	"github.com/celestiaorg/celestia-node/state"
@@ -22,7 +21,6 @@ import (
 
 func TestShareModule(t *testing.T) {
 	t.Parallel()
-	logs.SetDebugLogging()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	t.Cleanup(cancel)

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -284,9 +284,8 @@ func (s *Swamp) newNode(t node.Type, store nodebuilder.Store, options ...fx.Opti
 		return nil, err
 	}
 
-	// TODO(@Bidon15): If for some reason, we receive one of existing options
-	// like <core, host, hash> from the test case, we need to check them and not use
-	// default that are set here
+	// set port to zero so that OS allocates one
+	// this avoids port collissions between nodes and tests
 	cfg, _ := store.Config()
 	cfg.RPC.Port = "0"
 

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -30,7 +30,6 @@ import (
 	"github.com/celestiaorg/celestia-node/libs/keystore"
 	"github.com/celestiaorg/celestia-node/logs"
 	"github.com/celestiaorg/celestia-node/nodebuilder"
-	coremodule "github.com/celestiaorg/celestia-node/nodebuilder/core"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
@@ -214,6 +213,10 @@ func (s *Swamp) DefaultTestConfig(tp node.Type) *nodebuilder.Config {
 
 	cfg.Core.IP = ip
 	cfg.Core.Port = port
+
+	for _, bootstrapper := range s.Bootstrappers {
+		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bootstrapper.String())
+	}
 	return cfg
 }
 
@@ -221,53 +224,25 @@ func (s *Swamp) DefaultTestConfig(tp node.Type) *nodebuilder.Config {
 // and a mockstore to the MustNewNodeWithStore method
 func (s *Swamp) NewBridgeNode(options ...fx.Option) *nodebuilder.Node {
 	cfg := s.DefaultTestConfig(node.Bridge)
-	var err error
-	cfg.Core.IP, cfg.Core.Port, err = net.SplitHostPort(s.ClientContext.GRPCClient.Target())
-	require.NoError(s.t, err)
-	store := nodebuilder.MockStore(s.t, cfg)
-
-	return s.MustNewNodeWithStore(node.Bridge, store, options...)
+	return s.NewNodeWithConfig(node.Bridge, cfg, options...)
 }
 
 // NewFullNode creates a new instance of a FullNode providing a default config
 // and a mockstore to the MustNewNodeWithStore method
 func (s *Swamp) NewFullNode(options ...fx.Option) *nodebuilder.Node {
 	cfg := s.DefaultTestConfig(node.Full)
-	cfg.Header.TrustedPeers = []string{
-		"/ip4/1.2.3.4/tcp/12345/p2p/12D3KooWNaJ1y1Yio3fFJEXCZyd1Cat3jmrPdgkYCrHfKD3Ce21p",
-	}
-	// add all bootstrappers in suite as trusted peers
-	for _, bootstrapper := range s.Bootstrappers {
-		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bootstrapper.String())
-	}
-	store := nodebuilder.MockStore(s.t, cfg)
-
-	return s.MustNewNodeWithStore(node.Full, store, options...)
+	return s.NewNodeWithConfig(node.Full, cfg, options...)
 }
 
 // NewLightNode creates a new instance of a LightNode providing a default config
 // and a mockstore to the MustNewNodeWithStore method
 func (s *Swamp) NewLightNode(options ...fx.Option) *nodebuilder.Node {
 	cfg := s.DefaultTestConfig(node.Light)
-	cfg.Header.TrustedPeers = []string{
-		"/ip4/1.2.3.4/tcp/12345/p2p/12D3KooWNaJ1y1Yio3fFJEXCZyd1Cat3jmrPdgkYCrHfKD3Ce21p",
-	}
-	// add all bootstrappers in suite as trusted peers
-	for _, bootstrapper := range s.Bootstrappers {
-		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bootstrapper.String())
-	}
-
-	store := nodebuilder.MockStore(s.t, cfg)
-
-	return s.MustNewNodeWithStore(node.Light, store, options...)
+	return s.NewNodeWithConfig(node.Light, cfg, options...)
 }
 
 func (s *Swamp) NewNodeWithConfig(nodeType node.Type, cfg *nodebuilder.Config, options ...fx.Option) *nodebuilder.Node {
 	store := nodebuilder.MockStore(s.t, cfg)
-	// add all bootstrappers in suite as trusted peers
-	for _, bootstrapper := range s.Bootstrappers {
-		cfg.Header.TrustedPeers = append(cfg.Header.TrustedPeers, bootstrapper.String())
-	}
 	return s.MustNewNodeWithStore(nodeType, store, options...)
 }
 
@@ -292,24 +267,6 @@ func (s *Swamp) NewNodeWithStore(
 		state.WithKeyring(s.ClientContext.Keyring),
 		state.WithKeyName(state.AccountName(s.Accounts[0])),
 	)
-
-	switch tp {
-	case node.Bridge:
-		host, port, err := net.SplitHostPort(s.ClientContext.GRPCClient.Target())
-		if err != nil {
-			return nil, err
-		}
-		addr := net.JoinHostPort(host, port)
-		con, err := grpc.NewClient(
-			addr,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
-		require.NoError(s.t, err)
-		options = append(options,
-			coremodule.WithConnection(con),
-		)
-	default:
-	}
 
 	nd, err := s.newNode(tp, store, options...)
 	if err != nil {

--- a/nodebuilder/tests/sync_test.go
+++ b/nodebuilder/tests/sync_test.go
@@ -44,6 +44,8 @@ Full node:
 8. Wait for FN DASer to catch up to network head
 */
 func TestSyncAgainstBridge_NonEmptyChain(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), swamp.DefaultTestTimeout)
 	t.Cleanup(cancel)
 

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -1,4 +1,4 @@
-package shrex_getter //nolint:revive,stylecheck // underscore in pkg name will be fixed with shrex refactoring
+package shrex_getter
 
 import (
 	"context"


### PR DESCRIPTION
While working on #4330, I had to fix swamp tests s.t. I know pruning doesn't break anything. While diving again into swamp, I realized we have a bunch of garbage and unnecessary code that I removed + unified node setup and connections for all the tests. Also, now the integration tests should be **GREEN**.

Also runs these tests in parallel. On my machine, time goes from 122s -> 86s. There is one more test time optimization in #4330 that reduces the number to ~60s