### PR TITLE
fix(shrex): fix off-by-one in GetRangeNamespaceData test

### DIFF
--- a/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
@@ -483,7 +483,7 @@ func TestShrexGetter(t *testing.T) {
 
 		sharesAmount := odsSize * odsSize
 		fromIndex := rand.IntN(odsSize)
-		inclusiveToIndex := sharesAmount - fromIndex
+		inclusiveToIndex := sharesAmount - fromIndex - 1
 
 		from, err := shwap.SampleCoordsFrom1DIndex(fromIndex, odsSize)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Fix flaky `TestShrexGetter/GetRangeNamespaceData` caused by off-by-one error in range calculation
- `inclusiveToIndex` was computed as `sharesAmount - fromIndex`, which when `fromIndex` is 0 produces an exclusive end of `sharesAmount + 1`, exceeding the valid range and failing `RangeNamespaceDataID` verification


Ref: https://github.com/celestiaorg/celestia-node/actions/runs/22359956307/job/64710271257?pr=4808#step:4:445

Closes https://linear.app/celestia/issue/DA-1123/fix-off-by-one-in-getrangenamespacedata-test