### PR TITLE
Use row-level EDS access to avoid per-cell copies in ODS/Q4 writers

### DIFF
--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -99,9 +99,11 @@ func writeODSFile(f *os.File, axisRoots *share.AxisRoots, eds *rsmt2d.ExtendedDa
 // row-major order. Write finishes once all the shares are written or on the first instance of tail
 // padding share. Tail padding share are constant and aren't stored.
 func writeODS(w io.Writer, eds *rsmt2d.ExtendedDataSquare) error {
-	for i := range eds.Width() / 2 {
-		for j := range eds.Width() / 2 {
-			shr := eds.GetCell(i, j) // TODO: Avoid copying inside GetCell
+	half := eds.Width() / 2
+	for i := range half {
+		row := eds.Row(uint(i))
+		for j := range half {
+			shr := row[j]
 			ns, err := libshare.NewNamespaceFromBytes(shr[:libshare.NamespaceSize])
 			if err != nil {
 				return fmt.Errorf("creating namespace: %w", err)
@@ -110,8 +112,7 @@ func writeODS(w io.Writer, eds *rsmt2d.ExtendedDataSquare) error {
 				return nil
 			}
 
-			_, err = w.Write(shr)
-			if err != nil {
+			if _, err := w.Write(shr); err != nil {
 				return fmt.Errorf("writing share: %w", err)
 			}
 		}


### PR DESCRIPTION
Refactor ODS and Q4 writers to read rows via eds.Row instead of per-cell GetCell to reduce allocations and method call overhead. The ODS writer retains early termination on the first tail padding share and both functions preserve row-major write order and existing error handling.