### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: celestiaorg/.github/.github/actions/yamllint@v0.6.4
+      - uses: celestiaorg/.github/.github/actions/yamllint@9ee03305d3cc6cf520b7895436429aa853b58e70 # v0.6.4
 
   markdown-lint:
     name: Markdown Lint
@@ -115,7 +115,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       # Generate the binaries and release
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v2
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
         with:
           mdbook-version: "latest"
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Deploy main
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./specs/book
@@ -43,6 +43,6 @@ jobs:
         # because this job will fail for branches from forks.
         # https://github.com/celestiaorg/celestia-app/issues/1506
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: ./specs/book

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           args: --timeout 10m
           version: v2.10.1
@@ -152,7 +152,7 @@ jobs:
           retention-days: 5
 
       - name: upload coverage
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           env_vars: OS
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/issue-label-automation.yml
+++ b/.github/workflows/issue-label-automation.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check for External Contributor
-        uses: tspascoal/get-user-teams-membership@v3
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3
         id: teamCheck
         with:
           username: ${{ github.actor }}
@@ -26,7 +26,7 @@ jobs:
       # For issues we want to add a `needs:triage` label if it is unlabeled
       - name: Triage labeling
         if: ${{ github.event_name == 'issues' }}
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260 # master @ 2026-04-20 — archived action, replace in follow-up
         with:
           add-labels: "needs:triage"
           ignore-if-labeled: true
@@ -36,7 +36,7 @@ jobs:
       # author is not a member of the node team
       - name: External labeling
         if: ${{ steps.teamCheck.outputs.isTeamMember == 'false' }}
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260 # master @ 2026-04-20 — archived action, replace in follow-up
         with:
           add-labels: "external"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-bootstrapper-health.yml
+++ b/.github/workflows/test-bootstrapper-health.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ always() && needs.test-bootstrapper-health.result == 'failure' }}
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Summary
- Pins 10 flagged third-party actions across 5 workflows to full commit SHAs, with the original tag preserved in a trailing comment (one commit per workflow).
- Dereferenced annotated tags (codecov, peaceiris) to their underlying commit SHAs.
- Flags `andymckay/labeler` as archived (last updated 2022) — pinned to current master HEAD as an interim measure.
- Resolves 11 GitHub code scanning alerts under rule [`actions/unpinned-tag`](https://github.com/celestiaorg/celestia-node/security/code-scanning?query=rule%3Aactions%2Funpinned-tag).

## Why
`@vX` tags and especially `@master` can be silently repointed by a compromised action maintainer, giving an attacker write access to our repo's `GITHUB_TOKEN`. Full SHA pinning makes any update explicit and auditable in git history.

## Test plan
- [x] `actionlint` passes on all five modified workflows
- [ ] CI passes on this PR (exercises go-ci, ci_release preflight jobs)
- [ ] Post-merge: verify the 11 alerts auto-close on next CodeQL scan

## Follow-up
- [ ] Replace `andymckay/labeler` (archived, unmaintained since 2022) with a maintained alternative — the two `uses:` sites are in `.github/workflows/issue-label-automation.yml`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
