### PR TITLE
fix!(blobstream): implement MarshalJSON for DataRootTupleRoot

### DIFF
--- a/nodebuilder/blobstream/data_root_tuple_root.go
+++ b/nodebuilder/blobstream/data_root_tuple_root.go
@@ -17,6 +17,14 @@ import (
 // from a set of data root tuples.
 type DataRootTupleRoot bytes.HexBytes
 
+func (d *DataRootTupleRoot) MarshalJSON() ([]byte, error) {
+	if d == nil {
+		return nil, fmt.Errorf("empty DataRootTupleRoot")
+	}
+	// Delegate to the underlying HexBytes MarshalJSON method
+	return bytes.HexBytes(*d).MarshalJSON()
+}
+
 // DataRootTupleInclusionProof is the binary merkle
 // inclusion proof of a height to a data commitment.
 type DataRootTupleInclusionProof *merkle.Proof


### PR DESCRIPTION
The GetDataRootTupleRoot RPC method returns *DataRootTupleRoot (pointer type), but bytes.HexBytes.MarshalJSON() is defined on the value receiver, not the pointer receiver. When JSON marshaling encounters the pointer type without a corresponding pointer method, it falls back to default []byte marshaling (base64) instead of using the hex encoding.

Tested via curl:

```
curl -X GET \
    -H 'Content-Type: application/json' \
    -H "Authorization: Bearer $auth_token" \
    -d '{"jsonrpc":"2.0","id":1,"method":"blobstream.GetDataRootTupleRoot","params"'":[$start_height, $end_height]}" \
    $rpc_url | jq '.'
```

Was:
```
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": "DabRTxfztMyF/DlTii5qWallcomfPBBUACiPyG3HDNk="
}
```

Now:
```
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": "0DA6D14F17F3B4CC85FC39538A2E6A59A96572899F3C105400288FC86DC70CD9"
}
```