### PR TITLE
feat(client): run Fibre operations locally instead of via bridge

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -195,29 +195,28 @@ func (c *Client) initTxClient(
 	c.Fibre = nodebuilderfibre.NewModule(fibreSvc)
 
 	c.closer = func() error {
-		// Stop the appfibre client first so its validator-state subscription
-		// drains before the underlying gRPC connection is torn down.
-		err = appFibreClient.Stop(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to stop fibre client: %w", err)
+		// Run every shutdown step and collect errors with errors.Join so one
+		// failure doesn't leak the rest of the resources. Order still matters:
+		// appfibre.Client first (its validator-state subscription rides the
+		// gRPC conn), then blob/core/tx-client wrappers, then the gRPC conn
+		// itself.
+		var errs []error
+		if err := appFibreClient.Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to stop fibre client: %w", err))
 		}
-		err = conn.Close()
-		if err != nil {
-			return fmt.Errorf("failed to close grpc connection: %w", err)
+		if err := blobSvc.Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to stop blob service: %w", err))
 		}
-		err = blobSvc.Stop(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to stop blob service: %w", err)
+		if err := core.Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to stop core accessor: %w", err))
 		}
-		err = core.Stop(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to stop core accessor: %w", err)
+		if err := tc.Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to stop tx client: %w", err))
 		}
-		err = tc.Stop(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to stop tx client: %w", err)
+		if err := conn.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close grpc connection: %w", err))
 		}
-		return nil
+		return errors.Join(errs...)
 	}
 	return nil
 }

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -9,7 +9,11 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"google.golang.org/grpc"
 
+	appfibre "github.com/celestiaorg/celestia-app/v8/fibre"
+
 	"github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/fibre"
+	nodebuilderfibre "github.com/celestiaorg/celestia-node/nodebuilder/fibre"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	stateapi "github.com/celestiaorg/celestia-node/nodebuilder/state"
 	"github.com/celestiaorg/celestia-node/state"
@@ -37,6 +41,14 @@ type SubmitConfig struct {
 	//     submitting blobs). Parallel submission is not guaranteed to include blobs
 	//     in the same order as they were submitted.
 	TxWorkerAccounts int
+	// Fibre tunes the local appfibre.Client used for Fibre operations
+	// (Submit/Upload/Download/Deposit/Withdraw/Query*). When nil,
+	// appfibre.DefaultClientConfig() is used. DefaultKeyName and StateAddress
+	// are always taken from SubmitConfig.DefaultKeyName and
+	// CoreGRPCConfig.Addr respectively, so callers can safely set only the
+	// knobs they care about (UploadConcurrency, DownloadConcurrency,
+	// StateClientFn, Log, Tracer, Meter, Clock, etc.).
+	Fibre *appfibre.ClientConfig
 }
 
 func (cfg Config) Validate() error {
@@ -152,7 +164,43 @@ func (c *Client) initTxClient(
 		submitter: blobSvc,
 	}
 
+	// Build a local Fibre module so all Fibre operations run against consensus
+	// gRPC and FSPs directly, without routing through a bridge node. This mirrors
+	// how Blob.Submit uses blobSvc. ReadClient.Fibre (JSON-RPC bridge) is still
+	// exposed by NewReadClient for read-only users.
+	var appFibreCfg appfibre.ClientConfig
+	if submitCfg.Fibre != nil {
+		appFibreCfg = *submitCfg.Fibre
+	} else {
+		appFibreCfg = appfibre.DefaultClientConfig()
+	}
+	appFibreCfg.DefaultKeyName = submitCfg.DefaultKeyName
+	appFibreCfg.StateAddress = conn.Target()
+	appFibreClient, err := appfibre.NewClient(kr, appFibreCfg)
+	if err != nil {
+		_ = blobSvc.Stop(ctx)
+		_ = core.Stop(ctx)
+		_ = tc.Stop(ctx)
+		return fmt.Errorf("creating fibre client: %w", err)
+	}
+	err = appFibreClient.Start(ctx)
+	if err != nil {
+		_ = blobSvc.Stop(ctx)
+		_ = core.Stop(ctx)
+		_ = tc.Stop(ctx)
+		return fmt.Errorf("starting fibre client: %w", err)
+	}
+	accClient := fibre.NewAccountClient(tc, conn)
+	fibreSvc := fibre.NewService(appFibreClient, tc, accClient)
+	c.Fibre = nodebuilderfibre.NewModule(fibreSvc)
+
 	c.closer = func() error {
+		// Stop the appfibre client first so its validator-state subscription
+		// drains before the underlying gRPC connection is torn down.
+		err = appFibreClient.Stop(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to stop fibre client: %w", err)
+		}
 		err = conn.Close()
 		if err != nil {
 			return fmt.Errorf("failed to close grpc connection: %w", err)

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -11,9 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cristalhq/jwt/v5"
 	gomock "github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -274,6 +276,84 @@ func TestSubmission_QueuedSubmission(t *testing.T) {
 		})
 	}
 	wg.Wait()
+}
+
+// TestFibreEscrow exercises the Fibre escrow operations (Deposit, Withdraw,
+// QueryEscrowAccount, PendingWithdrawals) through the locally-wired Fibre
+// module on Client. These code paths hit consensus gRPC + TxClient directly
+// and never go through the bridge node, so they exercise the self-sufficient
+// wiring introduced in this PR.
+//
+// Upload/Download/Submit are not covered here because the default testnode
+// does not run Fibre servers on its validators — there are no FSPs to
+// collect availability signatures from, so Upload fails with insufficient
+// voting power. Those paths are validated at integration level against a
+// fibre-enabled network.
+func TestFibreEscrow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	accounts := []string{"Elon"}
+
+	cctx := setupConsensus(t, ctx, accounts...)
+	bn, adminToken := bridgeNode(t, ctx, cctx)
+
+	// Override UploadConcurrency via SubmitConfig.Fibre to exercise the new
+	// config-exposure plumbing end-to-end. DefaultKeyName and StateAddress are
+	// ignored here — SubmitConfig takes precedence, as documented on the field.
+	fibreCfg := appfibre.DefaultClientConfig()
+	fibreCfg.UploadConcurrency = 2
+	fibreCfg.DownloadConcurrency = 2
+
+	cfg := Config{
+		ReadConfig: ReadConfig{
+			BridgeDAAddr: "http://" + bn.RPCServer.ListenAddr(),
+			DAAuthToken:  adminToken,
+			EnableDATLS:  false,
+		},
+
+		SubmitConfig: SubmitConfig{
+			DefaultKeyName: accounts[0],
+			Network:        "private",
+			CoreGRPCConfig: CoreGRPCConfig{
+				Addr: cctx.GRPCClient.Target(),
+			},
+			Fibre: &fibreCfg,
+		},
+	}
+	client, err := New(ctx, cfg, cctx.Keyring)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	rec, err := cctx.Keyring.Key(accounts[0])
+	require.NoError(t, err)
+	addr, err := rec.GetAddress()
+	require.NoError(t, err)
+
+	// Deposit into Fibre escrow — this goes via our local TxClient, not the
+	// bridge. If the submit-side Fibre wiring still routed via JSON-RPC, this
+	// call would fail (the bridge has no key for `accounts[0]`).
+	depositAmount := sdktypes.NewCoin("utia", math.NewInt(10_000_000))
+	require.NoError(t, client.Fibre.Deposit(ctx, depositAmount, state.NewTxConfig()))
+
+	// Escrow query confirms the Deposit landed on-chain and the state read
+	// path goes directly to consensus gRPC (not JSON-RPC to the bridge).
+	esc, err := client.Fibre.QueryEscrowAccount(ctx, addr.String())
+	require.NoError(t, err)
+	require.NotNil(t, esc)
+	require.Equal(t, addr.String(), esc.Signer)
+	require.Equal(t, depositAmount.Amount, esc.Balance.Amount)
+
+	// Request a withdrawal to exercise another tx-emitting path.
+	withdrawAmount := sdktypes.NewCoin("utia", math.NewInt(1_000_000))
+	require.NoError(t, client.Fibre.Withdraw(ctx, withdrawAmount, state.NewTxConfig()))
+
+	pending, err := client.Fibre.PendingWithdrawals(ctx, addr.String())
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Equal(t, withdrawAmount.Amount, pending[0].Amount.Amount)
 }
 
 type mockAPI struct {

--- a/fibre/service.go
+++ b/fibre/service.go
@@ -24,6 +24,11 @@ var (
 	ErrClientNotAvailable = errors.New("fibre client is not available: node is not connected to a core endpoint")
 )
 
+// asyncSubmitTimeout bounds the background MsgPayForFibre broadcast kicked off
+// by Upload. It needs to cover gas estimation plus at least one block time;
+// 2 minutes is a comfortable upper bound on any mainnet-scale configuration.
+const asyncSubmitTimeout = 2 * time.Minute
+
 type Service struct {
 	*AccountClient
 
@@ -107,7 +112,7 @@ func (s *Service) Upload(
 	ctx context.Context,
 	ns libshare.Namespace,
 	data []byte,
-	_ *txclient.TxConfig,
+	options *txclient.TxConfig,
 ) (_ *appfibre.SignedPaymentPromise, _ appfibre.BlobID, err error) {
 	if s == nil {
 		return nil, nil, ErrClientNotAvailable
@@ -129,8 +134,54 @@ func (s *Service) Upload(
 		log.Errorw("uploading blob", "err", err, "namespace", ns.ID())
 		return nil, nil, err
 	}
-	// TODO: add async fibre submit
+
+	// Per ADR-013, Upload settles payment on-chain in the background so the
+	// caller is not blocked on tx inclusion. Errors are logged only; a
+	// follow-up change will add lifecycle tracking to wait for in-flight
+	// submissions during Service shutdown.
+	go s.asyncSubmitPayForFibre(promise, options)
+
 	return promise, blob.ID(), nil
+}
+
+// asyncSubmitPayForFibre broadcasts MsgPayForFibre for a promise returned by
+// Upload. It runs in its own goroutine with a fresh context so the Upload
+// caller can return (and cancel its context) immediately.
+func (s *Service) asyncSubmitPayForFibre(
+	promise *appfibre.SignedPaymentPromise,
+	options *txclient.TxConfig,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), asyncSubmitTimeout)
+	defer cancel()
+
+	protoPromise, err := promise.ToProto()
+	if err != nil {
+		log.Errorw("async pay-for-fibre: marshal promise", "err", err, "namespace", promise.Namespace)
+		return
+	}
+
+	signer, err := s.txClient.GetTxAuthorAccAddress(options)
+	if err != nil {
+		log.Errorw("async pay-for-fibre: resolve signer", "err", err, "namespace", promise.Namespace)
+		return
+	}
+
+	msg := &fibretypes.MsgPayForFibre{
+		Signer:              signer.String(),
+		PaymentPromise:      *protoPromise,
+		ValidatorSignatures: promise.ValidatorSignatures,
+	}
+	resp, err := s.txClient.SubmitMessage(ctx, msg, options)
+	if err != nil {
+		log.Errorw("async pay-for-fibre: submit", "err", err, "namespace", promise.Namespace)
+		return
+	}
+
+	log.Debugw("async pay-for-fibre submitted",
+		"namespace", promise.Namespace,
+		"height", resp.Height,
+		"tx-hash", resp.TxHash,
+	)
 }
 
 func (s *Service) Download(ctx context.Context, blobID appfibre.BlobID) (*appfibre.Blob, error) {

--- a/fibre/service.go
+++ b/fibre/service.go
@@ -135,6 +135,14 @@ func (s *Service) Upload(
 		return nil, nil, err
 	}
 
+	// The goroutine below calls SubmitMessage, which dereferences options
+	// (TxConfig.FeeGranterAddress) without a nil guard. A panic in a detached
+	// goroutine crashes the process, so normalize nil here for both this
+	// Service.Upload path and the async settlement path below.
+	if options == nil {
+		options = txclient.NewTxConfig()
+	}
+
 	// Per ADR-013, Upload settles payment on-chain in the background so the
 	// caller is not blocked on tx inclusion. Errors are logged only; a
 	// follow-up change will add lifecycle tracking to wait for in-flight
@@ -147,6 +155,11 @@ func (s *Service) Upload(
 // asyncSubmitPayForFibre broadcasts MsgPayForFibre for a promise returned by
 // Upload. It runs in its own goroutine with a fresh context so the Upload
 // caller can return (and cancel its context) immediately.
+//
+// TODO: this uses the sync SubmitMessage path (BroadcastTx + ConfirmTx), so
+// the goroutine blocks until chain inclusion. Once QueuedTxClient lands, move
+// to broadcast-sync + poll-status-async so broadcast errors surface to the
+// caller and the background goroutine only polls status.
 func (s *Service) asyncSubmitPayForFibre(
 	promise *appfibre.SignedPaymentPromise,
 	options *txclient.TxConfig,

--- a/nodebuilder/fibre/constructor.go
+++ b/nodebuilder/fibre/constructor.go
@@ -29,10 +29,7 @@ func ConstructModule(coreCfg *core.Config) fx.Option {
 				}),
 			),
 			newFibreService,
-			fx.Annotate(
-				newModule,
-				fx.As(new(Module)),
-			),
+			NewModule,
 		),
 		fxutil.ProvideIf(!coreCfg.IsEndpointConfigured(), func() (*fibre.Service, Module) {
 			return nil, &stubbedFibreModule{}

--- a/nodebuilder/fibre/module.go
+++ b/nodebuilder/fibre/module.go
@@ -18,8 +18,8 @@ type module struct {
 }
 
 // NewModule returns a Module backed by a local *fibre.Service. It is used by
-// bridge/full nodes to expose the Fibre JSON-RPC API, and by api/client.Client
-// to run all Fibre operations locally against a consensus endpoint and FSPs,
+// bridge nodes to expose the Fibre JSON-RPC API, and by api/client.Client to
+// run all Fibre operations locally against a consensus endpoint and FSPs,
 // without routing through a bridge node.
 func NewModule(service *fibre.Service) Module {
 	return &module{

--- a/nodebuilder/fibre/module.go
+++ b/nodebuilder/fibre/module.go
@@ -17,7 +17,11 @@ type module struct {
 	service *fibre.Service
 }
 
-func newModule(service *fibre.Service) *module {
+// NewModule returns a Module backed by a local *fibre.Service. It is used by
+// bridge/full nodes to expose the Fibre JSON-RPC API, and by api/client.Client
+// to run all Fibre operations locally against a consensus endpoint and FSPs,
+// without routing through a bridge node.
+func NewModule(service *fibre.Service) Module {
 	return &module{
 		service: service,
 	}


### PR DESCRIPTION
## Summary

- `api/client.Client` now builds a local `*appfibre.Client` + `*fibre.Service` and replaces `c.Fibre` with `nodebuilder/fibre.NewModule(svc)`. `Fibre.Submit`, `Upload`, `Download` and all escrow ops run directly against consensus gRPC + FSPs — no bridge hop.
- Exported `nodebuilder/fibre.NewModule` so `api/client` and the bridge share the same `Module` wrapping logic. `module` stays unexported; only the constructor moves.
- Implemented the ADR-013 async submission contract: `fibre.Service.Upload` now fires the `MsgPayForFibre` broadcast in a background goroutine with a fresh `context.Background()` + 2-minute timeout. Errors log; the caller returns as soon as off-chain upload + validator sig aggregation completes.
- `ReadClient.Fibre` (JSON-RPC to the bridge) is unchanged — read-only users keep working. `Client.Close()` stops the local `appfibre.Client` before tearing down the gRPC conn.

## Why

ADR-013 scoped the Fibre read path via `blob.Subscribe` on the node, but the submit path was routed through the bridge by JSON-RPC even though every Fibre method can execute locally given a keyring and a consensus endpoint — the same setup `Blob.Submit` already uses via `blobSubmitClient`. Routing through the bridge adds a hop, a base64-encoded 128 MiB payload on the write path, and a third-party dependency for callers that already hold consensus gRPC + a signer.

## Follow-up

- Add `sync.WaitGroup` + `Service.Stop()` to `fibre.Service` so `Client.Close()` can wait for in-flight async `MsgPayForFibre` broadcasts before tearing down the tx client. Keeping this out of this PR to keep the diff focused.

## Test plan

- [x] `go build -tags fibre ./...`
- [x] `go vet -tags fibre ./...`
- [x] `go test -tags fibre -count=1 -run TestFibreEscrow ./api/client/...` — new test covering Deposit → QueryEscrowAccount → Withdraw → PendingWithdrawals end-to-end over the locally-wired Fibre module.
- [x] `go test -tags fibre -count=1 -run TestSubmission ./api/client/...` — existing Blob.Submit path unaffected.
- [ ] `TestFibreEscrow` does **not** cover `Upload`/`Download`/`Submit` because the default testnode validators don't run Fibre servers — Upload fails with "not enough voting power: collected 0". That path is validated at integration level against a fibre-enabled network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
