### PR TITLE
fix: simplify fs keystore delete and rely on os.Remove

### DIFF
--- a/libs/keystore/fs_keystore.go
+++ b/libs/keystore/fs_keystore.go
@@ -88,18 +88,16 @@ func (f *fsKeystore) Get(n KeyName) (PrivKey, error) {
 func (f *fsKeystore) Delete(n KeyName) error {
 	path := f.pathTo(n.Base32())
 
-	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return fmt.Errorf("keystore: key '%s' not found", n)
-	} else if err != nil {
-		return fmt.Errorf("keystore: check before reading key '%s' failed: %w", n, err)
+	err := os.Remove(path)
+	if err == nil {
+		return nil
 	}
 
-	err = os.Remove(path)
-	if err != nil {
-		return fmt.Errorf("keystore: failed to delete key '%s': %w", n, err)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("keystore: key '%s' not found", n)
 	}
-	return nil
+
+	return fmt.Errorf("keystore: failed to delete key '%s': %w", n, err)
 }
 
 func (f *fsKeystore) List() ([]KeyName, error) {


### PR DESCRIPTION
Removed redundant os.Stat check from fsKeystore.Delete and rely solely on os.Remove. This preserves the existing “keystore: key '%s' not found” error for missing keys by mapping os.ErrNotExist from Remove, closes the TOCTOU window between Stat and Remove, and aligns the deletion logic with the rest of the codebase while avoiding an extra syscall.