### PR TITLE
fix(cmd/celestia): parse only store determination flags for auxiliary commands

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -29,6 +29,11 @@ func AuthCmd(fsets ...*flag.FlagSet) *cobra.Command {
 		Long: "Signs and outputs a hex-encoded JWT token with the given permissions. NOTE: only use this command when " +
 			"the node has already been initialized and started.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			err := ParseStoreDeterminationFlags(cmd, NodeType(cmd.Context()), args)
+			if err != nil {
+				return err
+			}
+
 			if len(args) != 1 {
 				return errors.New("must specify permissions")
 			}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,8 +12,14 @@ func RemoveConfigCmd(fsets ...*flag.FlagSet) *cobra.Command {
 		Use:   "config-remove",
 		Short: "Deletes the node's config",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := ParseStoreDeterminationFlags(cmd, NodeType(cmd.Context()), args)
+			if err != nil {
+				return err
+			}
+
 			ctx := cmd.Context()
+
 			return nodebuilder.RemoveConfig(StorePath(ctx))
 		},
 	}
@@ -31,8 +37,14 @@ func UpdateConfigCmd(fsets ...*flag.FlagSet) *cobra.Command {
 		Long: "Updates the node's outdated config with default values from newly-added fields. Check the config " +
 			" afterwards to ensure all old custom values were preserved.",
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := ParseStoreDeterminationFlags(cmd, NodeType(cmd.Context()), args)
+			if err != nil {
+				return err
+			}
+
 			ctx := cmd.Context()
+
 			return nodebuilder.UpdateConfig(NodeType(ctx), StorePath(ctx))
 		},
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -13,7 +13,12 @@ func Init(fsets ...*flag.FlagSet) *cobra.Command {
 		Use:   "init",
 		Short: "Initialization for Celestia Node. Passed flags have persisted effect.",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := ParseAllFlags(cmd, NodeType(cmd.Context()), args)
+			if err != nil {
+				return err
+			}
+
 			ctx := cmd.Context()
 
 			return nodebuilder.Init(NodeConfig(ctx), StorePath(ctx), NodeType(ctx))

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -56,7 +56,7 @@ func NewLight(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command 
 		Args:  cobra.NoArgs,
 		Short: "Manage your Light node",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			ctx := WithNodeType(cmd.Context(), node.Bridge)
+			ctx := WithNodeType(cmd.Context(), node.Light)
 			cmd.SetContext(ctx)
 			return nil
 		},

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -28,7 +28,10 @@ func NewBridge(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command
 		Args:  cobra.NoArgs,
 		Short: "Manage your Bridge node",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return PersistentPreRunEnv(cmd, node.Bridge, args)
+			ctx := WithNodeType(cmd.Context(), node.Bridge)
+			cmd.SetContext(ctx)
+
+			return nil
 		},
 	}
 	for _, option := range options {
@@ -53,7 +56,9 @@ func NewLight(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command 
 		Args:  cobra.NoArgs,
 		Short: "Manage your Light node",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return PersistentPreRunEnv(cmd, node.Light, args)
+			ctx := WithNodeType(cmd.Context(), node.Bridge)
+			cmd.SetContext(ctx)
+			return nil
 		},
 	}
 	for _, option := range options {
@@ -82,7 +87,9 @@ func NewFull(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command {
 				"DEPRECATION NOTICE: FULL NODE MODE WILL BE DEPRECATED SOON." +
 					" NODE OPERATORS SHOULD CONSIDER RUNNING A BRIDGE NODE INSTEAD IF THEY REQUIRE FULL DATA STORAGE FUNCTIONALITY.",
 			)
-			return PersistentPreRunEnv(cmd, node.Full, args)
+			ctx := WithNodeType(cmd.Context(), node.Full)
+			cmd.SetContext(ctx)
+			return nil
 		},
 	}
 	for _, option := range options {

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -27,7 +27,7 @@ func NewBridge(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command
 		Use:   "bridge [subcommand]",
 		Args:  cobra.NoArgs,
 		Short: "Manage your Bridge node",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := WithNodeType(cmd.Context(), node.Bridge)
 			cmd.SetContext(ctx)
 
@@ -55,7 +55,7 @@ func NewLight(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command 
 		Use:   "light [subcommand]",
 		Args:  cobra.NoArgs,
 		Short: "Manage your Light node",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := WithNodeType(cmd.Context(), node.Light)
 			cmd.SetContext(ctx)
 			return nil
@@ -82,7 +82,7 @@ func NewFull(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command {
 		Use:   "full [subcommand]",
 		Args:  cobra.NoArgs,
 		Short: "Manage your Full node",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			log.Error(
 				"DEPRECATION NOTICE: FULL NODE MODE WILL BE DEPRECATED SOON." +
 					" NODE OPERATORS SHOULD CONSIDER RUNNING A BRIDGE NODE INSTEAD IF THEY REQUIRE FULL DATA STORAGE FUNCTIONALITY.",

--- a/cmd/reset_store.go
+++ b/cmd/reset_store.go
@@ -13,7 +13,12 @@ func ResetStore(fsets ...*flag.FlagSet) *cobra.Command {
 		Use:   "unsafe-reset-store",
 		Short: "Resets the node's store to a new state. Leaves the keystore and config intact.",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := ParseStoreDeterminationFlags(cmd, NodeType(cmd.Context()), args)
+			if err != nil {
+				return err
+			}
+
 			ctx := cmd.Context()
 
 			return nodebuilder.Reset(StorePath(ctx), NodeType(ctx))

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -25,7 +25,12 @@ Options passed on start override configuration options only on start and are not
 		Aliases:      []string{"run", "daemon"},
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			err = ParseAllFlags(cmd, NodeType(cmd.Context()), args)
+			if err != nil {
+				return err
+			}
+
 			ctx := cmd.Context()
 
 			// override config with all modifiers passed on start


### PR DESCRIPTION
_Please review this PR carefuly_

---------------------------------

I've wanted to do this for a while - we do not need to parse the entire set of flags available for `Init` and `Start` for all other auxiliary commands as they're irrelevant.

This PR decouples this parsing logic into 
`ParseStoreDeterminationFlags` and `ParseAllFlags`

Now, all subcommands will run their own necessary parsing logic. 

This PR fixes a bug found by @vgonkivs where a LN would fatal out on `config-update` subcommand due to unrelated: 
```
celestia light config-update --p2p.network=mocha
2025-08-07T16:23:27.396+0300	FATAL	module/pruner	pruner/flags.go:43	ARCHIVAL MODE ENABLED BY ACCIDENT!!! Please explicitly pass `--archival` to enable archival mode!
```

This PR also only parses pruning flags for the `Bridge` node -- LNs all prune by default and don't have an archival option anyway.

Supersedes #4131 