### PR TITLE
fix(header): use upper bound block time for syncer tail estimation

### DIFF
--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -2,6 +2,7 @@ package header
 
 import (
 	"context"
+	"time"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -18,6 +19,11 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
+
+// maxBlockTime is the upper bound of expected block production time.
+// Used for syncer tail height estimation to ensure the tail stays within the pruning
+// window despite block time variance (real block times on mocha avg ~6.14s vs nominal 6s).
+const maxBlockTime = 7 * time.Second
 
 // newP2PExchange constructs a new Exchange for headers.
 func newP2PExchange[H libhead.Header[H]](
@@ -96,7 +102,7 @@ func newSyncer[H libhead.Header[H]](
 
 	opts := []sync.Option{
 		sync.WithParams(cfg.Syncer),
-		sync.WithBlockTime(modp2p.BlockTime),
+		sync.WithBlockTime(maxBlockTime),
 		sync.WithTrustingPeriod(trustingPeriod),
 	}
 	if MetricsEnabled {


### PR DESCRIPTION
## Summary

- Set syncer `blockTime` to 7s (upper bound) instead of the nominal 6s `BlockTime`
- Ensures `estimateTailHeight()` produces a conservative tail within the pruning window on first startup

## Problem

On first startup, the go-header syncer estimates the tail height by dividing `trustingPeriod` (7 days) by `blockTime` (6s) to get the number of blocks to retain. But real block times on mocha-4 average ~6.14s, causing the tail to overshoot the 7-day pruning window by ~3.8 hours. Since peers prune blocks older than 7 days, no peer can serve the tail header, and the light node fails to start:

```
Error: node: failed to start: error getting latest head during Start:
  subjective tail for head 10419180: updating tail:
  fetching SyncFromHeight tail(10318380): i/o deadline reached
```

## Fix

Use 7s as the block time upper bound for the syncer. This reduces blocks retained from 100,800 to 86,400, placing the tail at ~6.3 days — safely within the window.

| | Before (6s) | After (7s) |
|---|---|---|
| Blocks retained | 100,800 | 86,400 |
| Estimated tail age | ~7.16 days | ~6.3 days |
| Within pruning window | No | Yes |

## Test plan

- [x] Build passes
- [x] Lint clean
- [x] `nodebuilder/header` unit tests pass
- [x] Verified on mocha-4: light node starts and syncs successfully with 7s block time

Upstream go-header doc update: https://github.com/celestiaorg/go-header/pull/379

Closes: https://linear.app/celestia/issue/DA-1212/fix-light-node-tail-height-estimation-overshoots-pruning-window-on
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
