### PR TITLE
fix(state): include ABCI result code in balance query error

### DIFF
--- a/state/core_access.go
+++ b/state/core_access.go
@@ -247,7 +247,10 @@ func (ca *CoreAccessor) BalanceForAddress(ctx context.Context, addr Address) (*B
 
 	result, err := ca.abciQueryCli.ABCIQuery(ctx, req)
 	if err != nil || result.GetCode() != 0 {
-		err = fmt.Errorf("failed to query for balance: %w; result log: %s", err, result.GetLog())
+		err = fmt.Errorf(
+			"failed to query for balance: %w; result log: %s; result code: %d",
+			err, result.GetLog(), result.GetCode(),
+		)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Improves observability when `BalanceForAddress` fails: the wrapped error now includes the ABCI result code in addition to the result log.

## Changes

- Extend the error message in `BalanceForAddress` when `ABCIQuery` returns an error or non-zero code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
