### PR TITLE
fix(api)!: set request-size limit and write/idle timeouts on JSON-RPC server

### DIFF
--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -21,6 +21,26 @@ import (
 
 var log = logging.Logger("rpc")
 
+const (
+	// maxRequestSizeBytes caps the size of a single JSON-RPC HTTP request body
+	// accepted by the server. The go-jsonrpc default is 100 MiB, which is
+	// unnecessarily large for legitimate JSON-RPC payloads (including
+	// reasonable batches) and exposes the server to memory pressure from
+	// malicious or buggy clients.
+	maxRequestSizeBytes = 1 << 20 // 1 MiB
+
+	// writeTimeout bounds the time the server will spend writing a response
+	// to a single HTTP request. This prevents a slow or stalled client from
+	// holding server-side resources indefinitely while a response is in
+	// flight.
+	writeTimeout = 30 * time.Second
+
+	// idleTimeout bounds how long the server will keep an idle keep-alive
+	// connection open before closing it. Without an idle timeout a client
+	// could leave many idle connections open indefinitely.
+	idleTimeout = 120 * time.Second
+)
+
 type CORSConfig struct {
 	Enabled        bool
 	AllowedOrigins []string
@@ -59,7 +79,7 @@ func NewServer(
 	signer jwt.Signer,
 	verifier jwt.Verifier,
 ) *Server {
-	rpc := jsonrpc.NewServer()
+	rpc := jsonrpc.NewServer(jsonrpc.WithMaxRequestSize(maxRequestSizeBytes))
 	srv := &Server{
 		rpc:          rpc,
 		signer:       signer,
@@ -76,6 +96,11 @@ func NewServer(
 		Handler: srv.newHandlerStack(rpc),
 		// the amount of time allowed to read request headers. set to the default 2 seconds
 		ReadHeaderTimeout: 2 * time.Second,
+		// bound the time spent writing a response and the lifetime of idle
+		// keep-alive connections so malicious or stalled clients cannot
+		// hold server resources indefinitely.
+		WriteTimeout: writeTimeout,
+		IdleTimeout:  idleTimeout,
 	}
 
 	return srv

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -15,6 +15,8 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/rs/cors"
 
+	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
+
 	"github.com/celestiaorg/celestia-node/api/rpc/perms"
 	"github.com/celestiaorg/celestia-node/libs/authtoken"
 )
@@ -24,16 +26,22 @@ var log = logging.Logger("rpc")
 const (
 	// maxRequestSizeBytes caps the size of a single JSON-RPC HTTP request body
 	// accepted by the server. The go-jsonrpc default is 100 MiB, which is
-	// unnecessarily large for legitimate JSON-RPC payloads (including
-	// reasonable batches) and exposes the server to memory pressure from
-	// malicious or buggy clients.
-	maxRequestSizeBytes = 1 << 20 // 1 MiB
+	// unnecessarily large for legitimate JSON-RPC payloads and exposes the
+	// server to memory pressure from malicious or buggy clients.
+	//
+	// The cap is derived from appconsts.MaxTxSize (the hard per-tx limit
+	// enforced by celestia-app's CheckTx/ProcessProposal) with a 2x factor
+	// to cover base64 expansion of binary blob data (~1.37x) plus JSON
+	// envelope overhead and small request batches.
+	maxRequestSizeBytes = appconsts.MaxTxSize * 2 // 16 MiB
 
 	// writeTimeout bounds the time the server will spend writing a response
-	// to a single HTTP request. This prevents a slow or stalled client from
-	// holding server-side resources indefinitely while a response is in
-	// flight.
-	writeTimeout = 30 * time.Second
+	// to a single HTTP request, including time the handler is still
+	// computing. State-changing RPCs such as blob.Submit do not return
+	// until the transaction is included in a block, which on a congested
+	// mempool can span multiple block intervals, so the bound is set well
+	// above a typical web-request timeout.
+	writeTimeout = 5 * time.Minute
 
 	// idleTimeout bounds how long the server will keep an idle keep-alive
 	// connection open before closing it. Without an idle timeout a client
@@ -79,7 +87,7 @@ func NewServer(
 	signer jwt.Signer,
 	verifier jwt.Verifier,
 ) *Server {
-	rpc := jsonrpc.NewServer(jsonrpc.WithMaxRequestSize(maxRequestSizeBytes))
+	rpc := jsonrpc.NewServer(jsonrpc.WithMaxRequestSize(int64(maxRequestSizeBytes)))
 	srv := &Server{
 		rpc:          rpc,
 		signer:       signer,

--- a/api/rpc/server_test.go
+++ b/api/rpc/server_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -9,12 +10,14 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -393,6 +396,54 @@ func TestServer_NoTLS_PlainHTTP(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.NotNil(t, resp)
+}
+
+// TestRPCServer_RejectsOversizedRequest verifies that the JSON-RPC server
+// rejects request bodies that exceed the configured maximum request size.
+// go-jsonrpc reports an oversized request via an in-band JSON-RPC parse
+// error rather than an HTTP-level 4xx, so we assert on the response body.
+func TestRPCServer_RejectsOversizedRequest(t *testing.T) {
+	signer, verifier := createTestJWT(t)
+
+	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, signer, verifier)
+
+	ctx := context.Background()
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, srv.Stop(ctx)) })
+
+	addr := srv.ListenAddr()
+	require.NotEmpty(t, addr)
+
+	// Build a JSON-RPC request body larger than the configured max request
+	// size (maxRequestSizeBytes = 1 MiB). We pad the params with a long
+	// string to exceed the limit.
+	padding := strings.Repeat("a", maxRequestSizeBytes+1024)
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"oversized","params":["` + padding + `"]}`)
+	require.Greater(t, int64(len(body)), int64(maxRequestSizeBytes))
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post("http://"+addr, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// go-jsonrpc returns an explicit error mentioning the request being
+	// bigger than the maximum allowed.
+	assert.Contains(t, strings.ToLower(string(respBody)), "bigger than maximum",
+		"oversized request should be rejected with a max-size error; got: %s", string(respBody))
+}
+
+// TestRPCServer_HasWriteAndIdleTimeouts asserts that the underlying
+// http.Server is configured with non-zero WriteTimeout and IdleTimeout so
+// that slow or idle clients cannot hold connections open indefinitely.
+func TestRPCServer_HasWriteAndIdleTimeouts(t *testing.T) {
+	signer, verifier := createTestJWT(t)
+	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, signer, verifier)
+
+	assert.NotZero(t, srv.srv.WriteTimeout, "WriteTimeout should be set on the underlying http.Server")
+	assert.NotZero(t, srv.srv.IdleTimeout, "IdleTimeout should be set on the underlying http.Server")
 }
 
 func generateSelfSignedCert(t *testing.T) (certPath, keyPath string) {


### PR DESCRIPTION
## Summary

Hardens the JSON-RPC entrypoint against unbounded request bodies and long-held connections.

Changes in `api/rpc/server.go`:

- New constants:
  - `maxRequestSizeBytes = appconsts.MaxTxSize * 2` (16 MiB). Derived from the chain's hard per-tx limit (`MaxTxSize` = 8 MiB) with a 2x factor to cover base64 expansion of binary blob data (~1.37x) plus JSON envelope and small request batches. The previous `go-jsonrpc` default was 100 MiB.
  - `writeTimeout = 5 * time.Minute`. Bounds the time the server spends writing a response, including handler compute time. State-changing RPCs such as `blob.Submit` do not return until the transaction is included in a block, which on a congested mempool can span multiple block intervals.
  - `idleTimeout = 120 * time.Second`. Bounds idle keep-alive connections.
- Pass `jsonrpc.WithMaxRequestSize(int64(maxRequestSizeBytes))` to `jsonrpc.NewServer`.
- Set `WriteTimeout` and `IdleTimeout` on the `http.Server` (alongside the existing `ReadHeaderTimeout`).

### Follow-up

`go-jsonrpc` v0.10.1 has no `WithMaxBatchSize` option, so per-batch size enforcement relies on the overall request-size cap. An upstream feature for an explicit batch-element ceiling would be a useful follow-up.

Closes [PROTOCO-1745](https://linear.app/celestia/issue/PROTOCO-1745)

## Test plan

- [x] `TestRPCServer_RejectsOversizedRequest` posts a JSON-RPC body larger than `maxRequestSizeBytes` and asserts the server returns a parse-error mentioning the request being bigger than the maximum.
- [x] `TestRPCServer_HasWriteAndIdleTimeouts` asserts the underlying `http.Server` has non-zero `WriteTimeout` and `IdleTimeout`.
- [x] `go test ./api/rpc/...` passes.
- [x] `make lint` reports 0 Go issues.