### PR TITLE
!fix(api/share) encode share in sample json as base64

### DIFF
--- a/share/shwap/sample.go
+++ b/share/shwap/sample.go
@@ -91,23 +91,33 @@ func (s Sample) ToProto() *pb.Sample {
 
 // MarshalJSON encodes sample to the json encoded bytes.
 func (s Sample) MarshalJSON() ([]byte, error) {
-	pbSample := s.ToProto()
-	return json.Marshal(*pbSample)
+	jsonSample := struct {
+		Share     libshare.Share `json:"share"`
+		Proof     *nmt.Proof     `json:"proof"`
+		ProofType rsmt2d.Axis    `json:"proof_type"`
+	}{
+		Share:     s.Share,
+		Proof:     s.Proof,
+		ProofType: s.ProofType,
+	}
+	return json.Marshal(&jsonSample)
 }
 
 // UnmarshalJSON decodes bytes to the Sample.
 func (s *Sample) UnmarshalJSON(data []byte) error {
-	var ss pb.Sample
-	err := json.Unmarshal(data, &ss)
-	if err != nil {
+	var jsonSample struct {
+		Share     libshare.Share `json:"share"`
+		Proof     *nmt.Proof     `json:"proof"`
+		ProofType rsmt2d.Axis    `json:"proof_type"`
+	}
+	if err := json.Unmarshal(data, &jsonSample); err != nil {
 		return err
 	}
 
-	sample, err := SampleFromProto(&ss)
-	if err != nil {
-		return err
-	}
-	*s = sample
+	s.Share = jsonSample.Share
+	s.Proof = jsonSample.Proof
+	s.ProofType = jsonSample.ProofType
+
 	return nil
 }
 

--- a/share/shwap/sample_test.go
+++ b/share/shwap/sample_test.go
@@ -116,3 +116,29 @@ func BenchmarkSampleValidate(b *testing.B) {
 		_ = sample.Verify(root, 0, 0)
 	}
 }
+
+func TestSampleJSON(t *testing.T) {
+	const odsSize = 8
+	randEDS := edstest.RandEDS(t, odsSize)
+	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
+
+	for _, proofType := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
+		for rowIdx := range odsSize * 2 {
+			for colIdx := range odsSize * 2 {
+				idx := shwap.SampleCoords{Row: rowIdx, Col: colIdx}
+
+				sample, err := inMem.SampleForProofAxis(idx, proofType)
+				require.NoError(t, err)
+
+				b, err := sample.MarshalJSON()
+				require.NoError(t, err)
+
+				var sampleOut shwap.Sample
+				err = sampleOut.UnmarshalJSON(b)
+				require.NoError(t, err)
+
+				require.Equal(t, sample, sampleOut)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Per @zvolin report. So when adding test for the share.GetSamples I noticed another api inconsistency. Everywhere share is serialized as a base64 encoded data, so eg:
```
> share.GetRow
< {
  "shares": [
    "AAAAAAAAAAAAAAAAAAAAAAAAAGXRNXN/OAIch2QTuWuB/Bc/v09JV9yEzVs9cfLNf9mzU2bl/flYQkZKLpboGU5bD2cygc9uKM=",
    ...
  ],
  "side": "BOTH"
}
```
but get samples serializes share as object with data field
```
> share.GetSamples
< [
  {
    "share": {
      "data": "AAAAAAAAAAAAAAAAAAAAAAAAAGXRNXN/OAIch2QTuWuB/Bc/v09JV9yEzVs9cfLNf9mzU2bl/flYQkZKLpboGU5bD2cygc9uKM="
    },
    "proof": { ... }
  },
  ...
]
```

----
This PR changes json Sample encoding from proto to native json 