### PR TITLE
chore(make): add `mod` target to tidy all Go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,12 @@ cover:
 	@go-acc -o coverage.txt `go list ./... | grep -v nodebuilder/tests` -- -v
 .PHONY: cover
 
+## mod: Run go mod tidy on all subpackages.
+mod:
+	@echo "--> Running go mod tidy on all modules"
+	@find . -name 'go.mod' -execdir go mod tidy \;
+.PHONY: mod
+
 ## deps: Install dependencies.
 deps:
 	@echo "--> Installing Dependencies"


### PR DESCRIPTION
## Summary
- Adds a new `make mod` Makefile directive that runs `go mod tidy` on all subpackages containing a `go.mod` file
- Extracts the existing logic from the `fmt` target into a standalone, reusable target

## Test plan
- [ ] Run `make mod` and verify it tidies all `go.mod` files in the repo
- [ ] Run `make help` and verify the new target appears in the help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
