### PR TITLE
fix(core): use startNetwork retry helper in all core tests

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -14,8 +14,7 @@ func TestRemoteClient_Status(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
 	cfg := DefaultTestConfig()
-	network := NewNetwork(t, cfg)
-	require.NoError(t, network.Start())
+	network := startNetwork(t, cfg)
 	t.Cleanup(func() {
 		require.NoError(t, network.Stop())
 	})
@@ -30,8 +29,7 @@ func TestRemoteClient_StartBlockSubscription_And_GetBlock(t *testing.T) {
 	t.Cleanup(cancel)
 
 	cfg := DefaultTestConfig()
-	network := NewNetwork(t, cfg)
-	require.NoError(t, network.Start())
+	network := startNetwork(t, cfg)
 	t.Cleanup(func() {
 		require.NoError(t, network.Stop())
 	})

--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -3,8 +3,6 @@ package core
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -190,27 +188,7 @@ func TestExchange_StoreHistoricIfArchival(t *testing.T) {
 func createCoreFetcher(t *testing.T, cfg *testnode.Config) (*BlockFetcher, *Network) {
 	t.Helper()
 
-	// Retry up to 3 times to handle transient "address already in use" failures.
-	// These occur because MustGetFreePort uses UDP probing, but the actual listeners
-	// bind TCP — another process can grab the port in the window between the two.
-	const maxRetries = 3
-	var network *Network
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		if attempt > 0 {
-			reallocateTestNodePorts(cfg)
-		}
-		network = NewNetwork(t, cfg)
-		if err := network.Start(); err != nil {
-			if attempt < maxRetries-1 && isAddressInUseError(err) {
-				t.Logf("port conflict on attempt %d, retrying with new ports", attempt+1)
-				_ = network.Stop()
-				continue
-			}
-			require.NoError(t, err)
-		}
-		break
-	}
-
+	network := startNetwork(t, cfg)
 	t.Cleanup(func() {
 		require.NoError(t, network.Stop())
 	})
@@ -221,21 +199,6 @@ func createCoreFetcher(t *testing.T, cfg *testnode.Config) (*BlockFetcher, *Netw
 	fetcher, err := NewBlockFetcher(network.GRPCClient)
 	require.NoError(t, err)
 	return fetcher, network
-}
-
-// isAddressInUseError reports whether the error is a "bind: address already in use" error.
-func isAddressInUseError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "address already in use")
-}
-
-// reallocateTestNodePorts assigns fresh free ports to all network addresses in cfg,
-// replacing the ones allocated at config-creation time that may now be taken.
-func reallocateTestNodePorts(cfg *testnode.Config) {
-	cfg.TmConfig.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
-	cfg.TmConfig.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
-	cfg.TmConfig.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
-	cfg.AppConfig.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", testnode.MustGetFreePort())
-	cfg.AppConfig.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
 }
 
 // fillBlocks fills blocks until the context is canceled.

--- a/core/fetcher_no_race_test.go
+++ b/core/fetcher_no_race_test.go
@@ -17,8 +17,8 @@ func TestBlockFetcherHeaderValues(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	t.Cleanup(cancel)
 
-	network := NewNetwork(t, DefaultTestConfig())
-	require.NoError(t, network.Start())
+	cfg := DefaultTestConfig()
+	network := startNetwork(t, cfg)
 	t.Cleanup(func() {
 		require.NoError(t, network.Stop())
 	})

--- a/core/fetcher_test.go
+++ b/core/fetcher_test.go
@@ -14,8 +14,8 @@ func TestBlockFetcher_GetBlock_and_SubscribeNewBlockEvent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	t.Cleanup(cancel)
 
-	network := NewNetwork(t, DefaultTestConfig())
-	require.NoError(t, network.Start())
+	cfg := DefaultTestConfig()
+	network := startNetwork(t, cfg)
 	t.Cleanup(func() {
 		require.NoError(t, network.Stop())
 	})
@@ -50,8 +50,7 @@ func TestFetcher_Resubscription(t *testing.T) {
 	t.Cleanup(cancel)
 	// run new consensus node
 	cfg := DefaultTestConfig()
-	tn := NewNetwork(t, cfg)
-	require.NoError(t, tn.Start())
+	tn := startNetwork(t, cfg)
 	host, port, err := net.SplitHostPort(tn.GRPCClient.Target())
 	require.NoError(t, err)
 	client := newTestClient(t, host, port)
@@ -86,8 +85,7 @@ func TestFetcher_Resubscription(t *testing.T) {
 
 	// start new consensus node(some components in app can't be restarted)
 	// on the same address and listen for the new blocks
-	tn = NewNetwork(t, cfg)
-	require.NoError(t, tn.Start())
+	tn = startNetwork(t, cfg)
 	t.Cleanup(func() {
 		require.NoError(t, tn.Stop())
 	})

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -21,8 +21,8 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	network := NewNetwork(t, DefaultTestConfig())
-	require.NoError(t, network.Start())
+	cfg := DefaultTestConfig()
+	network := startNetwork(t, cfg)
 	t.Cleanup(func() {
 		require.NoError(t, network.Stop())
 	})

--- a/core/test_helpers_test.go
+++ b/core/test_helpers_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-app/v7/test/util/testnode"
+)
+
+// startNetwork creates and starts a test Network with retry logic to handle
+// transient "address already in use" failures. These occur because
+// MustGetFreePort uses UDP probing, but the actual listeners bind TCP —
+// another process can grab the port in the window between the two.
+func startNetwork(t *testing.T, cfg *testnode.Config) *Network {
+	t.Helper()
+
+	const maxRetries = 3
+	var network *Network
+	for attempt := range maxRetries {
+		if attempt > 0 {
+			reallocateTestNodePorts(cfg)
+		}
+		network = NewNetwork(t, cfg)
+		if err := network.Start(); err != nil {
+			if attempt < maxRetries-1 && isAddressInUseError(err) {
+				t.Logf("port conflict on attempt %d, retrying with new ports", attempt+1)
+				_ = network.Stop()
+				continue
+			}
+			require.NoError(t, err)
+		}
+		break
+	}
+	return network
+}
+
+// isAddressInUseError reports whether the error is a "bind: address already in use" error.
+func isAddressInUseError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "address already in use")
+}
+
+// reallocateTestNodePorts assigns fresh free ports to all network addresses in cfg,
+// replacing the ones allocated at config-creation time that may now be taken.
+func reallocateTestNodePorts(cfg *testnode.Config) {
+	cfg.TmConfig.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
+	cfg.TmConfig.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
+	cfg.TmConfig.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
+	cfg.AppConfig.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", testnode.MustGetFreePort())
+	cfg.AppConfig.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", testnode.MustGetFreePort())
+}


### PR DESCRIPTION
## Summary

- PR #4790 added port-in-use retry logic to `createCoreFetcher` in `exchange_test.go`, but all other direct `NewNetwork` + `Start` call sites were missed
- Extracts the retry logic into a shared `startNetwork(t, cfg)` helper in `core/test_helpers_test.go`
- Updates all remaining call sites across `fetcher_no_race_test.go`, `fetcher_test.go`, `header_test.go`, and `client_test.go`

Fixes flaky `TestBlockFetcherHeaderValues` failure observed in CI:
```
Error: Received unexpected error:
    failed to listen on 127.0.0.1:34754: listen tcp 127.0.0.1:34754: bind: address already in use
```

## Test plan
- [x] `go test ./core/...` passes locally
- [ ] CI unit tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes: https://linear.app/celestia/issue/DA-1202/fix-port-in-use-flakiness-in-all-core-tests