### PR TITLE
test(share/eds): t.Skip retrieval tests as flakey in CI

### DIFF
--- a/share/eds/retriever_test.go
+++ b/share/eds/retriever_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestRetriever_Retrieve(t *testing.T) {
+	// TODO @node-team: figure out why this regressed in CI
+	t.Skip("skipping retrieval as dangling component")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
Retrieval tests recently became extremely flakey in CI - let's skip as dangling component and come back to it later when we have time to sort out why it suddenly regressed.