### PR TITLE
fix(p2p): validate CELESTIA_CUSTOM netID and avoid empty network

### DIFF
--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -99,10 +99,10 @@ func parseNetworkFromEnv() (Network, error) {
 			"store!\n\n")
 		// ensure at least custom network is set
 		params := strings.Split(custom, ":")
-		if len(params) == 0 {
-			return network, fmt.Errorf("params: must provide at least <network_ID> to use a custom network")
+		netID := strings.TrimSpace(params[0])
+		if netID == "" {
+			return "", fmt.Errorf("params: must provide at least <network_ID> to use a custom network")
 		}
-		netID := params[0]
 		network = Network(netID)
 		addCustomNetwork(network)
 		// check if genesis hash provided and register it if exists
@@ -117,7 +117,7 @@ func parseNetworkFromEnv() (Network, error) {
 			bs := strings.Split(bootstrappers, ",")
 			_, err := parseAddrInfos(bs)
 			if err != nil {
-				return DefaultNetwork, fmt.Errorf("params: env %s: contains invalid multiaddress", EnvCustomNetwork)
+				return "", fmt.Errorf("params: env %s: contains invalid multiaddress", EnvCustomNetwork)
 			}
 			bootstrapList[Network(netID)] = bs
 		}


### PR DESCRIPTION
strings.Split always returns at least one element, so checking len(params) == 0 never caught empty CELESTIA_CUSTOM. This allowed addCustomNetwork("") to pollute global network lists. The fix validates that the first segment (netID) is non-empty and only then adds the custom network. Also return an empty Network with error for invalid bootstrapper addresses instead of DefaultNetwork to avoid misleading fallbacks. This aligns with docs and existing tests expecting errors on empty or malformed env values.