### PR TITLE
feat!(rpc): harden RPC server

### DIFF
--- a/api/rpc/middleware.go
+++ b/api/rpc/middleware.go
@@ -1,0 +1,92 @@
+package rpc
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// connLimit returns middleware that limits the number of concurrent requests.
+// When the limit is reached, new requests receive 503 Service Unavailable.
+func connLimit(maxConns int, next http.Handler) http.Handler {
+	sem := make(chan struct{}, maxConns)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case sem <- struct{}{}:
+			defer func() { <-sem }()
+			next.ServeHTTP(w, r)
+		default:
+			log.Warnw("connection limit reached, rejecting request", "remote", r.RemoteAddr)
+			http.Error(w, "server busy, try again later", http.StatusServiceUnavailable)
+		}
+	})
+}
+
+// rateLimit returns middleware that enforces per-IP rate limiting.
+// Requests exceeding the limit receive 429 Too Many Requests.
+// The background cleanup goroutine exits when ctx is canceled.
+func rateLimit(ctx context.Context, rps, burst int, next http.Handler) http.Handler {
+	var mu sync.Mutex
+	type entry struct {
+		limiter  *rate.Limiter
+		lastSeen time.Time
+	}
+	limiters := make(map[string]*entry)
+	rateL := rate.Limit(rps)
+
+	// Evict stale entries in the background.
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				mu.Lock()
+				for ip, e := range limiters {
+					if time.Since(e.lastSeen) > 10*time.Minute {
+						delete(limiters, ip)
+					}
+				}
+				mu.Unlock()
+			}
+		}
+	}()
+
+	getLimiter := func(ip string) *rate.Limiter {
+		mu.Lock()
+		defer mu.Unlock()
+		e, ok := limiters[ip]
+		if !ok {
+			l := rate.NewLimiter(rateL, burst)
+			limiters[ip] = &entry{limiter: l, lastSeen: time.Now()}
+			return l
+		}
+		e.lastSeen = time.Now()
+		return e.limiter
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := extractIP(r)
+		if !getLimiter(ip).Allow() {
+			log.Warnw("rate limit exceeded", "ip", ip)
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// extractIP returns the IP portion of RemoteAddr (strips port).
+func extractIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/api/rpc/middleware.go
+++ b/api/rpc/middleware.go
@@ -1,12 +1,10 @@
 package rpc
 
 import (
-	"context"
 	"net"
 	"net/http"
-	"sync"
-	"time"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/time/rate"
 )
 
@@ -28,47 +26,20 @@ func connLimit(maxConns int, next http.Handler) http.Handler {
 
 // rateLimit returns middleware that enforces per-IP rate limiting.
 // Requests exceeding the limit receive 429 Too Many Requests.
-// The background cleanup goroutine exits when ctx is canceled.
-func rateLimit(ctx context.Context, rps, burst int, next http.Handler) http.Handler {
-	var mu sync.Mutex
-	type entry struct {
-		limiter  *rate.Limiter
-		lastSeen time.Time
+func rateLimit(rps, burst, cacheSize int, next http.Handler) http.Handler {
+	cache, err := lru.New[string, *rate.Limiter](cacheSize)
+	if err != nil {
+		panic(err)
 	}
-	limiters := make(map[string]*entry)
+
 	rateL := rate.Limit(rps)
-
-	// Evict stale entries in the background.
-	go func() {
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				mu.Lock()
-				for ip, e := range limiters {
-					if time.Since(e.lastSeen) > 10*time.Minute {
-						delete(limiters, ip)
-					}
-				}
-				mu.Unlock()
-			}
-		}
-	}()
-
 	getLimiter := func(ip string) *rate.Limiter {
-		mu.Lock()
-		defer mu.Unlock()
-		e, ok := limiters[ip]
+		limiter, ok := cache.Get(ip)
 		if !ok {
-			l := rate.NewLimiter(rateL, burst)
-			limiters[ip] = &entry{limiter: l, lastSeen: time.Now()}
-			return l
+			limiter = rate.NewLimiter(rateL, burst)
+			cache.Add(ip, limiter)
 		}
-		e.lastSeen = time.Now()
-		return e.limiter
+		return limiter
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/rpc/middleware.go
+++ b/api/rpc/middleware.go
@@ -18,7 +18,9 @@ func connLimit(maxConns int, next http.Handler) http.Handler {
 			defer func() { <-sem }()
 			next.ServeHTTP(w, r)
 		default:
-			log.Debugw("connection limit reached, rejecting request", "remote", r.RemoteAddr)
+			log.Debugw("connection limit reached, rejecting request",
+				"remote", r.RemoteAddr, "max_conns", maxConns,
+			)
 			http.Error(w, "server busy, try again later", http.StatusServiceUnavailable)
 		}
 	})
@@ -46,7 +48,9 @@ func rateLimit(rps, burst, cacheSize int, next http.Handler) http.Handler {
 		ip := extractIP(r)
 		if !getLimiter(ip).Allow() {
 			// Debug-level to avoid log amplification under sustained rate-limit hits.
-			log.Debugw("rate limit exceeded", "ip", ip)
+			log.Debugw("rate limit exceeded",
+				"ip", ip, "rps", rps, "burst", burst,
+			)
 			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 			return
 		}

--- a/api/rpc/middleware.go
+++ b/api/rpc/middleware.go
@@ -20,7 +20,7 @@ func connLimit(maxConns int, next http.Handler) http.Handler {
 			defer func() { <-sem }()
 			next.ServeHTTP(w, r)
 		default:
-			log.Warnw("connection limit reached, rejecting request", "remote", r.RemoteAddr)
+			log.Debugw("connection limit reached, rejecting request", "remote", r.RemoteAddr)
 			http.Error(w, "server busy, try again later", http.StatusServiceUnavailable)
 		}
 	})
@@ -74,7 +74,8 @@ func rateLimit(ctx context.Context, rps, burst int, next http.Handler) http.Hand
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := extractIP(r)
 		if !getLimiter(ip).Allow() {
-			log.Warnw("rate limit exceeded", "ip", ip)
+			// Debug-level to avoid log amplification under sustained rate-limit hits.
+			log.Debugw("rate limit exceeded", "ip", ip)
 			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 			return
 		}

--- a/api/rpc/middleware_test.go
+++ b/api/rpc/middleware_test.go
@@ -1,0 +1,140 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testRemoteAddr = "1.2.3.4:1234"
+
+func TestConnLimit_AllowsWithinLimit(t *testing.T) {
+	handler := connLimit(2, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestConnLimit_RejectsOverLimit(t *testing.T) {
+	blocked := make(chan struct{})
+	released := make(chan struct{})
+	handler := connLimit(1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Block") == "true" {
+			close(blocked)
+			<-released
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-Block", "true")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}()
+
+	<-blocked
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	close(released)
+	wg.Wait()
+}
+
+func TestConnLimit_ReleasesSlotAfterRequest(t *testing.T) {
+	handler := connLimit(1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRateLimit_AllowsWithinLimit(t *testing.T) {
+	handler := rateLimit(context.Background(), 100, 10, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = testRemoteAddr
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRateLimit_RejectsOverBurst(t *testing.T) {
+	handler := rateLimit(context.Background(), 1, 3, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = testRemoteAddr
+
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "request %d should succeed", i)
+	}
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
+func TestRateLimit_DifferentIPsIndependent(t *testing.T) {
+	handler := rateLimit(context.Background(), 1, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req1 := httptest.NewRequest("GET", "/", nil)
+	req1.RemoteAddr = testRemoteAddr
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req1)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req1)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.RemoteAddr = "5.6.7.8:5678"
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req2)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestExtractIP(t *testing.T) {
+	tests := []struct {
+		remoteAddr string
+		expected   string
+	}{
+		{testRemoteAddr, "1.2.3.4"},
+		{"[::1]:1234", "::1"},
+		{"1.2.3.4", "1.2.3.4"},
+	}
+	for _, tt := range tests {
+		r := &http.Request{RemoteAddr: tt.remoteAddr}
+		assert.Equal(t, tt.expected, extractIP(r))
+	}
+}

--- a/api/rpc/middleware_test.go
+++ b/api/rpc/middleware_test.go
@@ -1,7 +1,6 @@
 package rpc
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -11,7 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testRemoteAddr = "1.2.3.4:1234"
+const (
+	testRemoteAddr = "1.2.3.4:1234"
+	testCacheSize  = 8
+)
 
 func TestConnLimit_AllowsWithinLimit(t *testing.T) {
 	handler := connLimit(2, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +74,7 @@ func TestConnLimit_ReleasesSlotAfterRequest(t *testing.T) {
 }
 
 func TestRateLimit_AllowsWithinLimit(t *testing.T) {
-	handler := rateLimit(context.Background(), 100, 10, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := rateLimit(100, 10, testCacheSize, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -84,7 +86,7 @@ func TestRateLimit_AllowsWithinLimit(t *testing.T) {
 }
 
 func TestRateLimit_RejectsOverBurst(t *testing.T) {
-	handler := rateLimit(context.Background(), 1, 3, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := rateLimit(1, 3, testCacheSize, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -103,7 +105,7 @@ func TestRateLimit_RejectsOverBurst(t *testing.T) {
 }
 
 func TestRateLimit_DifferentIPsIndependent(t *testing.T) {
-	handler := rateLimit(context.Background(), 1, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := rateLimit(1, 1, testCacheSize, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -122,6 +124,35 @@ func TestRateLimit_DifferentIPsIndependent(t *testing.T) {
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, req2)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestRateLimit_EvictedIPGetsFreshBurst verifies that when the LRU cache fills
+// up and an IP's limiter is evicted, the IP gets a brand-new bucket (full burst)
+// on its next request — not the old, exhausted state.
+func TestRateLimit_EvictedIPGetsFreshBurst(t *testing.T) {
+	const cacheSize = 2
+	handler := rateLimit(1, 1, cacheSize, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	do := func(remoteAddr string) int {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = remoteAddr
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// Drain IP A's burst.
+	assert.Equal(t, http.StatusOK, do("1.1.1.1:1"))
+	assert.Equal(t, http.StatusTooManyRequests, do("1.1.1.1:1"))
+
+	// Fill the cache past capacity with two more IPs, evicting A.
+	assert.Equal(t, http.StatusOK, do("2.2.2.2:1"))
+	assert.Equal(t, http.StatusOK, do("3.3.3.3:1"))
+
+	// A is evicted — next request from A should get a fresh limiter, not 429.
+	assert.Equal(t, http.StatusOK, do("1.1.1.1:1"))
 }
 
 func TestExtractIP(t *testing.T) {

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -21,6 +21,18 @@ import (
 
 var log = logging.Logger("rpc")
 
+// TODO(@Wondertan): Expose in config if requested
+const (
+	// maxRequestSize is 5 MiB, significantly lower than go-jsonrpc's 100 MiB default.
+	maxRequestSize = 5 << 20
+	// maxConcurrentConns caps simultaneous connections to bound goroutine/FD usage.
+	maxConcurrentConns = 500
+	// maxRequestsPerSecond is the per-IP sustained rate.
+	maxRequestsPerSecond = 100
+	// maxRequestBurst is the per-IP burst allowance.
+	maxRequestBurst = 200
+)
+
 type CORSConfig struct {
 	Enabled        bool
 	AllowedOrigins []string
@@ -35,6 +47,7 @@ type Server struct {
 	authDisabled bool
 
 	started    atomic.Bool
+	cancelFunc context.CancelFunc
 	corsConfig CORSConfig
 
 	tlsEnabled  bool
@@ -59,12 +72,17 @@ func NewServer(
 	signer jwt.Signer,
 	verifier jwt.Verifier,
 ) *Server {
-	rpc := jsonrpc.NewServer()
+	rpc := jsonrpc.NewServer(
+		jsonrpc.WithMaxRequestSize(maxRequestSize),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	srv := &Server{
 		rpc:          rpc,
 		signer:       signer,
 		verifier:     verifier,
 		authDisabled: authDisabled,
+		cancelFunc:   cancel,
 		corsConfig:   corsConfig,
 		tlsEnabled:   tlsConfig.Enabled,
 		tlsCertPath:  tlsConfig.CertPath,
@@ -73,26 +91,36 @@ func NewServer(
 
 	srv.srv = &http.Server{
 		Addr:    net.JoinHostPort(address, port),
-		Handler: srv.newHandlerStack(rpc),
+		Handler: srv.newHandlerStack(ctx, rpc),
 		// the amount of time allowed to read request headers. set to the default 2 seconds
 		ReadHeaderTimeout: 2 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}
 
 	return srv
 }
 
-// newHandlerStack returns wrapped rpc related handlers
-func (s *Server) newHandlerStack(core http.Handler) http.Handler {
-	if s.authDisabled {
+// newHandlerStack returns wrapped rpc related handlers.
+// Middleware order (outermost first): rate-limit → conn-limit → CORS/auth → RPC handler.
+func (s *Server) newHandlerStack(ctx context.Context, core http.Handler) http.Handler {
+	var h http.Handler
+	switch {
+	case s.authDisabled:
 		log.Warn("auth disabled, allowing all origins, methods and headers for CORS")
-		return s.corsAny(core)
+		h = s.corsAny(core)
+	case s.corsConfig.Enabled:
+		h = s.corsWithConfig(s.authHandler(core))
+	default:
+		h = s.authHandler(core)
 	}
 
-	if s.corsConfig.Enabled {
-		return s.corsWithConfig(s.authHandler(core))
-	}
-
-	return s.authHandler(core)
+	// Apply connection and rate limiting as outermost layers.
+	h = connLimit(maxConcurrentConns, h)
+	h = rateLimit(ctx, maxRequestsPerSecond, maxRequestBurst, h)
+	return h
 }
 
 // verifyAuth is the RPC server's auth middleware. This middleware is only
@@ -183,6 +211,7 @@ func (s *Server) Stop(ctx context.Context) error {
 		log.Warn("cannot stop server: already stopped")
 		return nil
 	}
+	s.cancelFunc()
 	err := s.srv.Shutdown(ctx)
 	if err != nil {
 		return err

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -45,6 +45,10 @@ type RateLimitConfig struct {
 	// Burst is the per-IP burst allowance — the bucket size that absorbs
 	// short spikes before sustained rate kicks in.
 	Burst int
+	// CacheSize is the max number of per-IP buckets retained.
+	// When exceeded, the least-recently-seen IP is evicted (and gets a fresh
+	// burst on its next request). Bounds memory under unique-IP floods.
+	CacheSize int
 }
 
 type CORSConfig struct {
@@ -61,7 +65,6 @@ type Server struct {
 	authDisabled bool
 
 	started      atomic.Bool
-	cancelFunc   context.CancelFunc
 	corsConfig   CORSConfig
 	rateLimitCfg RateLimitConfig
 
@@ -92,13 +95,11 @@ func NewServer(
 		jsonrpc.WithMaxRequestSize(maxRequestSize),
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
 	srv := &Server{
 		rpc:          rpc,
 		signer:       signer,
 		verifier:     verifier,
 		authDisabled: authDisabled,
-		cancelFunc:   cancel,
 		corsConfig:   corsConfig,
 		rateLimitCfg: rateLimitCfg,
 		tlsEnabled:   tlsConfig.Enabled,
@@ -108,7 +109,7 @@ func NewServer(
 
 	srv.srv = &http.Server{
 		Addr:    net.JoinHostPort(address, port),
-		Handler: srv.newHandlerStack(ctx, rpc),
+		Handler: srv.newHandlerStack(rpc),
 		// the amount of time allowed to read request headers. set to the default 2 seconds
 		ReadHeaderTimeout: 2 * time.Second,
 		ReadTimeout:       30 * time.Second,
@@ -122,7 +123,7 @@ func NewServer(
 
 // newHandlerStack returns wrapped rpc related handlers.
 // Middleware order (outermost first): rate-limit (opt-in) → conn-limit → CORS/auth → RPC handler.
-func (s *Server) newHandlerStack(ctx context.Context, core http.Handler) http.Handler {
+func (s *Server) newHandlerStack(core http.Handler) http.Handler {
 	var h http.Handler
 	switch {
 	case s.authDisabled:
@@ -138,7 +139,7 @@ func (s *Server) newHandlerStack(ctx context.Context, core http.Handler) http.Ha
 	// Per-IP rate limiting is opt-in: behind a reverse proxy all clients share
 	// one bucket (RemoteAddr == proxy), so the limit is best applied there.
 	if s.rateLimitCfg.Enabled {
-		h = rateLimit(ctx, s.rateLimitCfg.RequestsPerSec, s.rateLimitCfg.Burst, h)
+		h = rateLimit(s.rateLimitCfg.RequestsPerSec, s.rateLimitCfg.Burst, s.rateLimitCfg.CacheSize, h)
 	}
 	return h
 }
@@ -231,7 +232,6 @@ func (s *Server) Stop(ctx context.Context) error {
 		log.Warn("cannot stop server: already stopped")
 		return nil
 	}
-	s.cancelFunc()
 	err := s.srv.Shutdown(ctx)
 	if err != nil {
 		return err

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -15,23 +15,37 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/rs/cors"
 
+	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
+
 	"github.com/celestiaorg/celestia-node/api/rpc/perms"
 	"github.com/celestiaorg/celestia-node/libs/authtoken"
 )
 
 var log = logging.Logger("rpc")
 
-// TODO(@Wondertan): Expose in config if requested
 const (
-	// maxRequestSize is 5 MiB, significantly lower than go-jsonrpc's 100 MiB default.
-	maxRequestSize = 5 << 20
+	// maxRequestSize bounds JSON-RPC request bodies. Sized as 2× appconsts.MaxTxSize
+	// to cover base64 + JSON envelope overhead (~1.5×) on a worst-case blob.Submit,
+	// which packs all blobs into a single PFB tx capped at MaxTxSize.
+	maxRequestSize = int64(appconsts.MaxTxSize * 2)
 	// maxConcurrentConns caps simultaneous connections to bound goroutine/FD usage.
 	maxConcurrentConns = 500
-	// maxRequestsPerSecond is the per-IP sustained rate.
-	maxRequestsPerSecond = 100
-	// maxRequestBurst is the per-IP burst allowance.
-	maxRequestBurst = 200
 )
+
+// RateLimitConfig configures per-IP rate limiting based on the connection's
+// remote address. When the node runs behind a reverse proxy, RemoteAddr is
+// the proxy's address, so all clients share one bucket — in that case keep
+// this disabled and apply rate limiting at the proxy instead.
+type RateLimitConfig struct {
+	// Enabled toggles the per-IP rate limit middleware.
+	Enabled bool
+	// RequestsPerSec is the sustained per-IP request rate; requests above
+	// this rate (after burst is drained) get 429 Too Many Requests.
+	RequestsPerSec int
+	// Burst is the per-IP burst allowance — the bucket size that absorbs
+	// short spikes before sustained rate kicks in.
+	Burst int
+}
 
 type CORSConfig struct {
 	Enabled        bool
@@ -46,9 +60,10 @@ type Server struct {
 	listener     net.Listener
 	authDisabled bool
 
-	started    atomic.Bool
-	cancelFunc context.CancelFunc
-	corsConfig CORSConfig
+	started      atomic.Bool
+	cancelFunc   context.CancelFunc
+	corsConfig   CORSConfig
+	rateLimitCfg RateLimitConfig
 
 	tlsEnabled  bool
 	tlsCertPath string
@@ -69,6 +84,7 @@ func NewServer(
 	authDisabled bool,
 	corsConfig CORSConfig,
 	tlsConfig TLSConfig,
+	rateLimitCfg RateLimitConfig,
 	signer jwt.Signer,
 	verifier jwt.Verifier,
 ) *Server {
@@ -84,6 +100,7 @@ func NewServer(
 		authDisabled: authDisabled,
 		cancelFunc:   cancel,
 		corsConfig:   corsConfig,
+		rateLimitCfg: rateLimitCfg,
 		tlsEnabled:   tlsConfig.Enabled,
 		tlsCertPath:  tlsConfig.CertPath,
 		tlsKeyPath:   tlsConfig.KeyPath,
@@ -95,7 +112,7 @@ func NewServer(
 		// the amount of time allowed to read request headers. set to the default 2 seconds
 		ReadHeaderTimeout: 2 * time.Second,
 		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      60 * time.Second,
+		WriteTimeout:      5 * time.Minute, // 5m covers long unary calls
 		IdleTimeout:       120 * time.Second,
 		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}
@@ -104,7 +121,7 @@ func NewServer(
 }
 
 // newHandlerStack returns wrapped rpc related handlers.
-// Middleware order (outermost first): rate-limit → conn-limit → CORS/auth → RPC handler.
+// Middleware order (outermost first): rate-limit (opt-in) → conn-limit → CORS/auth → RPC handler.
 func (s *Server) newHandlerStack(ctx context.Context, core http.Handler) http.Handler {
 	var h http.Handler
 	switch {
@@ -117,9 +134,12 @@ func (s *Server) newHandlerStack(ctx context.Context, core http.Handler) http.Ha
 		h = s.authHandler(core)
 	}
 
-	// Apply connection and rate limiting as outermost layers.
 	h = connLimit(maxConcurrentConns, h)
-	h = rateLimit(ctx, maxRequestsPerSecond, maxRequestBurst, h)
+	// Per-IP rate limiting is opt-in: behind a reverse proxy all clients share
+	// one bucket (RemoteAddr == proxy), so the limit is best applied there.
+	if s.rateLimitCfg.Enabled {
+		h = rateLimit(ctx, s.rateLimitCfg.RequestsPerSec, s.rateLimitCfg.Burst, h)
+	}
 	return h
 }
 

--- a/api/rpc/server_test.go
+++ b/api/rpc/server_test.go
@@ -75,7 +75,7 @@ func TestServer_HandlerStackSelection(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			handler := server.newHandlerStack(testHandler)
+			handler := server.newHandlerStack(context.Background(), testHandler)
 
 			// Test OPTIONS request (CORS preflight)
 			req := httptest.NewRequest("OPTIONS", "/", nil)
@@ -119,7 +119,7 @@ func TestServer_AuthDisabledOverridesCORS(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := server.newHandlerStack(testHandler)
+	handler := server.newHandlerStack(context.Background(), testHandler)
 
 	// Test with different origin than configured
 	req := httptest.NewRequest("OPTIONS", "/", nil)
@@ -185,7 +185,7 @@ func TestServer_CORSConfigurationPassing(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			handler := server.newHandlerStack(testHandler)
+			handler := server.newHandlerStack(context.Background(), testHandler)
 
 			req := httptest.NewRequest("OPTIONS", "/", nil)
 			req.Header.Set("Origin", tt.testOrigin)
@@ -240,7 +240,7 @@ func TestServer_AuthMiddleware(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			handler := server.newHandlerStack(testHandler)
+			handler := server.newHandlerStack(context.Background(), testHandler)
 
 			req := httptest.NewRequest("GET", "/", nil)
 			if tt.token != "" {

--- a/api/rpc/server_test.go
+++ b/api/rpc/server_test.go
@@ -75,7 +75,7 @@ func TestServer_HandlerStackSelection(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			handler := server.newHandlerStack(context.Background(), testHandler)
+			handler := server.newHandlerStack(testHandler)
 
 			// Test OPTIONS request (CORS preflight)
 			req := httptest.NewRequest("OPTIONS", "/", nil)
@@ -119,7 +119,7 @@ func TestServer_AuthDisabledOverridesCORS(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := server.newHandlerStack(context.Background(), testHandler)
+	handler := server.newHandlerStack(testHandler)
 
 	// Test with different origin than configured
 	req := httptest.NewRequest("OPTIONS", "/", nil)
@@ -185,7 +185,7 @@ func TestServer_CORSConfigurationPassing(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			handler := server.newHandlerStack(context.Background(), testHandler)
+			handler := server.newHandlerStack(testHandler)
 
 			req := httptest.NewRequest("OPTIONS", "/", nil)
 			req.Header.Set("Origin", tt.testOrigin)
@@ -249,7 +249,7 @@ func TestServer_AuthMiddleware(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			handler := server.newHandlerStack(context.Background(), testHandler)
+			handler := server.newHandlerStack(testHandler)
 
 			req := httptest.NewRequest("GET", "/", nil)
 			if tt.token != "" {

--- a/api/rpc/server_test.go
+++ b/api/rpc/server_test.go
@@ -69,7 +69,7 @@ func TestServer_HandlerStackSelection(t *testing.T) {
 				AllowedHeaders: []string{"Content-Type"},
 			}
 
-			server := NewServer("localhost", "0", tt.authDisabled, corsConfig, TLSConfig{}, signer, verifier)
+			server := NewServer("localhost", "0", tt.authDisabled, corsConfig, TLSConfig{}, RateLimitConfig{}, signer, verifier)
 
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -113,7 +113,7 @@ func TestServer_AuthDisabledOverridesCORS(t *testing.T) {
 		AllowedHeaders: []string{"Content-Type"},
 	}
 
-	server := NewServer("localhost", "0", true, restrictiveCORS, TLSConfig{}, signer, verifier)
+	server := NewServer("localhost", "0", true, restrictiveCORS, TLSConfig{}, RateLimitConfig{}, signer, verifier)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -179,7 +179,7 @@ func TestServer_CORSConfigurationPassing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewServer("localhost", "0", false, tt.corsConfig, TLSConfig{}, signer, verifier)
+			server := NewServer("localhost", "0", false, tt.corsConfig, TLSConfig{}, RateLimitConfig{}, signer, verifier)
 
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -234,7 +234,16 @@ func TestServer_AuthMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewServer("localhost", "0", tt.authDisabled, CORSConfig{}, TLSConfig{}, signer, verifier)
+			server := NewServer(
+				"localhost",
+				"0",
+				tt.authDisabled,
+				CORSConfig{},
+				TLSConfig{},
+				RateLimitConfig{},
+				signer,
+				verifier,
+			)
 
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -290,7 +299,16 @@ func TestServer_VerifyAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewServer("localhost", "0", tt.authDisabled, CORSConfig{}, TLSConfig{}, signer, verifier)
+			server := NewServer(
+				"localhost",
+				"0",
+				tt.authDisabled,
+				CORSConfig{},
+				TLSConfig{},
+				RateLimitConfig{},
+				signer,
+				verifier,
+			)
 
 			permissions, err := server.verifyAuth(context.Background(), tt.token)
 
@@ -307,7 +325,7 @@ func TestServer_VerifyAuth(t *testing.T) {
 // TestServer_StartStop tests server lifecycle
 func TestServer_StartStop(t *testing.T) {
 	signer, verifier := createTestJWT(t)
-	server := NewServer("localhost", "0", false, CORSConfig{}, TLSConfig{}, signer, verifier)
+	server := NewServer("localhost", "0", false, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, signer, verifier)
 
 	ctx := context.Background()
 
@@ -339,7 +357,7 @@ func TestServer_TLS(t *testing.T) {
 		Enabled:  true,
 		CertPath: certFile,
 		KeyPath:  keyFile,
-	}, signer, verifier)
+	}, RateLimitConfig{}, signer, verifier)
 
 	ctx := context.Background()
 	err := srv.Start(ctx)
@@ -378,7 +396,7 @@ func TestServer_TLS(t *testing.T) {
 func TestServer_NoTLS_PlainHTTP(t *testing.T) {
 	signer, verifier := createTestJWT(t)
 
-	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, signer, verifier)
+	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, signer, verifier)
 
 	ctx := context.Background()
 	err := srv.Start(ctx)

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.36.0
+	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 )
@@ -371,7 +372,6 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c // indirect
 	golang.org/x/term v0.42.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gonum.org/v1/gonum v0.17.0 // indirect

--- a/nodebuilder/rpc/config.go
+++ b/nodebuilder/rpc/config.go
@@ -28,6 +28,10 @@ type RateLimitConfig struct {
 	// Burst is the per-IP burst allowance — the bucket size that absorbs
 	// short spikes before sustained rate kicks in.
 	Burst int
+	// CacheSize is the max number of per-IP buckets retained.
+	// When exceeded, the least-recently-seen IP is evicted (and gets a fresh
+	// burst on its next request). Bounds memory under unique-IP floods.
+	CacheSize int
 }
 
 type Config struct {
@@ -60,6 +64,7 @@ func DefaultRateLimitConfig() RateLimitConfig {
 		Enabled:        false,
 		RequestsPerSec: 100,
 		Burst:          200,
+		CacheSize:      8192,
 	}
 }
 

--- a/nodebuilder/rpc/config.go
+++ b/nodebuilder/rpc/config.go
@@ -16,6 +16,20 @@ type CORSConfig struct {
 	AllowedMethods []string
 }
 
+// RateLimitConfig configures per-IP rate limiting on the RPC server. The
+// limit is keyed by the connection's remote address, so behind a reverse
+// proxy all clients share a single bucket — keep this disabled in that
+// setup and apply rate limiting at the proxy instead.
+type RateLimitConfig struct {
+	Enabled bool
+	// RequestsPerSec is the sustained per-IP request rate; requests above
+	// this rate (after burst is drained) get 429 Too Many Requests.
+	RequestsPerSec int
+	// Burst is the per-IP burst allowance — the bucket size that absorbs
+	// short spikes before sustained rate kicks in.
+	Burst int
+}
+
 type Config struct {
 	Address     string
 	Port        string
@@ -24,15 +38,28 @@ type Config struct {
 	TLSEnabled  bool
 	TLSCertPath string
 	TLSKeyPath  string
+	RateLimit   RateLimitConfig
 }
 
 func DefaultConfig() Config {
 	return Config{
 		Address: defaultBindAddress,
 		// do NOT expose the same port as celestia-core by default so that both can run on the same machine
-		Port:     defaultPort,
-		SkipAuth: false,
-		CORS:     DefaultCORSConfig(),
+		Port:      defaultPort,
+		SkipAuth:  false,
+		CORS:      DefaultCORSConfig(),
+		RateLimit: DefaultRateLimitConfig(),
+	}
+}
+
+// DefaultRateLimitConfig disables rate limiting by default; production
+// deployments typically run behind a reverse proxy that handles rate
+// limiting correctly (with the real client IP).
+func DefaultRateLimitConfig() RateLimitConfig {
+	return RateLimitConfig{
+		Enabled:        false,
+		RequestsPerSec: 100,
+		Burst:          200,
 	}
 }
 
@@ -79,6 +106,12 @@ func (cfg *Config) Validate() error {
 		}
 		if _, err := os.Stat(cfg.TLSKeyPath); err != nil {
 			return fmt.Errorf("service/rpc: TLS key file error: %w", err)
+		}
+	}
+
+	if cfg.RateLimit.Enabled {
+		if cfg.RateLimit.RequestsPerSec <= 0 || cfg.RateLimit.Burst <= 0 {
+			return fmt.Errorf("service/rpc: rate limit RequestsPerSec and Burst must be > 0")
 		}
 	}
 

--- a/nodebuilder/rpc/config.go
+++ b/nodebuilder/rpc/config.go
@@ -118,6 +118,9 @@ func (cfg *Config) Validate() error {
 		if cfg.RateLimit.RequestsPerSec <= 0 || cfg.RateLimit.Burst <= 0 {
 			return fmt.Errorf("service/rpc: rate limit RequestsPerSec and Burst must be > 0")
 		}
+		if cfg.RateLimit.CacheSize <= 0 {
+			return fmt.Errorf("service/rpc: rate limit CacheSize must be > 0")
+		}
 	}
 
 	return nil

--- a/nodebuilder/rpc/config_test.go
+++ b/nodebuilder/rpc/config_test.go
@@ -18,6 +18,7 @@ func TestDefaultConfig(t *testing.T) {
 			AllowedHeaders: []string{},
 			AllowedMethods: []string{},
 		},
+		RateLimit: DefaultRateLimitConfig(),
 	}
 
 	assert.Equal(t, expected, DefaultConfig())

--- a/nodebuilder/rpc/constructors.go
+++ b/nodebuilder/rpc/constructors.go
@@ -49,5 +49,9 @@ func server(cfg *Config, signer jwt.Signer, verifier jwt.Verifier) *rpc.Server {
 		Enabled:  cfg.TLSEnabled,
 		CertPath: cfg.TLSCertPath,
 		KeyPath:  cfg.TLSKeyPath,
+	}, rpc.RateLimitConfig{
+		Enabled:        cfg.RateLimit.Enabled,
+		RequestsPerSec: cfg.RateLimit.RequestsPerSec,
+		Burst:          cfg.RateLimit.Burst,
 	}, signer, verifier)
 }

--- a/nodebuilder/rpc/constructors.go
+++ b/nodebuilder/rpc/constructors.go
@@ -53,5 +53,6 @@ func server(cfg *Config, signer jwt.Signer, verifier jwt.Verifier) *rpc.Server {
 		Enabled:        cfg.RateLimit.Enabled,
 		RequestsPerSec: cfg.RateLimit.RequestsPerSec,
 		Burst:          cfg.RateLimit.Burst,
+		CacheSize:      cfg.RateLimit.CacheSize,
 	}, signer, verifier)
 }

--- a/nodebuilder/rpc/flags.go
+++ b/nodebuilder/rpc/flags.go
@@ -21,6 +21,7 @@ var (
 	tlsEnabledFlag         = "rpc.tls"
 	tlsCertPathFlag        = "rpc.tls-cert"
 	tlsKeyPathFlag         = "rpc.tls-key"
+	rateLimitFlag          = "rpc.rate-limit"
 )
 
 // Flags gives a set of hardcoded node/rpc package flags.
@@ -83,6 +84,12 @@ func Flags() *flag.FlagSet {
 		tlsKeyPathFlag,
 		"",
 		"Path to TLS private key file (PEM format)",
+	)
+
+	flags.Bool(
+		rateLimitFlag,
+		false,
+		"Enable per-IP rate limiting on RPC server. Leave disabled when running behind a reverse proxy",
 	)
 
 	return flags
@@ -181,6 +188,13 @@ func ParseFlags(cmd *cobra.Command, cfg *Config) error {
 			"TLS cert/key paths provided but TLS is not enabled. Set --%s=true to apply these settings",
 			tlsEnabledFlag,
 		)
+	}
+
+	if val, err := cmd.Flags().GetBool(rateLimitFlag); err != nil {
+		return err
+	} else if val {
+		log.Info("RPC rate limiting enabled (--rpc.rate-limit)")
+		cfg.RateLimit.Enabled = true
 	}
 
 	return nil


### PR DESCRIPTION
- Set WithMaxRequestSize(16 MiB) on go-jsonrpc server (down from 100 MiB default)
- Add http.Server timeouts: ReadTimeout, WriteTimeout, IdleTimeout, MaxHeaderBytes
- Add per-IP rate limiting middleware(disabled by default)
- Add concurrent connection limiting middleware (500 max)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
