### PR TITLE
refactor(blob): decouple subscriber from service

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -59,8 +59,8 @@ type Service struct {
 	shareGetter shwap.Getter
 	// headerGetter fetches header by the provided height
 	headerGetter func(context.Context, uint64) (*header.ExtendedHeader, error)
-	// headerSub subscribes to new headers to supply to blob subscriptions.
-	headerSub func(ctx context.Context) (<-chan *header.ExtendedHeader, error)
+
+	subscriber *subscriber
 }
 
 func NewService(
@@ -69,17 +69,18 @@ func NewService(
 	headerGetter func(context.Context, uint64) (*header.ExtendedHeader, error),
 	headerSub func(ctx context.Context) (<-chan *header.ExtendedHeader, error),
 ) *Service {
-	return &Service{
+	s := &Service{
 		blobSubmitter: submitter,
 		shareGetter:   getter,
 		headerGetter:  headerGetter,
-		headerSub:     headerSub,
 	}
+	s.subscriber = newSubscriber(s.getAll, headerSub)
+	return s
 }
 
 func (s *Service) Start(context.Context) error {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	return nil
+	return s.subscriber.Start(s.ctx)
 }
 
 func (s *Service) Stop(context.Context) error {
@@ -87,80 +88,12 @@ func (s *Service) Stop(context.Context) error {
 	return nil
 }
 
-// SubscriptionResponse is the response type for the Subscribe method.
-// It contains the blobs and the height at which they were included.
-// If the Blobs slice is empty, it means that no blobs were included at the given height.
-type SubscriptionResponse struct {
-	Blobs  []*Blob
-	Height uint64
-}
-
 // Subscribe returns a channel that will receive SubscriptionResponse objects.
 // The channel will be closed when the context is canceled or the service is stopped.
 // Please note that no errors are returned: underlying operations are retried until successful.
 // Additionally, not reading from the returned channel will cause the stream to close after 16 messages.
 func (s *Service) Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan *SubscriptionResponse, error) {
-	if s.ctx == nil {
-		return nil, fmt.Errorf("service has not been started")
-	}
-
-	headerCh, err := s.headerSub(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	blobCh := make(chan *SubscriptionResponse, 16)
-	go func() {
-		defer close(blobCh)
-
-		for {
-			select {
-			case header, ok := <-headerCh:
-				if ctx.Err() != nil {
-					log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
-					return
-				}
-				if !ok {
-					log.Errorw("header channel closed for subscription", "namespace", ns.ID())
-					return
-				}
-				// close subscription before buffer overflows
-				if len(blobCh) == cap(blobCh) {
-					log.Debugw("blobsub: canceling subscription due to buffer overflow from slow reader", "namespace", ns.ID())
-					return
-				}
-
-				var blobs []*Blob
-				var err error
-				for {
-					blobs, err = s.getAll(ctx, header, []libshare.Namespace{ns})
-					if ctx.Err() != nil {
-						// context canceled, continuing would lead to unexpected missed heights for the client
-						log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
-						return
-					}
-					if err == nil {
-						// operation successful, break the loop
-						break
-					}
-				}
-
-				select {
-				case <-ctx.Done():
-					log.Debugw("blobsub: pending response canceled due to user ctx closing", "namespace", ns.ID())
-					return
-				case blobCh <- &SubscriptionResponse{Blobs: blobs, Height: header.Height()}:
-				}
-			case <-ctx.Done():
-				log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
-				return
-			case <-s.ctx.Done():
-				log.Debugw("blobsub: canceling subscription due to service ctx closing", "namespace", ns.ID())
-				return
-			}
-		}
-	}()
-	return blobCh, nil
+	return s.subscriber.subscribe(ctx, ns)
 }
 
 // Submit sends PFB transaction and reports the height at which it was included.

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -792,27 +792,27 @@ func TestService_Subscribe_MultipleNamespaces(t *testing.T) {
 	subCh2, err := service.Subscribe(ctx, ns2)
 	require.NoError(t, err)
 
-	for i := uint64(0); i < uint64(len(allBlobs)); i++ {
+	var i uint64
+	for i = uint64(0); i < uint64(len(blobs1)); i++ {
 		select {
 		case resp := <-subCh1:
 			assert.Equal(t, i+1, resp.Height)
-			if i < uint64(len(blobs1)) {
-				assert.NotEmpty(t, resp.Blobs)
-				for _, b := range resp.Blobs {
-					assert.Equal(t, ns1, b.Namespace())
-				}
-			} else {
-				assert.Empty(t, resp.Blobs)
+			assert.NotEmpty(t, resp.Blobs)
+			for _, b := range resp.Blobs {
+				assert.Equal(t, ns1, b.Namespace())
 			}
+		case <-time.After(time.Second * 2):
+			t.Fatalf("timeout waiting for subscription responses %d", i)
+		}
+	}
+
+	for i := i; i < uint64(len(blobs2)); i++ {
+		select {
 		case resp := <-subCh2:
 			assert.Equal(t, i+1, resp.Height)
-			if i >= uint64(len(blobs1)) {
-				assert.NotEmpty(t, resp.Blobs)
-				for _, b := range resp.Blobs {
-					assert.Equal(t, ns2, b.Namespace())
-				}
-			} else {
-				assert.Empty(t, resp.Blobs)
+			assert.NotEmpty(t, resp.Blobs)
+			for _, b := range resp.Blobs {
+				assert.Equal(t, ns2, b.Namespace())
 			}
 		case <-time.After(time.Second * 2):
 			t.Fatalf("timeout waiting for subscription responses %d", i)

--- a/blob/subscriber.go
+++ b/blob/subscriber.go
@@ -1,0 +1,147 @@
+package blob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	libshare "github.com/celestiaorg/go-square/v2/share"
+
+	"github.com/celestiaorg/celestia-node/header"
+)
+
+type (
+	// blobGetter is a function type that retrieves blobs from a given header
+	// for the specified namespaces.
+	blobGetter func(context.Context, *header.ExtendedHeader, []libshare.Namespace) ([]*Blob, error)
+	// headerSub is a function type that subscribes to new headers.
+	headerSub func(ctx context.Context) (<-chan *header.ExtendedHeader, error)
+)
+
+// SubscriptionResponse contains the blobs and the height at which they were included.
+// If the Blobs slice is empty, it means that no blobs were included at the given height.
+type SubscriptionResponse struct {
+	Blobs  []*Blob
+	Height uint64
+}
+
+// subscriber manages blob subscriptions by monitoring new headers and
+// retrieving relevant blob data for specified namespaces.
+type subscriber struct {
+	ctx context.Context
+
+	getter    blobGetter
+	headerSub headerSub
+}
+
+func newSubscriber(getter blobGetter, sub headerSub) *subscriber {
+	return &subscriber{
+		getter:    getter,
+		headerSub: sub,
+	}
+}
+
+func (s *subscriber) Start(ctx context.Context) error {
+	s.ctx = ctx
+	return nil
+}
+
+// subscribe creates a subscription for blobs in the specified namespace.
+// It returns a channel that will receive SubscriptionResponse messages
+// whenever new blobs are detected for the given namespace.
+func (s *subscriber) subscribe(ctx context.Context, ns libshare.Namespace) (<-chan *SubscriptionResponse, error) {
+	if s.ctx == nil {
+		if s.ctx == nil {
+			return nil, fmt.Errorf("subscriber has not been started")
+		}
+	}
+
+	headerCh, err := s.headerSub(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	blobCh := make(chan *SubscriptionResponse, 16)
+	go s.onHeadersReceived(ctx, headerCh, blobCh, ns)
+	return blobCh, nil
+}
+
+// onHeadersReceived is the subscription loop that processes incoming headers
+// and retrieves blob data for the specified namespace.
+func (s *subscriber) onHeadersReceived(
+	ctx context.Context,
+	headerCh <-chan *header.ExtendedHeader,
+	blobCh chan *SubscriptionResponse,
+	ns libshare.Namespace,
+) {
+	defer close(blobCh)
+
+	var (
+		hdr *header.ExtendedHeader
+		ok  bool
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
+			return
+		case <-s.ctx.Done():
+			log.Debugw("blobsub: canceling subscription. subscriber is stopped", "namespace", ns.ID())
+			return
+		case hdr, ok = <-headerCh:
+			if !ok {
+				log.Errorw("blobsub: header channel closed for subscription", "namespace", ns.ID())
+				return
+			}
+			break
+		}
+
+		// close subscription before buffer overflows
+		// TODO: not sure about this. Consider removing it.
+		if len(blobCh) == cap(blobCh) {
+			log.Debugw("blobsub: canceling subscription due to buffer overflow from slow reader", "namespace", ns.ID())
+			return
+		}
+
+		blobs, err := s.retrieveHeader(ctx, hdr, ns)
+		if err != nil && !errors.Is(err, ErrBlobNotFound) {
+			log.Debugw("blobsub: error retrieving header", "namespace", ns.ID(), "err", err)
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			log.Debugw("blobsub: pending response canceled due to user ctx closing", "namespace", ns.ID())
+			return
+		case blobCh <- &SubscriptionResponse{Blobs: blobs, Height: hdr.Height()}:
+		}
+	}
+}
+
+// retrieveHeader attempts to retrieve blobs from the given header for the
+// specified namespace.
+func (s *subscriber) retrieveHeader(
+	ctx context.Context,
+	hdr *header.ExtendedHeader,
+	ns libshare.Namespace,
+) ([]*Blob, error) {
+	for {
+		// No need to verify on ErrBlobNotFound, since getAll returns both empty values.
+		blobs, err := s.getter(ctx, hdr, []libshare.Namespace{ns})
+		if err == nil {
+			return blobs, nil
+		}
+
+		switch {
+		case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
+			return nil, err
+		case s.ctx.Err() != nil:
+			return nil, s.ctx.Err()
+		default:
+			// retry in case of internal error
+			log.Debugw("blobsub: error getting blobs", "namespace", ns.ID(), "err", err)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
The PR extracts blob subscription functionality into a separate subscriber component to decouple this logic from the blob service.

