### PR TITLE
param(share/availability)!: Decrease storage window from 30 days to 7 days + 1 hour

### DIFF
--- a/share/availability/window.go
+++ b/share/availability/window.go
@@ -9,8 +9,7 @@ import (
 const (
 	SamplingWindow = 7 * 24 * time.Hour // Ref: CIP-036
 	RequestWindow  = SamplingWindow
-	// StorageWindow TODO @renaynay: point it back to RequestWindow + 1 hr in following release
-	StorageWindow = (30 * 24 * time.Hour) + time.Hour
+	StorageWindow  = RequestWindow + time.Hour
 )
 
 var ErrOutsideSamplingWindow = errors.New("timestamp outside sampling window")

--- a/share/availability/window_test.go
+++ b/share/availability/window_test.go
@@ -12,5 +12,5 @@ import (
 func TestConsts(t *testing.T) {
 	assert.Equal(t, SamplingWindow, 7*24*time.Hour)
 	assert.Equal(t, RequestWindow, 7*24*time.Hour)
-	assert.Equal(t, StorageWindow, (30*24*time.Hour)+time.Hour)
+	assert.Equal(t, StorageWindow, RequestWindow+time.Hour)
 }


### PR DESCRIPTION
Decreases storage window to 7 days + 1 hour. Part of progressive rollout of 7-day sampling window.