### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -16,6 +16,9 @@ on:
         description: 'Tag for release'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   # set up go version for use through pipelines, setting
   # variable one time and setting outputs to access passing it
@@ -85,7 +88,8 @@ jobs:
     if: |
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch'
-    permissions: "write-all"
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   api_tests:
     name: Integration Tests API

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '30 8 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-bootstrapper-health.yml
+++ b/.github/workflows/test-bootstrapper-health.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 6 * * *" # 6 AM UTC daily
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-bootstrapper-health:
     name: Test Bootstrapper Health


### PR DESCRIPTION
## Summary
- Adds an explicit `permissions:` block to every workflow that was missing one (5 workflows, one per commit for easy review).
- Default is `contents: read`; `stale.yml` uses `issues: write` + `pull-requests: write`; the `goreleaser` job in `ci_release.yml` is narrowed from `"write-all"` to `contents: write` (no `packages: write` since `.goreleaser.yaml` does not publish packages).
- Resolves 25 GitHub code scanning alerts under rule [`actions/missing-workflow-permissions`](https://github.com/celestiaorg/celestia-node/security/code-scanning?query=rule%3Aactions%2Fmissing-workflow-permissions).

## Why
Every GitHub Actions job that doesn't declare `permissions:` inherits the repository's default `GITHUB_TOKEN` scope. Codifying least privilege at the workflow level means a compromised third-party action can't silently write releases, create issues, or publish packages. The `goreleaser` job's previous `permissions: "write-all"` was particularly broad.

## Test plan
- [x] `actionlint` passes on all five modified workflows
- [ ] CI passes on this PR (exercises `go-ci`, `integration-tests`, and `ci_release` preflight jobs)
- [ ] Post-merge: verify the 25 alerts auto-close on next CodeQL scan

## Notes
- `upload-docs` job in `ci_release.yml` already has its own `permissions: contents: write`; left untouched.
- Reusable workflows (`go-ci.yml`, `integration-tests.yml`) have workflow-level `permissions:` that restrict jobs-within per GitHub Actions semantics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
