### PR TITLE
ci: reintroduce breaking change detection as advisory workflow

### DIFF
--- a/.github/workflows/detect-breaking.yml
+++ b/.github/workflows/detect-breaking.yml
@@ -1,0 +1,54 @@
+name: Detect Breaking Changes
+
+on:
+  pull_request:
+    paths:
+      - "**/*.proto"
+      - "nodebuilder/**/config.go"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect-breaking:
+    name: Detect Breaking Changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Detect breaking changes
+        id: detect
+        continue-on-error: true
+        run: make detect-breaking BASE_BRANCH=${{ github.event.pull_request.base.ref }}
+
+      - name: Add breaking label
+        if: steps.detect.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['kind:break!']
+            });
+
+      - name: Remove breaking label
+        if: steps.detect.outcome == 'success'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'kind:break!'
+            });

--- a/Makefile
+++ b/Makefile
@@ -269,25 +269,29 @@ goreleaser-release:
 
 # detect changed files and parse output
 # to inspect changes to nodebuilder/**/config.go fields
-CHANGED_FILES      = $(shell git diff --name-only origin/main...HEAD)
+BASE_BRANCH ?= main
+GIT_REMOTE  ?= origin
+CHANGED_FILES      = $(shell git diff --name-only $(GIT_REMOTE)/$(BASE_BRANCH)...HEAD)
 detect-breaking:
-	@BREAK=false
-	@for file in ${CHANGED_FILES}; do \
+	@BREAK=false; \
+	for file in ${CHANGED_FILES}; do \
 		if echo $$file | grep -qE '\.proto$$'; then \
+			echo "proto change: $$file"; \
 			BREAK=true; \
 		fi; \
 		if echo $$file | grep -qE 'nodebuilder/.*/config\.go'; then \
-			DIFF_OUTPUT=$$(git diff origin/main...HEAD $$file); \
+			DIFF_OUTPUT=$$(git diff $(GIT_REMOTE)/$(BASE_BRANCH)...HEAD $$file); \
 			if echo "$$DIFF_OUTPUT" | grep -qE 'type Config struct|^\s+\w+\s+Config'; then \
+				echo "config struct change: $$file"; \
 				BREAK=true; \
 			fi; \
 		fi; \
 	done; \
 	if [ "$$BREAK" = true ]; then \
-		echo "break detected"; \
+		echo "breaking change detected"; \
 		exit 1; \
 	else \
-		echo "no break detected"; \
+		echo "no breaking change detected"; \
 		exit 0; \
 	fi
 .PHONY: detect-breaking


### PR DESCRIPTION
## Summary
- Adds a new `detect-breaking.yml` workflow that runs only when `.proto` or `nodebuilder/*/config.go` files change
- Auto-labels PRs with `kind:break!` when breaking changes are detected, removes the label when resolved
- Non-blocking — never fails CI, purely advisory
- Fixes the Makefile `detect-breaking` target: adds configurable `BASE_BRANCH`/`GIT_REMOTE` variables, fixes shell variable scoping bug, adds diagnostic output

The old `labels.yml` workflow was deleted in #4847 because required-labels enforcement was blocking PRs. This brings back just the detection/labeling part without any blocking behavior.

## Test plan
- [ ] Open a test PR that modifies a `.proto` file and verify the `kind:break!` label is applied
- [ ] Open a test PR that modifies a `nodebuilder/*/config.go` struct and verify the label is applied
- [ ] Open a PR with no breaking changes and verify no label is applied
- [ ] Run `make detect-breaking GIT_REMOTE=origin BASE_BRANCH=main` locally

Closes: https://linear.app/celestia/issue/PROTOCO-1285/reintroduce-breaking-change-detection-in-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
