### PR TITLE
fix(share/shwap): mismatched row roots error formatting

### DIFF
--- a/share/shwap/range_namespace_data.go
+++ b/share/shwap/range_namespace_data.go
@@ -180,7 +180,7 @@ func (rngdata *RangeNamespaceData) verifyShares(
 		return fmt.Errorf("mismatched number of rows: expected %d vs got %d", to.Row-from.Row+1, len(shares))
 	}
 	if len(expectedRoots) != len(shares) {
-		return fmt.Errorf("mismatched row roots: expected %d vs got %d", len(shares), expectedRoots)
+		return fmt.Errorf("mismatched row roots: expected %d vs got %d", len(shares), len(expectedRoots))
 	}
 	if rngdata.FirstIncompleteRowProof != nil && rngdata.FirstIncompleteRowProof.Start() != from.Col {
 		return fmt.Errorf(


### PR DESCRIPTION
Replace printing a slice with its length in the error message within RangeNamespaceData.verifyShares. Previously, the code passed the slice expectedRoots to a %d formatter, producing malformed output (e.g., %!d(MISSING=...)) instead of the intended count. This change aligns the message with the rest of the codebase, improves debuggability, and does not affect runtime logic.