### PR TITLE
 fix(core): retry test network start on port-in-use errors

### DIFF
--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -188,8 +190,27 @@ func TestExchange_StoreHistoricIfArchival(t *testing.T) {
 func createCoreFetcher(t *testing.T, cfg *testnode.Config) (*BlockFetcher, *Network) {
 	t.Helper()
 
-	network := NewNetwork(t, cfg)
-	require.NoError(t, network.Start())
+	// Retry up to 3 times to handle transient "address already in use" failures.
+	// These occur because MustGetFreePort uses UDP probing, but the actual listeners
+	// bind TCP — another process can grab the port in the window between the two.
+	const maxRetries = 3
+	var network *Network
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			reallocateTestNodePorts(cfg)
+		}
+		network = NewNetwork(t, cfg)
+		if err := network.Start(); err != nil {
+			if attempt < maxRetries-1 && isAddressInUseError(err) {
+				t.Logf("port conflict on attempt %d, retrying with new ports", attempt+1)
+				_ = network.Stop()
+				continue
+			}
+			require.NoError(t, err)
+		}
+		break
+	}
+
 	t.Cleanup(func() {
 		require.NoError(t, network.Stop())
 	})
@@ -200,6 +221,21 @@ func createCoreFetcher(t *testing.T, cfg *testnode.Config) (*BlockFetcher, *Netw
 	fetcher, err := NewBlockFetcher(network.GRPCClient)
 	require.NoError(t, err)
 	return fetcher, network
+}
+
+// isAddressInUseError reports whether the error is a "bind: address already in use" error.
+func isAddressInUseError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "address already in use")
+}
+
+// reallocateTestNodePorts assigns fresh free ports to all network addresses in cfg,
+// replacing the ones allocated at config-creation time that may now be taken.
+func reallocateTestNodePorts(cfg *testnode.Config) {
+	cfg.TmConfig.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
+	cfg.TmConfig.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
+	cfg.TmConfig.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
+	cfg.AppConfig.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", testnode.MustGetFreePort())
+	cfg.AppConfig.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
 }
 
 // fillBlocks fills blocks until the context is canceled.


### PR DESCRIPTION
 - `createCoreFetcher` in exchange tests occasionally fails with "address already in use" because `MustGetFreePort` probes via UDP while the
  actual listeners bind TCP — another process can grab the port in between
  - Add retry logic (up to 3 attempts) that reallocates all test node ports on failure
  - Extracted `isAddressInUseError` and `reallocateTestNodePorts` helpers for clarity

Example of CI failure:
https://github.com/celestiaorg/celestia-node/actions/runs/22147014078/job/64027068116?pr=4787#step:4:405

Closes: https://linear.app/celestia/issue/PROTOCO-1344/fixcore-retry-test-network-start-on-port-in-use-errors