### PR TITLE
!feat(api):Add headers to subscription response

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -97,6 +97,7 @@ func (s *Service) Stop(context.Context) error {
 // If the Blobs slice is empty, it means that no blobs were included at the given height.
 type SubscriptionResponse struct {
 	Blobs  []*Blob
+	Height uint64 // Deprecated: use Header.Height() instead. Kept for backwards compatibility.
 	Header *header.RawHeader
 }
 
@@ -157,7 +158,11 @@ func (s *Service) Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan 
 				case <-ctx.Done():
 					log.Debugw("blobsub: pending response canceled due to user ctx closing", "namespace", ns.ID())
 					return
-				case blobCh <- &SubscriptionResponse{Blobs: blobs, Header: &header.RawHeader}:
+				case blobCh <- &SubscriptionResponse{
+					Blobs:  blobs,
+					Height: header.Height(),
+					Header: &header.RawHeader,
+				}:
 				}
 			case <-ctx.Done():
 				log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -691,6 +691,9 @@ func TestService_Subscribe(t *testing.T) {
 			case resp := <-subCh:
 				assert.Empty(t, resp.Blobs)
 				assert.Equal(t, &headers[i].RawHeader, resp.Header)
+				// Verify backwards compatibility: Height field should still be populated even with no blobs
+				assert.Equal(t, headers[i].Height(), resp.Height, "Height should match Header.Height for backwards compatibility")
+				assert.Equal(t, uint64(resp.Header.Height), resp.Height, "resp.Height should equal resp.Header.Height")
 			case <-time.After(time.Second * 2):
 				t.Fatalf("timeout waiting for empty subscription response %d", i)
 			}


### PR DESCRIPTION
The `SubscriptionResponse` contains the height at which the blobs were included but no the timestamp. 
In our use case, the timestamp matters for delivery guarantees and deterministic behaviour. 
