### PR TITLE
shwap(shrex/server): fix logging on server side

### DIFF
--- a/share/shwap/p2p/shrex/server.go
+++ b/share/shwap/p2p/shrex/server.go
@@ -169,7 +169,7 @@ func (srv *Server) handleDataRequest(ctx context.Context, requestID request, str
 
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			logger.Errorf("file not found in store")
+			logger.Warn("file not found in store")
 			return respondStatus(logger, shrexpb.Status_NOT_FOUND, stream)
 		}
 		logger.Errorf("getting header %w", err)


### PR DESCRIPTION
Changed log level on server side in case if header is not found in store. It's not necessary bloating logs with errors since this is a normal case when header is not found.