### PR TITLE
fix(api/client-lib): fix close order for Celestia client lib

### DIFF
--- a/api/client/read_client.go
+++ b/api/client/read_client.go
@@ -34,7 +34,7 @@ type ReadClient struct {
 	Fraud      fraudapi.Module
 	Blobstream blobstreamapi.Module
 
-	chainCloser func() error
+	closer func() error
 }
 
 func (cfg ReadConfig) Validate() error {
@@ -103,7 +103,7 @@ func NewReadClient(ctx context.Context, cfg ReadConfig) (*ReadClient, error) {
 	}
 
 	// pass prev func as value to avoid recursive call during unwrap
-	chainCloser := func() error {
+	closer := func() error {
 		shareCloser()
 		blobstreamCloser()
 		headerCloser()
@@ -113,15 +113,15 @@ func NewReadClient(ctx context.Context, cfg ReadConfig) (*ReadClient, error) {
 	}
 
 	return &ReadClient{
-		Share:       &shareAPI,
-		Blobstream:  &blobstreamAPI,
-		Header:      &headerAPI,
-		Blob:        &readOnlyBlobAPI{&blobAPI},
-		chainCloser: chainCloser,
+		Share:      &shareAPI,
+		Blobstream: &blobstreamAPI,
+		Header:     &headerAPI,
+		Blob:       &readOnlyBlobAPI{&blobAPI},
+		closer:     closer,
 	}, nil
 }
 
 // Close closes all open connections to Celestia consensus nodes and Bridge nodes.
 func (c *ReadClient) Close() error {
-	return c.chainCloser()
+	return c.closer()
 }


### PR DESCRIPTION
Close could be called on nil client during Submission client construction.

```
2025-09-03 13:41:58 INFO [09-03|17:41:58.524] Key path                                 path=/home/celestia
2025-09-03 13:41:58 INFO [09-03|17:41:58.558] Core URL:                                url=http://localestia:26658/
2025-09-03 13:41:58 panic: runtime error: invalid memory address or nil pointer dereference
2025-09-03 13:41:58 [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3ab8226]
2025-09-03 13:41:58 
2025-09-03 13:41:58 goroutine 1 [running]:
2025-09-03 13:41:58 github.com/celestiaorg/celestia-node/api/client.(*Client).Close(...)
2025-09-03 13:41:58     /go/pkg/mod/github.com/celestiaorg/celestia-node@v0.25.3/api/client/client.go:145
2025-09-03 13:41:58 github.com/celestiaorg/celestia-node/api/client.New({0x52143c8, 0x8014400}, {{{0x7ffc101b3ecd, 0x17}, {0x0, 0x0}, 0x0, 0x0}, {{0x48ab231, 0xc}, ...}}, ...)
2025-09-03 13:41:58     /go/pkg/mod/github.com/celestiaorg/celestia-node@v0.25.3/api/client/client.go:81 +0x206
2025-09-03 13:41:58 github.com/celestiaorg/nitro-das-celestia/daserver.NewCelestiaDA(0xc0014e0dd0)
2025-09-03 13:41:58     /nitro-das-celestia/daserver/celestia.go:203 +0x396
2025-09-03 13:41:58 main.startup()
2025-09-03 13:41:58     /nitro-das-celestia/cmd/celestiadaserver.go:183 +0x40e
2025-09-03 13:41:58 main.main()
2025-09-03 13:41:58     /nitro-das-celestia/cmd/celestiadaserver.go:68 +0x17
2025-09-03 13:41:58 
2025-09-03 13:41:58 NAME: my_celes_key
2025-09-03 13:41:58 ADDRESS: celestia19uflsv5y4c5qu5j4gd48uxf63w5q8lz6629c6d
```