### PR TITLE
Revert "dep: bump go-square (#4540)"

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -115,7 +115,7 @@ func (b *Blob) Length() (int, error) {
 	if len(s) == 0 {
 		return 0, errors.New("blob with zero shares received")
 	}
-	return libshare.SparseSharesNeededV2(s[0].SequenceLen(), b.HasSigner()), nil
+	return libshare.SparseSharesNeeded(s[0].SequenceLen()), nil
 }
 
 // Signer returns blob's author.

--- a/blob/parser.go
+++ b/blob/parser.go
@@ -40,8 +40,7 @@ func (p *parser) set(index int, shrs []libshare.Share) ([]libshare.Share, error)
 	// `+=` as index could be updated in `skipPadding`
 	p.index += index
 	length := shrs[0].SequenceLen()
-	containsSigner := shrs[0].Version() == libshare.ShareVersionOne
-	p.length = libshare.SparseSharesNeededV2(length, containsSigner)
+	p.length = libshare.SparseSharesNeeded(length)
 	return shrs, nil
 }
 

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -152,7 +152,7 @@ func TestBlobService_Get(t *testing.T) {
 					require.True(t, bytes.Equal(smpls[0].ToBytes(), resultShares[shareOffset].ToBytes()),
 						fmt.Sprintf("issue on %d attempt. ROW:%d, COL: %d, blobIndex:%d", i, row, col, blobs[i].index),
 					)
-					shareOffset += libshare.SparseSharesNeededV2(uint32(len(blobs[i].Data())), blobs[i].HasSigner())
+					shareOffset += libshare.SparseSharesNeeded(uint32(len(blobs[i].Data())))
 				}
 			},
 		},
@@ -533,7 +533,7 @@ func TestService_Get(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, smpls[0].Share, resultShares[shareOffset], fmt.Sprintf("issue on %d attempt", i))
-		shareOffset += libshare.SparseSharesNeededV2(uint32(len(blob.Data())), blob.HasSigner())
+		shareOffset += libshare.SparseSharesNeeded(uint32(len(blob.Data())))
 	}
 }
 
@@ -595,7 +595,7 @@ func TestService_GetAllWithoutPadding(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, smpls[0].Share, resultShares[shareOffset])
-		shareOffset += libshare.SparseSharesNeededV2(uint32(len(blob.Data())), blob.HasSigner())
+		shareOffset += libshare.SparseSharesNeeded(uint32(len(blob.Data())))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/celestiaorg/go-header v0.7.2
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2
 	github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076
-	github.com/celestiaorg/go-square/v2 v2.3.2
+	github.com/celestiaorg/go-square/v2 v2.3.1
 	github.com/celestiaorg/nmt v0.24.1
 	github.com/celestiaorg/rsmt2d v0.14.0
 	github.com/cometbft/cometbft v0.38.17

--- a/go.sum
+++ b/go.sum
@@ -819,8 +819,8 @@ github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
 github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076 h1:PYInrsYzrDIsZW9Yb86OTi2aEKuPcpgJt6Mc0Jlc/yg=
 github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076/go.mod h1:hlidgivKyvv7m4Yl2Fdf2mSTmazZYxX8+bnr5IQrI98=
-github.com/celestiaorg/go-square/v2 v2.3.2 h1:taVqiK0UyWl1H1lNQ8UEYo3ZbubJtoWcMgVtAdRWtGs=
-github.com/celestiaorg/go-square/v2 v2.3.2/go.mod h1:NeHFT8wbfGWNEieqOBL55copZd6DPchX3CEAlRkCt30=
+github.com/celestiaorg/go-square/v2 v2.3.1 h1:CDdiQ+QkKPOQEcyDPODgP/PbAEzqUcftsohCPcbvsnw=
+github.com/celestiaorg/go-square/v2 v2.3.1/go.mod h1:6M2txj0j6dkoE+cgwyG0EqrEPhbZpM2R1lsWEopMIBc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
 github.com/celestiaorg/nmt v0.24.1 h1:MhGKqp257eq2EQQKcva1H/BSYFqIt0Trk8/t3IWfWSw=


### PR DESCRIPTION
This version of go-square is **breaking** and should not be released.