### PR TITLE
feat(blob)!: allow Subscribe to resume from a given height

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -151,8 +151,11 @@ func (c *Client) initTxClient(
 	}
 	c.State = core
 
-	// setup blob submission service using core
-	blobSvc := blob.NewService(core, nil, nil, nil)
+	// setup blob submission service using core. Subscribe-related header
+	// accessors are intentionally nil here because Client routes
+	// Blob.Subscribe through the bridge via JSON-RPC (ReadClient.Blob);
+	// this local service only powers Blob.Submit.
+	blobSvc := blob.NewService(core, nil, nil, nil, nil)
 	err = blobSvc.Start(ctx)
 	if err != nil {
 		_ = core.Stop(ctx)

--- a/blob/service.go
+++ b/blob/service.go
@@ -60,7 +60,14 @@ type Service struct {
 	shareGetter shwap.Getter
 	// headerGetter fetches header by the provided height
 	headerGetter func(context.Context, uint64) (*header.ExtendedHeader, error)
+	// waitForHeight blocks until the header at the given height is available
+	// in the local store. Used by Subscribe's fromHeight>0 path to follow the
+	// chain forward from a caller-specified starting point (including past
+	// heights, for subscribers that need to resume after a restart).
+	waitForHeight func(context.Context, uint64) (*header.ExtendedHeader, error)
 	// headerSub subscribes to new headers to supply to blob subscriptions.
+	// Used by Subscribe's fromHeight==0 path so callers don't need to know
+	// the current head height upfront.
 	headerSub func(ctx context.Context) (<-chan *header.ExtendedHeader, error)
 	// metrics tracks blob-related metrics
 	metrics *metrics
@@ -70,12 +77,14 @@ func NewService(
 	submitter Submitter,
 	getter shwap.Getter,
 	headerGetter func(context.Context, uint64) (*header.ExtendedHeader, error),
+	waitForHeight func(context.Context, uint64) (*header.ExtendedHeader, error),
 	headerSub func(ctx context.Context) (<-chan *header.ExtendedHeader, error),
 ) *Service {
 	return &Service{
 		blobSubmitter: submitter,
 		shareGetter:   getter,
 		headerGetter:  headerGetter,
+		waitForHeight: waitForHeight,
 		headerSub:     headerSub,
 		metrics:       nil, // Will be initialized via WithMetrics() if needed
 	}
@@ -101,79 +110,143 @@ type SubscriptionResponse struct {
 	Header *header.RawHeader
 }
 
-// Subscribe returns a channel that will receive SubscriptionResponse objects.
-// The channel will be closed when the context is canceled or the service is stopped.
-// Please note that no errors are returned: underlying operations are retried until successful.
-// Additionally, not reading from the returned channel will cause the stream to close after 16 messages.
-func (s *Service) Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan *SubscriptionResponse, error) {
+// Subscribe returns a channel that will receive SubscriptionResponse objects
+// for blobs landing under ns.
+//
+// fromHeight controls the starting point:
+//   - fromHeight == 0: start from the current head via the live header
+//     subscription. Preserves the historical behavior — callers that just
+//     want "follow new blobs" don't need to know the current height.
+//   - fromHeight  > 0: start at that height and step forward one block at
+//     a time using WaitForHeight, which blocks until each successive
+//     header is available in the local store. This lets a subscriber
+//     resume after a restart without missing blobs.
+//
+// The channel is closed when ctx is canceled or the service is stopped.
+// Underlying operations are retried until successful; no error is returned
+// once the subscription is established. Not reading from the returned
+// channel will cause the stream to close after 16 messages.
+func (s *Service) Subscribe(
+	ctx context.Context,
+	ns libshare.Namespace,
+	fromHeight uint64,
+) (<-chan *SubscriptionResponse, error) {
 	if s.ctx == nil {
 		return nil, fmt.Errorf("service has not been started")
 	}
 
 	log.Infow("subscribing for blobs",
 		"namespaces", ns.String(),
+		"from_height", fromHeight,
 	)
-	headerCh, err := s.headerSub(ctx)
+
+	headers, err := s.headerStream(ctx, fromHeight)
 	if err != nil {
 		return nil, err
 	}
 
 	blobCh := make(chan *SubscriptionResponse, 16)
+	go s.forwardBlobs(ctx, ns, headers, blobCh)
+	return blobCh, nil
+}
+
+// headerStream returns a channel of ExtendedHeaders driving the
+// subscription loop. fromHeight==0 reuses the existing headerSub (live
+// tip); fromHeight>0 iterates WaitForHeight(h) for h = fromHeight,
+// fromHeight+1, ..., so the subscriber can replay history and keep
+// following from a specified point.
+func (s *Service) headerStream(
+	ctx context.Context,
+	fromHeight uint64,
+) (<-chan *header.ExtendedHeader, error) {
+	if fromHeight == 0 {
+		return s.headerSub(ctx)
+	}
+	if s.waitForHeight == nil {
+		return nil, fmt.Errorf("waitForHeight not configured: cannot start subscription from height %d", fromHeight)
+	}
+	out := make(chan *header.ExtendedHeader, 16)
 	go func() {
-		defer close(blobCh)
-
-		for {
-			select {
-			case header, ok := <-headerCh:
-				if ctx.Err() != nil {
-					log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
-					return
+		defer close(out)
+		for h := fromHeight; ; h++ {
+			hdr, err := s.waitForHeight(ctx, h)
+			if err != nil {
+				if ctx.Err() == nil {
+					log.Errorw("blobsub: waitForHeight failed", "height", h, "err", err)
 				}
-				if !ok {
-					log.Errorw("header channel closed for subscription", "namespace", ns.ID())
-					return
-				}
-				// close subscription before buffer overflows
-				if len(blobCh) == cap(blobCh) {
-					log.Debugw("blobsub: canceling subscription due to buffer overflow from slow reader", "namespace", ns.ID())
-					return
-				}
-
-				var blobs []*Blob
-				var err error
-				for {
-					blobs, err = s.getAll(ctx, header, []libshare.Namespace{ns})
-					if ctx.Err() != nil {
-						// context canceled, continuing would lead to unexpected missed heights for the client
-						log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
-						return
-					}
-					if err == nil {
-						// operation successful, break the loop
-						break
-					}
-				}
-
-				select {
-				case <-ctx.Done():
-					log.Debugw("blobsub: pending response canceled due to user ctx closing", "namespace", ns.ID())
-					return
-				case blobCh <- &SubscriptionResponse{
-					Blobs:  blobs,
-					Height: header.Height(),
-					Header: &header.RawHeader,
-				}:
-				}
-			case <-ctx.Done():
-				log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
 				return
-			case <-s.ctx.Done():
-				log.Debugw("blobsub: canceling subscription due to service ctx closing", "namespace", ns.ID())
+			}
+			select {
+			case out <- hdr:
+			case <-ctx.Done():
 				return
 			}
 		}
 	}()
-	return blobCh, nil
+	return out, nil
+}
+
+// forwardBlobs consumes headers from the header stream and emits one
+// SubscriptionResponse per header. Factored out of Subscribe so it is
+// shared by both the live-tip and resume-from-height header sources.
+func (s *Service) forwardBlobs(
+	ctx context.Context,
+	ns libshare.Namespace,
+	headers <-chan *header.ExtendedHeader,
+	out chan<- *SubscriptionResponse,
+) {
+	defer close(out)
+	for {
+		select {
+		case hdr, ok := <-headers:
+			if ctx.Err() != nil {
+				log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
+				return
+			}
+			if !ok {
+				log.Errorw("header channel closed for subscription", "namespace", ns.ID())
+				return
+			}
+			// Close subscription before buffer overflows — protects the
+			// subscription goroutine against a slow reader starving it
+			// and the chain moving ahead faster than events can drain.
+			if len(out) == cap(out) {
+				log.Debugw("blobsub: canceling subscription due to buffer overflow from slow reader", "namespace", ns.ID())
+				return
+			}
+
+			var blobs []*Blob
+			var err error
+			for {
+				blobs, err = s.getAll(ctx, hdr, []libshare.Namespace{ns})
+				if ctx.Err() != nil {
+					// Context canceled, continuing would lead to unexpected missed heights for the client.
+					log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
+					return
+				}
+				if err == nil {
+					break
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				log.Debugw("blobsub: pending response canceled due to user ctx closing", "namespace", ns.ID())
+				return
+			case out <- &SubscriptionResponse{
+				Blobs:  blobs,
+				Height: hdr.Height(),
+				Header: &hdr.RawHeader,
+			}:
+			}
+		case <-ctx.Done():
+			log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
+			return
+		case <-s.ctx.Done():
+			log.Debugw("blobsub: canceling subscription due to service ctx closing", "namespace", ns.ID())
+			return
+		}
+	}
 }
 
 // Submit sends PFB transaction and reports the height at which it was included.

--- a/blob/service.go
+++ b/blob/service.go
@@ -168,17 +168,29 @@ func (s *Service) headerStream(
 	out := make(chan *header.ExtendedHeader, 16)
 	go func() {
 		defer close(out)
+
+		// Merge the user context with the Service's lifecycle context so
+		// Service.Stop cancels the WaitForHeight loop promptly even if the
+		// user context is still alive. Without this, a subscriber holding a
+		// long-lived ctx would block the loop indefinitely after Stop: the
+		// forwardBlobs consumer exits via s.ctx.Done but nobody drains out,
+		// so the channel send or the next waitForHeight never returns.
+		mergedCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		stopPropagate := context.AfterFunc(s.ctx, cancel)
+		defer stopPropagate()
+
 		for h := fromHeight; ; h++ {
-			hdr, err := s.waitForHeight(ctx, h)
+			hdr, err := s.waitForHeight(mergedCtx, h)
 			if err != nil {
-				if ctx.Err() == nil {
+				if mergedCtx.Err() == nil {
 					log.Errorw("blobsub: waitForHeight failed", "height", h, "err", err)
 				}
 				return
 			}
 			select {
 			case out <- hdr:
-			case <-ctx.Done():
+			case <-mergedCtx.Done():
 				return
 			}
 		}

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -665,7 +665,7 @@ func TestService_Subscribe(t *testing.T) {
 
 	t.Run("successful subscription", func(t *testing.T) {
 		ns := blobs[0].Namespace()
-		subCh, err := service.Subscribe(ctx, ns)
+		subCh, err := service.Subscribe(ctx, ns, 0)
 		require.NoError(t, err)
 
 		for i := uint64(0); i < uint64(len(blobs)); i++ {
@@ -683,7 +683,7 @@ func TestService_Subscribe(t *testing.T) {
 		ns, err := libshare.NewV0Namespace([]byte("nonexist"))
 		require.NoError(t, err)
 
-		subCh, err := service.Subscribe(ctx, ns)
+		subCh, err := service.Subscribe(ctx, ns, 0)
 		require.NoError(t, err)
 
 		// check that empty responses are received (as no matching blobs were found)
@@ -707,7 +707,7 @@ func TestService_Subscribe(t *testing.T) {
 
 		ns := blobs[0].Namespace()
 
-		subCh, err := service.Subscribe(subCtx, ns)
+		subCh, err := service.Subscribe(subCtx, ns, 0)
 		require.NoError(t, err)
 
 		// cancel the subscription context after receiving the first response
@@ -733,7 +733,7 @@ func TestService_Subscribe(t *testing.T) {
 
 	t.Run("graceful shutdown", func(t *testing.T) {
 		ns := blobs[0].Namespace()
-		subCh, err := service.Subscribe(ctx, ns)
+		subCh, err := service.Subscribe(ctx, ns, 0)
 		require.NoError(t, err)
 
 		// cancel the subscription context after receiving the last response
@@ -786,9 +786,9 @@ func TestService_Subscribe_MultipleNamespaces(t *testing.T) {
 	ns1 := blobs1[0].Namespace()
 	ns2 := blobs2[0].Namespace()
 
-	subCh1, err := service.Subscribe(ctx, ns1)
+	subCh1, err := service.Subscribe(ctx, ns1, 0)
 	require.NoError(t, err)
-	subCh2, err := service.Subscribe(ctx, ns2)
+	subCh2, err := service.Subscribe(ctx, ns2, 0)
 	require.NoError(t, err)
 
 	var i int
@@ -880,6 +880,12 @@ func createServiceWithSub(ctx context.Context, t testing.TB, blobs []*Blob) (*Se
 		return headers[height-1], nil
 		// return headerStore.GetByHeight(ctx, height)
 	}
+	waitFn := func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
+		if height == 0 || int(height) > len(headers) {
+			return nil, fmt.Errorf("height %d out of test range", height)
+		}
+		return headers[height-1], nil
+	}
 	fn2 := func(ctx context.Context) (<-chan *header.ExtendedHeader, error) {
 		headerChan := make(chan *header.ExtendedHeader, len(headers))
 		defer func() {
@@ -900,7 +906,7 @@ func createServiceWithSub(ctx context.Context, t testing.TB, blobs []*Blob) (*Se
 			nd, err := eds.NamespaceData(ctx, accessor, ns)
 			return nd, err
 		})
-	return NewService(nil, shareGetter, fn, fn2), headers
+	return NewService(nil, shareGetter, fn, waitFn, fn2), headers
 }
 
 func createService(ctx context.Context, t testing.TB, shares []libshare.Share) *Service {
@@ -941,10 +947,13 @@ func createService(ctx context.Context, t testing.TB, shares []libshare.Share) *
 	fn := func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
 		return headerStore.GetByHeight(ctx, height)
 	}
+	waitFn := func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
+		return nil, fmt.Errorf("waitForHeight not implemented in createService helper")
+	}
 	fn2 := func(ctx context.Context) (<-chan *header.ExtendedHeader, error) {
 		return nil, fmt.Errorf("not implemented")
 	}
-	return NewService(nil, shareGetter, fn, fn2)
+	return NewService(nil, shareGetter, fn, waitFn, fn2)
 }
 
 // TestProveCommitmentAllCombinations tests proving all the commitments in a block.

--- a/nodebuilder/blob/blob.go
+++ b/nodebuilder/blob/blob.go
@@ -42,8 +42,18 @@ type Module interface {
 		namespace libshare.Namespace,
 		shareCommitment []byte,
 	) (*blob.CommitmentProof, error)
-	// Subscribe to published blobs from the given namespace as they are included.
-	Subscribe(_ context.Context, _ libshare.Namespace) (<-chan *blob.SubscriptionResponse, error)
+	// Subscribe to published blobs from the given namespace as they are
+	// included, starting at fromHeight.
+	//
+	// A fromHeight of 0 means "start from the current chain head". A value
+	// greater than zero starts the stream at that block height so a
+	// subscriber can resume after a restart (including replaying past
+	// blocks) without missing blobs.
+	Subscribe(
+		_ context.Context,
+		_ libshare.Namespace,
+		fromHeight uint64,
+	) (<-chan *blob.SubscriptionResponse, error)
 }
 
 type API struct {
@@ -86,6 +96,7 @@ type API struct {
 		Subscribe func(
 			context.Context,
 			libshare.Namespace,
+			uint64,
 		) (<-chan *blob.SubscriptionResponse, error) `perm:"read"`
 	}
 }
@@ -138,6 +149,7 @@ func (api *API) Included(
 func (api *API) Subscribe(
 	ctx context.Context,
 	namespace libshare.Namespace,
+	fromHeight uint64,
 ) (<-chan *blob.SubscriptionResponse, error) {
-	return api.Internal.Subscribe(ctx, namespace)
+	return api.Internal.Subscribe(ctx, namespace, fromHeight)
 }

--- a/nodebuilder/blob/mocks/api.go
+++ b/nodebuilder/blob/mocks/api.go
@@ -128,16 +128,16 @@ func (mr *MockModuleMockRecorder) Submit(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // Subscribe mocks base method.
-func (m *MockModule) Subscribe(arg0 context.Context, arg1 share.Namespace) (<-chan *blob.SubscriptionResponse, error) {
+func (m *MockModule) Subscribe(arg0 context.Context, arg1 share.Namespace, arg2 uint64) (<-chan *blob.SubscriptionResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subscribe", arg0, arg1)
+	ret := m.ctrl.Call(m, "Subscribe", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan *blob.SubscriptionResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Subscribe indicates an expected call of Subscribe.
-func (mr *MockModuleMockRecorder) Subscribe(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockModuleMockRecorder) Subscribe(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockModule)(nil).Subscribe), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockModule)(nil).Subscribe), arg0, arg1, arg2)
 }

--- a/nodebuilder/blob/module.go
+++ b/nodebuilder/blob/module.go
@@ -14,24 +14,31 @@ import (
 
 func ConstructModule() fx.Option {
 	return fx.Module("blob",
+		// GetByHeight is provided at module scope because other modules
+		// (e.g. nodebuilder/da) depend on this plain func signature.
 		fx.Provide(
 			func(service headerService.Module) func(context.Context, uint64) (*header.ExtendedHeader, error) {
 				return service.GetByHeight
 			},
 		),
-		fx.Provide(
-			func(service headerService.Module) func(context.Context) (<-chan *header.ExtendedHeader, error) {
-				return service.Subscribe
-			},
-		),
+		// WaitForHeight and Subscribe are consumed directly inside the
+		// Service constructor below rather than as separate fx providers,
+		// so fx doesn't have to disambiguate two providers that share the
+		// GetByHeight func signature.
 		fx.Provide(fx.Annotate(
 			func(
 				state state.Module,
 				sGetter shwap.Getter,
-				getByHeightFn func(context.Context, uint64) (*header.ExtendedHeader, error),
-				subscribeFn func(context.Context) (<-chan *header.ExtendedHeader, error),
+				getByHeight func(context.Context, uint64) (*header.ExtendedHeader, error),
+				headerMod headerService.Module,
 			) *blob.Service {
-				return blob.NewService(state, sGetter, getByHeightFn, subscribeFn)
+				return blob.NewService(
+					state,
+					sGetter,
+					getByHeight,
+					headerMod.WaitForHeight,
+					headerMod.Subscribe,
+				)
 			},
 			fx.OnStart(func(ctx context.Context, serv *blob.Service) error {
 				return serv.Start(ctx)


### PR DESCRIPTION
## Summary

\`Blob.Subscribe\` now takes a \`fromHeight uint64\` parameter so a subscriber can rejoin the stream starting at a specific block height. The existing live-tip behavior is preserved via \`fromHeight == 0\`.

Motivation: downstream consumers (e.g. the ev-node Fibre DA adapter sitting in evstack/ev-node) need a way to resume a blob subscription after a restart without missing blocks. The current \`Subscribe\` only exposes the live header subscription, so anything that dropped offline before the next header had no way to replay missed blocks without cobbling together \`GetAll\` calls per height.

## API change

\`\`\`go
-   Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan *SubscriptionResponse, error)
+   Subscribe(ctx context.Context, ns libshare.Namespace, fromHeight uint64) (<-chan *SubscriptionResponse, error)
\`\`\`

\`fromHeight == 0\` → start from the live tip via the existing headerSub stream (back-compat for any caller that just wants "follow new blobs").

\`fromHeight > 0\` → drives the subscription from a WaitForHeight loop: for \`h := fromHeight\`, call \`waitForHeight(ctx, h)\` (which blocks until the header is available in the local store), emit the \`SubscriptionResponse\`, then \`h++\`. This covers both historical replay (past heights return immediately from the local store) and forward follow (future heights block until the chain advances).

## Implementation

- \`blob.Service\` gains a \`waitForHeight\` accessor alongside the existing \`headerGetter\` and \`headerSub\`. \`Subscribe\`'s body is factored into \`headerStream\` (chooses which header source to drive from, based on \`fromHeight\`) and \`forwardBlobs\` (the shared emit loop). The live-tip and resume-from-height paths reuse \`forwardBlobs\` verbatim.
- \`nodebuilder/blob/module.go\` keeps \`GetByHeight\` as a top-level \`fx.Provide\` because other modules (e.g. \`nodebuilder/da\`) already depend on that plain \`func(context.Context, uint64) (*header.ExtendedHeader, error)\` signature. \`WaitForHeight\` and \`Subscribe\` are consumed inline by the Service constructor so fx doesn't have to disambiguate two providers that share \`GetByHeight\`'s func type.
- \`nodebuilder/blob.Module\` interface + \`API\` struct + gomock stub updated to the 3-arg signature.
- \`api/client.Client.initTxClient\`'s local blob service gets a fifth \`nil\` — Subscribe on the self-sufficient client still goes through \`ReadClient\` JSON-RPC, not this local \`*blob.Service\`.

## Test plan

- [x] \`go build -tags fibre ./...\` clean
- [x] \`go vet -tags fibre ./...\` clean (pre-existing warning in \`cmd/rpc.go:88\` unrelated)
- [x] \`go test -tags fibre -count=1 ./blob/...\` — existing Subscribe tests pass with \`fromHeight=0\`
- [x] \`go test -tags fibre -count=1 -run 'TestFibreEscrow|TestSubmission\$' ./api/client/...\` — no regressions in the self-sufficient client path

## Follow-up

Consumers in evstack/ev-node need a matching API change (\`fiber.DA.Listen(ctx, namespace, fromHeight)\`); a paired PR lands on their \`julien/fiber\` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
