### PR TITLE
fix: precedence to avoid masking Byzantine errors in SharesAvailable

### DIFF
--- a/share/availability/full/availability.go
+++ b/share/availability/full/availability.go
@@ -89,7 +89,8 @@ func (fa *ShareAvailability) SharesAvailable(ctx context.Context, header *header
 		}
 		log.Errorw("availability validation failed", "root", dah.String(), "err", err.Error())
 		var byzantineErr *byzantine.ErrByzantine
-		if errors.Is(err, shwap.ErrNotFound) || errors.Is(err, context.DeadlineExceeded) && !errors.As(err, &byzantineErr) {
+		if (errors.Is(err, shwap.ErrNotFound) || errors.Is(err, context.DeadlineExceeded)) &&
+			!errors.As(err, &byzantineErr) {
 			return share.ErrNotAvailable
 		}
 		return err


### PR DESCRIPTION
The error handling in share/availability/full/availability.go used a disjunction combined with a conjunction without explicit parentheses, relying on Go’s operator precedence where && binds tighter than ||. As a result, shwap.ErrNotFound was always mapped to share.ErrNotAvailable even when the same error chain also contained a *byzantine.ErrByzantine via errors.Join, which could mask Byzantine faults as mere unavailability. This change groups the NotFound and DeadlineExceeded checks together and only maps to ErrNotAvailable if neither condition is accompanied by a Byzantine error. The intended behavior aligns with tests expecting NotFound and DeadlineExceeded to map to ErrNotAvailable while propagating Byzantine errors distinctly.
