### PR TITLE
refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -837,8 +837,8 @@ func BenchmarkGetByCommitment(b *testing.B) {
 	require.NoError(b, err)
 	service := createService(ctx, b, shares)
 	indexer := &parser{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		b.ReportAllocs()
 		indexer.reset()
 		indexer.verifyFn = func(blob *Blob) bool {

--- a/header/headertest/serde_test.go
+++ b/header/headertest/serde_test.go
@@ -73,7 +73,7 @@ func BenchmarkMsgID(b *testing.B) {
 
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = header.MsgID(msg)
 	}
 }

--- a/share/shwap/row_test.go
+++ b/share/shwap/row_test.go
@@ -143,8 +143,7 @@ func BenchmarkRowValidate(b *testing.B) {
 	row, err := RowFromEDS(eds, 0, Left)
 	require.NoError(b, err)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = row.Verify(root, 0)
 	}
 }

--- a/share/shwap/sample_test.go
+++ b/share/shwap/sample_test.go
@@ -111,8 +111,7 @@ func BenchmarkSampleValidate(b *testing.B) {
 	sample, err := inMem.SampleForProofAxis(shwap.SampleCoords{}, rsmt2d.Row)
 	require.NoError(b, err)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = sample.Verify(root, 0, 0)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->


These changes use b.Loop() to simplify the code and improve performance
Supported by Go Team, more info: https://go.dev/blog/testing-b-loop and https://go.dev/issue/73137.

Before:

```shell
 go test -run=^$ -bench=. ./blob  
goos: darwin
goarch: arm64
pkg: github.com/celestiaorg/celestia-node/blob
cpu: Apple M4
BenchmarkGetByCommitment-10    	    4675	    336084 ns/op	 1053903 B/op	    3418 allocs/op
PASS
ok  	github.com/celestiaorg/celestia-node/blob	3.784s

---

go test -run=^$ -bench=. ./header/headertest    
goos: darwin
goarch: arm64
pkg: github.com/celestiaorg/celestia-node/header/headertest
cpu: Apple M4
BenchmarkMsgID-10    	   39388	     33899 ns/op	  165967 B/op	     593 allocs/op
PASS
ok  	github.com/celestiaorg/celestia-node/header/headertest	2.866s

---

go test -run=^$ -bench=. ./share/shwap                 
goos: darwin
goarch: arm64
pkg: github.com/celestiaorg/celestia-node/share/shwap
cpu: Apple M4
BenchmarkRowValidate-10       	   37148	     32432 ns/op
BenchmarkSampleValidate-10    	 1000000	      1137 ns/op
PASS
ok  	github.com/celestiaorg/celestia-node/share/shwap	3.656s

```

After:


```shell

go test -run=^$ -bench=. ./blob       
goos: darwin
goarch: arm64
pkg: github.com/celestiaorg/celestia-node/blob
cpu: Apple M4
BenchmarkGetByCommitment-10    	    6092	    195211 ns/op	 1053908 B/op	    3418 allocs/op
PASS
ok  	github.com/celestiaorg/celestia-node/blob	3.558s


---

go test -run=^$ -bench=. ./header/headertest    
goos: darwin
goarch: arm64
pkg: github.com/celestiaorg/celestia-node/header/headertest
cpu: Apple M4
BenchmarkMsgID-10    	   59661	     20424 ns/op	  165957 B/op	     593 allocs/op
PASS
ok  	github.com/celestiaorg/celestia-node/header/headertest	2.491s

---


 go test -run=^$ -bench=. ./share/shwap  
goos: darwin
goarch: arm64
pkg: github.com/celestiaorg/celestia-node/share/shwap
cpu: Apple M4
BenchmarkRowValidate-10       	   35263	     33798 ns/op
BenchmarkSampleValidate-10    	  996700	      1180 ns/op
PASS
ok  	github.com/celestiaorg/celestia-node/share/shwap	3.404s



```

