### PR TITLE
fix: loop to handle integer count properly

### DIFF
--- a/cmd/celestia/cmd_test.go
+++ b/cmd/celestia/cmd_test.go
@@ -139,7 +139,7 @@ func parseSignatureForHelpString(methodSig reflect.StructField) string {
 		}
 	}
 	simplifiedSignature += ") -> ("
-	for i := range out - 1 {
+	for i := 0; i < out; i++ {
 		simplifiedSignature += methodSig.Type.Out(i).String()
 		if i != out-2 {
 			simplifiedSignature += ", "


### PR DESCRIPTION
changed the loop since `out` is an int and can’t be used with `range`.
now it just runs a normal `for` from 0 to `out - 1`.
this stops the compile error.
