### PR TITLE
fix(header/sync): bump recencyThreshold to 3x blockTime

### DIFF
--- a/nodebuilder/header/constructors.go
+++ b/nodebuilder/header/constructors.go
@@ -103,6 +103,7 @@ func newSyncer[H libhead.Header[H]](
 	opts := []sync.Option{
 		sync.WithParams(cfg.Syncer),
 		sync.WithBlockTime(maxBlockTime),
+		sync.WithRecencyThreshold(maxBlockTime * 3),
 		sync.WithTrustingPeriod(trustingPeriod),
 	}
 	if MetricsEnabled {


### PR DESCRIPTION
  Bumps the syncer `recencyThreshold` from `blockTime * 2` to `blockTime * 3` (14s → 21s on mainnet). The previous default leaves only ~`blockTime` of budget for the ingestion pipeline after accounting for the BFT consensus round implicit in `Header.Time()`, which is routinely exceeded under normal load and produces spurious `non recent subjective head` warnings  plus redundant fallback requests to trusted peers. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-node/pull/4966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
