### PR TITLE
fix!(blobstream): change GetDataRootTupleRoot return type

### DIFF
--- a/nodebuilder/blobstream/blobstream.go
+++ b/nodebuilder/blobstream/blobstream.go
@@ -13,7 +13,7 @@ type Module interface {
 	// GetDataRootTupleRoot collects the data roots over a provided ordered range of blocks,
 	// and then creates a new Merkle root of those data roots. The range is end exclusive.
 	// It's in the header module because it only needs access to the headers to generate the proof.
-	GetDataRootTupleRoot(ctx context.Context, start, end uint64) (*DataRootTupleRoot, error)
+	GetDataRootTupleRoot(ctx context.Context, start, end uint64) (DataRootTupleRoot, error)
 
 	// GetDataRootTupleInclusionProof creates an inclusion proof, for the data root tuple of block
 	// height `height`, in the set of blocks defined by `start` and `end`. The range
@@ -28,7 +28,7 @@ type Module interface {
 // API is a wrapper around the Module for RPC.
 type API struct {
 	Internal struct {
-		GetDataRootTupleRoot           func(ctx context.Context, start, end uint64) (*DataRootTupleRoot, error) `perm:"read"`
+		GetDataRootTupleRoot           func(ctx context.Context, start, end uint64) (DataRootTupleRoot, error) `perm:"read"`
 		GetDataRootTupleInclusionProof func(
 			ctx context.Context,
 			height, start, end uint64,
@@ -36,7 +36,7 @@ type API struct {
 	}
 }
 
-func (api *API) GetDataRootTupleRoot(ctx context.Context, start, end uint64) (*DataRootTupleRoot, error) {
+func (api *API) GetDataRootTupleRoot(ctx context.Context, start, end uint64) (DataRootTupleRoot, error) {
 	return api.Internal.GetDataRootTupleRoot(ctx, start, end)
 }
 

--- a/nodebuilder/blobstream/mocks/api.go
+++ b/nodebuilder/blobstream/mocks/api.go
@@ -52,10 +52,10 @@ func (mr *MockModuleMockRecorder) GetDataRootTupleInclusionProof(arg0, arg1, arg
 }
 
 // GetDataRootTupleRoot mocks base method.
-func (m *MockModule) GetDataRootTupleRoot(arg0 context.Context, arg1, arg2 uint64) (*bytes.HexBytes, error) {
+func (m *MockModule) GetDataRootTupleRoot(arg0 context.Context, arg1, arg2 uint64) (bytes.HexBytes, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDataRootTupleRoot", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*bytes.HexBytes)
+	ret0, _ := ret[0].(bytes.HexBytes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/nodebuilder/blobstream/service.go
+++ b/nodebuilder/blobstream/service.go
@@ -24,7 +24,7 @@ func NewService(headerMod headerServ.Module) *Service {
 
 // GetDataRootTupleRoot collects the data roots over a provided ordered range of blocks,
 // and then creates a new Merkle root of those data roots. The range is end exclusive.
-func (s *Service) GetDataRootTupleRoot(ctx context.Context, start, end uint64) (*DataRootTupleRoot, error) {
+func (s *Service) GetDataRootTupleRoot(ctx context.Context, start, end uint64) (DataRootTupleRoot, error) {
 	log.Debugw("validating the data commitment range", "start", start, "end", end)
 	err := s.validateDataRootTupleRootRange(ctx, start, end)
 	if err != nil {
@@ -36,13 +36,7 @@ func (s *Service) GetDataRootTupleRoot(ctx context.Context, start, end uint64) (
 		return nil, err
 	}
 	log.Debugw("hashing the data root tuples", "start", start, "end", end)
-	root, err := hashDataRootTuples(encodedDataRootTuples)
-	if err != nil {
-		return nil, err
-	}
-	// Create data commitment
-	dataRootTupleRoot := DataRootTupleRoot(root)
-	return &dataRootTupleRoot, nil
+	return hashDataRootTuples(encodedDataRootTuples)
 }
 
 // GetDataRootTupleInclusionProof creates an inclusion proof for the data root of block

--- a/nodebuilder/blobstream/service_test.go
+++ b/nodebuilder/blobstream/service_test.go
@@ -2,10 +2,12 @@ package blobstream
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/cometbft/cometbft/crypto/merkle"
+	"github.com/cometbft/cometbft/libs/bytes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -136,6 +138,15 @@ func TestHashDataRootTuples(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedHash, result)
+
+				res := bytes.HexBytes(result)
+				hash, err := json.Marshal(res)
+				require.NoError(t, err)
+
+				var data bytes.HexBytes
+				err = json.Unmarshal(hash, &data)
+				require.NoError(t, err)
+				assert.Equal(t, result, data.Bytes())
 			}
 		})
 	}
@@ -181,6 +192,14 @@ func TestProveDataRootTuples(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedProof, *result)
+				dtProof := (DataRootTupleInclusionProof)(*result)
+				data, err := json.Marshal(dtProof)
+				require.NoError(t, err)
+
+				var newDtProof DataRootTupleInclusionProof
+				err = json.Unmarshal(data, &newDtProof)
+				require.NoError(t, err)
+				assert.Equal(t, dtProof, newDtProof)
 			}
 		})
 	}


### PR DESCRIPTION
Change the return type of the GetDataRootTupleRoot in blobstream service. 

Changed the return type from *DataRootTupleRoot to DataRootTupleRoot, because DataRootTupleRoot is a type alias of byte.HexBytes(which is a type definition for `[]byte`). Since []byte is a reference type, there is no need to return a pointer.