### PR TITLE
fix(state): pass long lived core accessor ctx into txclient setup as ctx is now used to control lifecycle of tx workers

### DIFF
--- a/state/core_access.go
+++ b/state/core_access.go
@@ -529,7 +529,7 @@ func (ca *CoreAccessor) setupTxClient(ctx context.Context) error {
 		opts = append(opts, user.WithAdditionalCoreEndpoints(ca.coreConns[1:]))
 	}
 
-	client, err := user.SetupTxClient(ctx, ca.keyring, ca.coreConns[0], encCfg, opts...)
+	client, err := user.SetupTxClient(ca.ctx, ca.keyring, ca.coreConns[0], encCfg, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to setup a tx client: %w", err)
 	}


### PR DESCRIPTION
Fixes bug causing txclient tx workers to stop as ctx we passed to tx client setup was short lived startup ctx

overrides stuck/jailed https://github.com/celestiaorg/celestia-node/pull/4631 