### PR TITLE
fix(pruner): fix race condition in TestFindPruneableHeaders

### DIFF
--- a/pruner/service_test.go
+++ b/pruner/service_test.go
@@ -258,7 +258,8 @@ func TestFindPruneableHeaders(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = serv.Start(ctx)
+			serv.ctx = ctx
+			err = serv.loadCheckpoint(ctx)
 			require.NoError(t, err)
 
 			lastPruned, err := serv.lastPruned(ctx)


### PR DESCRIPTION
## Summary

- `serv.Start(ctx)` was spawning a background prune goroutine that would race ahead, advance the checkpoint past all prunable headers, and leave nothing for the test's own `findPruneableHeaders` call to find
- Replaced `serv.Start(ctx)` with direct `serv.loadCheckpoint(ctx)` — consistent with every other test in the file (`TestService`, `TestService_FailedAreRecorded`, `TestPrune_LargeNumberOfBlocks`)

Ref: https://github.com/celestiaorg/celestia-node/actions/runs/22154073145/job/64053017961#step:4:424

Closes: https://linear.app/celestia/issue/PROTOCO-1342/fixpruner-fix-race-condition-in-testfindpruneableheaders