### PR TITLE
fix(share/shwap/p2p/shrex): defer stream close in doRequest

### DIFF
--- a/share/shwap/p2p/shrex/client.go
+++ b/share/shwap/p2p/shrex/client.go
@@ -84,6 +84,12 @@ func (c *Client) doRequest(
 	if err != nil {
 		return statusOpenStreamErr, fmt.Errorf("open stream: %w", err)
 	}
+	defer func() {
+		err = stream.Close()
+		if err != nil {
+			log.Errorw("closing stream", "err", err, "peer", peer.String())
+		}
+	}()
 
 	c.setStreamDeadlines(ctx, logger, stream)
 


### PR DESCRIPTION
Fixes stream leak in shrex

Found by @vgonkivs 