### PR TITLE
add state client

### DIFF
--- a/fibre/stateclient/stateclient.go
+++ b/fibre/stateclient/stateclient.go
@@ -2,7 +2,9 @@ package stateclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cometbft/cometbft/crypto/merkle"
@@ -10,6 +12,8 @@ import (
 	core "github.com/cometbft/cometbft/types"
 	tmservice "github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	logging "github.com/ipfs/go-log/v2"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
 	"github.com/celestiaorg/celestia-app/v9/fibre/state"
@@ -20,6 +24,14 @@ import (
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
+
+var log = logging.Logger("fibre/stateclient")
+
+// ErrNoFibreProviderInfo is returned by fetchHostAt when a validator has not
+// registered fibre provider info via x/valaddr. The absence is proven against
+// the trusted AppHash, so this is an authoritative answer, not a transient
+// failure.
+var ErrNoFibreProviderInfo = errors.New("no fibre provider info")
 
 // abciQuerier is the narrow surface of [tmservice.ServiceClient] that this
 // package depends on. Defined as an interface so tests can supply a stub
@@ -46,6 +58,14 @@ type Client struct {
 	prt          *merkle.ProofRuntime
 
 	chainID string
+
+	// hostCache is populated once in Start via prefetchHosts and never
+	// re-populated thereafter. A cache hit in GetHost evicts the entry so
+	// subsequent reads for the same validator go through fetchHostAt and
+	// hit the chain for fresh state. The cache is a one-shot startup
+	// warmup, not a persistent cache — no TTL/refresh.
+	hostMu    sync.Mutex
+	hostCache map[string]validator.Host
 }
 
 // NewClient builds a fibre [state.Client] backed by the local header store and
@@ -63,6 +83,7 @@ func NewClient(
 		network:      network,
 		abciQueryCli: tmservice.NewServiceClient(conn),
 		prt:          prt,
+		hostCache:    make(map[string]validator.Host),
 	}
 }
 
@@ -89,15 +110,39 @@ func (c *Client) GetByHeight(ctx context.Context, height uint64) (validator.Set,
 	return validator.Set{ValidatorSet: hdr.ValidatorSet, Height: hdr.Height()}, nil
 }
 
-// GetHost resolves a validator's fibre network host via ABCI with merkle proof
-// verification against the trusted AppHash from the local head.
+// GetHost resolves a validator's fibre network host. If the cache (populated
+// at Start) has an entry, it is returned and evicted from the cache so the
+// next read goes to the chain for fresh state. Otherwise a single-key ABCI
+// query is issued and verified against the trusted AppHash from the local
+// head.
 func (c *Client) GetHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
-	consAddr := sdk.ConsAddress(val.Address.Bytes())
+	cacheKey := sdk.ConsAddress(val.Address.Bytes()).String()
+
+	c.hostMu.Lock()
+	if h, ok := c.hostCache[cacheKey]; ok {
+		delete(c.hostCache, cacheKey)
+		c.hostMu.Unlock()
+		return h, nil
+	}
+	c.hostMu.Unlock()
+
 	head, err := c.store.Head(ctx)
 	if err != nil {
 		return "", fmt.Errorf("fetch head: %w", err)
 	}
+	return c.fetchHostAt(ctx, val, head)
+}
 
+// fetchHostAt issues a single-key ABCI query for the validator's fibre
+// provider info and verifies the returned proof against head.AppHash.
+// All callers must pass a head they have already pinned, so concurrent
+// prefetch queries anchor to the same AppHash.
+func (c *Client) fetchHostAt(
+	ctx context.Context,
+	val *core.Validator,
+	head *header.ExtendedHeader,
+) (validator.Host, error) {
+	consAddr := sdk.ConsAddress(val.Address.Bytes())
 	key := valaddr.GetFibreProviderInfoKey(consAddr)
 	// AppHash at height H is the state root after applying block H-1, so we
 	// query at H-1 to be consistent with head.AppHash.
@@ -131,7 +176,7 @@ func (c *Client) GetHost(ctx context.Context, val *core.Validator) (validator.Ho
 		if err := c.prt.VerifyFromKeys(proofOps, head.AppHash, keypath, nil); err != nil {
 			return "", fmt.Errorf("verify absence proof: %w", err)
 		}
-		return "", fmt.Errorf("no fibre provider info for validator %s", consAddr)
+		return "", fmt.Errorf("validator %s: %w", consAddr, ErrNoFibreProviderInfo)
 	}
 
 	if err := c.prt.VerifyValueFromKeys(proofOps, head.AppHash, keypath, value); err != nil {
@@ -143,6 +188,43 @@ func (c *Client) GetHost(ctx context.Context, val *core.Validator) (validator.Ho
 		return "", fmt.Errorf("unmarshal FibreProviderInfo: %w", err)
 	}
 	return validator.Host(info.GetHost()), nil
+}
+
+// prefetchHosts fans out fetchHostAt across the head's validator set and
+// stores successfully-verified hosts in hostCache. All proofs anchor to
+// the same head.AppHash. Validators without registered provider info are
+// the common case and are silently skipped; other per-validator errors
+// (transport, proof verification) are logged as warnings since they may
+// indicate a misbehaving gRPC endpoint.
+func (c *Client) prefetchHosts(ctx context.Context, head *header.ExtendedHeader) {
+	vals := head.ValidatorSet.Validators
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(16)
+	for _, v := range vals {
+		g.Go(func() error {
+			consAddr := sdk.ConsAddress(v.Address.Bytes())
+			host, err := c.fetchHostAt(gctx, v, head)
+			if err != nil {
+				if !errors.Is(err, ErrNoFibreProviderInfo) {
+					log.Warnw("prefetch host failed",
+						"validator", consAddr.String(), "err", err)
+				}
+				return nil
+			}
+			c.hostMu.Lock()
+			c.hostCache[consAddr.String()] = host
+			c.hostMu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	c.hostMu.Lock()
+	cached := len(c.hostCache)
+	c.hostMu.Unlock()
+	log.Infow("host prefetch completed",
+		"cached", cached, "validators", len(vals), "height", head.Height())
 }
 
 // ChainID returns the chain ID detected during Start.
@@ -163,13 +245,7 @@ func (c *Client) Start(ctx context.Context) error {
 		return fmt.Errorf("fetch head for chain-id: %w", err)
 	}
 	c.chainID = head.ChainID()
-
-	if c.chainID != c.network.String() {
-		return fmt.Errorf(
-			"fibre state client: chain-id mismatch: header=%q network=%q",
-			c.chainID, c.network,
-		)
-	}
+	c.prefetchHosts(ctx, head)
 	return nil
 }
 

--- a/fibre/stateclient/stateclient.go
+++ b/fibre/stateclient/stateclient.go
@@ -1,0 +1,224 @@
+package stateclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cometbft/cometbft/crypto/merkle"
+	"github.com/cometbft/cometbft/proto/tendermint/crypto"
+	core "github.com/cometbft/cometbft/types"
+	tmservice "github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"google.golang.org/grpc"
+
+	"github.com/celestiaorg/celestia-app/v9/fibre/state"
+	"github.com/celestiaorg/celestia-app/v9/fibre/validator"
+	valaddr "github.com/celestiaorg/celestia-app/v9/x/valaddr/types"
+	libhead "github.com/celestiaorg/go-header"
+
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+)
+
+// hostCacheTTL bounds how long a successful GetHost lookup is reused without
+// re-querying ABCI. Validator host changes are operator-driven and rare, so a
+// short TTL is enough to absorb burst lookups during upload without staleness.
+const hostCacheTTL = time.Minute
+
+// abciQuerier is the narrow surface of [tmservice.ServiceClient] that this
+// package depends on. Defined as an interface so tests can supply a stub
+// without implementing the full gRPC ServiceClient.
+type abciQuerier interface {
+	ABCIQuery(ctx context.Context, in *tmservice.ABCIQueryRequest, opts ...grpc.CallOption) (*tmservice.ABCIQueryResponse, error)
+}
+
+// Client is a [state.Client] implementation that resolves validator sets and
+// hosts from the node's verified header chain instead of trusting a remote
+// gRPC endpoint.
+//
+//   - Validator sets come from locally synced [header.ExtendedHeader]s.
+//   - Validator hosts are queried via ABCI with a merkle proof against
+//     the trusted AppHash from the header.
+//   - ChainID is taken from the local head.
+//   - VerifyPromise is a no-op: light/bridge nodes don't verify fibre payment
+//     promises; that's the provider's job.
+type Client struct {
+	store   libhead.Store[*header.ExtendedHeader]
+	network p2p.Network
+
+	abciQueryCli abciQuerier
+	prt          *merkle.ProofRuntime
+
+	chainID string
+
+	hostMu    sync.Mutex
+	hostCache map[string]hostCacheEntry
+}
+
+type hostCacheEntry struct {
+	host    validator.Host
+	expires time.Time
+}
+
+// NewClient builds a fibre [state.Client] backed by the local header store and
+// a gRPC connection used only for ABCI queries (with merkle proof verification).
+func NewClient(
+	store libhead.Store[*header.ExtendedHeader],
+	conn *grpc.ClientConn,
+	network p2p.Network,
+) *Client {
+	prt := merkle.DefaultProofRuntime()
+	prt.RegisterOpDecoder(storetypes.ProofOpIAVLCommitment, storetypes.CommitmentOpDecoder)
+	prt.RegisterOpDecoder(storetypes.ProofOpSimpleMerkleCommitment, storetypes.CommitmentOpDecoder)
+	return &Client{
+		store:        store,
+		network:      network,
+		abciQueryCli: tmservice.NewServiceClient(conn),
+		prt:          prt,
+		hostCache:    make(map[string]hostCacheEntry),
+	}
+}
+
+// Head returns the latest validator set from the local header store.
+// The header is already verified by the header chain — no remote round-trip,
+// no extra verification.
+func (c *Client) Head(ctx context.Context) (validator.Set, error) {
+	head, err := c.store.Head(ctx)
+	if err != nil {
+		return validator.Set{}, fmt.Errorf("fetch head: %w", err)
+	}
+	return validator.Set{ValidatorSet: head.ValidatorSet, Height: head.Height()}, nil
+}
+
+// GetByHeight returns the validator set at the given height from the local
+// header store. If the header is not yet synced locally, the underlying store
+// returns an error — we deliberately do NOT fall back to a remote endpoint;
+// the whole point is to trust only verified headers.
+func (c *Client) GetByHeight(ctx context.Context, height uint64) (validator.Set, error) {
+	hdr, err := c.store.GetByHeight(ctx, height)
+	if err != nil {
+		return validator.Set{}, fmt.Errorf("fetch header by height %d: %w", height, err)
+	}
+	return validator.Set{ValidatorSet: hdr.ValidatorSet, Height: hdr.Height()}, nil
+}
+
+// GetHost resolves a validator's fibre network host via ABCI with merkle proof
+// verification against the trusted AppHash from the local head.
+// Successful lookups are cached for [hostCacheTTL]; misses and errors are not
+// cached so transient failures don't get pinned.
+func (c *Client) GetHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
+	consAddr := sdk.ConsAddress(val.Address.Bytes())
+	cacheKey := consAddr.String()
+	if host, ok := c.lookupHostCache(cacheKey); ok {
+		return host, nil
+	}
+
+	head, err := c.store.Head(ctx)
+	if err != nil {
+		return "", fmt.Errorf("fetch head: %w", err)
+	}
+
+	key := valaddr.GetFibreProviderInfoKey(consAddr)
+	// AppHash at height H is the state root after applying block H-1, so we
+	// query at H-1 to be consistent with head.AppHash.
+	resp, err := c.abciQueryCli.ABCIQuery(ctx, &tmservice.ABCIQueryRequest{
+		Path:   fmt.Sprintf("store/%s/key", valaddr.StoreKey),
+		Data:   key,
+		Height: int64(head.Height()) - 1,
+		Prove:  true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("abci query: %w", err)
+	}
+	if resp.GetCode() != 0 {
+		return "", fmt.Errorf("abci query non-zero code: %s", resp.GetLog())
+	}
+	if resp.GetProofOps() == nil {
+		return "", fmt.Errorf("missing proof ops for validator %s", consAddr)
+	}
+
+	value := resp.GetValue()
+	proofOps := &crypto.ProofOps{Ops: make([]crypto.ProofOp, len(resp.ProofOps.Ops))}
+	for i, op := range resp.ProofOps.Ops {
+		proofOps.Ops[i] = crypto.ProofOp{Type: op.Type, Key: op.Key, Data: op.Data}
+	}
+	keypath := [][]byte{[]byte(valaddr.StoreKey), key}
+
+	// Empty value means the validator hasn't registered fibre provider info.
+	// Verify the absence proof so a malicious endpoint can't fabricate "not
+	// registered" by stripping the value.
+	if len(value) == 0 {
+		if err := c.prt.VerifyFromKeys(proofOps, head.AppHash, keypath, nil); err != nil {
+			return "", fmt.Errorf("verify absence proof: %w", err)
+		}
+		return "", fmt.Errorf("no fibre provider info for validator %s", consAddr)
+	}
+
+	if err := c.prt.VerifyValueFromKeys(proofOps, head.AppHash, keypath, value); err != nil {
+		return "", fmt.Errorf("verify proof: %w", err)
+	}
+
+	var info valaddr.FibreProviderInfo
+	if err := info.Unmarshal(value); err != nil {
+		return "", fmt.Errorf("unmarshal FibreProviderInfo: %w", err)
+	}
+	host := validator.Host(info.GetHost())
+	c.storeHostCache(cacheKey, host)
+	return host, nil
+}
+
+func (c *Client) lookupHostCache(key string) (validator.Host, bool) {
+	c.hostMu.Lock()
+	defer c.hostMu.Unlock()
+
+	entry, ok := c.hostCache[key]
+	if !ok {
+		return "", false
+	}
+
+	if time.Now().After(entry.expires) {
+		delete(c.hostCache, key)
+		return "", false
+	}
+	return entry.host, true
+}
+
+func (c *Client) storeHostCache(key string, host validator.Host) {
+	c.hostMu.Lock()
+	c.hostCache[key] = hostCacheEntry{host: host, expires: time.Now().Add(hostCacheTTL)}
+	c.hostMu.Unlock()
+}
+
+// ChainID returns the chain ID detected during Start.
+func (c *Client) ChainID() string { return c.chainID }
+
+// VerifyPromise is a no-op on light nodes, because they don't verify
+// fibre payment promises — that's the provider's job. We return a zero
+// [state.VerifiedPromise] so callers that ignore the value continue to work.
+func (c *Client) VerifyPromise(context.Context, *state.PaymentPromise) (state.VerifiedPromise, error) {
+	return state.VerifiedPromise{}, nil
+}
+
+// Start seeds the chain ID from the local head and, when running on a
+// well-known network, sanity-checks that the header chain ID matches.
+func (c *Client) Start(ctx context.Context) error {
+	head, err := c.store.Head(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch head for chain-id: %w", err)
+	}
+	c.chainID = head.ChainID()
+
+	if c.chainID != c.network.String() {
+		return fmt.Errorf(
+			"fibre state client: chain-id mismatch: header=%q network=%q",
+			c.chainID, c.network,
+		)
+	}
+	return nil
+}
+
+// Stop is a no-op: the gRPC conn and header store are owned elsewhere.
+func (c *Client) Stop(context.Context) error { return nil }

--- a/fibre/stateclient/stateclient.go
+++ b/fibre/stateclient/stateclient.go
@@ -3,8 +3,6 @@ package stateclient
 import (
 	"context"
 	"fmt"
-	"sync"
-	"time"
 
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cometbft/cometbft/crypto/merkle"
@@ -22,11 +20,6 @@ import (
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
-
-// hostCacheTTL bounds how long a successful GetHost lookup is reused without
-// re-querying ABCI. Validator host changes are operator-driven and rare, so a
-// short TTL is enough to absorb burst lookups during upload without staleness.
-const hostCacheTTL = time.Minute
 
 // abciQuerier is the narrow surface of [tmservice.ServiceClient] that this
 // package depends on. Defined as an interface so tests can supply a stub
@@ -53,14 +46,6 @@ type Client struct {
 	prt          *merkle.ProofRuntime
 
 	chainID string
-
-	hostMu    sync.Mutex
-	hostCache map[string]hostCacheEntry
-}
-
-type hostCacheEntry struct {
-	host    validator.Host
-	expires time.Time
 }
 
 // NewClient builds a fibre [state.Client] backed by the local header store and
@@ -78,7 +63,6 @@ func NewClient(
 		network:      network,
 		abciQueryCli: tmservice.NewServiceClient(conn),
 		prt:          prt,
-		hostCache:    make(map[string]hostCacheEntry),
 	}
 }
 
@@ -107,15 +91,8 @@ func (c *Client) GetByHeight(ctx context.Context, height uint64) (validator.Set,
 
 // GetHost resolves a validator's fibre network host via ABCI with merkle proof
 // verification against the trusted AppHash from the local head.
-// Successful lookups are cached for [hostCacheTTL]; misses and errors are not
-// cached so transient failures don't get pinned.
 func (c *Client) GetHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
 	consAddr := sdk.ConsAddress(val.Address.Bytes())
-	cacheKey := consAddr.String()
-	if host, ok := c.lookupHostCache(cacheKey); ok {
-		return host, nil
-	}
-
 	head, err := c.store.Head(ctx)
 	if err != nil {
 		return "", fmt.Errorf("fetch head: %w", err)
@@ -165,31 +142,7 @@ func (c *Client) GetHost(ctx context.Context, val *core.Validator) (validator.Ho
 	if err := info.Unmarshal(value); err != nil {
 		return "", fmt.Errorf("unmarshal FibreProviderInfo: %w", err)
 	}
-	host := validator.Host(info.GetHost())
-	c.storeHostCache(cacheKey, host)
-	return host, nil
-}
-
-func (c *Client) lookupHostCache(key string) (validator.Host, bool) {
-	c.hostMu.Lock()
-	defer c.hostMu.Unlock()
-
-	entry, ok := c.hostCache[key]
-	if !ok {
-		return "", false
-	}
-
-	if time.Now().After(entry.expires) {
-		delete(c.hostCache, key)
-		return "", false
-	}
-	return entry.host, true
-}
-
-func (c *Client) storeHostCache(key string, host validator.Host) {
-	c.hostMu.Lock()
-	c.hostCache[key] = hostCacheEntry{host: host, expires: time.Now().Add(hostCacheTTL)}
-	c.hostMu.Unlock()
+	return validator.Host(info.GetHost()), nil
 }
 
 // ChainID returns the chain ID detected during Start.

--- a/fibre/stateclient/stateclient.go
+++ b/fibre/stateclient/stateclient.go
@@ -32,7 +32,7 @@ const hostCacheTTL = time.Minute
 // package depends on. Defined as an interface so tests can supply a stub
 // without implementing the full gRPC ServiceClient.
 type abciQuerier interface {
-	ABCIQuery(ctx context.Context, in *tmservice.ABCIQueryRequest, opts ...grpc.CallOption) (*tmservice.ABCIQueryResponse, error)
+	ABCIQuery(context.Context, *tmservice.ABCIQueryRequest, ...grpc.CallOption) (*tmservice.ABCIQueryResponse, error)
 }
 
 // Client is a [state.Client] implementation that resolves validator sets and

--- a/fibre/stateclient/stateclient_test.go
+++ b/fibre/stateclient/stateclient_test.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	core "github.com/cometbft/cometbft/types"
 	tmservice "github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -38,7 +36,6 @@ func newTestClient(t *testing.T, abci abciQuerier, network p2p.Network) *Client 
 		store:        headertest.NewStore(t),
 		network:      network,
 		abciQueryCli: abci,
-		hostCache:    make(map[string]hostCacheEntry),
 	}
 	return c
 }
@@ -112,27 +109,4 @@ func TestGetHostABCIErrors(t *testing.T) {
 		_, err := c.GetHost(ctx, val)
 		require.ErrorContains(t, err, "missing proof ops")
 	})
-}
-
-func TestGetHostCacheReuse(t *testing.T) {
-	stub := &stubABCI{err: errors.New("must not be called")}
-	c := newTestClient(t, stub, p2p.Private)
-
-	// Pre-seed the cache and verify a lookup returns the cached host without
-	// hitting ABCI.
-	cacheKey := "some-cons-addr"
-	c.storeHostCache(cacheKey, "validator.example:9090")
-
-	got, ok := c.lookupHostCache(cacheKey)
-	require.True(t, ok)
-	assert.EqualValues(t, "validator.example:9090", got)
-	assert.Zero(t, stub.calls)
-}
-
-func TestHostCacheExpiry(t *testing.T) {
-	c := newTestClient(t, &stubABCI{}, p2p.Private)
-	c.hostCache["k"] = hostCacheEntry{host: "stale", expires: time.Now().Add(-time.Second)}
-
-	_, ok := c.lookupHostCache("k")
-	require.False(t, ok)
 }

--- a/fibre/stateclient/stateclient_test.go
+++ b/fibre/stateclient/stateclient_test.go
@@ -3,22 +3,30 @@ package stateclient
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	core "github.com/cometbft/cometbft/types"
 	tmservice "github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	appstate "github.com/celestiaorg/celestia-app/v9/fibre/state"
+	"github.com/celestiaorg/celestia-app/v9/fibre/validator"
 
 	"github.com/celestiaorg/celestia-node/header/headertest"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 // stubABCI lets a test control the ABCIQuery response and observe call counts.
+// The call counter is atomic so it stays sound under prefetchHosts' parallel
+// fan-out and TestConcurrentGetHost's parallel readers.
 type stubABCI struct {
-	calls int
+	calls atomic.Int64
 	resp  *tmservice.ABCIQueryResponse
 	err   error
 }
@@ -26,7 +34,7 @@ type stubABCI struct {
 func (s *stubABCI) ABCIQuery(
 	context.Context, *tmservice.ABCIQueryRequest, ...grpc.CallOption,
 ) (*tmservice.ABCIQueryResponse, error) {
-	s.calls++
+	s.calls.Add(1)
 	return s.resp, s.err
 }
 
@@ -36,6 +44,7 @@ func newTestClient(t *testing.T, abci abciQuerier, network p2p.Network) *Client 
 		store:        headertest.NewStore(t),
 		network:      network,
 		abciQueryCli: abci,
+		hostCache:    make(map[string]validator.Host),
 	}
 	return c
 }
@@ -55,21 +64,14 @@ func TestHeadAndGetByHeight(t *testing.T) {
 	require.Equal(t, set.Hash(), got.Hash())
 }
 
-func TestStartChainIDAndMismatch(t *testing.T) {
+func TestStartSeedsChainID(t *testing.T) {
 	ctx := context.Background()
 
-	// headertest store generates chain-id "test"; matching network → Start ok.
 	c := newTestClient(t, &stubABCI{}, p2p.Network("test"))
 	require.NoError(t, c.Start(ctx))
 	head, err := c.store.Head(ctx)
 	require.NoError(t, err)
 	require.Equal(t, head.ChainID(), c.ChainID())
-
-	// Mismatch → Start errors.
-	c2 := newTestClient(t, &stubABCI{}, p2p.Arabica)
-	err = c2.Start(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "chain-id mismatch")
 }
 
 func TestVerifyPromiseNoop(t *testing.T) {
@@ -93,7 +95,7 @@ func TestGetHostABCIErrors(t *testing.T) {
 		c := newTestClient(t, stub, p2p.Private)
 		_, err := c.GetHost(ctx, val)
 		require.ErrorContains(t, err, "abci query")
-		require.Equal(t, 1, stub.calls)
+		require.Equal(t, int64(1), stub.calls.Load())
 	})
 
 	t.Run("non-zero code", func(t *testing.T) {
@@ -109,4 +111,123 @@ func TestGetHostABCIErrors(t *testing.T) {
 		_, err := c.GetHost(ctx, val)
 		require.ErrorContains(t, err, "missing proof ops")
 	})
+}
+
+// TestGetHostCacheHitEvicts checks that a GetHost call hitting the
+// prefetch-populated cache returns immediately, evicts the entry, and
+// makes no ABCI call.
+func TestGetHostCacheHitEvicts(t *testing.T) {
+	stub := &stubABCI{}
+	c := newTestClient(t, stub, p2p.Private)
+
+	addr := make([]byte, 20)
+	for i := range addr {
+		addr[i] = 0xAA
+	}
+	val := &core.Validator{Address: addr}
+	cacheKey := sdk.ConsAddress(addr).String()
+	c.hostCache[cacheKey] = validator.Host("cached.example:9090")
+
+	got, err := c.GetHost(context.Background(), val)
+	require.NoError(t, err)
+	require.Equal(t, validator.Host("cached.example:9090"), got)
+	require.Zero(t, stub.calls.Load(), "cache hit must not touch ABCI")
+
+	_, present := c.hostCache[cacheKey]
+	require.False(t, present, "cache hit must evict the entry")
+}
+
+// TestGetHostSecondCallMissesCache checks that after a cache hit evicts
+// an entry, the next call for the same validator falls through to a
+// fresh ABCI query.
+func TestGetHostSecondCallMissesCache(t *testing.T) {
+	stub := &stubABCI{err: errors.New("forced miss")}
+	c := newTestClient(t, stub, p2p.Private)
+
+	addr := make([]byte, 20)
+	for i := range addr {
+		addr[i] = 0xBB
+	}
+	val := &core.Validator{Address: addr}
+	cacheKey := sdk.ConsAddress(addr).String()
+	c.hostCache[cacheKey] = validator.Host("cached.example:9090")
+
+	got, err := c.GetHost(context.Background(), val)
+	require.NoError(t, err)
+	require.Equal(t, validator.Host("cached.example:9090"), got)
+	require.Zero(t, stub.calls.Load(), "first call must be served from cache")
+
+	_, err = c.GetHost(context.Background(), val)
+	require.ErrorContains(t, err, "abci query")
+	require.Equal(t, int64(1), stub.calls.Load(), "second call must query ABCI exactly once")
+}
+
+// TestStartPrefetchToleratesErrors verifies that Start completes
+// successfully even when every per-validator ABCI query fails, leaving
+// the cache empty. Failures here include both transport errors and
+// malformed responses.
+func TestStartPrefetchToleratesErrors(t *testing.T) {
+	t.Run("transport error", func(t *testing.T) {
+		stub := &stubABCI{err: errors.New("boom")}
+		c := newTestClient(t, stub, p2p.Network("test"))
+		require.NoError(t, c.Start(context.Background()))
+		require.Empty(t, c.hostCache)
+		require.Greater(t, stub.calls.Load(), int64(0), "prefetch must attempt at least one query")
+	})
+
+	t.Run("missing proof ops", func(t *testing.T) {
+		stub := &stubABCI{resp: &tmservice.ABCIQueryResponse{}}
+		c := newTestClient(t, stub, p2p.Network("test"))
+		require.NoError(t, c.Start(context.Background()))
+		require.Empty(t, c.hostCache)
+		require.Greater(t, stub.calls.Load(), int64(0))
+	})
+}
+
+// TestConcurrentGetHost exercises GetHost from many goroutines in
+// parallel, each targeting a distinct cached validator. With -race this
+// catches any unsoundness in the cache mutex / eviction path.
+func TestConcurrentGetHost(t *testing.T) {
+	stub := &stubABCI{err: errors.New("should not be reached")}
+	c := newTestClient(t, stub, p2p.Private)
+
+	const N = 50
+	addrs := make([][]byte, N)
+	for i := range N {
+		addr := make([]byte, 20)
+		addr[0] = byte(i)
+		addrs[i] = addr
+		c.hostCache[sdk.ConsAddress(addr).String()] = validator.Host(fmt.Sprintf("h%d", i))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := range N {
+		go func(i int) {
+			defer wg.Done()
+			val := &core.Validator{Address: addrs[i]}
+			got, err := c.GetHost(context.Background(), val)
+			require.NoError(t, err)
+			require.Equal(t, validator.Host(fmt.Sprintf("h%d", i)), got)
+		}(i)
+	}
+	wg.Wait()
+
+	require.Zero(t, stub.calls.Load(), "every call should hit cache")
+	require.Empty(t, c.hostCache, "every cache hit should evict")
+}
+
+// TestNewClientInitializesHostCache guards against a regression where
+// the production constructor forgets to make the hostCache map and
+// prefetchHosts would panic on a nil-map write.
+func TestNewClientInitializesHostCache(t *testing.T) {
+	conn, err := grpc.NewClient(
+		"passthrough:test",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	c := NewClient(headertest.NewStore(t), conn, p2p.Private)
+	require.NotNil(t, c.hostCache)
 }

--- a/fibre/stateclient/stateclient_test.go
+++ b/fibre/stateclient/stateclient_test.go
@@ -1,0 +1,138 @@
+package stateclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	core "github.com/cometbft/cometbft/types"
+	tmservice "github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	appstate "github.com/celestiaorg/celestia-app/v9/fibre/state"
+
+	"github.com/celestiaorg/celestia-node/header/headertest"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+)
+
+// stubABCI lets a test control the ABCIQuery response and observe call counts.
+type stubABCI struct {
+	calls int
+	resp  *tmservice.ABCIQueryResponse
+	err   error
+}
+
+func (s *stubABCI) ABCIQuery(
+	context.Context, *tmservice.ABCIQueryRequest, ...grpc.CallOption,
+) (*tmservice.ABCIQueryResponse, error) {
+	s.calls++
+	return s.resp, s.err
+}
+
+func newTestClient(t *testing.T, abci abciQuerier, network p2p.Network) *Client {
+	t.Helper()
+	c := &Client{
+		store:        headertest.NewStore(t),
+		network:      network,
+		abciQueryCli: abci,
+		hostCache:    make(map[string]hostCacheEntry),
+	}
+	return c
+}
+
+func TestHeadAndGetByHeight(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t, &stubABCI{}, p2p.Private)
+
+	set, err := c.Head(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, set.ValidatorSet)
+	require.Greater(t, set.Height, uint64(0))
+
+	got, err := c.GetByHeight(ctx, set.Height)
+	require.NoError(t, err)
+	require.Equal(t, set.Height, got.Height)
+	require.Equal(t, set.Hash(), got.Hash())
+}
+
+func TestStartChainIDAndMismatch(t *testing.T) {
+	ctx := context.Background()
+
+	// headertest store generates chain-id "test"; matching network → Start ok.
+	c := newTestClient(t, &stubABCI{}, p2p.Network("test"))
+	require.NoError(t, c.Start(ctx))
+	head, err := c.store.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, head.ChainID(), c.ChainID())
+
+	// Mismatch → Start errors.
+	c2 := newTestClient(t, &stubABCI{}, p2p.Arabica)
+	err = c2.Start(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chain-id mismatch")
+}
+
+func TestVerifyPromiseNoop(t *testing.T) {
+	c := newTestClient(t, &stubABCI{}, p2p.Private)
+	got, err := c.VerifyPromise(context.Background(), &appstate.PaymentPromise{})
+	require.NoError(t, err)
+	require.Equal(t, appstate.VerifiedPromise{}, got)
+}
+
+func TestStopNoop(t *testing.T) {
+	c := newTestClient(t, &stubABCI{}, p2p.Private)
+	require.NoError(t, c.Stop(context.Background()))
+}
+
+func TestGetHostABCIErrors(t *testing.T) {
+	ctx := context.Background()
+	val := &core.Validator{Address: make([]byte, 20)}
+
+	t.Run("transport error", func(t *testing.T) {
+		stub := &stubABCI{err: errors.New("boom")}
+		c := newTestClient(t, stub, p2p.Private)
+		_, err := c.GetHost(ctx, val)
+		require.ErrorContains(t, err, "abci query")
+		require.Equal(t, 1, stub.calls)
+	})
+
+	t.Run("non-zero code", func(t *testing.T) {
+		stub := &stubABCI{resp: &tmservice.ABCIQueryResponse{Code: 1, Log: "nope"}}
+		c := newTestClient(t, stub, p2p.Private)
+		_, err := c.GetHost(ctx, val)
+		require.ErrorContains(t, err, "non-zero code")
+	})
+
+	t.Run("missing proof ops", func(t *testing.T) {
+		stub := &stubABCI{resp: &tmservice.ABCIQueryResponse{}}
+		c := newTestClient(t, stub, p2p.Private)
+		_, err := c.GetHost(ctx, val)
+		require.ErrorContains(t, err, "missing proof ops")
+	})
+}
+
+func TestGetHostCacheReuse(t *testing.T) {
+	stub := &stubABCI{err: errors.New("must not be called")}
+	c := newTestClient(t, stub, p2p.Private)
+
+	// Pre-seed the cache and verify a lookup returns the cached host without
+	// hitting ABCI.
+	cacheKey := "some-cons-addr"
+	c.storeHostCache(cacheKey, "validator.example:9090")
+
+	got, ok := c.lookupHostCache(cacheKey)
+	require.True(t, ok)
+	assert.EqualValues(t, "validator.example:9090", got)
+	assert.Zero(t, stub.calls)
+}
+
+func TestHostCacheExpiry(t *testing.T) {
+	c := newTestClient(t, &stubABCI{}, p2p.Private)
+	c.hostCache["k"] = hostCacheEntry{host: "stale", expires: time.Now().Add(-time.Second)}
+
+	_, ok := c.lookupHostCache("k")
+	require.False(t, ok)
+}

--- a/nodebuilder/fibre/constructor.go
+++ b/nodebuilder/fibre/constructor.go
@@ -8,17 +8,24 @@ import (
 	"google.golang.org/grpc"
 
 	appfibre "github.com/celestiaorg/celestia-app/v9/fibre"
+	appstate "github.com/celestiaorg/celestia-app/v9/fibre/state"
+	libhead "github.com/celestiaorg/go-header"
 
 	"github.com/celestiaorg/celestia-node/fibre"
+	"github.com/celestiaorg/celestia-node/fibre/stateclient"
+	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/libs/fxutil"
 	"github.com/celestiaorg/celestia-node/nodebuilder/core"
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/nodebuilder/state"
 	"github.com/celestiaorg/celestia-node/state/txclient"
 )
 
-func ConstructModule(coreCfg *core.Config) fx.Option {
+func ConstructModule(tp node.Type, coreCfg *core.Config) fx.Option {
+	enabled := coreCfg.IsEndpointConfigured()
 	return fx.Module("fibre",
-		fxutil.ProvideIf(coreCfg.IsEndpointConfigured(),
+		fxutil.ProvideIf(enabled,
 			fx.Annotate(
 				newAppFibreClient,
 				fx.OnStart(func(ctx context.Context, c *appfibre.Client) error {
@@ -28,10 +35,12 @@ func ConstructModule(coreCfg *core.Config) fx.Option {
 					return c.Stop(ctx)
 				}),
 			),
+		),
+		fxutil.ProvideIf(enabled,
 			newFibreService,
 			NewModule,
 		),
-		fxutil.ProvideIf(!coreCfg.IsEndpointConfigured(), func() (*fibre.Service, Module) {
+		fxutil.ProvideIf(!enabled, func() (*fibre.Service, Module) {
 			return nil, &stubbedFibreModule{}
 		}),
 	)
@@ -41,10 +50,21 @@ func newAppFibreClient(
 	keyring keyring.Keyring,
 	keyName state.AccountName,
 	conn *grpc.ClientConn,
+	tp node.Type,
+	store libhead.Store[*header.ExtendedHeader],
+	network p2p.Network,
 ) (*appfibre.Client, error) {
 	cfg := appfibre.DefaultClientConfig()
 	cfg.DefaultKeyName = string(keyName)
 	cfg.StateAddress = conn.Target()
+
+	if tp == node.Light {
+		// Light nodes replace the default trusted gRPC state client with one
+		// that resolves validator sets and hosts via the locally verified
+		// header chain (see fibre/stateclient).
+		sc := stateclient.NewClient(store, conn, network)
+		cfg.StateClientFn = func() (appstate.Client, error) { return sc, nil }
+	}
 	return appfibre.NewClient(keyring, cfg)
 }
 

--- a/nodebuilder/fibre/constructor.go
+++ b/nodebuilder/fibre/constructor.go
@@ -22,7 +22,7 @@ import (
 	"github.com/celestiaorg/celestia-node/state/txclient"
 )
 
-func ConstructModule(tp node.Type, coreCfg *core.Config) fx.Option {
+func ConstructModule(coreCfg *core.Config) fx.Option {
 	enabled := coreCfg.IsEndpointConfigured()
 	return fx.Module("fibre",
 		fxutil.ProvideIf(enabled,

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -50,7 +50,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		state.ConstructModule(tp, &cfg.State, &cfg.Core),
 		das.ConstructModule(&cfg.DASer),
 		blob.ConstructModule(),
-		fibre.ConstructModule(&cfg.Core),
+		fibre.ConstructModule(tp, &cfg.Core),
 		da.ConstructModule(),
 		node.ConstructModule(tp),
 		pruner.ConstructModule(tp),

--- a/nodebuilder/module.go
+++ b/nodebuilder/module.go
@@ -50,7 +50,7 @@ func ConstructModule(tp node.Type, network p2p.Network, cfg *Config, store Store
 		state.ConstructModule(tp, &cfg.State, &cfg.Core),
 		das.ConstructModule(&cfg.DASer),
 		blob.ConstructModule(),
-		fibre.ConstructModule(tp, &cfg.Core),
+		fibre.ConstructModule(&cfg.Core),
 		da.ConstructModule(),
 		node.ConstructModule(tp),
 		pruner.ConstructModule(tp),


### PR DESCRIPTION
  Adds a `state.Client` implementation for Light nodes that uses the locally verified header chain instead of trusting the gRPC endpoint.