### PR TITLE
refactor(blob): refactor blob's commitment proof verification method

### DIFF
--- a/blob/blob_fuzz_test.go
+++ b/blob/blob_fuzz_test.go
@@ -43,7 +43,7 @@ func FuzzBlobUnmarshal(f *testing.F) {
 type verifyCorpus struct {
 	CP         *CommitmentProof `json:"commitment_proof"`
 	Root       []byte           `json:"root"`
-	SThreshold int              `json:"sub_threshold"`
+	Commitment Commitment       `json:"commitment"`
 }
 
 func FuzzCommitmentProofVerify(f *testing.F) {
@@ -87,6 +87,6 @@ func FuzzCommitmentProofVerify(f *testing.F) {
 		if commitProof == nil {
 			return
 		}
-		_, _ = commitProof.Verify(val.Root, val.SThreshold)
+		_ = commitProof.Verify(val.Root, val.Commitment)
 	})
 }

--- a/blob/commitment_proof.go
+++ b/blob/commitment_proof.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v6/pkg/proof"
+	"github.com/celestiaorg/go-square/merkle"
 	"github.com/celestiaorg/go-square/v3/inclusion"
 	libshare "github.com/celestiaorg/go-square/v3/share"
 	"github.com/celestiaorg/nmt"
@@ -83,17 +84,29 @@ func (commitmentProof *CommitmentProof) Validate() error {
 }
 
 // Verify verifies that a commitment proof is valid, i.e., the subtree roots commit
-// to some data that was posted to a square.
-// Expects the commitment proof to be properly formulated and validated
-// using the Validate() function.
-func (commitmentProof *CommitmentProof) Verify(root []byte, subtreeRootThreshold int) (bool, error) {
-	if len(root) == 0 {
-		return false, errors.New("root must be non-empty")
+// to specific data that was posted to a square.
+func (commitmentProof *CommitmentProof) Verify(dataRoot, commitment []byte) error {
+	if len(dataRoot) == 0 {
+		return errors.New("root must be non-empty")
+	}
+
+	if len(commitment) == 0 {
+		return errors.New("commitment must be non-empty")
+	}
+
+	err := commitmentProof.Validate()
+	if err != nil {
+		return err
+	}
+
+	root := merkle.HashFromByteSlices(commitmentProof.SubtreeRoots)
+	if !bytes.Equal(commitment, root) {
+		return errors.New("current proof does not belong to the provided commitment")
 	}
 
 	rp := commitmentProof.RowProof
-	if err := rp.Validate(root); err != nil {
-		return false, err
+	if err := rp.Validate(dataRoot); err != nil {
+		return err
 	}
 
 	nmtHasher := nmt.NewNmtHasher(appconsts.NewBaseHashFunc(), libshare.NamespaceSize, true)
@@ -102,10 +115,6 @@ func (commitmentProof *CommitmentProof) Verify(root []byte, subtreeRootThreshold
 	numberOfShares := 0
 	for _, proof := range commitmentProof.SubtreeRootProofs {
 		numberOfShares += proof.End() - proof.Start()
-	}
-
-	if subtreeRootThreshold <= 0 {
-		return false, errors.New("subtreeRootThreshold must be > 0")
 	}
 
 	// use the computed total number of shares to calculate the subtree roots
@@ -121,15 +130,15 @@ func (commitmentProof *CommitmentProof) Verify(root []byte, subtreeRootThreshold
 		// calculate the share range that each subtree root commits to.
 		ranges, err := nmt.ToLeafRanges(subtreeRootProof.Start(), subtreeRootProof.End(), subtreeRootsWidth)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		if len(commitmentProof.SubtreeRoots) < subtreeRootsCursor {
-			return false, fmt.Errorf("len(commitmentProof.SubtreeRoots)=%d < subtreeRootsCursor=%d",
+			return fmt.Errorf("len(commitmentProof.SubtreeRoots)=%d < subtreeRootsCursor=%d",
 				len(commitmentProof.SubtreeRoots), subtreeRootsCursor)
 		}
 		if len(commitmentProof.SubtreeRoots) < subtreeRootsCursor+len(ranges) {
-			return false, fmt.Errorf("len(commitmentProof.SubtreeRoots)=%d < subtreeRootsCursor+len(ranges)=%d",
+			return fmt.Errorf("len(commitmentProof.SubtreeRoots)=%d < subtreeRootsCursor+len(ranges)=%d",
 				len(commitmentProof.SubtreeRoots), subtreeRootsCursor+len(ranges))
 		}
 		valid, err := subtreeRootProof.VerifySubtreeRootInclusion(
@@ -139,21 +148,24 @@ func (commitmentProof *CommitmentProof) Verify(root []byte, subtreeRootThreshold
 			commitmentProof.RowProof.RowRoots[i],
 		)
 		if err != nil {
-			return false, err
+			return err
 		}
 		if !valid {
-			return false,
-				fmt.Errorf(
-					"subtree root proof for range [%d, %d) is invalid",
-					subtreeRootProof.Start(),
-					subtreeRootProof.End(),
-				)
+			return fmt.Errorf(
+				"subtree root proof for range [%d, %d) is invalid",
+				subtreeRootProof.Start(),
+				subtreeRootProof.End(),
+			)
 		}
 		subtreeRootsCursor += len(ranges)
 	}
 
 	// verify row roots to data root proof
-	return commitmentProof.RowProof.VerifyProof(root), nil
+	valid := commitmentProof.RowProof.VerifyProof(dataRoot)
+	if !valid {
+		return fmt.Errorf("row roots were not included in the data root")
+	}
+	return nil
 }
 
 // MarshalJSON marshals an CommitmentProof to JSON. Uses tendermint encoder for row proof for compatibility.

--- a/blob/repro_test.go
+++ b/blob/repro_test.go
@@ -3,58 +3,73 @@ package blob
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/celestiaorg/celestia-app/v6/pkg/proof"
+	"github.com/celestiaorg/go-square/v3/inclusion"
+	libshare "github.com/celestiaorg/go-square/v3/share"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/pb"
 )
 
-// Reported at https://github.com/celestiaorg/celestia-node/issues/3731.
 func TestCommitmentProofRowProofVerifyWithEmptyRoot(t *testing.T) {
+	libBlob, err := libshare.GenerateV0Blobs([]int{8}, true)
+	require.NoError(t, err)
+	nodeBlob, err := ToNodeBlobs(libBlob...)
+	require.NoError(t, err)
+	roots, err := inclusion.GenerateSubtreeRoots(libBlob[0], subtreeRootThreshold)
+	require.NoError(t, err)
+
 	cp := &CommitmentProof{
+		SubtreeRoots: roots,
 		RowProof: proof.RowProof{
 			Proofs: []*proof.Proof{{}},
 		},
 	}
 	root := []byte{0xd3, 0x4d, 0x34}
-	if _, err := cp.Verify(root, 1); err == nil {
+	if err := cp.Verify(root, nodeBlob[0].Commitment); err == nil {
 		t.Fatal("expected a non-nil error")
 	}
 }
 
-// Reported at https://github.com/celestiaorg/celestia-node/issues/3730.
 func TestCommitmentProofRowProofVerify(t *testing.T) {
+	libBlob, err := libshare.GenerateV0Blobs([]int{8}, true)
+	require.NoError(t, err)
+	nodeBlob, err := ToNodeBlobs(libBlob...)
+	require.NoError(t, err)
+	roots, err := inclusion.GenerateSubtreeRoots(libBlob[0], subtreeRootThreshold)
+	require.NoError(t, err)
 	cp := &CommitmentProof{
+		SubtreeRoots: roots,
 		RowProof: proof.RowProof{
 			Proofs: []*proof.Proof{{}},
 		},
 	}
-	if _, err := cp.Verify(nil, 1); err == nil {
+	if err := cp.Verify(nil, nodeBlob[0].Commitment); err == nil {
 		t.Fatal("expected a non-nil error")
 	}
 }
 
-// Reported at https://github.com/celestiaorg/celestia-node/issues/3729.
 func TestCommitmentProofVerifySliceBound(t *testing.T) {
+	libBlob, err := libshare.GenerateV0Blobs([]int{8}, true)
+	require.NoError(t, err)
+	nodeBlob, err := ToNodeBlobs(libBlob...)
+	require.NoError(t, err)
+	roots, err := inclusion.GenerateSubtreeRoots(libBlob[0], subtreeRootThreshold)
+	require.NoError(t, err)
+
 	proof := nmt.ProtoToProof(pb.Proof{End: 1})
 	cp := &CommitmentProof{
+		SubtreeRoots: roots,
 		SubtreeRootProofs: []*nmt.Proof{
 			&proof,
 		},
 	}
-	if _, err := cp.Verify(nil, 1); err == nil {
+	if err := cp.Verify([]byte{0xd3, 0x4d, 0x34}, nodeBlob[0].Commitment); err == nil {
 		t.Fatal("expected a non-nil error")
 	}
 }
 
-// Reported at https://github.com/celestiaorg/celestia-node/issues/3728.
-func TestCommitmentProofVerifyZeroSubThreshold(t *testing.T) {
-	cp := new(CommitmentProof)
-	if _, err := cp.Verify(nil, 0); err == nil {
-		t.Fatal("expected a non-nil error")
-	}
-}
-
-// Reported at https://github.com/celestiaorg/celestia-node/issues/3727.
 func TestBlobUnmarshalRepro(t *testing.T) {
 	blob := new(Blob)
 	if err := blob.UnmarshalJSON([]byte("{}")); err == nil {

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -19,14 +19,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
-	pkgproof "github.com/celestiaorg/celestia-app/v6/pkg/proof"
 	"github.com/celestiaorg/celestia-app/v6/pkg/wrapper"
 	"github.com/celestiaorg/go-header/store"
-	"github.com/celestiaorg/go-square/merkle"
-	"github.com/celestiaorg/go-square/v3/inclusion"
 	libshare "github.com/celestiaorg/go-square/v3/share"
-	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
 
 	"github.com/celestiaorg/celestia-node/header"
@@ -973,7 +968,12 @@ func TestProveCommitmentAllCombinations(t *testing.T) {
 
 func proveAndVerifyShareCommitments(t *testing.T, blobSize int) {
 	msgs, blobs, nss, eds, _, _, dataRoot := edstest.GenerateTestBlock(t, blobSize, 10)
-	for msgIndex, msg := range msgs {
+	randomBlob, err := libshare.GenerateV0Blobs([]int{10}, true)
+	require.NoError(t, err)
+	nodeBlob, err := ToNodeBlobs(randomBlob...)
+	require.NoError(t, err)
+
+	for msgIndex := range msgs {
 		t.Run(fmt.Sprintf("msgIndex=%d", msgIndex), func(t *testing.T) {
 			blb, err := NewBlob(blobs[msgIndex].ShareVersion(), nss[msgIndex], blobs[msgIndex].Data(), nil)
 			require.NoError(t, err)
@@ -985,109 +985,19 @@ func proveAndVerifyShareCommitments(t *testing.T, blobSize int) {
 
 			// make sure the actual commitment attests to the data
 			require.NoError(t, actualCommitmentProof.Validate())
-			valid, err := actualCommitmentProof.Verify(
+			err = actualCommitmentProof.Verify(
 				dataRoot,
-				appconsts.SubtreeRootThreshold,
+				blb.Commitment,
 			)
 			require.NoError(t, err)
-			require.True(t, valid)
 
-			// generate an expected proof and verify it's valid
-			expectedCommitmentProof := generateCommitmentProofFromBlock(t, eds, nss[msgIndex], blobs[msgIndex], dataRoot)
-			require.NoError(t, expectedCommitmentProof.Validate())
-			valid, err = expectedCommitmentProof.Verify(
+			err = actualCommitmentProof.Verify(
 				dataRoot,
-				appconsts.SubtreeRootThreshold,
+				nodeBlob[0].Commitment,
 			)
-			require.NoError(t, err)
-			require.True(t, valid)
-
-			// make sure the expected proof is the same as the actual on
-			assert.Equal(t, expectedCommitmentProof, *actualCommitmentProof)
-
-			// make sure the expected commitment commits to the subtree roots in the result proof
-			actualCommitment, _ := merkle.ProofsFromByteSlices(actualCommitmentProof.SubtreeRoots)
-			assert.Equal(t, msg.ShareCommitments[0], actualCommitment)
+			require.Error(t, err)
 		})
 	}
-}
-
-// generateCommitmentProofFromBlock takes a block and a PFB index and generates the commitment proof
-// using the traditional way of doing, instead of using the API.
-func generateCommitmentProofFromBlock(
-	t *testing.T,
-	eds *rsmt2d.ExtendedDataSquare,
-	ns libshare.Namespace,
-	blob *libshare.Blob,
-	dataRoot []byte,
-) CommitmentProof {
-	// create the blob from the data
-	blb, err := NewBlob(blob.ShareVersion(),
-		ns,
-		blob.Data(),
-		nil,
-	)
-	require.NoError(t, err)
-
-	// convert the blob to a number of shares
-	blobShares, err := BlobsToShares(blb)
-	require.NoError(t, err)
-
-	// find the first share of the blob in the ODS
-	startShareIndex := -1
-	for i, sh := range eds.FlattenedODS() {
-		if bytes.Equal(sh, blobShares[0].ToBytes()) {
-			startShareIndex = i
-			break
-		}
-	}
-	require.Greater(t, startShareIndex, 0)
-
-	// create an inclusion proof of the blob using the share range instead of the commitment
-	sharesProof, err := pkgproof.NewShareInclusionProofFromEDS(
-		eds,
-		ns,
-		libshare.NewRange(startShareIndex, startShareIndex+len(blobShares)),
-	)
-	require.NoError(t, err)
-	require.NoError(t, sharesProof.Validate(dataRoot))
-
-	// calculate the subtree roots
-	subtreeRoots := make([][]byte, 0)
-	dataCursor := 0
-	for _, proof := range sharesProof.ShareProofs {
-		ranges, err := nmt.ToLeafRanges(
-			int(proof.Start),
-			int(proof.End),
-			inclusion.SubTreeWidth(len(blobShares), subtreeRootThreshold),
-		)
-		require.NoError(t, err)
-		roots, err := computeSubtreeRoots(
-			blobShares[dataCursor:int32(dataCursor)+proof.End-proof.Start],
-			ranges,
-			int(proof.Start),
-		)
-		require.NoError(t, err)
-		subtreeRoots = append(subtreeRoots, roots...)
-		dataCursor += int(proof.End - proof.Start)
-	}
-
-	// convert the nmt proof to be accepted by the commitment proof
-	nmtProofs := make([]*nmt.Proof, 0)
-	for _, proof := range sharesProof.ShareProofs {
-		nmtProof := nmt.NewInclusionProof(int(proof.Start), int(proof.End), proof.Nodes, true)
-		nmtProofs = append(nmtProofs, &nmtProof)
-	}
-
-	commitmentProof := CommitmentProof{
-		SubtreeRoots:      subtreeRoots,
-		SubtreeRootProofs: nmtProofs,
-		NamespaceID:       sharesProof.NamespaceId,
-		RowProof:          *sharesProof.RowProof,
-		NamespaceVersion:  uint8(sharesProof.NamespaceVersion),
-	}
-
-	return commitmentProof
 }
 
 func rawBlobSize(totalSize int) int {


### PR DESCRIPTION
Refactored `commitmentProof.Verify` method:
1) removed subtree root threshold from the input params(the node is using a const threshold in all places of the code)
2) added commitment to the input params
3) remove bool value from the returned values