### PR TITLE
feat(shrex): add per-peer-IP rate limiting to shrex server

### DIFF
--- a/share/shwap/p2p/shrex/error.go
+++ b/share/shwap/p2p/shrex/error.go
@@ -6,12 +6,17 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 )
 
-// isResourceExhausted reports whether err represents a stream reset with the
-// StreamResourceLimitExceeded code, meaning the remote peer rejected the request
-// because it hit a resource limit (stream count or memory budget).
+// isResourceExhausted reports whether err represents a stream reset indicating
+// the remote peer is temporarily overloaded. Two reset codes qualify:
+//   - StreamResourceLimitExceeded: rcmgr rejected the stream (concurrency or memory limit)
+//   - StreamRateLimited: the per-IP rate limiter rejected the stream
 func isResourceExhausted(err error) bool {
 	var streamErr *network.StreamError
-	return errors.As(err, &streamErr) && streamErr.ErrorCode == network.StreamResourceLimitExceeded
+	if !errors.As(err, &streamErr) {
+		return false
+	}
+	return streamErr.ErrorCode == network.StreamResourceLimitExceeded ||
+		streamErr.ErrorCode == network.StreamRateLimited
 }
 
 // ErrorContains reports whether any error in err's tree matches any error in targets tree.

--- a/share/shwap/p2p/shrex/metrics.go
+++ b/share/shwap/p2p/shrex/metrics.go
@@ -29,6 +29,7 @@ const (
 	statusSendStatusErr     status = "send_status_err"
 	statusSendRespErr       status = "send_resp_err"
 	statusResourceExhausted status = "resource_exhausted"
+	statusRateLimited       status = "rate_limited"
 
 	// general statuses that are applied to both the client and the server
 	statusSuccess     status = "success"

--- a/share/shwap/p2p/shrex/rate_limit.go
+++ b/share/shwap/p2p/shrex/rate_limit.go
@@ -1,0 +1,80 @@
+package shrex
+
+import (
+	"net/netip"
+	"os"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	libp2prate "github.com/libp2p/go-libp2p/x/rate"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+// disableRateLimiting disables the per-IP rate limiter when set to "1".
+// Intended for debugging and testing; do not use in production.
+var disableRateLimiting = os.Getenv("CELESTIA_SHREX_DISABLE_RATE_LIMITING") == "1"
+
+// rateLimitPerPeer is the sustained request rate allowed per peer IP (requests/sec).
+// A light node runs 16 workers × 16 samples = 256 requests per DAS round. With
+// a ~3s block time that is ~85 req/s in steady state, allowing the bucket to
+// refill one full DAS round worth of tokens between blocks.
+//
+// Rate limiting is applied globally per IP across all shrex protocol types. Expensive
+// requests (EdsID, RowID) are naturally bounded by their per-request memory cost and
+// disk I/O — the rcmgr memory budget and physical disk limits constrain them more
+// tightly than any token bucket could. The rate limiter exists primarily to prevent
+// sequential flooding of cheap requests (SampleID) that can cycle rapidly under the
+// rcmgr concurrency cap.
+var rateLimitPerPeer = 85.0
+
+// rateBurstPerPeer is the token-bucket burst size per peer IP.
+// Sized for one full DAS round from a single light node: 16 workers × 16 samples
+// = 256 streams opened nearly simultaneously.
+var rateBurstPerPeer = 256
+
+// newPeerRateLimiter returns a per-IP rate limiter for the shrex server.
+// Returns nil if rate limiting is disabled via CELESTIA_SHREX_DISABLE_RATE_LIMITING.
+//
+// Limiting is per individual IP (/32 IPv4, /128 IPv6) for Sybil resistance: a peer
+// cycling multiple identities from the same IP shares one bucket. The trade-off is
+// that nodes behind shared NAT compete for the same bucket; this is accepted since
+// Celestia node operators typically run on dedicated IPs.
+//
+// Loopback addresses (127.0.0.0/8, ::1/128) are exempted so localhost connections
+// (tests, local tooling) are never rejected. libp2prate treats Limit{} (RPS==0) as
+// unlimited (rate.Inf), matching the convention used by libp2p's identify protocol.
+//
+// The libp2p x/rate package handles bucket memory cleanup automatically via expiry.
+func newPeerRateLimiter() *libp2prate.Limiter {
+	if disableRateLimiting {
+		log.Warn("server: rate limiting disabled via CELESTIA_SHREX_DISABLE_RATE_LIMITING")
+		return nil
+	}
+	limit := libp2prate.Limit{RPS: rateLimitPerPeer, Burst: rateBurstPerPeer}
+	return &libp2prate.Limiter{
+		NetworkPrefixLimits: []libp2prate.PrefixLimit{
+			{Prefix: netip.MustParsePrefix("127.0.0.0/8"), Limit: libp2prate.Limit{}},
+			{Prefix: netip.MustParsePrefix("::1/128"), Limit: libp2prate.Limit{}},
+		},
+		SubnetRateLimiter: libp2prate.SubnetLimiter{
+			IPv4SubnetLimits: []libp2prate.SubnetLimit{{PrefixLength: 32, Limit: limit}},
+			IPv6SubnetLimits: []libp2prate.SubnetLimit{{PrefixLength: 128, Limit: limit}},
+			GracePeriod:      time.Minute,
+		},
+	}
+}
+
+// remoteIP extracts the IP address of the remote peer from a stream's connection multiaddr.
+// Returns the zero (invalid) netip.Addr when the address cannot be parsed, e.g. for relay
+// or circuit-relay transports. An invalid addr causes SubnetLimiter.Allow to return false
+// because netip.Addr{}.Prefix() errors, which the limiter treats as denied. Non-IP
+// connections are therefore blocked outright, which is acceptable: Celestia peers
+// communicate exclusively over IP.
+func remoteIP(s network.Stream) netip.Addr {
+	ip, err := manet.ToIP(s.Conn().RemoteMultiaddr())
+	if err != nil {
+		return netip.Addr{}
+	}
+	addr, _ := netip.AddrFromSlice(ip)
+	return addr.Unmap()
+}

--- a/share/shwap/p2p/shrex/server.go
+++ b/share/shwap/p2p/shrex/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	libp2prate "github.com/libp2p/go-libp2p/x/rate"
 	"go.uber.org/zap"
 
 	"github.com/celestiaorg/go-libp2p-messenger/serde"
@@ -29,6 +30,8 @@ type Server struct {
 
 	store store.AccessorGetter
 
+	rateLimiter *libp2prate.Limiter
+
 	params  *ServerParams
 	metrics *Metrics
 }
@@ -47,11 +50,12 @@ func NewServer(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	srv := &Server{
-		ctx:    ctx,
-		cancel: cancel,
-		store:  store,
-		host:   host,
-		params: params,
+		ctx:         ctx,
+		cancel:      cancel,
+		store:       store,
+		host:        host,
+		params:      params,
+		rateLimiter: newPeerRateLimiter(),
 	}
 	return srv, nil
 }
@@ -103,6 +107,16 @@ func (srv *Server) streamHandler(ctx context.Context, id newRequestID) network.S
 			log.Warnw("server: failed to attach stream to shrex service scope", "err", err)
 			s.ResetWithError(network.StreamResourceLimitExceeded) //nolint:errcheck
 			srv.metrics.observeRequest(ctx, requestID.Name(), statusResourceExhausted, time.Since(handleTime))
+			return
+		}
+
+		// enforce per-peer-IP rate limit to prevent sequential request flooding.
+		// we call Allow() directly instead of using the Limiter.Limit() middleware
+		// so that rate-limited streams are counted in metrics.
+		// rateLimiter is nil when CELESTIA_SHREX_DISABLE_RATE_LIMITING=1.
+		if srv.rateLimiter != nil && !srv.rateLimiter.Allow(remoteIP(s)) {
+			s.ResetWithError(network.StreamRateLimited) //nolint:errcheck
+			srv.metrics.observeRequest(ctx, requestID.Name(), statusRateLimited, time.Since(handleTime))
 			return
 		}
 


### PR DESCRIPTION
Add token-bucket rate limiting using the libp2p x/rate package to bound sequential request flooding that the resource manager's concurrency limits alone in #4898 cannot prevent. The rcmgr enforces concurrent stream and memory caps; rate limiting adds a temporal bound so a peer rapidly cycling streams under the cap cannot sustain an unbounded request rate.

Limiting is applied per individual IP (/32 IPv4, /128 IPv6) rather than per peer ID, providing Sybil resistance: a peer cycling identities from the same IP shares one bucket. The trade-off is that multiple legitimate nodes behind a shared NAT compete for the same tokens; this is documented and accepted given that Celestia node operators typically run on dedicated IPs.

Loopback addresses (127.0.0.0/8, ::1/128) are exempted from rate limiting.

Burst is sized for one full DAS round from a light node (16 workers × 16 samples = 256 streams); refill rate (20 req/s) allows the bucket to recover between blocks. Peers exceeding the budget receive StreamRateLimited, which the client surfaces as ErrResourceExhausted and handles with per-peer cooldown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
