### PR TITLE
fix: treat CELESTIA_CUSTOM parse errors as fatal in ParseNetwork

### DIFF
--- a/nodebuilder/p2p/flags.go
+++ b/nodebuilder/p2p/flags.go
@@ -68,8 +68,12 @@ func ParseFlags(
 // ParseNetwork tries to parse the network from the flags and environment,
 // and returns either the parsed network or the build's default network
 func ParseNetwork(cmd *cobra.Command) (Network, error) {
-	if envNetwork, err := parseNetworkFromEnv(); envNetwork != "" {
-		return envNetwork, err
+	envNetwork, err := parseNetworkFromEnv()
+	if err != nil {
+		return "", err
+	}
+	if envNetwork != "" {
+		return envNetwork, nil
 	}
 	parsed := cmd.Flag(networkFlag).Value.String()
 	switch parsed {


### PR DESCRIPTION
ParseNetwork previously ignored errors returned by parseNetworkFromEnv when CELESTIA_CUSTOM was set but invalid, and silently fell back to the CLI network flag or default network. This could cause a node to join an unintended network if the custom env var was misconfigured. Now ParseNetwork returns any error from parseNetworkFromEnv and only falls back to flags when CELESTIA_CUSTOM is unset, making custom network configuration failures explicit instead of silent.