### PR TITLE
ci: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
       - run: |
           npm install -g markdownlint-cli@0.32.1
           markdownlint --config .markdownlint.yaml '**/*.md'


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 18.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
The node-version field in markdown-linter.yml has been changed accordingly.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)
