### PR TITLE
chore(ci): pin golangci-lint to v2.10.0 and fix new gosec warnings

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9.2.0
         with:
           args: --timeout 10m
-          version: latest
+          version: v2.10.0
 
   lint-imports:
     needs: [setup]

--- a/api/client/grpc.go
+++ b/api/client/grpc.go
@@ -25,7 +25,7 @@ type CoreGRPCConfig struct {
 	// AuthToken is the authentication token to be used for gRPC authentication.
 	// If left empty, the client will not include the authentication token in its requests.
 	// Note: AuthToken is insecure without TLS
-	AuthToken string
+	AuthToken string //nolint:gosec // not a hardcoded credential, user-provided config
 }
 
 func (cfg *CoreGRPCConfig) Validate() error {

--- a/nodebuilder/init.go
+++ b/nodebuilder/init.go
@@ -166,7 +166,7 @@ func initRoot(path string) error {
 		return err
 	}
 
-	return os.Remove(f.Name())
+	return os.Remove(filepath.Join(path, ".check"))
 }
 
 // resetDir removes all files from the given directory and reinitializes it


### PR DESCRIPTION
 Summary                                                                                          
   - Pin `golangci-lint` version from `latest` to `v2.10.0` in CI workflow  
   - Fix two new `gosec` warnings introduced in v2.10.0:
     - `G117` in `api/client/grpc.go`: exported `AuthToken` field matches secret pattern (false positive — user-provided config, not a hardcoded
    credential)
     - `G703` in `nodebuilder/init.go`: path traversal via `f.Name()` (false positive — path is not user-controlled)

   There is a deadlock for other PRs:
   - Without the `nolint:gosec` directives, the **new** linter (v2.10.0) fails on G117/G703 violations
   - With the `nolint:gosec` directives, the **old** linter (v2.9.0) fails on `nolintlint` because it doesn't recognize the unknown directives

Closes: https://linear.app/celestia/issue/PROTOCO-1346/choreci-pin-golangci-lint-to-v2100-and-fix-new-gosec-warnings