### PR TITLE
chore: add tastora submodule to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,9 @@ updates:
         update-types:
           - "patch"
   - package-ecosystem: gomod
-    directory: "/"
+    directories:
+      - "/"
+      - "/nodebuilder/tests/tastora"
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## Summary
- Add `/nodebuilder/tests/tastora` to the dependabot gomod `directories` so both Go modules are updated together
- Prevents CI failures on dependabot PRs where the tastora submodule still pins old dependency versions

Closes #4825
Closes https://linear.app/celestia/issue/DA-1177