### PR TITLE
fix(shwap/rngNamespaceData): fix for RangeNamespaceDataFromShares

### DIFF
--- a/share/shwap/range_namespace_data.go
+++ b/share/shwap/range_namespace_data.go
@@ -122,12 +122,12 @@ func RangeNamespaceDataFromShares(
 		extendedRowShares[len(extendedRowShares)-1] = extendedRowShares[len(extendedRowShares)-1][:to.Col+1]
 	}
 
-	for row, rowShares := range extendedRowShares {
-		if len(rowShares) >= odsSize {
+	for row := range extendedRowShares {
+		if len(extendedRowShares[row]) >= odsSize {
 			// keep only original data
-			extendedRowShares[row] = rowShares[:odsSize]
+			extendedRowShares[row] = extendedRowShares[row][:odsSize]
 		}
-		for col, shr := range rowShares {
+		for col, shr := range extendedRowShares[row] {
 			if !namespace.Equals(shr.Namespace()) {
 				return RangeNamespaceData{}, fmt.Errorf("mismatched namespace for share at: row %d, col: %d", row, col)
 			}

--- a/store/getter.go
+++ b/store/getter.go
@@ -123,6 +123,14 @@ func (g *Getter) GetRangeNamespaceData(
 		}
 		return shwap.RangeNamespaceData{}, fmt.Errorf("getting accessor from store:%w", err)
 	}
+
+	logger := log.With(
+		"height", h.Height(),
+		"from", from,
+		"to", to,
+	)
+	defer utils.CloseAndLog(logger, "getter/rng", acc)
+
 	rngData, err := acc.RangeNamespaceData(ctx, from, to)
 	if err != nil {
 		return shwap.RangeNamespaceData{}, fmt.Errorf("getting range from accessor:%w", err)


### PR DESCRIPTION
Fix a bug where the namespace validation loop used a stale slice reference after truncation. The range variable rowShares captured the slice before extendedRowShares[row] was truncated to ODS size, causing the validation to iterate over the  original untruncated data instead of the truncated slice.