### PR TITLE
feat: Add pin node type

### DIFF
--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -27,10 +27,12 @@ func init() {
 	bridgeCmd := cmdnode.NewBridge(WithSubcommands())
 	lightCmd := cmdnode.NewLight(WithSubcommands())
 	fullCmd := cmdnode.NewFull(WithSubcommands())
+	pinCmd := cmdnode.NewPin(WithSubcommands())
 	rootCmd.AddCommand(
 		bridgeCmd,
 		lightCmd,
 		fullCmd,
+		pinCmd,
 		docgenCmd,
 		versionCmd,
 	)
@@ -49,7 +51,7 @@ func run() error {
 }
 
 var rootCmd = &cobra.Command{
-	Use: "celestia [  bridge  ||  full ||  light  ] [subcommand]",
+	Use: "celestia [  bridge  ||  full ||  light || pin ] [subcommand]",
 	Short: `
 	    ____      __          __  _
 	  / ____/__  / /__  _____/ /_(_)___ _

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/nodebuilder/pruner"
 	"github.com/celestiaorg/celestia-node/nodebuilder/rpc"
+	"github.com/celestiaorg/celestia-node/nodebuilder/share"
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
 
@@ -22,6 +23,7 @@ func NewBridge(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command
 		rpc.Flags(),
 		state.Flags(),
 		pruner.Flags(),
+		share.Flags(),
 	}
 	cmd := &cobra.Command{
 		Use:   "bridge [subcommand]",
@@ -50,6 +52,7 @@ func NewLight(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command 
 		rpc.Flags(),
 		state.Flags(),
 		pruner.Flags(),
+		share.Flags(),
 	}
 	cmd := &cobra.Command{
 		Use:   "light [subcommand]",
@@ -77,6 +80,7 @@ func NewFull(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command {
 		rpc.Flags(),
 		state.Flags(),
 		pruner.Flags(),
+		share.Flags(),
 	}
 	cmd := &cobra.Command{
 		Use:   "full [subcommand]",
@@ -89,6 +93,34 @@ func NewFull(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command {
 			)
 			ctx := WithNodeType(cmd.Context(), node.Full)
 			cmd.SetContext(ctx)
+			return nil
+		},
+	}
+	for _, option := range options {
+		option(cmd, flags)
+	}
+	return cmd
+}
+func NewPin(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command {
+	flags := []*pflag.FlagSet{
+		NodeFlags(),
+		p2p.Flags(),
+		header.Flags(),
+		MiscFlags(),
+		core.Flags(),
+		rpc.Flags(),
+		state.Flags(),
+		pruner.Flags(),
+		share.Flags(),
+	}
+	cmd := &cobra.Command{
+		Use:   "pin [subcommand]",
+		Args:  cobra.NoArgs,
+		Short: "Manage your Pin node (targeted namespace storage)",
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := WithNodeType(cmd.Context(), node.Pin)
+			cmd.SetContext(ctx)
+
 			return nil
 		},
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/nodebuilder/pruner"
 	rpc_cfg "github.com/celestiaorg/celestia-node/nodebuilder/rpc"
+	"github.com/celestiaorg/celestia-node/nodebuilder/share"
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 )
 
@@ -135,13 +136,18 @@ func ParseAllFlags(cmd *cobra.Command, nodeType node.Type, args []string) error 
 		return err
 	}
 
+	err = share.ParseFlags(cmd, &cfg.Share)
+	if err != nil {
+		return err
+	}
+
 	opt := pruner.ParseFlags(cmd, nodeType)
 	if opt != nil {
 		ctx = WithNodeOptions(ctx, opt)
 	}
 
 	switch nodeType {
-	case node.Light, node.Full:
+	case node.Light, node.Full, node.Pin:
 		err = header.ParseFlags(cmd, &cfg.Header)
 		if err != nil {
 			return err

--- a/core/eds.go
+++ b/core/eds.go
@@ -28,7 +28,7 @@ func storeEDS(
 	var err error
 	var storedQ4 bool
 	// archival nodes should not store Q4 outside the availability window.
-	if availability.IsWithinWindow(eh.Time(), availability.StorageWindow) {
+	if availability.IsWithinWindow(eh.Time(), window) {
 		err = store.PutODSQ4(ctx, eh.DAH, eh.Height(), eds)
 		storedQ4 = true
 	} else {

--- a/core/eds.go
+++ b/core/eds.go
@@ -26,14 +26,20 @@ func storeEDS(
 	}
 
 	var err error
+	var storedQ4 bool
 	// archival nodes should not store Q4 outside the availability window.
-	if availability.IsWithinWindow(eh.Time(), window) {
+	if availability.IsWithinWindow(eh.Time(), availability.StorageWindow) {
 		err = store.PutODSQ4(ctx, eh.DAH, eh.Height(), eds)
+		storedQ4 = true
 	} else {
 		err = store.PutODS(ctx, eh.DAH, eh.Height(), eds)
 	}
+
 	if err == nil {
-		log.Debugw("stored EDS for height", "height", eh.Height(), "EDS size", len(eh.DAH.RowRoots))
+		log.Debugw("stored EDS for height",
+			"height", eh.Height(),
+			"EDS size", len(eh.DAH.RowRoots),
+			"storedQ4", storedQ4)
 	}
 	return err
 }

--- a/libs/utils/namespace.go
+++ b/libs/utils/namespace.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	libshare "github.com/celestiaorg/go-square/v3/share"
+)
+
+// ParseNamespace parses a namespace from a hex string.
+// It supports both:
+//   - Full 58-character hex (29 bytes): version byte + 28 byte ID
+//   - Short hex (up to 20 characters / 10 bytes): user portion only, left-padded as v0
+func ParseNamespace(id string) (libshare.Namespace, error) {
+	if id == "" {
+		return libshare.Namespace{}, nil
+	}
+
+	decoded, err := hex.DecodeString(id)
+	if err != nil {
+		return libshare.Namespace{}, fmt.Errorf("invalid hex: %w", err)
+	}
+
+	// Full namespace (29 bytes = 1 version + 28 ID)
+	if len(decoded) == libshare.NamespaceSize {
+		return libshare.NewNamespaceFromBytes(decoded)
+	}
+
+	// Short format: treat as user portion of a v0 namespace (max 10 bytes)
+	if len(decoded) <= 10 {
+		return libshare.NewV0Namespace(decoded)
+	}
+
+	return libshare.Namespace{}, fmt.Errorf(
+		"invalid namespace length: got %d bytes, expected %d (full) or <= 10 (short v0)",
+		len(decoded), libshare.NamespaceSize,
+	)
+}
+

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -49,7 +49,7 @@ func DefaultConfig(tp node.Type) *Config {
 	}
 
 	switch tp {
-	case node.Bridge:
+	case node.Bridge, node.Pin:
 		return commonConfig
 	case node.Light, node.Full:
 		commonConfig.DASer = das.DefaultConfig(tp)

--- a/nodebuilder/das/module.go
+++ b/nodebuilder/das/module.go
@@ -14,7 +14,7 @@ import (
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	// If DASer is disabled, provide the stub implementation for any node type
 	// Also provide the stub implementation for bridge nodes as they do not need DASer
-	if !cfg.Enabled || tp == node.Bridge {
+	if !cfg.Enabled || tp == node.Bridge || tp == node.Pin {
 		return fx.Module(
 			"das",
 			fx.Provide(newDaserStub),

--- a/nodebuilder/fraud/module.go
+++ b/nodebuilder/fraud/module.go
@@ -26,7 +26,7 @@ func ConstructModule(tp node.Type) fx.Option {
 			baseComponent,
 			fx.Provide(newFraudServiceWithSync),
 		)
-	case node.Full, node.Bridge:
+	case node.Full, node.Bridge, node.Pin:
 		return fx.Module(
 			"fraud",
 			baseComponent,

--- a/nodebuilder/header/config.go
+++ b/nodebuilder/header/config.go
@@ -45,10 +45,9 @@ func DefaultConfig(tp node.Type) Config {
 	}
 
 	switch tp {
-	case node.Full, node.Bridge:
+	case node.Full, node.Bridge, node.Pin:
 		cfg.Store.StoreCacheSize = 2048
 		cfg.Store.IndexCacheSize = 4096
-
 		cfg.Syncer.PruningWindow = 0 // reset pruning window to zero
 		return cfg
 	case node.Light:
@@ -99,6 +98,9 @@ func (cfg *Config) Validate(tp node.Type) error {
 			return fmt.Errorf("module/header: Syncer.PruningWindow must not be less then sampling storage window (%s)",
 				availability.StorageWindow)
 		}
+	case node.Pin:
+		// Pin nodes are allowed to sync from a specific height/hash
+		return nil
 	default:
 		panic("invalid node type")
 	}

--- a/nodebuilder/header/flags.go
+++ b/nodebuilder/header/flags.go
@@ -15,12 +15,17 @@ func Flags() *flag.FlagSet {
 	flags := &flag.FlagSet{}
 
 	flags.AddFlagSet(TrustedPeersFlags())
+	flags.AddFlagSet(SyncFromFlags())
 	return flags
 }
 
 // ParseFlags parses Header package flags from the given cmd and applies them to the passed config.
-func ParseFlags(cmd *cobra.Command, cfg *Config) error {
-	return ParseTrustedPeerFlags(cmd, cfg)
+func ParseFlags(cmd *cobra.Command, cfg *Config) (err error) {
+	err = ParseTrustedPeerFlags(cmd, cfg)
+	if err != nil {
+		return err
+	}
+	return ParseSyncFromFlags(cmd, cfg)
 }
 
 // TrustedPeersFlags returns a set of flags.
@@ -52,5 +57,39 @@ func ParseTrustedPeerFlags(
 		}
 	}
 	cfg.TrustedPeers = append(cfg.TrustedPeers, tpeers...)
+	return nil
+}
+
+func SyncFromFlags() *flag.FlagSet {
+	flags := &flag.FlagSet{}
+	flags.String(
+		"header.sync-from-hash",
+		"",
+		"Hex-encoded hash of the header to start syncing from.",
+	)
+	flags.Uint64(
+		"header.sync-from-height",
+		0,
+		"Height of the header to start syncing from.",
+	)
+	return flags
+}
+
+func ParseSyncFromFlags(cmd *cobra.Command, cfg *Config) error {
+	hash, err := cmd.Flags().GetString("header.sync-from-hash")
+	if err != nil {
+		return err
+	}
+	if hash != "" {
+		cfg.Syncer.SyncFromHash = hash
+	}
+
+	height, err := cmd.Flags().GetUint64("header.sync-from-height")
+	if err != nil {
+		return err
+	}
+	if height != 0 {
+		cfg.Syncer.SyncFromHeight = height
+	}
 	return nil
 }

--- a/nodebuilder/header/module.go
+++ b/nodebuilder/header/module.go
@@ -109,7 +109,7 @@ func ConstructModule[H libhead.Header[H]](tp node.Type, cfg *Config) fx.Option {
 				return pidstore.NewPeerIDStore(ctx, ds)
 			}),
 		)
-	case node.Bridge:
+	case node.Bridge, node.Pin:
 		return fx.Module(
 			"header",
 			baseComponents,

--- a/nodebuilder/node/type.go
+++ b/nodebuilder/node/type.go
@@ -23,6 +23,8 @@ const (
 	Light
 	// Full is a Celestia Node that stores blocks in their entirety.
 	Full
+	// Pin is a Celestia Node that pins and stores data for a specific namespace.
+	Pin
 )
 
 // String converts Type to its string representation.
@@ -54,6 +56,7 @@ var typeToString = map[Type]string{
 	Bridge: "Bridge",
 	Light:  "Light",
 	Full:   "Full",
+	Pin:    "Pin",
 }
 
 // typeToString maps strings representations of all valid Types.
@@ -61,10 +64,11 @@ var stringToType = map[string]Type{
 	"bridge": Bridge,
 	"light":  Light,
 	"full":   Full,
+	"pin":    Pin,
 }
 
 // orderedTypes is a slice of all valid types in order of priority.
-var orderedTypes = []Type{Bridge, Full, Light}
+var orderedTypes = []Type{Bridge, Full, Light, Pin}
 
 // GetTypes returns a list of all known types in order of priority.
 func GetTypes() []Type {

--- a/nodebuilder/p2p/config.go
+++ b/nodebuilder/p2p/config.go
@@ -61,7 +61,7 @@ func DefaultConfig(tp node.Type) Config {
 			"/ip6/::/tcp/2121",
 		},
 		MutualPeers:  []string{},
-		PeerExchange: tp == node.Bridge || tp == node.Full,
+		PeerExchange: tp == node.Bridge || tp == node.Full || tp == node.Pin,
 		ConnManager:  defaultConnManagerConfig(tp),
 	}
 }

--- a/nodebuilder/p2p/misc.go
+++ b/nodebuilder/p2p/misc.go
@@ -32,7 +32,7 @@ func defaultConnManagerConfig(tp node.Type) connManagerConfig {
 			High:        100,
 			GracePeriod: time.Minute,
 		}
-	case node.Bridge, node.Full:
+	case node.Bridge, node.Full, node.Pin:
 		return connManagerConfig{
 			Low:         800,
 			High:        1000,

--- a/nodebuilder/p2p/module.go
+++ b/nodebuilder/p2p/module.go
@@ -36,7 +36,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	)
 
 	switch tp {
-	case node.Full, node.Bridge:
+	case node.Full, node.Bridge, node.Pin:
 		return fx.Module(
 			"p2p",
 			baseComponents,

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -26,7 +26,7 @@ func newDHT(
 	switch tp {
 	case node.Light:
 		mode = dht.ModeClient
-	case node.Bridge, node.Full:
+	case node.Bridge, node.Full, node.Pin:
 		mode = dht.ModeServer
 	default:
 		return nil, fmt.Errorf("unsupported node type: %s", tp)

--- a/nodebuilder/pruner/config.go
+++ b/nodebuilder/pruner/config.go
@@ -1,13 +1,21 @@
 package pruner
 
+import (
+	"time"
+
+	"github.com/celestiaorg/celestia-node/share/availability"
+)
+
 var MetricsEnabled bool
 
 type Config struct {
 	EnableService bool
+	StorageWindow time.Duration
 }
 
 func DefaultConfig() *Config {
 	return &Config{
 		EnableService: true,
+		StorageWindow: availability.StorageWindow,
 	}
 }

--- a/nodebuilder/pruner/flags.go
+++ b/nodebuilder/pruner/flags.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	"github.com/celestiaorg/celestia-node/share/availability"
 )
 
 const (
@@ -44,6 +45,10 @@ func ParseFlags(cmd *cobra.Command, tp node.Type) fx.Option {
 		dur, err := cmd.Flags().GetDuration(windowFlag)
 		if err != nil {
 			log.Fatal(err)
+		}
+		if dur < availability.SamplingWindow {
+			log.Fatalf("pruning window (%s) cannot be less than sampling window (%s)",
+				dur, availability.SamplingWindow)
 		}
 		cfg.StorageWindow = dur
 	}

--- a/nodebuilder/pruner/flags.go
+++ b/nodebuilder/pruner/flags.go
@@ -1,8 +1,6 @@
 package pruner
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"go.uber.org/fx"
@@ -42,9 +40,8 @@ func ParseFlags(cmd *cobra.Command, tp node.Type) fx.Option {
 	log.Info("PRUNING MODE ENABLED. Node will prune blocks to save space.")
 
 	cfg := DefaultConfig()
-	window := cmd.Flag(windowFlag).Value.String()
-	if window != "0s" {
-		dur, err := time.ParseDuration(window)
+	if cmd.Flag(windowFlag).Changed {
+		dur, err := cmd.Flags().GetDuration(windowFlag)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/nodebuilder/pruner/flags.go
+++ b/nodebuilder/pruner/flags.go
@@ -27,8 +27,8 @@ func Flags() *flag.FlagSet {
 func ParseFlags(cmd *cobra.Command, tp node.Type) fx.Option {
 	archivalChanged := cmd.Flag(archivalFlag).Changed
 	if archivalChanged {
-		if tp != node.Full && tp != node.Bridge {
-			log.Fatal("Archival mode is only supported for Full and Bridge nodes")
+		if tp != node.Full && tp != node.Bridge && tp != node.Pin {
+			log.Fatal("Archival mode is only supported for Full, Bridge, and Pin nodes")
 		}
 		log.Info("ARCHIVAL MODE ENABLED. All blocks will be synced and stored, however archival blocks will " +
 			"be trimmed after the storage window. Expect to see pruning logs as the pruner will still run to trim")

--- a/nodebuilder/pruner/module.go
+++ b/nodebuilder/pruner/module.go
@@ -11,7 +11,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	modshare "github.com/celestiaorg/celestia-node/nodebuilder/share"
 	"github.com/celestiaorg/celestia-node/pruner"
-	"github.com/celestiaorg/celestia-node/share/availability"
+	corepruner "github.com/celestiaorg/celestia-node/pruner"
 	fullavail "github.com/celestiaorg/celestia-node/share/availability/full"
 	"github.com/celestiaorg/celestia-node/share/availability/light"
 	"github.com/celestiaorg/celestia-node/share/shwap/p2p/discovery"
@@ -23,16 +23,16 @@ func ConstructModule(tp node.Type) fx.Option {
 	prunerService := fx.Options(
 		fx.Provide(fx.Annotate(
 			newPrunerService,
-			fx.OnStart(func(ctx context.Context, p *pruner.Service) error {
+			fx.OnStart(func(ctx context.Context, p *corepruner.Service) error {
 				return p.Start(ctx)
 			}),
-			fx.OnStop(func(ctx context.Context, p *pruner.Service) error {
+			fx.OnStop(func(ctx context.Context, p *corepruner.Service) error {
 				return p.Stop(ctx)
 			}),
 		)),
 		// This is necessary to invoke the pruner service as independent thanks to a
 		// quirk in FX.
-		fx.Invoke(func(_ *pruner.Service) {}),
+		fx.Invoke(func(_ *corepruner.Service) {}),
 	)
 
 	baseComponents := fx.Options(
@@ -49,35 +49,56 @@ func ConstructModule(tp node.Type) fx.Option {
 		// LNs enforce pruning by default
 		return fx.Module("prune",
 			baseComponents,
-			fx.Supply(modshare.Window(availability.SamplingWindow)),
+			fx.Provide(func(cfg *Config) modshare.Window {
+				return modshare.Window(cfg.StorageWindow)
+			}),
 			// TODO(@walldiss @renaynay): remove conversion after Availability and Pruner interfaces are merged
 			//  note this provide exists in pruner module to avoid cyclical imports
-			fx.Provide(func(la *light.ShareAvailability) pruner.Pruner { return la }),
+			fx.Provide(func(la *light.ShareAvailability) corepruner.Pruner { return la }),
 		)
 	case node.Full:
 		return fx.Module("prune",
 			baseComponents,
-			fx.Supply(modshare.Window(availability.StorageWindow)),
+			fx.Provide(func(cfg *Config) modshare.Window {
+				return modshare.Window(cfg.StorageWindow)
+			}),
 			fx.Provide(func(cfg *Config) []fullavail.Option {
 				if cfg.EnableService {
 					return make([]fullavail.Option, 0)
 				}
 				return []fullavail.Option{fullavail.WithArchivalMode()}
 			}),
-			fx.Provide(func(fa *fullavail.ShareAvailability) pruner.Pruner { return fa }),
+			fx.Provide(func(fa *fullavail.ShareAvailability) corepruner.Pruner { return fa }),
 			fx.Invoke(convertToPruned),
 		)
 	case node.Bridge:
 		return fx.Module("prune",
 			baseComponents,
+			fx.Provide(func(cfg *Config) modshare.Window {
+				return modshare.Window(cfg.StorageWindow)
+			}),
 			fx.Provide(func(cfg *Config) ([]core.Option, []fullavail.Option) {
 				if cfg.EnableService {
 					return make([]core.Option, 0), make([]fullavail.Option, 0)
 				}
 				return []core.Option{core.WithArchivalMode()}, []fullavail.Option{fullavail.WithArchivalMode()}
 			}),
-			fx.Provide(func(fa *fullavail.ShareAvailability) pruner.Pruner { return fa }),
-			fx.Supply(modshare.Window(availability.StorageWindow)),
+			fx.Provide(func(fa *fullavail.ShareAvailability) corepruner.Pruner { return fa }),
+			fx.Invoke(convertToPruned),
+		)
+	case node.Pin:
+		return fx.Module("prune",
+			baseComponents,
+			fx.Provide(func(cfg *Config) modshare.Window {
+				return modshare.Window(cfg.StorageWindow)
+			}),
+			fx.Provide(func(cfg *Config) ([]core.Option, []fullavail.Option) {
+				if cfg.EnableService {
+					return make([]core.Option, 0), make([]fullavail.Option, 0)
+				}
+				return []core.Option{core.WithArchivalMode()}, []fullavail.Option{fullavail.WithArchivalMode()}
+			}),
+			fx.Provide(func(fa *fullavail.ShareAvailability) corepruner.Pruner { return fa }),
 			fx.Invoke(convertToPruned),
 		)
 	default:
@@ -87,7 +108,7 @@ func ConstructModule(tp node.Type) fx.Option {
 
 func advertiseArchival() fx.Option {
 	return fx.Provide(func(tp node.Type, pruneCfg *Config) discovery.Option {
-		if (tp == node.Full || tp == node.Bridge) && !pruneCfg.EnableService {
+		if (tp == node.Full || tp == node.Bridge || tp == node.Pin) && !pruneCfg.EnableService {
 			return discovery.WithAdvertise()
 		}
 		var opt discovery.Option

--- a/nodebuilder/rpc/module.go
+++ b/nodebuilder/rpc/module.go
@@ -28,7 +28,7 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 	)
 
 	switch tp {
-	case node.Light, node.Full, node.Bridge:
+	case node.Light, node.Full, node.Bridge, node.Pin:
 		return fx.Module(
 			"rpc",
 			baseComponents,

--- a/nodebuilder/settings.go
+++ b/nodebuilder/settings.go
@@ -131,7 +131,7 @@ func WithMetrics(metricOpts []otlpmetrichttp.Option, nodeType node.Type) fx.Opti
 			baseComponents,
 			samplingMetrics,
 		)
-	case node.Bridge:
+	case node.Bridge, node.Pin:
 		opts = fx.Options(
 			baseComponents,
 			fx.Invoke(share.WithStoreMetrics),

--- a/nodebuilder/share/bitswap.go
+++ b/nodebuilder/share/bitswap.go
@@ -35,7 +35,7 @@ func dataExchange(tp node.Type, params bitSwapParams) exchange.SessionExchange {
 	}
 
 	switch tp {
-	case node.Full, node.Bridge:
+	case node.Full, node.Bridge, node.Pin:
 		bs := bitswap.New(params.Ctx, net, params.Bs)
 		net.Start(bs.Client, bs.Server)
 		params.Lifecycle.Append(fx.Hook{

--- a/nodebuilder/share/config.go
+++ b/nodebuilder/share/config.go
@@ -31,6 +31,10 @@ type Config struct {
 
 	LightAvailability *light.Parameters `toml:",omitempty"`
 	Discovery         *discovery.Parameters
+
+	// NamespaceID is used to filter shares to be stored in the EDS store.
+	// Only shares with the specific namespace will be stored.
+	NamespaceID string
 }
 
 func DefaultConfig(tp node.Type) Config {

--- a/nodebuilder/share/flags.go
+++ b/nodebuilder/share/flags.go
@@ -1,0 +1,38 @@
+package share
+
+import (
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	namespaceIDFlag = "share.namespace_id"
+)
+
+// Flags gives a set of share flags.
+func Flags() *flag.FlagSet {
+	flags := &flag.FlagSet{}
+
+	flags.String(
+		namespaceIDFlag,
+		"",
+		"The specific Namespace ID to store. Only shares with this ID will be kept on disk.",
+	)
+
+	return flags
+}
+
+// ParseFlags parses share flags from the given cmd and saves them to the passed config.
+func ParseFlags(
+	cmd *cobra.Command,
+	cfg *Config,
+) error {
+	namespaceID, err := cmd.Flags().GetString(namespaceIDFlag)
+	if err != nil {
+		return err
+	}
+	if namespaceID != "" {
+		cfg.NamespaceID = namespaceID
+	}
+	return nil
+}

--- a/nodebuilder/state/module.go
+++ b/nodebuilder/state/module.go
@@ -48,7 +48,7 @@ func ConstructModule(tp node.Type, cfg *Config, coreCfg *core.Config) fx.Option 
 	)
 
 	switch tp {
-	case node.Light, node.Full, node.Bridge:
+	case node.Light, node.Full, node.Bridge, node.Pin:
 		return fx.Module(
 			"state",
 			baseComponents,

--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -297,11 +297,11 @@ func constraintBadgerConfig() *dsbadger.Options {
 	// enabling this option may allow us to see detect corrupted data
 	opts.ChecksumVerificationMode = options.OnBlockRead
 	opts.VerifyValueChecksum = true
-	// default 64mib => 16mib - enable block cache for compression support
-	// BadgerDB requires a non-zero block cache when compression is enabled
-	opts.BlockCacheSize = 16 << 20
-	// enable compression for significant disk space savings
-	opts.Compression = options.ZSTD
+	// default 64mib => 0 - disable block cache
+	// most of our component maintain their own caches, so this is not needed
+	opts.BlockCacheSize = 0
+	// not much gain as it compresses the LSM only as well compression requires block cache
+	opts.Compression = options.None
 
 	// MemTables:
 	// default 64mib => 16mib - decreases memory usage and makes compaction more often

--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -297,11 +297,11 @@ func constraintBadgerConfig() *dsbadger.Options {
 	// enabling this option may allow us to see detect corrupted data
 	opts.ChecksumVerificationMode = options.OnBlockRead
 	opts.VerifyValueChecksum = true
-	// default 64mib => 0 - disable block cache
-	// most of our component maintain their own caches, so this is not needed
-	opts.BlockCacheSize = 0
-	// not much gain as it compresses the LSM only as well compression requires block cache
-	opts.Compression = options.None
+	// default 64mib => 16mib - enable block cache for compression support
+	// BadgerDB requires a non-zero block cache when compression is enabled
+	opts.BlockCacheSize = 16 << 20
+	// enable compression for significant disk space savings
+	opts.Compression = options.ZSTD
 
 	// MemTables:
 	// default 64mib => 16mib - decreases memory usage and makes compaction more often

--- a/store/file/ods_q4.go
+++ b/store/file/ods_q4.go
@@ -39,18 +39,7 @@ func CreateODSQ4(
 	pathODS, pathQ4 string,
 	roots *share.AxisRoots,
 	eds *rsmt2d.ExtendedDataSquare,
-) error {
-	return CreateODSQ4WithFilter(pathODS, pathQ4, roots, eds, nil)
-}
-
-// CreateODSQ4WithFilter creates ODS and Q4 files with optional namespace filtering.
-// If filter is provided, shares not matching the filter are zeroed out in the ODS file.
-// This is used by Pin nodes to store only data for tracked namespaces.
-func CreateODSQ4WithFilter(
-	pathODS, pathQ4 string,
-	roots *share.AxisRoots,
-	eds *rsmt2d.ExtendedDataSquare,
-	filter NamespaceFilter,
+	options ...WriteOption,
 ) error {
 	errCh := make(chan error)
 	go func() {
@@ -59,7 +48,7 @@ func CreateODSQ4WithFilter(
 		errCh <- createQ4(pathQ4, eds)
 	}()
 
-	err := CreateODSWithFilter(pathODS, roots, eds, filter)
+	err := CreateODS(pathODS, roots, eds, options...)
 	q4Err := <-errCh
 
 	if err != nil && q4Err != nil {

--- a/store/file/ods_q4.go
+++ b/store/file/ods_q4.go
@@ -39,6 +39,7 @@ func CreateODSQ4(
 	pathODS, pathQ4 string,
 	roots *share.AxisRoots,
 	eds *rsmt2d.ExtendedDataSquare,
+	filter NamespaceFilter,
 ) error {
 	errCh := make(chan error)
 	go func() {
@@ -47,7 +48,7 @@ func CreateODSQ4(
 		errCh <- createQ4(pathQ4, eds)
 	}()
 
-	err := CreateODS(pathODS, roots, eds)
+	err := CreateODS(pathODS, roots, eds, filter)
 	q4Err := <-errCh
 
 	if err != nil && q4Err != nil {

--- a/store/file/ods_q4.go
+++ b/store/file/ods_q4.go
@@ -39,6 +39,17 @@ func CreateODSQ4(
 	pathODS, pathQ4 string,
 	roots *share.AxisRoots,
 	eds *rsmt2d.ExtendedDataSquare,
+) error {
+	return CreateODSQ4WithFilter(pathODS, pathQ4, roots, eds, nil)
+}
+
+// CreateODSQ4WithFilter creates ODS and Q4 files with optional namespace filtering.
+// If filter is provided, shares not matching the filter are zeroed out in the ODS file.
+// This is used by Pin nodes to store only data for tracked namespaces.
+func CreateODSQ4WithFilter(
+	pathODS, pathQ4 string,
+	roots *share.AxisRoots,
+	eds *rsmt2d.ExtendedDataSquare,
 	filter NamespaceFilter,
 ) error {
 	errCh := make(chan error)
@@ -48,7 +59,7 @@ func CreateODSQ4(
 		errCh <- createQ4(pathQ4, eds)
 	}()
 
-	err := CreateODS(pathODS, roots, eds, filter)
+	err := CreateODSWithFilter(pathODS, roots, eds, filter)
 	q4Err := <-errCh
 
 	if err != nil && q4Err != nil {

--- a/store/file/ods_q4_test.go
+++ b/store/file/ods_q4_test.go
@@ -67,9 +67,11 @@ func TestValidateODSQ4FileSize(t *testing.T) {
 		valid      bool
 	}{
 		{
-			name:       "valid",
-			createFile: CreateODSQ4,
-			valid:      true,
+			name: "valid",
+			createFile: func(pathODS, pathQ4 string, roots *share.AxisRoots, eds *rsmt2d.ExtendedDataSquare) error {
+				return CreateODSQ4(pathODS, pathQ4, roots, eds)
+			},
+			valid: true,
 		},
 		{
 			name: "shorter q4",

--- a/store/file/ods_test.go
+++ b/store/file/ods_test.go
@@ -89,9 +89,11 @@ func TestValidateODSSize(t *testing.T) {
 		valid      bool
 	}{
 		{
-			name:       "valid",
-			createFile: CreateODS,
-			valid:      true,
+			name: "valid",
+			createFile: func(path string, roots *share.AxisRoots, eds *rsmt2d.ExtendedDataSquare) error {
+				return CreateODS(path, roots, eds)
+			},
+			valid: true,
 		},
 		{
 			name: "shorter",

--- a/store/getter.go
+++ b/store/getter.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -91,6 +92,16 @@ func (g *Getter) GetNamespaceData(
 	h *header.ExtendedHeader,
 	ns libshare.Namespace,
 ) (shwap.NamespaceData, error) {
+	if g.store.nsStore != nil && bytes.Equal(ns.Bytes(), g.store.params.NamespaceID.Bytes()) {
+		nd, err := g.store.nsStore.get(ctx, h.Height())
+		if err == nil {
+			return nd, nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			log.Errorw("failed to get namespace data from cache", "height", h.Height(), "err", err)
+		}
+	}
+
 	acc, err := g.store.GetByHeight(ctx, h.Height())
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {

--- a/store/getter.go
+++ b/store/getter.go
@@ -92,34 +92,21 @@ func (g *Getter) GetNamespaceData(
 	h *header.ExtendedHeader,
 	ns libshare.Namespace,
 ) (shwap.NamespaceData, error) {
-	// Debug: log namespace lookup attempts
-	if g.store.nsStore != nil {
-		log.Debugw("nsStore lookup attempt",
-			"height", h.Height(),
-			"requested_ns", ns.String(),
-			"configured_ns", g.store.params.NamespaceID.String(),
-			"match", bytes.Equal(ns.Bytes(), g.store.params.NamespaceID.Bytes()),
-		)
-	}
-
-	if g.store.nsStore != nil && bytes.Equal(ns.Bytes(), g.store.params.NamespaceID.Bytes()) {
+	// Pin Node optimization: try namespace cache first for tracked namespace
+	if g.store.nsStore != nil && bytes.Equal(ns.Bytes(), g.store.params.TrackedNamespace.Bytes()) {
 		nd, err := g.store.nsStore.get(ctx, h.Height())
 		if err == nil {
-			log.Debugw("nsStore HIT - fast path", "height", h.Height())
 			return nd, nil
 		}
 		if !errors.Is(err, ErrNotFound) {
-			log.Errorw("failed to get namespace data from cache", "height", h.Height(), "err", err)
-		} else {
-			log.Warnw("nsStore MISS - data not found, falling back", "height", h.Height())
+			log.Warnw("failed to get namespace data from cache", "height", h.Height(), "err", err)
 		}
+		// Fall through to standard path if not in cache
 	}
 
-	log.Debugw("falling back to ODS accessor (slow path)", "height", h.Height(), "namespace", ns.String())
 	acc, err := g.store.GetByHeight(ctx, h.Height())
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			log.Debugw("ODS not found, will cascade to network", "height", h.Height())
 			return nil, shwap.ErrNotFound
 		}
 		return nil, fmt.Errorf("get accessor from store:%w", err)
@@ -130,7 +117,6 @@ func (g *Getter) GetNamespaceData(
 	)
 	defer utils.CloseAndLog(logger, "getter/nd", acc)
 
-	log.Debugw("reading namespace data from ODS file", "height", h.Height())
 	nd, err := eds.NamespaceData(ctx, acc, ns)
 	if err != nil {
 		return nil, fmt.Errorf("get nd from accessor:%w", err)

--- a/store/namespace_store.go
+++ b/store/namespace_store.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ipfs/go-datastore"
+
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+// namespaceStore provides persistent storage for verified NamespaceData (shares + proofs).
+// It allows the node to serve verified blob data for a specific namespace without storing
+// the full ODS/EDS files.
+type namespaceStore struct {
+	ds datastore.Batching
+}
+
+func newNamespaceStore(ds datastore.Batching) *namespaceStore {
+	return &namespaceStore{ds: ds}
+}
+
+func (ns *namespaceStore) put(ctx context.Context, height uint64, data shwap.NamespaceData) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	buf := new(bytes.Buffer)
+	_, err := data.WriteTo(buf)
+	if err != nil {
+		return fmt.Errorf("serializing namespace data: %w", err)
+	}
+
+	key := datastore.NewKey(fmt.Sprintf("%d", height))
+	return ns.ds.Put(ctx, key, buf.Bytes())
+}
+
+func (ns *namespaceStore) get(ctx context.Context, height uint64) (shwap.NamespaceData, error) {
+	key := datastore.NewKey(fmt.Sprintf("%d", height))
+	val, err := ns.ds.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	var data shwap.NamespaceData
+	_, err = data.ReadFrom(bytes.NewReader(val))
+	if err != nil {
+		return nil, fmt.Errorf("deserializing namespace data: %w", err)
+	}
+
+	return data, nil
+}
+
+func (ns *namespaceStore) delete(ctx context.Context, height uint64) error {
+	key := datastore.NewKey(fmt.Sprintf("%d", height))
+	return ns.ds.Delete(ctx, key)
+}

--- a/store/store_options.go
+++ b/store/store_options.go
@@ -2,11 +2,22 @@ package store
 
 import (
 	"errors"
+
+	libshare "github.com/celestiaorg/go-square/v3/share"
+	"github.com/ipfs/go-datastore"
+
+	"github.com/celestiaorg/celestia-node/store/file"
 )
 
 type Parameters struct {
 	// RecentBlocksCacheSize is the size of the cache for recent blocks.
 	RecentBlocksCacheSize int
+	// NamespaceFilter is a filter for shares to be stored in the EDS store.
+	NamespaceFilter file.NamespaceFilter `toml:"-"`
+	// NamespaceID is the namespace that the node is tracking.
+	NamespaceID libshare.Namespace `toml:"-"`
+	// Datastore is used for persistent storage of namespace data.
+	Datastore datastore.Batching `toml:"-"`
 }
 
 // DefaultParameters returns the default configuration values for the EDS store parameters.

--- a/store/store_options.go
+++ b/store/store_options.go
@@ -1,23 +1,40 @@
 package store
 
 import (
+	"bytes"
 	"errors"
 
-	libshare "github.com/celestiaorg/go-square/v3/share"
 	"github.com/ipfs/go-datastore"
+
+	libshare "github.com/celestiaorg/go-square/v3/share"
 
 	"github.com/celestiaorg/celestia-node/store/file"
 )
 
+// NewNamespaceFilter creates a filter that matches a specific namespace.
+// Returns nil if the namespace is empty (no filtering).
+func NewNamespaceFilter(ns libshare.Namespace) file.NamespaceFilter {
+	if ns.IsEmpty() {
+		return nil
+	}
+	return func(other libshare.Namespace) bool {
+		return bytes.Equal(other.Bytes(), ns.Bytes())
+	}
+}
+
 type Parameters struct {
 	// RecentBlocksCacheSize is the size of the cache for recent blocks.
 	RecentBlocksCacheSize int
-	// NamespaceFilter is a filter for shares to be stored in the EDS store.
-	NamespaceFilter file.NamespaceFilter `toml:"-"`
-	// NamespaceID is the namespace that the node is tracking.
-	NamespaceID libshare.Namespace `toml:"-"`
-	// Datastore is used for persistent storage of namespace data.
-	Datastore datastore.Batching `toml:"-"`
+
+	// ---- Pin Node Options (optional, leave zero values for standard nodes) ----
+
+	// TrackedNamespace is the namespace to track for Pin nodes.
+	// If set, enables namespace-specific optimizations.
+	TrackedNamespace libshare.Namespace `toml:"-"`
+
+	// NamespaceDatastore is used for persistent storage of namespace data.
+	// Required if TrackedNamespace is set.
+	NamespaceDatastore datastore.Batching `toml:"-"`
 }
 
 // DefaultParameters returns the default configuration values for the EDS store parameters.
@@ -32,4 +49,9 @@ func (p *Parameters) Validate() error {
 		return errors.New("recent eds cache size cannot be negative")
 	}
 	return nil
+}
+
+// IsNamespaceTrackingEnabled returns true if namespace tracking is configured.
+func (p *Parameters) IsNamespaceTrackingEnabled() bool {
+	return !p.TrackedNamespace.IsEmpty() && p.NamespaceDatastore != nil
 }


### PR DESCRIPTION
# Add Pin Node Type

Introduces a new Pin node type that enables namespace-filtered data storage and synchronization. 
1. It reads ODS from the core.ip like a bridge node
2. Discards blocks which don't contain data under their namespace
3. Stores only blobs from the namespace provided by the user

## Motivation

Hosted providers need fine-grained control over data retention to price reads according to actual namespace usage from the users they serve. Different clients have different requirements: 
 - 1st might need a 7-day retention policy only
 - 2nd needs full archival data for their entire namespace since block N
 - 3rd is priced more on reads due to higher blob usage
 - 4th is paying little as they are submitting close to none

The Pin node type enables this by allowing operators to selectively store and retain data only for configured namespaces, rather than requiring full network archival per each customer they serve.

## Summary

  - Add Pin node type with dedicated CLI commands
  - Implement namespace filtering for ODS file storage - only store data for configured namespaces
  - Add namespace tracking store to record which namespaces are pinned
  - Add --pin.namespaces flag to configure target namespaces
  - Allow Pin nodes to optionally run with --archival flag
  - Validate minimum pruning window against sampling window

 ## Changes

  - nodebuilder/node/type.go: New Pin node type
  - store/: Namespace filtering and tracking in ODS storage
  - nodebuilder/share/: Pin-specific module configuration
  - nodebuilder/pruner/: Support for Pin node pruning behavior
  - cmd/: CLI integration for pin node commands