### PR TITLE
feat: add the ability to submit blobs in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ vendor
 coverage.txt
 go.work
 go.work.sum
+.gocache/

--- a/docs/adr/adr-009-public-api.md
+++ b/docs/adr/adr-009-public-api.md
@@ -412,6 +412,14 @@ type BankModule interface {
 }
 ```
 
+Nodes can enable parallel PayForBlob submission by configuring `state.WorkerAccounts`.
+The default value of `1` retains the existing single-account behaviour, while setting
+`0` disables the parallel pool entirely. Values greater than `1` cause the node to
+automatically create `parallel-worker-*` accounts and issue fee grants so the default
+signer pays their transaction fees. Parallel submission currently only applies when
+the default signer and fee granter are used; specifying alternate values in
+`TxConfig` falls back to the single-account path.
+
 ##### Staking (same as pre-mainnet staking module)
 
 ```go

--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
 	github.com/benbjohnson/clock v1.3.5
-	github.com/celestiaorg/celestia-app/v6 v6.0.5-mocha
+	github.com/celestiaorg/celestia-app/v6 v6.0.5-mocha.0.20250926041208-7a619208c27c // v6.0.5-mocha
 	github.com/celestiaorg/go-fraud v0.2.3
 	github.com/celestiaorg/go-header v0.7.3
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2
 	github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076
 	github.com/celestiaorg/go-square/v3 v3.0.1
-	github.com/celestiaorg/nmt v0.24.1
-	github.com/celestiaorg/rsmt2d v0.15.0
+	github.com/celestiaorg/nmt v0.24.2
+	github.com/celestiaorg/rsmt2d v0.15.1
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-sdk v0.50.13
 	github.com/cristalhq/jwt/v5 v5.4.0

--- a/go.sum
+++ b/go.sum
@@ -798,8 +798,8 @@ github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFos
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/boxo v0.29.0-fork-4 h1:A202u8w3Iqjw4ZlqSukfiMbefQEN+740GUj1Z3VI960=
 github.com/celestiaorg/boxo v0.29.0-fork-4/go.mod h1:rXql6ncaLZZfLqDG3Cuw9ZYQKd3rMU5bk1TGXF0+ZL0=
-github.com/celestiaorg/celestia-app/v6 v6.0.5-mocha h1:yulXc4wCoN/6Tk7LN60dq0qHuHjuMiOoutPFz29I02A=
-github.com/celestiaorg/celestia-app/v6 v6.0.5-mocha/go.mod h1:nxy0MoB7daPjWKpt07hrX3ASrQ4lWyT7QiudqrJRoYY=
+github.com/celestiaorg/celestia-app/v6 v6.0.5-mocha.0.20250926041208-7a619208c27c h1:VFh2bk9jKXYnRlKWXVMqHvWOfF40ZeiYBDTQoERw0nY=
+github.com/celestiaorg/celestia-app/v6 v6.0.5-mocha.0.20250926041208-7a619208c27c/go.mod h1:S7nnfmN6ZiMGthW+60mUCryeTz60MWyj6rNiJ+e2t6w=
 github.com/celestiaorg/celestia-core v0.39.4 h1:h0WaG8KsP0JyiAVhHipoIgvBP0CYLG/9whUccy1lDlY=
 github.com/celestiaorg/celestia-core v0.39.4/go.mod h1:t7cSYwLFmpz5RjIBpC3QjpbRoa+RfQ0ULdh+LciKuq8=
 github.com/celestiaorg/cosmos-sdk v0.51.2 h1:a9WguK7BaeuqCVnOa3m3ThwXKBL/RxQ46gRz+TP4yKQ=
@@ -824,10 +824,10 @@ github.com/celestiaorg/ibc-go/v8 v8.7.2 h1:AWae851fdX7pJWlGnUBKlKJzpr4c2t5m4TLs6
 github.com/celestiaorg/ibc-go/v8 v8.7.2/go.mod h1:E3WTax+cfyDIehNRpwEI96/0E8GBtU1g9XWr18qUGZ8=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
-github.com/celestiaorg/nmt v0.24.1 h1:MhGKqp257eq2EQQKcva1H/BSYFqIt0Trk8/t3IWfWSw=
-github.com/celestiaorg/nmt v0.24.1/go.mod h1:IhLnJDgCdP70crZFpgihFmU6G+PGeXN37tnMRm+/4iU=
-github.com/celestiaorg/rsmt2d v0.15.0 h1:iCw+ghtH+xUK0dFIVZv4dGptoXJK/76UBj6aVsu9h7w=
-github.com/celestiaorg/rsmt2d v0.15.0/go.mod h1:E1GzIiYgMw1mPVWXyQSCSOFVGXoTMHQouh4C6fj5IT0=
+github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpchg=
+github.com/celestiaorg/nmt v0.24.2/go.mod h1:vgLBpWBi8F5KLxTdXSwb7AU4NhiIQ1AQRGa+PzdcLEA=
+github.com/celestiaorg/rsmt2d v0.15.1 h1:NF4D0LX501oDjw00RoJrTUrMHrO+Kv0LewL0FKQU7hg=
+github.com/celestiaorg/rsmt2d v0.15.1/go.mod h1:WKkpXoD1foHn4qgFx6GNoz36Wm0fbCh29ze4rA7ZwCs=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=

--- a/nodebuilder/state/config.go
+++ b/nodebuilder/state/config.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 
 	"github.com/celestiaorg/celestia-node/libs/utils"
@@ -19,6 +21,17 @@ type Config struct {
 	// EnableEstimatorTLS specifies whether to use TLS for the gRPC connection to the
 	// estimator service
 	EnableEstimatorTLS bool
+	// WorkerAccounts defines how many accounts the TxClient should manage for
+	// PayForBlob submissions. A value of 0 disables queued submission entirely, which
+	// results in submitting blobs immediately without waiting for previous blobs to be
+	// confirmed. This is not reccomended at this time. Setting the value to a value of
+	// 1 enables queued submission, which means blobs are added to a queue and submitted
+	// one after another. No additional accounts are initialized. Values greater than 1
+	// enable automatic creation and management of additional worker accounts for
+	// parallel submissions. This means that blobs can be submitted by multiple different
+	// signers, and that blobs will not be submitted on chain in the original sending order.
+	// This is highly reccomended for high throughput chains.
+	WorkerAccounts int
 }
 
 func DefaultConfig() Config {
@@ -26,11 +39,16 @@ func DefaultConfig() Config {
 		DefaultKeyName:     DefaultKeyName,
 		DefaultBackendName: defaultBackendName,
 		EstimatorAddress:   "",
+		WorkerAccounts:     1,
 	}
 }
 
 // Validate performs basic validation of the config.
 func (cfg *Config) Validate() error {
+	if cfg.WorkerAccounts < 0 {
+		return fmt.Errorf("worker accounts must be zero or positive")
+	}
+
 	if cfg.EstimatorAddress == "" {
 		return nil
 	}

--- a/nodebuilder/state/core.go
+++ b/nodebuilder/state/core.go
@@ -43,6 +43,9 @@ func coreAccessor(
 			opts = append(opts, state.WithEstimatorServiceTLS())
 		}
 	}
+	if cfg.WorkerAccounts > 0 {
+		opts = append(opts, state.WithWorkerAccounts(cfg.WorkerAccounts))
+	}
 
 	ca, err := state.NewCoreAccessor(keyring, string(keyname), sync, client, network.String(), opts...)
 

--- a/nodebuilder/state/flags.go
+++ b/nodebuilder/state/flags.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -12,6 +13,7 @@ var (
 	keyringBackendFlag          = "keyring.backend"
 	estimatorServiceAddressFlag = "estimator.service.address"
 	estimatorServiceTLSFlag     = "estimator.service.tls"
+	txWorkerAccountsFlag        = "tx.worker.accounts"
 )
 
 // Flags gives a set of hardcoded State flags.
@@ -36,6 +38,12 @@ func Flags() *flag.FlagSet {
 		false,
 		"enables TLS for the estimator service gRPC connection",
 	)
+	flags.Int(
+		txWorkerAccountsFlag,
+		1,
+		"specifies how many accounts the TxClient manages for PayForBlob submission.\n"+
+			"0 disables parallel submission. Values greater than 1 automatically create \"parallel-worker-*\" accounts and grant them fees using the default signer.",
+	)
 
 	return flags
 }
@@ -55,5 +63,12 @@ func ParseFlags(cmd *cobra.Command, cfg *Config) {
 
 	if cmd.Flag(estimatorServiceTLSFlag).Changed {
 		cfg.EnableEstimatorTLS = true
+	}
+
+	if cmd.Flag(txWorkerAccountsFlag).Changed {
+		value, err := strconv.Atoi(cmd.Flag(txWorkerAccountsFlag).Value.String())
+		if err == nil {
+			cfg.WorkerAccounts = value
+		}
 	}
 }

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -51,6 +51,12 @@ type CoreAccessor struct {
 
 	keyring keyring.Keyring
 	client  *user.TxClient
+	// workerAccounts defines how many accounts the tx client manages for
+	// PayForBlob submissions. A value of zero keeps async submission.
+	// Value of 1 uses synchonous submission. Value of > 1 uses parallel
+	// submission. Parallel and async submission are not guaranteed to
+	// include blobs in the same order as they were submitted.
+	workerAccounts int
 
 	// TODO @renaynay: clean this up -- only one!!!!
 	defaultSignerAccount string
@@ -155,6 +161,12 @@ func (ca *CoreAccessor) Stop(_ context.Context) error {
 		ca.estimatorConn = nil
 	}
 
+	if ca.client != nil {
+		if pool := ca.client.ParallelPool(); pool != nil {
+			pool.Stop()
+		}
+	}
+
 	return nil
 }
 
@@ -213,6 +225,38 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 		opts = append(opts, feeGrant)
 	}
 
+	if ca.canUseParallel(cfg) {
+		resultsC, err := client.SubmitPayForBlobParallel(ctx, libBlobs, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to submit blobs: %w", err)
+		}
+
+		result, err := ca.waitForParallelResult(ctx, resultsC)
+		if err != nil {
+			return nil, err
+		}
+
+		if result.Error != nil {
+			if apperrors.IsInsufficientFee(result.Error) {
+				if cfg.isGasPriceSet {
+					return nil, fmt.Errorf("failed to submit blobs due to insufficient gas price in txconfig: %w", result.Error)
+				}
+				return nil, fmt.Errorf("failed to submit blobs due to insufficient estimated gas price %f: %w", gasPrice, result.Error)
+			}
+			return nil, fmt.Errorf("failed to submit blobs: %w", result.Error)
+		}
+
+		if result.TxResponse == nil {
+			return nil, fmt.Errorf("failed to submit blobs: parallel submission returned nil response")
+		}
+
+		if result.TxResponse.Code == 0 {
+			ca.markSuccessfulPFB()
+		}
+
+		return convertToSdkTxResponse(result.TxResponse), nil
+	}
+
 	response, err := client.SubmitPayForBlobWithAccount(ctx, account.Name(), libBlobs, opts...)
 	if err == nil {
 		// metrics should only be counted on a successful PFB tx
@@ -231,6 +275,45 @@ func (ca *CoreAccessor) SubmitPayForBlob(
 	}
 
 	return nil, fmt.Errorf("failed to submit blobs: %w", err)
+}
+
+func (ca *CoreAccessor) canUseParallel(cfg *TxConfig) bool {
+	if ca.workerAccounts <= 0 {
+		return false
+	}
+	if cfg == nil {
+		return true
+	}
+
+	defaultAddr := ca.defaultSignerAddress.String()
+
+	if signer := cfg.SignerAddress(); signer != "" && signer != defaultAddr {
+		return false
+	}
+	if key := cfg.KeyName(); key != "" && key != ca.defaultSignerAccount {
+		return false
+	}
+	if granter := cfg.FeeGranterAddress(); granter != "" && granter != defaultAddr {
+		return false
+	}
+
+	return true
+}
+
+func (ca *CoreAccessor) waitForParallelResult(ctx context.Context, resultsC chan user.SubmissionResult) (user.SubmissionResult, error) {
+	if resultsC == nil {
+		return user.SubmissionResult{}, fmt.Errorf("failed to submit blobs: parallel submission not configured")
+	}
+
+	select {
+	case <-ctx.Done():
+		return user.SubmissionResult{}, fmt.Errorf("failed to submit blobs: %w", ctx.Err())
+	case result, ok := <-resultsC:
+		if !ok {
+			return user.SubmissionResult{}, fmt.Errorf("failed to submit blobs: parallel submission results channel closed")
+		}
+		return result, nil
+	}
 }
 
 func (ca *CoreAccessor) AccountAddress(context.Context) (Address, error) {
@@ -522,6 +605,10 @@ func (ca *CoreAccessor) setupTxClient(ctx context.Context) error {
 
 		opts = append(opts, user.WithEstimatorService(estimatorConn))
 		ca.estimatorConn = estimatorConn
+	}
+
+	if ca.workerAccounts > 0 {
+		opts = append(opts, user.WithTxWorkers(ca.workerAccounts))
 	}
 
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)

--- a/state/core_access_test.go
+++ b/state/core_access_test.go
@@ -5,6 +5,7 @@ package state
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v6/test/util/testnode"
 	apptypes "github.com/celestiaorg/celestia-app/v6/x/blob/types"
 	libshare "github.com/celestiaorg/go-square/v3/share"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestSubmitPayForBlob(t *testing.T) {
@@ -244,4 +246,82 @@ func buildAccessor(t *testing.T, opts ...Option) (*CoreAccessor, []string) {
 	ca, err := NewCoreAccessor(cctx.Keyring, accounts[0], nil, conn, chainID, opts...)
 	require.NoError(t, err)
 	return ca, accounts
+}
+
+func TestParallelPayForBlobSubmission(t *testing.T) {
+	const (
+		workerAccounts = 4
+		blobCount      = 10
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	chainID := "private"
+
+	t.Helper()
+	accounts := []string{
+		"jimmy", "carl", "sheen", "cindy",
+	}
+
+	config := testnode.DefaultConfig().
+		WithChainID(chainID).
+		WithFundedAccounts(accounts...).
+		WithDelayedPrecommitTimeout(time.Millisecond)
+
+	cctx, _, grpcAddr := testnode.NewNetwork(t, config)
+
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	ca, err := NewCoreAccessor(cctx.Keyring, accounts[0], nil, conn, chainID, WithWorkerAccounts(workerAccounts))
+	require.NoError(t, err)
+	err = ca.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ca.Stop(ctx)
+	})
+
+	blobs := make([][]*libshare.Blob, blobCount)
+	for i := 0; i < blobCount; i++ {
+		generated, err := libshare.GenerateV0Blobs([]int{8}, false)
+		require.NoError(t, err)
+		blobs[i] = generated
+	}
+
+	responses := make([]*TxResponse, blobCount)
+	var g errgroup.Group
+
+	for i := 0; i < blobCount; i++ {
+		idx := i
+		g.Go(func() error {
+			resp, err := ca.SubmitPayForBlob(ctx, blobs[idx], NewTxConfig())
+			if err != nil {
+				return err
+			}
+			if resp == nil {
+				return fmt.Errorf("nil response for blob %d", idx)
+			}
+			if resp.Code != 0 {
+				return fmt.Errorf("unexpected code for blob %d: %d", idx, resp.Code)
+			}
+			responses[idx] = resp
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
+
+	hashes := make(map[string]struct{}, blobCount)
+	for _, resp := range responses {
+		require.NotNil(t, resp)
+		hashes[resp.TxHash] = struct{}{}
+	}
+	require.Len(t, hashes, blobCount)
+
+	for i := 1; i < workerAccounts; i++ {
+		name := fmt.Sprintf("parallel-worker-%d", i)
+		_, err := ca.keyring.Key(name)
+		require.NoError(t, err, "expected worker account %s", name)
+	}
 }

--- a/state/option.go
+++ b/state/option.go
@@ -28,3 +28,12 @@ func WithAdditionalCoreEndpoints(conns []*grpc.ClientConn) Option {
 		ca.coreConns = append(ca.coreConns, conns...)
 	}
 }
+
+// WithWorkerAccounts configures the CoreAccessor to manage the provided number of
+// worker accounts via the TxClient. A value of zero leaves parallel
+// submission disabled.
+func WithWorkerAccounts(workerAccounts int) Option {
+	return func(ca *CoreAccessor) {
+		ca.workerAccounts = workerAccounts
+	}
+}


### PR DESCRIPTION
This is a draft until we get an official release from app, but it would be super useful for me to get reviews from node folks as I do not know what I'm doing in this repo :sweat_smile: 

Currently, node automatically submits blobs asynchronously. Meaning we can submit multiple per block, but the ordering isn't guaranteed.

This adds the ability to submit blobs in parallel and the ability to submit blobs synchronously.

 Synchronous (workers == 1) has a single worker that has a queue of blobs. It submits the blob, waits for it to be confirmed, and then submits the next blob in the queue. This doesn't guarantee order, as its possible a tx fails or gets evicted and the next blob in the queue does not. However most importantly avoids sequence mismatches since we're only ever submitting a single blob from an account at once. The account that is submitting the blob here is the one passed to TxClient.
 
Parallel submission works in the exact same way, except there are more than one worker. In order to manage these accounts, it creates new ones and grants them a feegrant by submitting a single transaction for all accounts that don't already have this. This ofc means that different accounts will submit blobs. All accounts are in the same keyring that has the main account.
 
 
