### PR TITLE
chore(deps): bump go-header to v0.8.5-rc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/benbjohnson/clock v1.3.5
 	github.com/celestiaorg/celestia-app/v7 v7.0.2-mocha
 	github.com/celestiaorg/go-fraud v0.2.3
-	github.com/celestiaorg/go-header v0.8.4-rc
+	github.com/celestiaorg/go-header v0.8.5-rc
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2
 	github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076
 	github.com/celestiaorg/go-square/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -806,8 +806,8 @@ github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4 h1:udw77B
 github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4/go.mod h1:W+pI1NsUsz3tcsAACMtfC+IZdnQTnC/7VfPoJBQuts0=
 github.com/celestiaorg/go-fraud v0.2.3 h1:vsGmd5HtGL92q/pvjN0cpDsXn7hGJSbVZwOJl+dNX8E=
 github.com/celestiaorg/go-fraud v0.2.3/go.mod h1:h2Or0jHka/TDlQ3XsJV6OibIiwm49UiGVEu2jHKzybA=
-github.com/celestiaorg/go-header v0.8.4-rc h1:qZHacP9ede92J+8C8JDEO6Ho4/WVp9BiuL6l8n4/deg=
-github.com/celestiaorg/go-header v0.8.4-rc/go.mod h1:bleBZgLYeSciRZEpLrn7+Cw6400zJwSEbXYw+SP9lcs=
+github.com/celestiaorg/go-header v0.8.5-rc h1:IHmXqYAUfbrwcz0At3BUvg36zKVM0nmVwO9iZ9Ny2AI=
+github.com/celestiaorg/go-header v0.8.5-rc/go.mod h1:bleBZgLYeSciRZEpLrn7+Cw6400zJwSEbXYw+SP9lcs=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
 github.com/celestiaorg/go-libp2p-pubsub v0.6.2-0.20260225133553-213565e2a428 h1:xoPAwLmTwmwUCDZ8shNCTyMMXEjU/5O0bSyuTBBRkeA=

--- a/nodebuilder/tests/tastora/go.mod
+++ b/nodebuilder/tests/tastora/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/celestiaorg/go-fraud v0.2.3 // indirect
-	github.com/celestiaorg/go-header v0.8.4-rc // indirect
+	github.com/celestiaorg/go-header v0.8.5-rc // indirect
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2 // indirect
 	github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076 // indirect
 	github.com/celestiaorg/go-square/v2 v2.3.3 // indirect

--- a/nodebuilder/tests/tastora/go.sum
+++ b/nodebuilder/tests/tastora/go.sum
@@ -800,8 +800,8 @@ github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4 h1:udw77B
 github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4/go.mod h1:W+pI1NsUsz3tcsAACMtfC+IZdnQTnC/7VfPoJBQuts0=
 github.com/celestiaorg/go-fraud v0.2.3 h1:vsGmd5HtGL92q/pvjN0cpDsXn7hGJSbVZwOJl+dNX8E=
 github.com/celestiaorg/go-fraud v0.2.3/go.mod h1:h2Or0jHka/TDlQ3XsJV6OibIiwm49UiGVEu2jHKzybA=
-github.com/celestiaorg/go-header v0.8.4-rc h1:qZHacP9ede92J+8C8JDEO6Ho4/WVp9BiuL6l8n4/deg=
-github.com/celestiaorg/go-header v0.8.4-rc/go.mod h1:bleBZgLYeSciRZEpLrn7+Cw6400zJwSEbXYw+SP9lcs=
+github.com/celestiaorg/go-header v0.8.5-rc h1:IHmXqYAUfbrwcz0At3BUvg36zKVM0nmVwO9iZ9Ny2AI=
+github.com/celestiaorg/go-header v0.8.5-rc/go.mod h1:bleBZgLYeSciRZEpLrn7+Cw6400zJwSEbXYw+SP9lcs=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
 github.com/celestiaorg/go-libp2p-pubsub v0.6.2-0.20260225133553-213565e2a428 h1:xoPAwLmTwmwUCDZ8shNCTyMMXEjU/5O0bSyuTBBRkeA=


### PR DESCRIPTION
## Summary
- Bumps go-header from v0.8.4-rc to v0.8.5-rc
- Key fix: parallelize `performRequest` to avoid sequential per-peer timeouts, further improving light node startup

Closes: https://linear.app/celestia/issue/DA-1219/bump-go-header-to-v085-rc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
