### PR TITLE
fix: fixed logical typo

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: |
           npm install -g markdownlint-cli@0.41.0
           markdownlint --config .markdownlint.yaml '**/*.md'

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -67,9 +67,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: |
-          npm install -g markdownlint-cli@0.32.1
+          npm install -g markdownlint-cli@0.41.0
           markdownlint --config .markdownlint.yaml '**/*.md'
 
   go-ci:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See the [official docs page](https://docs.celestia.org/how-to-guides/nodes-overv
 
 ## Supported architectures
 
-Celestia-app officially supports the following architectures:
+Celestia-node officially supports the following architectures:
 
 - `linux/amd64`
 - `linux/arm64`


### PR DESCRIPTION
## Description

- Сorrected logical typo in `README.md`. 
- Updated `ci_release.yml`

## Details

- Celestia-app → Celestia-node
- Updated node version to 24
Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)
- Updated markdownlint-cli version to 0.41.0
