### PR TITLE
feat: Add storage-only mode for Bridge nodes with P2P disabled and ODS-only storage

### DIFF
--- a/core/eds_test.go
+++ b/core/eds_test.go
@@ -56,7 +56,6 @@ func TestStoreEDS_ODSOnly(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a fresh store for each test
 			testDir := t.TempDir()
 			testStore, err := store.NewStore(store.DefaultParameters(), testDir)
 			require.NoError(t, err)
@@ -65,7 +64,6 @@ func TestStoreEDS_ODSOnly(t *testing.T) {
 				require.NoError(t, err)
 			}()
 
-			// Create a test EDS and header
 			eds := edstest.RandEDS(t, 4)
 			roots, err := share.NewAxisRoots(eds)
 			require.NoError(t, err)
@@ -78,25 +76,20 @@ func TestStoreEDS_ODSOnly(t *testing.T) {
 				DAH: roots,
 			}
 
-			// Store EDS with the given configuration
 			err = storeEDS(ctx, eh, eds, testStore, tt.window, tt.archival, tt.odsOnly)
 			require.NoError(t, err)
 
-			// For blocks outside window (non-archival), storage is skipped
 			if !tt.archival && !availability.IsWithinWindow(eh.Time(), tt.window) {
-				// Block should not be stored
 				has, err := testStore.HasByHeight(ctx, eh.Height())
 				require.NoError(t, err)
 				require.False(t, has, "Block outside window should not be stored")
 				return
 			}
 
-			// Verify the block exists in store
 			has, err := testStore.HasByHeight(ctx, eh.Height())
 			require.NoError(t, err)
 			require.True(t, has, "Block should exist in store")
 
-			// Check if Q4 file exists using store's HasQ4ByHash method
 			datahash := share.DataHash(roots.Hash())
 			hasQ4, err := testStore.HasQ4ByHash(ctx, datahash)
 			require.NoError(t, err)

--- a/core/exchange.go
+++ b/core/exchange.go
@@ -30,6 +30,7 @@ type Exchange struct {
 
 	availabilityWindow time.Duration
 	archival           bool
+	odsOnly            bool
 
 	metrics *exchangeMetrics
 }
@@ -62,6 +63,7 @@ func NewExchange(
 		construct:          construct,
 		availabilityWindow: p.availabilityWindow,
 		archival:           p.archival,
+		odsOnly:            p.odsOnly,
 		metrics:            metrics,
 	}, nil
 }
@@ -150,7 +152,7 @@ func (ce *Exchange) Get(ctx context.Context, hash libhead.Hash) (*header.Extende
 			&block.Height, hash, eh.Hash())
 	}
 
-	err = storeEDS(ctx, eh, eds, ce.store, ce.availabilityWindow, ce.archival)
+	err = storeEDS(ctx, eh, eds, ce.store, ce.availabilityWindow, ce.archival, ce.odsOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +198,7 @@ func (ce *Exchange) getExtendedHeaderByHeight(ctx context.Context, height int64)
 		trace.WithAttributes(attribute.Int("square_size", eh.DAH.SquareSize())),
 	)
 
-	err = storeEDS(ctx, eh, eds, ce.store, ce.availabilityWindow, ce.archival)
+	err = storeEDS(ctx, eh, eds, ce.store, ce.availabilityWindow, ce.archival, ce.odsOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/core/listener.go
+++ b/core/listener.go
@@ -34,6 +34,7 @@ type Listener struct {
 	store              *store.Store
 	availabilityWindow time.Duration
 	archival           bool
+	odsOnly            bool
 
 	headerBroadcaster libhead.Broadcaster[*header.ExtendedHeader]
 	hashBroadcaster   shrexsub.BroadcastFn
@@ -80,6 +81,7 @@ func NewListener(
 		store:              store,
 		availabilityWindow: p.availabilityWindow,
 		archival:           p.archival,
+		odsOnly:            p.odsOnly,
 		listenerTimeout:    5 * blocktime,
 		metrics:            metrics,
 		chainID:            p.chainID,
@@ -191,7 +193,7 @@ func (cl *Listener) handleNewSignedBlock(ctx context.Context, b types.EventDataS
 		trace.WithAttributes(attribute.Int("square_size", eh.DAH.SquareSize())),
 	)
 
-	err = storeEDS(ctx, eh, eds, cl.store, cl.availabilityWindow, cl.archival)
+	err = storeEDS(ctx, eh, eds, cl.store, cl.availabilityWindow, cl.archival, cl.odsOnly)
 	if err != nil {
 		return fmt.Errorf("storing EDS: %w", err)
 	}

--- a/core/option.go
+++ b/core/option.go
@@ -14,6 +14,7 @@ type params struct {
 	chainID            string
 	availabilityWindow time.Duration
 	archival           bool
+	odsOnly            bool
 }
 
 func defaultParams() params {
@@ -46,5 +47,13 @@ func WithAvailabilityWindow(window time.Duration) Option {
 func WithArchivalMode() Option {
 	return func(p *params) {
 		p.archival = true
+	}
+}
+
+// WithODSOnly is a functional option that enables ODS-only storage mode.
+// When enabled, all blocks are stored using PutODS instead of PutODSQ4.
+func WithODSOnly() Option {
+	return func(p *params) {
+		p.odsOnly = true
 	}
 }

--- a/nodebuilder/fraud/module.go
+++ b/nodebuilder/fraud/module.go
@@ -20,12 +20,12 @@ var log = logging.Logger("module/fraud")
 // stubFraudService is a no-op fraud service for when P2P is disabled.
 type stubFraudService struct{}
 
-func (s *stubFraudService) Get(ctx context.Context, proofType fraud.ProofType) ([]fraud.Proof[*header.ExtendedHeader], error) {
+func (s *stubFraudService) Get(_ context.Context, _ fraud.ProofType) ([]fraud.Proof[*header.ExtendedHeader], error) {
 	// Return ErrNotFound so ServiceBreaker thinks there are no fraud proofs
 	return nil, datastore.ErrNotFound
 }
 
-func (s *stubFraudService) Subscribe(proofType fraud.ProofType) (fraud.Subscription[*header.ExtendedHeader], error) {
+func (s *stubFraudService) Subscribe(_ fraud.ProofType) (fraud.Subscription[*header.ExtendedHeader], error) {
 	return &stubFraudSubscription{}, nil
 }
 
@@ -42,27 +42,29 @@ func (s *stubFraudSubscription) Cancel() {
 	// No-op
 }
 
-func (s *stubFraudService) Broadcast(ctx context.Context, proof fraud.Proof[*header.ExtendedHeader]) error {
+func (s *stubFraudService) Broadcast(_ context.Context, _ fraud.Proof[*header.ExtendedHeader]) error {
 	return errors.New("fraud service is disabled (P2P is disabled)")
 }
 
-func (s *stubFraudService) AddVerifier(proofType fraud.ProofType, verifier fraud.Verifier[*header.ExtendedHeader]) error {
+func (s *stubFraudService) AddVerifier(_ fraud.ProofType, _ fraud.Verifier[*header.ExtendedHeader]) error {
 	// No-op: storage-only nodes don't verify fraud proofs
 	return nil
 }
 
-var _ fraud.Service[*header.ExtendedHeader] = (*stubFraudService)(nil)
-var _ Module = (*stubModule)(nil)
+var (
+	_ fraud.Service[*header.ExtendedHeader] = (*stubFraudService)(nil)
+	_ Module                                = (*stubModule)(nil)
+)
 
 type stubModule struct {
 	fraud.Service[*header.ExtendedHeader]
 }
 
-func (s *stubModule) Subscribe(ctx context.Context, proofType fraud.ProofType) (<-chan *Proof, error) {
+func (s *stubModule) Subscribe(_ context.Context, _ fraud.ProofType) (<-chan *Proof, error) {
 	return nil, errors.New("fraud service is disabled (P2P is disabled)")
 }
 
-func (s *stubModule) Get(ctx context.Context, proofType fraud.ProofType) ([]Proof, error) {
+func (s *stubModule) Get(_ context.Context, _ fraud.ProofType) ([]Proof, error) {
 	return nil, errors.New("fraud service is disabled (P2P is disabled)")
 }
 

--- a/nodebuilder/fraud/module.go
+++ b/nodebuilder/fraud/module.go
@@ -21,7 +21,6 @@ var log = logging.Logger("module/fraud")
 type stubFraudService struct{}
 
 func (s *stubFraudService) Get(_ context.Context, _ fraud.ProofType) ([]fraud.Proof[*header.ExtendedHeader], error) {
-	// Return ErrNotFound so ServiceBreaker thinks there are no fraud proofs
 	return nil, datastore.ErrNotFound
 }
 
@@ -33,13 +32,11 @@ func (s *stubFraudService) Subscribe(_ fraud.ProofType) (fraud.Subscription[*hea
 type stubFraudSubscription struct{}
 
 func (s *stubFraudSubscription) Proof(ctx context.Context) (fraud.Proof[*header.ExtendedHeader], error) {
-	// Block forever - storage-only nodes don't receive fraud proofs via P2P
 	<-ctx.Done()
 	return nil, ctx.Err()
 }
 
 func (s *stubFraudSubscription) Cancel() {
-	// No-op
 }
 
 func (s *stubFraudService) Broadcast(_ context.Context, _ fraud.Proof[*header.ExtendedHeader]) error {
@@ -47,7 +44,6 @@ func (s *stubFraudService) Broadcast(_ context.Context, _ fraud.Proof[*header.Ex
 }
 
 func (s *stubFraudService) AddVerifier(_ fraud.ProofType, _ fraud.Verifier[*header.ExtendedHeader]) error {
-	// No-op: storage-only nodes don't verify fraud proofs
 	return nil
 }
 
@@ -83,7 +79,6 @@ func ConstructModule(tp node.Type, p2pCfg *modp2p.Config) fx.Option {
 		}),
 	)
 
-	// If P2P is disabled, provide stub fraud service
 	if p2pDisabled && tp == node.Bridge {
 		return fx.Module(
 			"fraud",

--- a/nodebuilder/fraud/module.go
+++ b/nodebuilder/fraud/module.go
@@ -1,6 +1,10 @@
 package fraud
 
 import (
+	"context"
+	"errors"
+
+	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"
 
@@ -8,17 +12,84 @@ import (
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 var log = logging.Logger("module/fraud")
 
-func ConstructModule(tp node.Type) fx.Option {
+// stubFraudService is a no-op fraud service for when P2P is disabled.
+type stubFraudService struct{}
+
+func (s *stubFraudService) Get(ctx context.Context, proofType fraud.ProofType) ([]fraud.Proof[*header.ExtendedHeader], error) {
+	// Return ErrNotFound so ServiceBreaker thinks there are no fraud proofs
+	return nil, datastore.ErrNotFound
+}
+
+func (s *stubFraudService) Subscribe(proofType fraud.ProofType) (fraud.Subscription[*header.ExtendedHeader], error) {
+	return &stubFraudSubscription{}, nil
+}
+
+// stubFraudSubscription is a no-op subscription for when P2P is disabled.
+type stubFraudSubscription struct{}
+
+func (s *stubFraudSubscription) Proof(ctx context.Context) (fraud.Proof[*header.ExtendedHeader], error) {
+	// Block forever - storage-only nodes don't receive fraud proofs via P2P
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *stubFraudSubscription) Cancel() {
+	// No-op
+}
+
+func (s *stubFraudService) Broadcast(ctx context.Context, proof fraud.Proof[*header.ExtendedHeader]) error {
+	return errors.New("fraud service is disabled (P2P is disabled)")
+}
+
+func (s *stubFraudService) AddVerifier(proofType fraud.ProofType, verifier fraud.Verifier[*header.ExtendedHeader]) error {
+	// No-op: storage-only nodes don't verify fraud proofs
+	return nil
+}
+
+var _ fraud.Service[*header.ExtendedHeader] = (*stubFraudService)(nil)
+var _ Module = (*stubModule)(nil)
+
+type stubModule struct {
+	fraud.Service[*header.ExtendedHeader]
+}
+
+func (s *stubModule) Subscribe(ctx context.Context, proofType fraud.ProofType) (<-chan *Proof, error) {
+	return nil, errors.New("fraud service is disabled (P2P is disabled)")
+}
+
+func (s *stubModule) Get(ctx context.Context, proofType fraud.ProofType) ([]Proof, error) {
+	return nil, errors.New("fraud service is disabled (P2P is disabled)")
+}
+
+func newStubFraudService() (Module, fraud.Service[*header.ExtendedHeader], error) {
+	stub := &stubFraudService{}
+	return &stubModule{Service: stub}, stub, nil
+}
+
+func ConstructModule(tp node.Type, p2pCfg *modp2p.Config) fx.Option {
+	p2pDisabled := p2pCfg != nil && p2pCfg.Disabled
+
 	baseComponent := fx.Options(
 		fx.Provide(Unmarshaler),
 		fx.Provide(func(serv fraud.Service[*header.ExtendedHeader]) fraud.Getter[*header.ExtendedHeader] {
 			return serv
 		}),
 	)
+
+	// If P2P is disabled, provide stub fraud service
+	if p2pDisabled && tp == node.Bridge {
+		return fx.Module(
+			"fraud",
+			baseComponent,
+			fx.Provide(newStubFraudService),
+		)
+	}
+
 	switch tp {
 	case node.Light:
 		return fx.Module(

--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -12,7 +12,7 @@ import (
 
 	libfraud "github.com/celestiaorg/go-fraud"
 	libhead "github.com/celestiaorg/go-header"
-	"github.com/celestiaorg/go-header/p2p"
+	headp2p "github.com/celestiaorg/go-header/p2p"
 	"github.com/celestiaorg/go-header/store"
 	"github.com/celestiaorg/go-header/sync"
 
@@ -30,7 +30,7 @@ func newP2PExchange[H libhead.Header[H]](
 	network modp2p.Network,
 	host host.Host,
 	conngater *conngater.BasicConnectionGater,
-	pidstore p2p.PeerIDStore,
+	pidstore headp2p.PeerIDStore,
 ) (libhead.Exchange[H], error) {
 	peers, err := cfg.trustedPeers(bpeers)
 	if err != nil {
@@ -42,17 +42,17 @@ func newP2PExchange[H libhead.Header[H]](
 		host.Peerstore().AddAddrs(peer.ID, peer.Addrs, peerstore.PermanentAddrTTL)
 	}
 
-	opts := []p2p.Option[p2p.ClientParameters]{
-		p2p.WithParams(cfg.Client),
-		p2p.WithNetworkID[p2p.ClientParameters](network.String()),
-		p2p.WithChainID(network.String()),
-		p2p.WithPeerIDStore[p2p.ClientParameters](pidstore),
+	opts := []headp2p.Option[headp2p.ClientParameters]{
+		headp2p.WithParams(cfg.Client),
+		headp2p.WithNetworkID[headp2p.ClientParameters](network.String()),
+		headp2p.WithChainID(network.String()),
+		headp2p.WithPeerIDStore[headp2p.ClientParameters](pidstore),
 	}
 	if MetricsEnabled {
-		opts = append(opts, p2p.WithMetrics[p2p.ClientParameters]())
+		opts = append(opts, headp2p.WithMetrics[headp2p.ClientParameters]())
 	}
 
-	exchange, err := p2p.NewExchange[H](host, ids, conngater, opts...)
+	exchange, err := headp2p.NewExchange[H](host, ids, conngater, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -27,7 +27,7 @@ var log = logging.Logger("module/header")
 // stubBroadcaster is a no-op broadcaster for when P2P is disabled.
 type stubBroadcaster[H libhead.Header[H]] struct{}
 
-func (s *stubBroadcaster[H]) Broadcast(ctx context.Context, header H, opts ...pubsub.PubOpt) error {
+func (s *stubBroadcaster[H]) Broadcast(_ context.Context, _ H, _ ...pubsub.PubOpt) error {
 	// No-op: storage-only nodes don't broadcast headers
 	return nil
 }

--- a/nodebuilder/header/module_test.go
+++ b/nodebuilder/header/module_test.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/fx/fxtest"
 
 	libhead "github.com/celestiaorg/go-header"
-	"github.com/celestiaorg/go-header/p2p"
+	headp2p "github.com/celestiaorg/go-header/p2p"
 	"github.com/celestiaorg/go-header/store"
 
 	"github.com/celestiaorg/celestia-node/header"
@@ -40,7 +40,7 @@ func TestConstructModule_StoreParams(t *testing.T) {
 			ds := datastore.NewMapDatastore()
 			return ds, ds
 		}),
-		ConstructModule[*header.ExtendedHeader](node.Light, &cfg),
+		ConstructModule[*header.ExtendedHeader](node.Light, &cfg, &modp2p.Config{}),
 		fx.Invoke(
 			func(s libhead.Store[*header.ExtendedHeader]) {
 				ss := s.(*store.Store[*header.ExtendedHeader])
@@ -59,8 +59,8 @@ func TestConstructModule_ExchangeParams(t *testing.T) {
 	cfg := DefaultConfig(node.Light)
 	cfg.Client.MaxHeadersPerRangeRequest = 15
 	cfg.TrustedPeers = []string{"/ip4/1.2.3.4/tcp/12345/p2p/12D3KooWNaJ1y1Yio3fFJEXCZyd1Cat3jmrPdgkYCrHfKD3Ce21p"}
-	var exchange *p2p.Exchange[*header.ExtendedHeader]
-	var exchangeServer *p2p.ExchangeServer[*header.ExtendedHeader]
+	var exchange *headp2p.Exchange[*header.ExtendedHeader]
+	var exchangeServer *headp2p.ExchangeServer[*header.ExtendedHeader]
 
 	app := fxtest.New(t,
 		fx.Provide(pidstore.NewPeerIDStore),
@@ -71,13 +71,13 @@ func TestConstructModule_ExchangeParams(t *testing.T) {
 		fx.Provide(func() datastore.Batching {
 			return datastore.NewMapDatastore()
 		}),
-		ConstructModule[*header.ExtendedHeader](node.Light, &cfg),
+		ConstructModule[*header.ExtendedHeader](node.Light, &cfg, &modp2p.Config{}),
 		fx.Provide(func(b datastore.Batching) (*conngater.BasicConnectionGater, error) {
 			return conngater.NewBasicConnectionGater(b)
 		}),
 		fx.Invoke(
-			func(e libhead.Exchange[*header.ExtendedHeader], server *p2p.ExchangeServer[*header.ExtendedHeader]) {
-				ex := e.(*p2p.Exchange[*header.ExtendedHeader])
+			func(e libhead.Exchange[*header.ExtendedHeader], server *headp2p.ExchangeServer[*header.ExtendedHeader]) {
+				ex := e.(*headp2p.Exchange[*header.ExtendedHeader])
 				exchange = ex
 				exchangeServer = server
 			}),

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -55,7 +55,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		share.ConstructModule(tp, &cfg.Share, &cfg.P2P),
 		state.ConstructModule(tp, &cfg.State, &cfg.Core),
 		das.ConstructModule(tp, &cfg.DASer),
-		fraud.ConstructModule(tp),
+		fraud.ConstructModule(tp, &cfg.P2P),
 		blob.ConstructModule(),
 		da.ConstructModule(),
 		node.ConstructModule(tp),

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -2,6 +2,7 @@ package nodebuilder
 
 import (
 	"context"
+	"fmt"
 
 	"go.uber.org/fx"
 
@@ -29,6 +30,11 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		return fx.Error(err)
 	}
 
+	// Validate P2P config with Share config (for cross-module validation)
+	if err := cfg.P2P.ValidateWithShareConfig(tp, &cfg.Share); err != nil {
+		return fx.Error(fmt.Errorf("nodebuilder: config validation: %w", err))
+	}
+
 	baseComponents := fx.Options(
 		fx.Supply(tp),
 		fx.Supply(network),
@@ -41,12 +47,12 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		fx.Supply(store.Config),
 		fx.Provide(store.Datastore),
 		fx.Provide(store.Keystore),
-		core.ConstructModule(tp, &cfg.Core),
+		core.ConstructModule(tp, &cfg.Core, &cfg.Share),
 		fx.Supply(node.StorePath(store.Path())),
 		// modules provided by the node
 		p2p.ConstructModule(tp, &cfg.P2P),
-		modhead.ConstructModule[*header.ExtendedHeader](tp, &cfg.Header),
-		share.ConstructModule(tp, &cfg.Share),
+		modhead.ConstructModule[*header.ExtendedHeader](tp, &cfg.Header, &cfg.P2P),
+		share.ConstructModule(tp, &cfg.Share, &cfg.P2P),
 		state.ConstructModule(tp, &cfg.State, &cfg.Core),
 		das.ConstructModule(tp, &cfg.DASer),
 		fraud.ConstructModule(tp),

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -30,7 +30,6 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		return fx.Error(err)
 	}
 
-	// Validate P2P config with Share config (for cross-module validation)
 	if err := cfg.P2P.ValidateWithShareConfig(tp, &cfg.Share); err != nil {
 		return fx.Error(fmt.Errorf("nodebuilder: config validation: %w", err))
 	}

--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -59,14 +59,14 @@ type Node struct {
 	// block store
 	EDSStore *store.Store `optional:"true"`
 
-	// p2p components
-	Host         host.Host
-	ConnGater    *conngater.BasicConnectionGater
-	Routing      routing.PeerRouting
-	DataExchange exchange.SessionExchange
-	BlockService blockservice.BlockService
+	// p2p components (optional when P2P is disabled)
+	Host         host.Host                       `optional:"true"`
+	ConnGater    *conngater.BasicConnectionGater `optional:"true"`
+	Routing      routing.PeerRouting             `optional:"true"`
+	DataExchange exchange.SessionExchange        `optional:"true"`
+	BlockService blockservice.BlockService       `optional:"true"`
 	// p2p protocols
-	PubSub *pubsub.PubSub
+	PubSub *pubsub.PubSub `optional:"true"`
 	// services
 	ShareServ     share.Module  // not optional
 	HeaderServ    header.Module // not optional
@@ -122,16 +122,21 @@ func (n *Node) Start(ctx context.Context) error {
 		strings.ToLower(n.Type.String()),
 		n.Network)
 
-	addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(n.Host))
-	if err != nil {
-		log.Errorw("Retrieving multiaddress information", "err", err)
-		return err
+	// Only print P2P addresses if P2P is enabled
+	if n.Host != nil {
+		addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(n.Host))
+		if err != nil {
+			log.Errorw("Retrieving multiaddress information", "err", err)
+			return err
+		}
+		fmt.Println("The p2p host is listening on:")
+		for _, addr := range addrs {
+			fmt.Println("* ", addr.String())
+		}
+		fmt.Println()
+	} else {
+		log.Info("P2P networking is disabled (storage-only mode)")
 	}
-	fmt.Println("The p2p host is listening on:")
-	for _, addr := range addrs {
-		fmt.Println("* ", addr.String())
-	}
-	fmt.Println()
 	return nil
 }
 

--- a/nodebuilder/p2p/config.go
+++ b/nodebuilder/p2p/config.go
@@ -93,11 +93,9 @@ func (cfg *Config) mutualPeers() (_ []peer.AddrInfo, err error) {
 // Validate performs basic validation of the config.
 func (cfg *Config) Validate(tp node.Type) error {
 	if cfg.Disabled {
-		// P2P disabled is only supported for Bridge nodes
 		if tp != node.Bridge {
 			return fmt.Errorf("p2p.disabled is only supported for Bridge nodes")
 		}
-		// If disabled, other P2P configs are ignored
 		return nil
 	}
 	return nil

--- a/nodebuilder/p2p/config_test.go
+++ b/nodebuilder/p2p/config_test.go
@@ -1,0 +1,151 @@
+package p2p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		tp      node.Type
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "P2P disabled for Bridge node - valid",
+			cfg: Config{
+				Disabled: true,
+			},
+			tp:      node.Bridge,
+			wantErr: false,
+		},
+		{
+			name: "P2P disabled for Light node - invalid",
+			cfg: Config{
+				Disabled: true,
+			},
+			tp:      node.Light,
+			wantErr: true,
+			errMsg:  "p2p.disabled is only supported for Bridge nodes",
+		},
+		{
+			name: "P2P disabled for Full node - invalid",
+			cfg: Config{
+				Disabled: true,
+			},
+			tp:      node.Full,
+			wantErr: true,
+			errMsg:  "p2p.disabled is only supported for Bridge nodes",
+		},
+		{
+			name: "P2P enabled - valid",
+			cfg: Config{
+				Disabled: false,
+			},
+			tp:      node.Bridge,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate(tt.tp)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfig_ValidateWithShareConfig(t *testing.T) {
+	// Create a mock share config struct using reflection to avoid import cycle
+	type mockShareConfig struct {
+		StoreODSOnly bool
+	}
+
+	tests := []struct {
+		name     string
+		cfg      Config
+		tp       node.Type
+		shareCfg interface{}
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name: "P2P disabled with ODS-only enabled - valid",
+			cfg: Config{
+				Disabled: true,
+			},
+			tp: node.Bridge,
+			shareCfg: &mockShareConfig{
+				StoreODSOnly: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "P2P disabled without ODS-only - invalid",
+			cfg: Config{
+				Disabled: true,
+			},
+			tp: node.Bridge,
+			shareCfg: &mockShareConfig{
+				StoreODSOnly: false,
+			},
+			wantErr: true,
+			errMsg:  "p2p.disabled requires share.store_ods_only to be enabled",
+		},
+		{
+			name: "P2P enabled - validation skipped",
+			cfg: Config{
+				Disabled: false,
+			},
+			tp: node.Bridge,
+			shareCfg: &mockShareConfig{
+				StoreODSOnly: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "P2P disabled for Light node - invalid",
+			cfg: Config{
+				Disabled: true,
+			},
+			tp: node.Light,
+			shareCfg: &mockShareConfig{
+				StoreODSOnly: true,
+			},
+			wantErr: true,
+			errMsg:  "p2p.disabled is only supported for Bridge nodes",
+		},
+		{
+			name: "P2P disabled with nil share config - no error",
+			cfg: Config{
+				Disabled: true,
+			},
+			tp:       node.Bridge,
+			shareCfg: nil,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.ValidateWithShareConfig(tt.tp, tt.shareCfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+

--- a/nodebuilder/p2p/config_test.go
+++ b/nodebuilder/p2p/config_test.go
@@ -148,4 +148,3 @@ func TestConfig_ValidateWithShareConfig(t *testing.T) {
 		})
 	}
 }
-

--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -14,8 +14,9 @@ import (
 const EnvCustomNetwork = "CELESTIA_CUSTOM"
 
 const (
-	networkFlag = "p2p.network"
-	mutualFlag  = "p2p.mutual"
+	networkFlag  = "p2p.network"
+	mutualFlag   = "p2p.mutual"
+	disabledFlag = "p2p.disabled"
 )
 
 // Flags gives a set of p2p flags.
@@ -37,6 +38,14 @@ Peers must bidirectionally point to each other. (Format: multiformats.io/multiad
 			"both init and start to take effect. Assumes mainnet (%s) unless otherwise specified.",
 			listAvailableNetworks(),
 			DefaultNetwork.String()),
+	)
+	flags.Bool(
+		disabledFlag,
+		false,
+		"Disables all P2P networking. When enabled, the node will not initialize P2P host, DHT, "+
+			"Gossip (PubSub), Shrex servers/clients, or Bitswap servers/clients. "+
+			"This is useful for storage-only Bridge nodes (e.g., hosted RPC providers). "+
+			"Only supported for Bridge nodes.",
 	)
 
 	return flags
@@ -62,6 +71,15 @@ func ParseFlags(
 	if len(mutualPeers) != 0 {
 		cfg.MutualPeers = mutualPeers
 	}
+
+	disabled, err := cmd.Flags().GetBool(disabledFlag)
+	if err != nil {
+		return err
+	}
+	if disabled {
+		cfg.Disabled = true
+	}
+
 	return nil
 }
 

--- a/nodebuilder/p2p/module.go
+++ b/nodebuilder/p2p/module.go
@@ -1,8 +1,22 @@
 package p2p
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/exchange"
 	logging "github.com/ipfs/go-log/v2"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	hst "github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/metrics"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/core/routing"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
@@ -11,8 +25,119 @@ import (
 
 var log = logging.Logger("module/p2p")
 
+// newModuleDisabled creates a disabled P2P module that returns errors for all operations.
+func newModuleDisabled() Module {
+	return &moduleDisabled{}
+}
+
+// moduleDisabled is a stub implementation of Module for when P2P is disabled.
+type moduleDisabled struct{}
+
+func (m *moduleDisabled) Info(context.Context) (peer.AddrInfo, error) {
+	return peer.AddrInfo{}, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) Peers(context.Context) ([]peer.ID, error) {
+	return nil, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) PeerInfo(context.Context, peer.ID) (peer.AddrInfo, error) {
+	return peer.AddrInfo{}, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) Connect(context.Context, peer.AddrInfo) error {
+	return fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) ClosePeer(context.Context, peer.ID) error {
+	return fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) Connectedness(context.Context, peer.ID) (network.Connectedness, error) {
+	return network.NotConnected, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) NATStatus(context.Context) (network.Reachability, error) {
+	return network.ReachabilityUnknown, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) BlockPeer(context.Context, peer.ID) error {
+	return fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) UnblockPeer(context.Context, peer.ID) error {
+	return fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) ListBlockedPeers(context.Context) ([]peer.ID, error) {
+	return nil, nil
+}
+
+func (m *moduleDisabled) Protect(context.Context, peer.ID, string) error {
+	return fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) Unprotect(context.Context, peer.ID, string) (bool, error) {
+	return false, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) IsProtected(context.Context, peer.ID, string) (bool, error) {
+	return false, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) BandwidthStats(context.Context) (metrics.Stats, error) {
+	return metrics.Stats{}, nil
+}
+
+func (m *moduleDisabled) BandwidthForPeer(context.Context, peer.ID) (metrics.Stats, error) {
+	return metrics.Stats{}, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) BandwidthForProtocol(context.Context, protocol.ID) (metrics.Stats, error) {
+	return metrics.Stats{}, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) ResourceState(context.Context) (rcmgr.ResourceManagerStat, error) {
+	return rcmgr.ResourceManagerStat{}, nil
+}
+
+func (m *moduleDisabled) PubSubPeers(context.Context, string) ([]peer.ID, error) {
+	return nil, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) PubSubTopics(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (m *moduleDisabled) Ping(context.Context, peer.ID) (time.Duration, error) {
+	return 0, fmt.Errorf("p2p is disabled")
+}
+
+func (m *moduleDisabled) ConnectionState(context.Context, peer.ID) ([]ConnectionState, error) {
+	return nil, fmt.Errorf("p2p is disabled")
+}
+
 // ConstructModule collects all the components and services related to p2p.
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
+	// If P2P is disabled, return minimal module with nil/empty implementations
+	if cfg.Disabled {
+		return fx.Module(
+			"p2p",
+			fx.Supply(cfg),
+			// Provide nil implementations for optional dependencies
+			fx.Provide(func() HostBase { return nil }),
+			fx.Provide(func() hst.Host { return nil }),
+			fx.Provide(func() *pubsub.PubSub { return nil }),
+			fx.Provide(func() routing.PeerRouting { return nil }),
+			fx.Provide(func() exchange.SessionExchange { return nil }),
+			fx.Provide(func() blockservice.BlockService { return nil }),
+			fx.Provide(func() *conngater.BasicConnectionGater { return nil }),
+			fx.Provide(func() *metrics.BandwidthCounter { return nil }),
+			fx.Provide(func() network.ResourceManager { return nil }),
+			fx.Provide(newModuleDisabled),
+		)
+	}
+
 	// sanitize config values before constructing module
 	baseComponents := fx.Options(
 		fx.Supply(cfg),

--- a/nodebuilder/share/config.go
+++ b/nodebuilder/share/config.go
@@ -31,6 +31,12 @@ type Config struct {
 
 	LightAvailability *light.Parameters `toml:",omitempty"`
 	Discovery         *discovery.Parameters
+
+	// StoreODSOnly when true, stores only ODS (Original Data Square) instead of ODSQ4.
+	// This is useful for storage-only Bridge nodes that don't serve samples via P2P.
+	// When enabled, all blocks are stored using PutODS regardless of availability window.
+	// Only supported for Bridge nodes.
+	StoreODSOnly bool
 }
 
 func DefaultConfig(tp node.Type) Config {
@@ -58,6 +64,11 @@ func (cfg *Config) Validate(tp node.Type) error {
 		if err := cfg.LightAvailability.Validate(); err != nil {
 			return fmt.Errorf("nodebuilder/share: %w", err)
 		}
+	}
+
+	// StoreODSOnly is only valid for Bridge nodes
+	if cfg.StoreODSOnly && tp != node.Bridge {
+		return fmt.Errorf("store.ods_only is only supported for Bridge nodes")
 	}
 
 	if err := cfg.Discovery.Validate(); err != nil {

--- a/nodebuilder/share/config.go
+++ b/nodebuilder/share/config.go
@@ -66,7 +66,6 @@ func (cfg *Config) Validate(tp node.Type) error {
 		}
 	}
 
-	// StoreODSOnly is only valid for Bridge nodes
 	if cfg.StoreODSOnly && tp != node.Bridge {
 		return fmt.Errorf("store.ods_only is only supported for Bridge nodes")
 	}

--- a/nodebuilder/share/config_test.go
+++ b/nodebuilder/share/config_test.go
@@ -1,0 +1,77 @@
+package share
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+)
+
+func TestConfig_Validate_StoreODSOnly(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		tp      node.Type
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "ODS-only for Bridge node - valid",
+			cfg: Config{
+				StoreODSOnly: true,
+			},
+			tp:      node.Bridge,
+			wantErr: false,
+		},
+		{
+			name: "ODS-only for Light node - invalid",
+			cfg: Config{
+				StoreODSOnly: true,
+			},
+			tp:      node.Light,
+			wantErr: true,
+			errMsg:  "store.ods_only is only supported for Bridge nodes",
+		},
+		{
+			name: "ODS-only for Full node - invalid",
+			cfg: Config{
+				StoreODSOnly: true,
+			},
+			tp:      node.Full,
+			wantErr: true,
+			errMsg:  "store.ods_only is only supported for Bridge nodes",
+		},
+		{
+			name: "ODS-only disabled - valid for all node types",
+			cfg: Config{
+				StoreODSOnly: false,
+			},
+			tp:      node.Bridge,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set required fields to avoid validation errors
+			tt.cfg.EDSStoreParams = DefaultConfig(tt.tp).EDSStoreParams
+			tt.cfg.Discovery = DefaultConfig(tt.tp).Discovery
+			tt.cfg.ShrexClient = DefaultConfig(tt.tp).ShrexClient
+			tt.cfg.ShrexServer = DefaultConfig(tt.tp).ShrexServer
+			tt.cfg.PeerManagerParams = DefaultConfig(tt.tp).PeerManagerParams
+			if tt.tp == node.Light {
+				tt.cfg.LightAvailability = DefaultConfig(tt.tp).LightAvailability
+			}
+
+			err := tt.cfg.Validate(tt.tp)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+

--- a/nodebuilder/share/config_test.go
+++ b/nodebuilder/share/config_test.go
@@ -74,4 +74,3 @@ func TestConfig_Validate_StoreODSOnly(t *testing.T) {
 		})
 	}
 }
-

--- a/nodebuilder/share/config_test.go
+++ b/nodebuilder/share/config_test.go
@@ -54,7 +54,6 @@ func TestConfig_Validate_StoreODSOnly(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set required fields to avoid validation errors
 			tt.cfg.EDSStoreParams = DefaultConfig(tt.tp).EDSStoreParams
 			tt.cfg.Discovery = DefaultConfig(tt.tp).Discovery
 			tt.cfg.ShrexClient = DefaultConfig(tt.tp).ShrexClient

--- a/nodebuilder/share/constructors.go
+++ b/nodebuilder/share/constructors.go
@@ -55,10 +55,10 @@ func bridgeAndFullGetter(
 ) shwap.Getter {
 	var cascade []shwap.Getter
 	cascade = append(cascade, storeGetter)
-	if cfg.UseShareExchange {
+	if cfg.UseShareExchange && shrexGetter != nil {
 		cascade = append(cascade, shrexGetter)
 	}
-	if cfg.UseBitswap {
+	if cfg.UseBitswap && bitswapGetter != nil {
 		cascade = append(cascade, bitswapGetter)
 	}
 	return getters.NewCascadeGetter(cascade)

--- a/nodebuilder/storage_only_test.go
+++ b/nodebuilder/storage_only_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
-	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 func TestStorageOnlyMode_P2PDisabled(t *testing.T) {
@@ -71,7 +71,7 @@ func TestStorageOnlyMode_ValidationFailure(t *testing.T) {
 
 	// Attempt to create node - should fail during module construction
 	store := MockStore(t, cfg)
-	_, err = New(node.Bridge, p2p.Private, store)
+	_, err = New(node.Bridge, modp2p.Private, store)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "p2p.disabled requires share.store_ods_only to be enabled")
 }
@@ -120,8 +120,7 @@ func TestStorageOnlyMode_OnlyBridgeSupported(t *testing.T) {
 	cfg.Share.StoreODSOnly = true
 
 	store := MockStore(t, cfg)
-	_, err = New(node.Light, p2p.Private, store)
+	_, err = New(node.Light, modp2p.Private, store)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "p2p.disabled is only supported for Bridge nodes")
 }
-

--- a/nodebuilder/storage_only_test.go
+++ b/nodebuilder/storage_only_test.go
@@ -1,0 +1,127 @@
+//go:build !race
+
+package nodebuilder
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/core"
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+)
+
+func TestStorageOnlyMode_P2PDisabled(t *testing.T) {
+	// Start a test core node
+	consNode := core.StartTestNode(t)
+	host, port, err := net.SplitHostPort(consNode.GRPCClient.Target())
+	require.NoError(t, err)
+
+	// Create config with P2P disabled and ODS-only enabled
+	cfg := DefaultConfig(node.Bridge)
+	cfg.Core.IP = host
+	cfg.Core.Port = port
+	cfg.P2P.Disabled = true
+	cfg.Share.StoreODSOnly = true
+
+	// Create node with storage-only mode
+	nd := TestNodeWithConfig(t, node.Bridge, cfg)
+	require.NotNil(t, nd)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the node
+	err = nd.Start(ctx)
+	require.NoError(t, err)
+
+	// Verify P2P components are nil
+	require.Nil(t, nd.Host, "P2P Host should be nil when P2P is disabled")
+	require.Nil(t, nd.ConnGater, "ConnGater should be nil when P2P is disabled")
+	require.Nil(t, nd.Routing, "Routing should be nil when P2P is disabled")
+	require.Nil(t, nd.DataExchange, "DataExchange should be nil when P2P is disabled")
+	require.Nil(t, nd.BlockService, "BlockService should be nil when P2P is disabled")
+	require.Nil(t, nd.PubSub, "PubSub should be nil when P2P is disabled")
+
+	// Verify core components are still available
+	require.NotNil(t, nd.RPCServer, "RPC Server should be available")
+	require.NotNil(t, nd.ShareServ, "Share service should be available")
+	require.NotNil(t, nd.HeaderServ, "Header service should be available")
+	require.NotNil(t, nd.StateServ, "State service should be available")
+
+	// Stop the node
+	err = nd.Stop(ctx)
+	require.NoError(t, err)
+}
+
+func TestStorageOnlyMode_ValidationFailure(t *testing.T) {
+	consNode := core.StartTestNode(t)
+	host, port, err := net.SplitHostPort(consNode.GRPCClient.Target())
+	require.NoError(t, err)
+
+	// Create config with P2P disabled but ODS-only NOT enabled (should fail)
+	cfg := DefaultConfig(node.Bridge)
+	cfg.Core.IP = host
+	cfg.Core.Port = port
+	cfg.P2P.Disabled = true
+	cfg.Share.StoreODSOnly = false // This should cause validation to fail
+
+	// Attempt to create node - should fail during module construction
+	store := MockStore(t, cfg)
+	_, err = New(node.Bridge, p2p.Private, store)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "p2p.disabled requires share.store_ods_only to be enabled")
+}
+
+func TestODSOnlyStorage_ConfigApplied(t *testing.T) {
+	consNode := core.StartTestNode(t)
+	host, port, err := net.SplitHostPort(consNode.GRPCClient.Target())
+	require.NoError(t, err)
+
+	// Create config with ODS-only enabled
+	cfg := DefaultConfig(node.Bridge)
+	cfg.Core.IP = host
+	cfg.Core.Port = port
+	cfg.Share.StoreODSOnly = true
+
+	// Verify config is set correctly
+	require.True(t, cfg.Share.StoreODSOnly, "StoreODSOnly should be true")
+
+	// Create node - should succeed
+	nd := TestNodeWithConfig(t, node.Bridge, cfg)
+	require.NotNil(t, nd)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = nd.Start(ctx)
+	require.NoError(t, err)
+
+	// Node should start successfully with ODS-only config
+	require.NotNil(t, nd.ShareServ)
+
+	err = nd.Stop(ctx)
+	require.NoError(t, err)
+}
+
+func TestStorageOnlyMode_OnlyBridgeSupported(t *testing.T) {
+	consNode := core.StartTestNode(t)
+	host, port, err := net.SplitHostPort(consNode.GRPCClient.Target())
+	require.NoError(t, err)
+
+	// Try to create Light node with P2P disabled - should fail
+	cfg := DefaultConfig(node.Light)
+	cfg.Core.IP = host
+	cfg.Core.Port = port
+	cfg.P2P.Disabled = true
+	cfg.Share.StoreODSOnly = true
+
+	store := MockStore(t, cfg)
+	_, err = New(node.Light, p2p.Private, store)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "p2p.disabled is only supported for Bridge nodes")
+}
+

--- a/nodebuilder/storage_only_test.go
+++ b/nodebuilder/storage_only_test.go
@@ -15,30 +15,25 @@ import (
 )
 
 func TestStorageOnlyMode_P2PDisabled(t *testing.T) {
-	// Start a test core node
 	consNode := core.StartTestNode(t)
 	host, port, err := net.SplitHostPort(consNode.GRPCClient.Target())
 	require.NoError(t, err)
 
-	// Create config with P2P disabled and ODS-only enabled
 	cfg := DefaultConfig(node.Bridge)
 	cfg.Core.IP = host
 	cfg.Core.Port = port
 	cfg.P2P.Disabled = true
 	cfg.Share.StoreODSOnly = true
 
-	// Create node with storage-only mode
 	nd := TestNodeWithConfig(t, node.Bridge, cfg)
 	require.NotNil(t, nd)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start the node
 	err = nd.Start(ctx)
 	require.NoError(t, err)
 
-	// Verify P2P components are nil
 	require.Nil(t, nd.Host, "P2P Host should be nil when P2P is disabled")
 	require.Nil(t, nd.ConnGater, "ConnGater should be nil when P2P is disabled")
 	require.Nil(t, nd.Routing, "Routing should be nil when P2P is disabled")
@@ -46,13 +41,11 @@ func TestStorageOnlyMode_P2PDisabled(t *testing.T) {
 	require.Nil(t, nd.BlockService, "BlockService should be nil when P2P is disabled")
 	require.Nil(t, nd.PubSub, "PubSub should be nil when P2P is disabled")
 
-	// Verify core components are still available
 	require.NotNil(t, nd.RPCServer, "RPC Server should be available")
 	require.NotNil(t, nd.ShareServ, "Share service should be available")
 	require.NotNil(t, nd.HeaderServ, "Header service should be available")
 	require.NotNil(t, nd.StateServ, "State service should be available")
 
-	// Stop the node
 	err = nd.Stop(ctx)
 	require.NoError(t, err)
 }
@@ -62,14 +55,12 @@ func TestStorageOnlyMode_ValidationFailure(t *testing.T) {
 	host, port, err := net.SplitHostPort(consNode.GRPCClient.Target())
 	require.NoError(t, err)
 
-	// Create config with P2P disabled but ODS-only NOT enabled (should fail)
 	cfg := DefaultConfig(node.Bridge)
 	cfg.Core.IP = host
 	cfg.Core.Port = port
 	cfg.P2P.Disabled = true
-	cfg.Share.StoreODSOnly = false // This should cause validation to fail
+	cfg.Share.StoreODSOnly = false
 
-	// Attempt to create node - should fail during module construction
 	store := MockStore(t, cfg)
 	_, err = New(node.Bridge, modp2p.Private, store)
 	require.Error(t, err)
@@ -81,16 +72,13 @@ func TestODSOnlyStorage_ConfigApplied(t *testing.T) {
 	host, port, err := net.SplitHostPort(consNode.GRPCClient.Target())
 	require.NoError(t, err)
 
-	// Create config with ODS-only enabled
 	cfg := DefaultConfig(node.Bridge)
 	cfg.Core.IP = host
 	cfg.Core.Port = port
 	cfg.Share.StoreODSOnly = true
 
-	// Verify config is set correctly
 	require.True(t, cfg.Share.StoreODSOnly, "StoreODSOnly should be true")
 
-	// Create node - should succeed
 	nd := TestNodeWithConfig(t, node.Bridge, cfg)
 	require.NotNil(t, nd)
 
@@ -100,7 +88,6 @@ func TestODSOnlyStorage_ConfigApplied(t *testing.T) {
 	err = nd.Start(ctx)
 	require.NoError(t, err)
 
-	// Node should start successfully with ODS-only config
 	require.NotNil(t, nd.ShareServ)
 
 	err = nd.Stop(ctx)
@@ -112,7 +99,6 @@ func TestStorageOnlyMode_OnlyBridgeSupported(t *testing.T) {
 	host, port, err := net.SplitHostPort(consNode.GRPCClient.Target())
 	require.NoError(t, err)
 
-	// Try to create Light node with P2P disabled - should fail
 	cfg := DefaultConfig(node.Light)
 	cfg.Core.IP = host
 	cfg.Core.Port = port

--- a/share/availability/full/options.go
+++ b/share/availability/full/options.go
@@ -2,6 +2,7 @@ package full
 
 type params struct {
 	archival bool
+	odsOnly  bool
 }
 
 // Option is a function that configures light availability Parameters
@@ -12,6 +13,7 @@ type Option func(*params)
 func defaultParams() *params {
 	return &params{
 		archival: false,
+		odsOnly:  false,
 	}
 }
 
@@ -21,5 +23,13 @@ func defaultParams() *params {
 func WithArchivalMode() Option {
 	return func(p *params) {
 		p.archival = true
+	}
+}
+
+// WithODSOnly is a functional option to enable ODS-only storage mode.
+// When enabled, all blocks are stored using PutODS instead of PutODSQ4.
+func WithODSOnly() Option {
+	return func(p *params) {
+		p.odsOnly = true
 	}
 }


### PR DESCRIPTION
## Summary
Adds support for storage-only Bridge nodes that run without P2P networking, enabling hosted RPC providers to operate with minimal resource usage.

## Changes
- **P2P Disabled Mode**: New `p2p.disabled` config flag (CLI: `--p2p.disabled`) that disables all P2P components (host, DHT, Gossip, Shrex, Bitswap) for Bridge nodes
- **ODS-Only Storage**: New `share.store_ods_only` config flag that stores only ODS instead of ODSQ4, reducing storage requirements
- **Cross-Module Validation**: Enforces that `p2p.disabled` requires `share.store_ods_only` to be enabled
- **Stub Implementations**: Provides no-op implementations for P2P-dependent services (fraud, header subscriber/broadcaster) when P2P is disabled

## Testing
- Config validation tests for both P2P and Share modules
- Integration tests verifying storage-only mode behavior
- ODS-only storage behavior tests

## Use Case
Enables Bridge nodes to operate as storage-only RPC providers without P2P overhead, ideal for hosted infrastructure providers. #4296 