### PR TITLE
core: return explicit error on AddPartWithoutProof ok=false in partsToBlock

### DIFF
--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -289,7 +289,7 @@ func partsToBlock(parts []*tmproto.Part) (*types.Block, error) {
 			return nil, err
 		}
 		if !ok {
-			return nil, err
+			return nil, fmt.Errorf("core/fetcher: failed to add part (index %d): duplicate or invalid", part.Index)
 		}
 	}
 	pbb := new(tmproto.Block)


### PR DESCRIPTION
This change fixes incorrect error handling in partsToBlock where a false ok result from PartSet.AddPartWithoutProof led to returning nil, err with err being nil, effectively masking failures such as duplicate or otherwise non-added parts. By returning a concrete error with context (part index) when ok is false, we ensure block reconstruction errors are surfaced to callers, aligning with CometBFT semantics that reserve non-nil err for validation failures and use ok=false for non-added cases (commonly duplicates). This prevents silent success, improves diagnosability, and maintains correct behavior in higher-level consumers like receiveBlockByHeight/receiveBlockByHash, Listener, and Exchange.