### PR TITLE
fix(core): Return partial response for headers if one fails

### DIFF
--- a/core/exchange.go
+++ b/core/exchange.go
@@ -135,6 +135,15 @@ func (ce *Exchange) getRangeByHeight(ctx context.Context, from, amount uint64) (
 	}
 
 	if err := errGroup.Wait(); err != nil {
+		// return partial range if possible
+		for i, h := range headers {
+			if h == nil || h.IsZero() {
+				if i > 0 {
+					return headers[:i], nil
+				}
+				break
+			}
+		}
 		return nil, err
 	}
 	log.Debugw("received headers", "from", from, "to", from+amount, "after", time.Since(start))

--- a/core/exchange.go
+++ b/core/exchange.go
@@ -135,9 +135,10 @@ func (ce *Exchange) getRangeByHeight(ctx context.Context, from, amount uint64) (
 	}
 
 	if err := errGroup.Wait(); err != nil {
-		// return partial range if possible
+		// Return a best-effort contiguous prefix of fetched headers to save re-work. Concurrent
+		// cancellation may nil a slot below the failure, so the prefix is gap-free but may be short.
 		for i, h := range headers {
-			if h == nil || h.IsZero() {
+			if h == nil {
 				if i > 0 {
 					return headers[:i], nil
 				}

--- a/core/exchange.go
+++ b/core/exchange.go
@@ -120,7 +120,10 @@ func (ce *Exchange) getRangeByHeight(ctx context.Context, from, amount uint64) (
 	headers := make([]*header.ExtendedHeader, amount)
 
 	start := time.Now()
-	errGroup, ctx := errgroup.WithContext(ctx)
+	// A plain errgroup (not WithContext) avoids cancelling sibling fetches on the first
+	// failure, so every height runs to completion and headers[:firstNil] is the largest
+	// contiguous prefix.
+	var errGroup errgroup.Group
 	errGroup.SetLimit(concurrencyLimit)
 	for i := range headers {
 		errGroup.Go(func() error {
@@ -135,8 +138,7 @@ func (ce *Exchange) getRangeByHeight(ctx context.Context, from, amount uint64) (
 	}
 
 	if err := errGroup.Wait(); err != nil {
-		// Return a best-effort contiguous prefix of fetched headers to save re-work. Concurrent
-		// cancellation may nil a slot below the failure, so the prefix is gap-free but may be short.
+		// On failure, return the contiguous prefix already fetched so the caller skips re-work.
 		for i, h := range headers {
 			if h == nil {
 				if i > 0 {

--- a/core/exchange.go
+++ b/core/exchange.go
@@ -120,7 +120,7 @@ func (ce *Exchange) getRangeByHeight(ctx context.Context, from, amount uint64) (
 	headers := make([]*header.ExtendedHeader, amount)
 
 	start := time.Now()
-	// A plain errgroup (not WithContext) avoids cancelling sibling fetches on the first
+	// A plain errgroup (not WithContext) avoids canceling sibling fetches on the first
 	// failure, so every height runs to completion and headers[:firstNil] is the largest
 	// contiguous prefix.
 	var errGroup errgroup.Group

--- a/core/exchange_partial_test.go
+++ b/core/exchange_partial_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/store"
+)
+
+// gappyBlockAPIClient fails BlockByHeight for one height instantly and delays every other,
+// so the mid-range failure lands while the lower fetches are still in flight.
+type gappyBlockAPIClient struct {
+	coregrpc.BlockAPIClient
+	failHeight int64
+	delay      time.Duration
+}
+
+func (g *gappyBlockAPIClient) BlockByHeight(
+	ctx context.Context,
+	in *coregrpc.BlockByHeightRequest,
+	opts ...grpc.CallOption,
+) (coregrpc.BlockAPI_BlockByHeightClient, error) {
+	if in.Height == g.failHeight {
+		return nil, errors.New("gappy: height unavailable")
+	}
+	time.Sleep(g.delay)
+	return g.BlockAPIClient.BlockByHeight(ctx, in, opts...)
+}
+
+// TestExchange_ReturnsLargestContiguousRange verifies that a mid-range failure does not
+// cancel the lower in-flight fetches, so the full contiguous prefix below it is returned.
+func TestExchange_ReturnsLargestContiguousRange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	const (
+		to         = 15
+		failHeight = 10
+	)
+
+	cfg := DefaultTestConfig()
+	_, network := createCoreFetcher(t, cfg)
+	_, err := network.WaitForHeightWithTimeout(to, 20*time.Second)
+	require.NoError(t, err)
+
+	fetcher := &BlockFetcher{client: &gappyBlockAPIClient{
+		BlockAPIClient: coregrpc.NewBlockAPIClient(network.GRPCClient),
+		failHeight:     failHeight,
+		delay:          100 * time.Millisecond,
+	}}
+
+	st, err := store.NewStore(store.DefaultParameters(), t.TempDir())
+	require.NoError(t, err)
+	ce, err := NewExchange(fetcher, st, header.MakeExtendedHeader)
+	require.NoError(t, err)
+
+	from, err := ce.GetByHeight(ctx, 1)
+	require.NoError(t, err)
+
+	headers, err := ce.GetRangeByHeight(ctx, from, to)
+	require.NoError(t, err)
+
+	require.Len(t, headers, failHeight-2)
+	for i, h := range headers {
+		require.Equal(t, uint64(2+i), h.Height())
+	}
+}

--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -185,6 +185,48 @@ func TestExchange_StoreHistoricIfArchival(t *testing.T) {
 	}
 }
 
+// TestExchange_ReturnsPartialRange tests that the Exchange
+// is able to return a partial range of headers if a routine fails
+// in the err group.
+func TestExchange_ReturnsPartialRange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cfg := DefaultTestConfig()
+	fetcher, cctx := createCoreFetcher(t, cfg)
+	t.Cleanup(func() {
+		require.NoError(t, cctx.Stop())
+	})
+	generated := generateNonEmptyBlocks(t, ctx, fetcher, cfg, cctx.Context)
+	require.GreaterOrEqual(t, len(generated), 20)
+
+	store, err := store.NewStore(store.DefaultParameters(), t.TempDir())
+	require.NoError(t, err)
+
+	ce, err := NewExchange(fetcher, store, header.MakeExtendedHeader)
+	require.NoError(t, err)
+
+	// initialize store with genesis block
+	genHeight := int64(1)
+	genBlock, err := fetcher.GetBlock(ctx, genHeight)
+	require.NoError(t, err)
+	genHeader, err := ce.Get(ctx, genBlock.Header.Hash().Bytes())
+	require.NoError(t, err)
+
+	to := generated[len(generated)-1].height
+	_, err = cctx.WaitForHeight(int64(to))
+	require.NoError(t, err)
+
+	shortCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	t.Cleanup(cancel)
+
+	headers, err := ce.GetRangeByHeight(shortCtx, genHeader, to+20) // attempt to fetch non-existent blocks
+
+	require.NoError(t, err)
+	unexpectedAmount := (to + 20) - genHeader.Height() + 1
+	assert.Less(t, uint64(len(headers)), unexpectedAmount)
+}
+
 func createCoreFetcher(t *testing.T, cfg *testnode.Config) (*BlockFetcher, *Network) {
 	t.Helper()
 

--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -185,9 +185,8 @@ func TestExchange_StoreHistoricIfArchival(t *testing.T) {
 	}
 }
 
-// TestExchange_ReturnsPartialRange tests that the Exchange
-// is able to return a partial range of headers if a routine fails
-// in the err group.
+// TestExchange_ReturnsPartialRange verifies that when the requested range extends past the
+// chain tip, the Exchange returns the contiguous prefix that exists instead of failing.
 func TestExchange_ReturnsPartialRange(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -220,11 +219,15 @@ func TestExchange_ReturnsPartialRange(t *testing.T) {
 	shortCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	t.Cleanup(cancel)
 
-	headers, err := ce.GetRangeByHeight(shortCtx, genHeader, to+20) // attempt to fetch non-existent blocks
+	headers, err := ce.GetRangeByHeight(shortCtx, genHeader, to+20)
 
 	require.NoError(t, err)
-	unexpectedAmount := (to + 20) - genHeader.Height() + 1
-	assert.Less(t, uint64(len(headers)), unexpectedAmount)
+	requested := (to + 20) - (genHeader.Height() + 1)
+	assert.GreaterOrEqual(t, uint64(len(headers)), to-genHeader.Height())
+	assert.Less(t, uint64(len(headers)), requested)
+	for i, h := range headers {
+		require.Equal(t, genHeader.Height()+1+uint64(i), h.Height())
+	}
 }
 
 func createCoreFetcher(t *testing.T, cfg *testnode.Config) (*BlockFetcher, *Network) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
 	github.com/benbjohnson/clock v1.3.5
 	github.com/celestiaorg/celestia-app/v9 v9.0.4
-	github.com/celestiaorg/go-header v0.8.5
+	github.com/celestiaorg/go-header v0.8.6
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2
 	github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076
 	github.com/celestiaorg/go-square/v4 v4.0.0-rc5

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0 h1:GyDYfK8dLETlUI7F+w+3QYQgAs
 github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0/go.mod h1:T4K9O18zQNKNpt4YvTL3lcUt4aKOEU05ZIFWVdQi3Ak=
 github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4 h1:udw77BU45zmvTV7798FhR1wHFmsFpu4GnA5mubtMcR0=
 github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4/go.mod h1:W+pI1NsUsz3tcsAACMtfC+IZdnQTnC/7VfPoJBQuts0=
-github.com/celestiaorg/go-header v0.8.5 h1:MkzlioiSeybKVNDa0805fS3mS3NG8ub93Gs2xaKwSZ4=
-github.com/celestiaorg/go-header v0.8.5/go.mod h1:DKl6pcKCJ0ehGUgDmfxBNz6Lv0Ky4E1Oyrcx96eQm/4=
+github.com/celestiaorg/go-header v0.8.6 h1:UNyLYFt+CDMovNEk1ytv32A5iSd8WMealSmUIIb9MZE=
+github.com/celestiaorg/go-header v0.8.6/go.mod h1:tldb47kH5olZHpbJ4I+FiETI9EvSj6vhojWSrcG0WYA=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
 github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076 h1:PYInrsYzrDIsZW9Yb86OTi2aEKuPcpgJt6Mc0Jlc/yg=

--- a/nodebuilder/tests/tastora/go.mod
+++ b/nodebuilder/tests/tastora/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.0 // indirect
-	github.com/celestiaorg/go-header v0.8.5 // indirect
+	github.com/celestiaorg/go-header v0.8.6 // indirect
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2 // indirect
 	github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076 // indirect
 	github.com/celestiaorg/go-square/v2 v2.3.3 // indirect

--- a/nodebuilder/tests/tastora/go.sum
+++ b/nodebuilder/tests/tastora/go.sum
@@ -232,8 +232,8 @@ github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0 h1:GyDYfK8dLETlUI7F+w+3QYQgAs
 github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0/go.mod h1:T4K9O18zQNKNpt4YvTL3lcUt4aKOEU05ZIFWVdQi3Ak=
 github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4 h1:udw77BU45zmvTV7798FhR1wHFmsFpu4GnA5mubtMcR0=
 github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4/go.mod h1:W+pI1NsUsz3tcsAACMtfC+IZdnQTnC/7VfPoJBQuts0=
-github.com/celestiaorg/go-header v0.8.5 h1:MkzlioiSeybKVNDa0805fS3mS3NG8ub93Gs2xaKwSZ4=
-github.com/celestiaorg/go-header v0.8.5/go.mod h1:DKl6pcKCJ0ehGUgDmfxBNz6Lv0Ky4E1Oyrcx96eQm/4=
+github.com/celestiaorg/go-header v0.8.6 h1:UNyLYFt+CDMovNEk1ytv32A5iSd8WMealSmUIIb9MZE=
+github.com/celestiaorg/go-header v0.8.6/go.mod h1:tldb47kH5olZHpbJ4I+FiETI9EvSj6vhojWSrcG0WYA=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
 github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076 h1:PYInrsYzrDIsZW9Yb86OTi2aEKuPcpgJt6Mc0Jlc/yg=


### PR DESCRIPTION
Fixes an issue where we would discard all headers in case one failed. Now we can at least return the ones we synced successfully (as long as they're contiguous from `from`) so we don't need to do duplicate work. 