### PR TITLE
fix(nodebuilder/pruner)!: Remove pruner config from nodes config

### DIFF
--- a/cmd/celestia/cmd_test.go
+++ b/cmd/celestia/cmd_test.go
@@ -49,7 +49,7 @@ func TestLight(t *testing.T) {
 		output := &bytes.Buffer{}
 		rootCmd.SetOut(output)
 		rootCmd.SetArgs([]string{
-			"bridge",
+			"light",
 			"--node.store", ".celestia-light",
 			"init",
 		})

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -131,6 +131,9 @@ func ParseAllFlags(cmd *cobra.Command, nodeType node.Type, args []string) error 
 		return err
 	}
 
+	opt := pruner.ParseFlags(cmd, nodeType)
+	ctx = WithNodeOptions(ctx, opt)
+
 	switch nodeType {
 	case node.Light, node.Full:
 		err = header.ParseFlags(cmd, &cfg.Header)
@@ -138,7 +141,6 @@ func ParseAllFlags(cmd *cobra.Command, nodeType node.Type, args []string) error 
 			return err
 		}
 	case node.Bridge:
-		pruner.ParseFlags(cmd, &cfg.Pruner, nodeType)
 	default:
 		panic(fmt.Sprintf("invalid node type: %v", nodeType))
 	}

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
-	"github.com/celestiaorg/celestia-node/nodebuilder/pruner"
 	"github.com/celestiaorg/celestia-node/nodebuilder/rpc"
 	"github.com/celestiaorg/celestia-node/nodebuilder/share"
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
@@ -34,7 +33,6 @@ type Config struct {
 	Share  share.Config
 	Header header.Config
 	DASer  das.Config `toml:",omitempty"`
-	Pruner pruner.Config
 }
 
 // DefaultConfig provides a default Config for a given Node Type 'tp'.
@@ -48,7 +46,6 @@ func DefaultConfig(tp node.Type) *Config {
 		RPC:    rpc.DefaultConfig(),
 		Share:  share.DefaultConfig(tp),
 		Header: header.DefaultConfig(tp),
-		Pruner: pruner.DefaultConfig(),
 	}
 
 	switch tp {

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -53,7 +53,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		blob.ConstructModule(),
 		da.ConstructModule(),
 		node.ConstructModule(tp),
-		pruner.ConstructModule(tp, &cfg.Pruner),
+		pruner.ConstructModule(tp),
 		rpc.ConstructModule(tp, &cfg.RPC),
 		blobstream.ConstructModule(),
 	)

--- a/nodebuilder/pruner/config.go
+++ b/nodebuilder/pruner/config.go
@@ -5,9 +5,3 @@ var MetricsEnabled bool
 type Config struct {
 	EnableService bool
 }
-
-func DefaultConfig() Config {
-	return Config{
-		EnableService: true,
-	}
-}

--- a/nodebuilder/pruner/module.go
+++ b/nodebuilder/pruner/module.go
@@ -19,7 +19,7 @@ import (
 
 var log = logging.Logger("module/pruner")
 
-func ConstructModule(tp node.Type, cfg *Config) fx.Option {
+func ConstructModule(tp node.Type) fx.Option {
 	prunerService := fx.Options(
 		fx.Provide(fx.Annotate(
 			newPrunerService,
@@ -36,9 +36,13 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	)
 
 	baseComponents := fx.Options(
-		fx.Supply(cfg),
+		// supply the default config, which can only be overridden by
+		// passing the `--archival` flag
+		fx.Supply(&Config{
+			EnableService: true,
+		}),
 		// TODO @renaynay: move this to share module construction
-		advertiseArchival(tp, cfg),
+		advertiseArchival(),
 		prunerService,
 	)
 
@@ -53,36 +57,29 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 			fx.Provide(func(la *light.ShareAvailability) pruner.Pruner { return la }),
 		)
 	case node.Full:
-		fullAvailOpts := make([]fullavail.Option, 0)
-
-		if !cfg.EnableService {
-			// populate archival mode opts
-			fullAvailOpts = []fullavail.Option{fullavail.WithArchivalMode()}
-		}
-
 		return fx.Module("prune",
 			baseComponents,
 			fx.Supply(modshare.Window(availability.StorageWindow)),
-			fx.Supply(fullAvailOpts),
+			fx.Provide(func(cfg *Config) []fullavail.Option {
+				if cfg.EnableService {
+					return make([]fullavail.Option, 0)
+				}
+				return []fullavail.Option{fullavail.WithArchivalMode()}
+			}),
 			fx.Provide(func(fa *fullavail.ShareAvailability) pruner.Pruner { return fa }),
 			convertToPruned(),
 		)
 	case node.Bridge:
-		coreOpts := make([]core.Option, 0)
-		fullAvailOpts := make([]fullavail.Option, 0)
-
-		if !cfg.EnableService {
-			// populate archival mode opts
-			coreOpts = []core.Option{core.WithArchivalMode()}
-			fullAvailOpts = []fullavail.Option{fullavail.WithArchivalMode()}
-		}
-
 		return fx.Module("prune",
 			baseComponents,
+			fx.Provide(func(cfg *Config) ([]core.Option, []fullavail.Option) {
+				if cfg.EnableService {
+					return make([]core.Option, 0), make([]fullavail.Option, 0)
+				}
+				return []core.Option{core.WithArchivalMode()}, []fullavail.Option{fullavail.WithArchivalMode()}
+			}),
 			fx.Provide(func(fa *fullavail.ShareAvailability) pruner.Pruner { return fa }),
 			fx.Supply(modshare.Window(availability.StorageWindow)),
-			fx.Supply(coreOpts),
-			fx.Supply(fullAvailOpts),
 			convertToPruned(),
 		)
 	default:
@@ -90,11 +87,11 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	}
 }
 
-func advertiseArchival(tp node.Type, pruneCfg *Config) fx.Option {
-	if (tp == node.Full || tp == node.Bridge) && !pruneCfg.EnableService {
-		return fx.Supply(discovery.WithAdvertise())
-	}
-	return fx.Provide(func() discovery.Option {
+func advertiseArchival() fx.Option {
+	return fx.Provide(func(tp node.Type, pruneCfg *Config) discovery.Option {
+		if (tp == node.Full || tp == node.Bridge) && !pruneCfg.EnableService {
+			return discovery.WithAdvertise()
+		}
 		var opt discovery.Option
 		return opt
 	})


### PR DESCRIPTION
The pruner config field has been removed from the config as it was rendered ineffectual by https://github.com/celestiaorg/celestia-node/pull/4303. 

**Now, users MUST PASS `--archival` when running their node to disable pruning (and ensure the node runs in archival mode)**

Resolves #4477 