### PR TITLE
fix: correct ODS size calculation in CreateFraudExtHeader

### DIFF
--- a/header/headertest/fraud/testing.go
+++ b/header/headertest/fraud/testing.go
@@ -89,7 +89,7 @@ func CreateFraudExtHeader(
 	t *testing.T,
 	eh *header.ExtendedHeader,
 ) *header.ExtendedHeader {
-	square := edstest.RandByzantineEDS(t, len(eh.DAH.RowRoots))
+	square := edstest.RandByzantineEDS(t, len(eh.DAH.RowRoots)/2)
 	dah, err := da.NewDataAvailabilityHeader(square)
 	require.NoError(t, err)
 	eh.DAH = &dah


### PR DESCRIPTION
The CreateFraudExtHeader function was incorrectly using EDS size instead of ODS size
when calling RandByzantineEDS. This caused the function to create Byzantine EDS
with wrong dimensions.

- Changed len(eh.DAH.RowRoots) to len(eh.DAH.RowRoots)/2
- RandByzantineEDS expects ODS size (Original Data Square), not EDS size
- EDS size is always 2x the ODS size due to erasure coding extension