### PR TITLE
fix: remove network suffix from version if multiple tags point to the same…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,24 @@ DIR_FULLPATH=$(shell pwd)
 versioningPath := github.com/celestiaorg/celestia-node/nodebuilder/node
 tastoraPath := github.com/celestiaorg/celestia-node/nodebuilder/tests/tastora
 OS := $(shell uname -s)
+VERSION = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || \
+              git describe --tags --dirty=-dev 2>/dev/null || \
+              git rev-parse --short HEAD)
+
 LDFLAGS = -ldflags="-X $(versioningPath).buildTime=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
                     -X $(versioningPath).lastCommit=$(shell git rev-parse HEAD) \
                     -X $(versioningPath).semanticVersion=$(shell \
-                      git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || \
-                      git describe --tags --dirty=-dev 2>/dev/null || \
-                      git rev-parse --short HEAD) \
+                      if [ $$(git tag --points-at HEAD | wc -l) -gt 1 ]; then \
+                        echo "$(VERSION)" | cut -d'-' -f1; \
+                      else \
+                        echo "$(VERSION)"; \
+                      fi) \
                     -X $(tastoraPath).defaultNodeTag=$(or $(CELESTIA_NODE_TAG),$(shell \
-                      git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || \
-                      git describe --tags --dirty=-dev 2>/dev/null || \
-                      git rev-parse --short HEAD))"
+                      if [ $$(git tag --points-at HEAD | wc -l) -gt 1 ]; then \
+                        echo "$(VERSION)" | cut -d'-' -f1; \
+                      else \
+                        echo "$(VERSION)"; \
+                      fi))"
 TAGS=integration
 SHORT=
 ifeq (${PREFIX},)


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->

fixes #4604

# Overview

Main issue is that currently it is not reliable the idea of automatically detecting which tag was checked out when multiple tags point to the same commit, and this often leads to confusion, e.g mocha build reporting as arabica.
The fix relies on removing the suffix upon multiple tags and retain the current behavior otherwise.

This PR consolidates the solution adopted in celestia-app to fix the same issue https://github.com/celestiaorg/celestia-app/pull/5894 


Tested checking out to v0.27.4-mocha and building locally:

without the fix: celestia version returns:
 ```
Semantic version: v0.27.4-arabica
Commit: 1a47ce5e2935afb53679b3120eda0a025435cb21
Build Date: 2025-09-30T09:30:03Z
System version: amd64/linux
Golang version: go1.24.6
```
with the fix: celestia version returns:
```
Semantic version: v0.27.4
Commit: 1a47ce5e2935afb53679b3120eda0a025435cb21
Build Date: 2025-09-30T09:30:03Z
System version: amd64/linux
Golang version: go1.24.6
```
