### PR TITLE
fix(bitswap): propagate HasByHeight result in Blockstore.Has

### DIFF
--- a/share/shwap/p2p/bitswap/block_store.go
+++ b/share/shwap/p2p/bitswap/block_store.go
@@ -77,11 +77,11 @@ func (b *Blockstore) Has(ctx context.Context, cid cid.Cid) (bool, error) {
 		return false, err
 	}
 
-	_, err = b.Getter.HasByHeight(ctx, blk.Height())
+	has, err := b.Getter.HasByHeight(ctx, blk.Height())
 	if err != nil {
 		return false, fmt.Errorf("checking EDS Accessor for height %v: %w", blk.Height(), err)
 	}
-	return true, nil
+	return has, nil
 }
 
 func (b *Blockstore) Put(context.Context, blocks.Block) error {


### PR DESCRIPTION
Blockstore.Has ignored the boolean returned by Getter.HasByHeight and unconditionally returned true, causing false-positive availability and skewed Bitswap scheduling/metrics. This change returns the actual has value while preserving existing error handling.