### PR TITLE
chore(das): remove unused subscriberDone channel from DASer

### DIFF
--- a/das/daser.go
+++ b/das/daser.go
@@ -33,9 +33,8 @@ type DASer struct {
 	store      checkpointStore
 	subscriber subscriber
 
-	cancel         context.CancelFunc
-	subscriberDone chan struct{}
-	running        atomic.Bool
+	cancel  context.CancelFunc
+	running atomic.Bool
 }
 
 type (
@@ -54,14 +53,13 @@ func NewDASer(
 	options ...Option,
 ) (*DASer, error) {
 	d := &DASer{
-		params:         DefaultParameters(),
-		da:             da,
-		bcast:          bcast,
-		hsub:           hsub,
-		getter:         getter,
-		store:          newCheckpointStore(dstore),
-		subscriber:     newSubscriber(),
-		subscriberDone: make(chan struct{}),
+		params:     DefaultParameters(),
+		da:         da,
+		bcast:      bcast,
+		hsub:       hsub,
+		getter:     getter,
+		store:      newCheckpointStore(dstore),
+		subscriber: newSubscriber(),
 	}
 
 	for _, applyOpt := range options {


### PR DESCRIPTION
The DASer struct had a subscriberDone chan struct{} field that was only allocated in NewDASer and never used anywhere in the codebase. Subscriber lifecycle and shutdown are already handled via the embedded done type and its wait method. This change removes the dead field and its allocation, relying solely on the existing done-based mechanism and avoiding an unnecessary channel allocation.