### PR TITLE
fix: correct typo in TODO tag

### DIFF
--- a/state/core_access.go
+++ b/state/core_access.go
@@ -254,7 +254,7 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 	prefixedAccountKey := append(v2bank.CreateAccountBalancesPrefix(addr.Bytes()), []byte(appconsts.BondDenom)...)
 	req := &tmservice.ABCIQueryRequest{
 		Data: prefixedAccountKey,
-		// TODO @renayay: once https://github.com/cosmos/cosmos-sdk/pull/12674 is merged, use const instead
+		// TODO @renaynay: once https://github.com/cosmos/cosmos-sdk/pull/12674 is merged, use const instead
 		Path:   fmt.Sprintf("store/%s/key", banktypes.StoreKey),
 		Height: int64(head.Height() - 1),
 		Prove:  true,


### PR DESCRIPTION

Changed `@renayay` to `@renaynay` in TODO comment

