### PR TITLE
docs: fix typos in comments and error messages

### DIFF
--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -290,7 +290,7 @@ func constraintBadgerConfig() *dsbadger.Options {
 	opts.GcDiscardRatio = 0.125
 	// removes the pause in between GC rounds
 	// empirically, it doesn't cause any noticeable performance impact
-	// while it significantly speeds up disk space reclaimation for deleted data
+	// while it significantly speeds up disk space reclamation for deleted data
 	opts.GcSleep = 0
 
 	// badger stores checksum for every value, but doesn't verify it by default

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -167,7 +167,7 @@ func (s *Swamp) DefaultTestConfig(tp node.Type) *nodebuilder.Config {
 	cfg.Core.IP = ip
 	cfg.Core.Port = port
 	// set port to zero so that OS allocates one
-	// this avoids port collissions between nodes and tests
+	// this avoids port collisions between nodes and tests
 	cfg.RPC.Port = "0"
 
 	for _, bootstrapper := range s.Bootstrappers {

--- a/share/shwap/getters/cascade.go
+++ b/share/shwap/getters/cascade.go
@@ -123,7 +123,7 @@ func (cg *CascadeGetter) GetRangeNamespaceData(
 	}
 	if from >= to {
 		return shwap.RangeNamespaceData{},
-			fmt.Errorf("start must not be bigger or eqaul to end: %d-%d", from, to)
+			fmt.Errorf("start must not be bigger or equal to end: %d-%d", from, to)
 	}
 
 	get := func(ctx context.Context, get shwap.Getter) (shwap.RangeNamespaceData, error) {

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -71,7 +71,7 @@ type CoreAccessor struct {
 	estimatorServiceTLS  bool
 	estimatorConn        *grpc.ClientConn
 
-	// these fields are mutatable and thus need to be protected by a mutex
+	// these fields are mutable and thus need to be protected by a mutex
 	lock            sync.Mutex
 	lastPayForBlob  int64
 	payForBlobCount int64


### PR DESCRIPTION

- **`nodebuilder/store.go`**: fixed `reclaimation` → `reclamation`
- **`nodebuilder/tests/swamp/swamp.go`**: fixed `collissions` → `collisions`
- **`share/shwap/getters/cascade.go`**: fixed `eqaul` → `equal`
- **`state/core_access.go`**: fixed `mutatable` → `mutable`

