### PR TITLE
fix(grpc): correctly wait for ClientConn to reach Ready state

### DIFF
--- a/nodebuilder/core/constructors.go
+++ b/nodebuilder/core/constructors.go
@@ -90,8 +90,17 @@ func grpcClient(lc fx.Lifecycle, cfg EndpointConfig) (*grpc.ClientConn, error) {
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
 			conn.Connect()
-			if !conn.WaitForStateChange(ctx, connectivity.Ready) {
-				return errors.New("couldn't connect to core endpoint")
+			for {
+				state := conn.GetState()
+				if state == connectivity.Ready {
+					break
+				}
+				if state == connectivity.Shutdown {
+					return errors.New("couldn't connect to core endpoint")
+				}
+				if !conn.WaitForStateChange(ctx, state) {
+					return errors.New("couldn't connect to core endpoint")
+				}
 			}
 			return nil
 		},

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -689,8 +689,17 @@ func setupEstimatorConnection(ctx context.Context, addr string, tlsEnabled bool)
 	}
 
 	conn.Connect()
-	if !conn.WaitForStateChange(ctx, connectivity.Ready) {
-		return nil, errors.New("couldn't connect to core endpoint")
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			break
+		}
+		if state == connectivity.Shutdown {
+			return nil, errors.New("couldn't connect to core endpoint")
+		}
+		if !conn.WaitForStateChange(ctx, state) {
+			return nil, errors.New("couldn't connect to core endpoint")
+		}
 	}
 	return conn, nil
 }


### PR DESCRIPTION
The previous readiness check used WaitForStateChange(ctx, connectivity.Ready), which waits for a transition out of Ready rather than into Ready, providing no guarantee that the connection became ready and often returning immediately. This caused startup paths and tests to proceed without a truly established gRPC connection. This change replaces that usage with a proper loop that calls Connect(), polls GetState(), breaks on Ready, fails on Shutdown, and uses WaitForStateChange(ctx, state) with the provided context for timeouts. This ensures connections are actually ready before proceeding.