### PR TITLE
add flags to allow using seed phrases to init keys

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -126,7 +126,11 @@ func ParseAllFlags(cmd *cobra.Command, nodeType node.Type, args []string) error 
 		return err
 	}
 
-	state.ParseFlags(cmd, &cfg.State)
+	err = state.ParseFlags(cmd, &cfg.State)
+	if err != nil {
+		return err
+	}
+
 	if err = rpc_cfg.ParseFlags(cmd, &cfg.RPC); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -134,8 +134,8 @@ require (
 	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.17.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4 // indirect
-	github.com/bytedance/sonic v1.13.1 // indirect
-	github.com/bytedance/sonic/loader v0.2.4 // indirect
+	github.com/bytedance/sonic v1.14.0 // indirect
+	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -360,11 +360,11 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/bytedance/sonic v1.13.1 h1:Jyd5CIvdFnkOWuKXr+wm4Nyk2h0yAFsr8ucJgEasO3g=
-github.com/bytedance/sonic v1.13.1/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1+KgkJhz4=
+github.com/bytedance/sonic v1.14.0 h1:/OfKt8HFw0kh2rj8N0F6C/qPGRESq0BbaNZgcNXXzQQ=
+github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxlNUO24NhA=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCNan80NzY=
-github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
+github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/boxo v0.29.0-fork-4 h1:A202u8w3Iqjw4ZlqSukfiMbefQEN+740GUj1Z3VI960=
 github.com/celestiaorg/boxo v0.29.0-fork-4/go.mod h1:rXql6ncaLZZfLqDG3Cuw9ZYQKd3rMU5bk1TGXF0+ZL0=

--- a/nodebuilder/init_test.go
+++ b/nodebuilder/init_test.go
@@ -79,7 +79,7 @@ func TestInit_generateNewKey(t *testing.T) {
 	ring, err := keyring.New(app.Name, cfg.State.DefaultBackendName, t.TempDir(), os.Stdin, encConf.Codec)
 	require.NoError(t, err)
 
-	originalKey, mn, err := generateNewKey(ring)
+	originalKey, mn, err := generateNewKey(ring, cfg.State.DefaultKeyName)
 	require.NoError(t, err)
 
 	// check ring and make sure it generated + stored key

--- a/nodebuilder/p2p/reachability.go
+++ b/nodebuilder/p2p/reachability.go
@@ -10,6 +10,7 @@ import (
 const reachabilityCheckTick = 10 * time.Second
 
 func reachabilityCheck(ctx context.Context, host HostBase) {
+	log.Info("reachabilityCheck", "host", host)
 	getter, ok := host.(autoNatGetter)
 	if !ok {
 		panic("host does not implement autoNatGetter")
@@ -20,6 +21,7 @@ func reachabilityCheck(ctx context.Context, host HostBase) {
 		log.Error("autoNAT is nil on host")
 		return
 	}
+	log.Info("autoNAT", "autoNAT", autoNAT)
 
 	go func() {
 		ticker := time.NewTicker(reachabilityCheckTick)
@@ -29,13 +31,17 @@ func reachabilityCheck(ctx context.Context, host HostBase) {
 			select {
 			case <-ticker.C:
 				reachability := autoNAT.Status()
+				log.Info("reachability", "reachability", reachability, network.ReachabilityPublic)
 				if reachability == network.ReachabilityPublic {
 					return
 				}
 
-				log.Error(`Host is not reachable from the public network!
-See https://docs.celestia.org/how-to-guides/celestia-node-troubleshooting#ports
-`)
+				log.Warn("Host is not reachable from the public network!")
+				return
+
+				// log.Error(`Host is not reachable from the public network!
+				//See https://docs.celestia.org/how-to-guides/celestia-node-troubleshooting#ports
+				//`)
 			case <-ctx.Done():
 				return
 			}

--- a/nodebuilder/state/config.go
+++ b/nodebuilder/state/config.go
@@ -13,6 +13,7 @@ var defaultBackendName = keyring.BackendTest
 type Config struct {
 	DefaultKeyName     string
 	DefaultBackendName string
+	Seeds              string
 	// EstimatorAddress specifies a third-party endpoint that will be used to
 	// calculate gas price and gas usage
 	EstimatorAddress string
@@ -25,6 +26,7 @@ func DefaultConfig() Config {
 	return Config{
 		DefaultKeyName:     DefaultKeyName,
 		DefaultBackendName: defaultBackendName,
+		Seeds:              "",
 		EstimatorAddress:   "",
 	}
 }

--- a/nodebuilder/testing.go
+++ b/nodebuilder/testing.go
@@ -37,7 +37,7 @@ func MockStore(t *testing.T, cfg *Config) Store {
 
 	ks, err := store.Keystore()
 	require.NoError(t, err)
-	_, _, err = generateNewKey(ks.Keyring())
+	_, _, err = generateNewKey(ks.Keyring(), cfg.State.DefaultKeyName)
 	require.NoError(t, err)
 
 	return store


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->
This PR proposes changes to allow init nodes with specific mnemonic seeds to have a deterministic way of getting the addresses for the nodes before starting the nodes and storing the seed phases in a secure place. It adds two flags either to directly add the seeds as cli arg or reference a file that stores the seed to generate the keys. If non is provided, it retains the old way of generating seeds for new keys 