### PR TITLE
fix: preserve original header hash in FraudMaker for proper chain linking

### DIFF
--- a/header/headertest/fraud/testing.go
+++ b/header/headertest/fraud/testing.go
@@ -55,6 +55,9 @@ func (f *FraudMaker) MakeExtendedHeader(odsSize int, edsStore *store.Store) head
 			return header.MakeExtendedHeader(h, comm, vals, eds)
 		}
 
+		// Save the hash of the original header before any modifications
+		f.prevHash = h.Hash()
+
 		hdr := *h
 		if h.Height == f.height {
 			adder := ipld.NewProofsAdder(odsSize, false)
@@ -80,7 +83,6 @@ func (f *FraudMaker) MakeExtendedHeader(odsSize int, edsStore *store.Store) head
 
 		*h = hdr
 		*comm = *commit
-		f.prevHash = h.Hash()
 		return header.MakeExtendedHeader(h, comm, vals, eds)
 	}
 }


### PR DESCRIPTION
Fix f.prevHash assignment to save original header hash before modifications,
ensuring correct block chain hash linking in fraud test scenarios.