### PR TITLE
fix(shwap): reject nil inputs in proto decoders

### DIFF
--- a/nodebuilder/share/get_range_result.go
+++ b/nodebuilder/share/get_range_result.go
@@ -48,6 +48,10 @@ func newGetRangeResult(
 	endRow := (endIndex - 1) / odsSize
 	numRows := endRow - startRow + 1
 
+	if len(rngdata.Shares) != numRows {
+		return nil, errors.New("range data row count does not match requested range")
+	}
+
 	nmtProofs := make([]*nmt.Proof, numRows)
 	nmtProofs[0] = rngdata.FirstIncompleteRowProof
 	if startRow != endRow {

--- a/share/shwap/range_namespace_data.go
+++ b/share/shwap/range_namespace_data.go
@@ -291,9 +291,12 @@ func (rngdata *RangeNamespaceData) IsEmpty() bool {
 }
 
 func RangeNamespaceDataFromProto(nd *pb.RangeNamespaceData) (RangeNamespaceData, error) {
-	shares := make([][]libshare.Share, len(nd.Shares))
+	if nd == nil {
+		return RangeNamespaceData{}, errors.New("pb RangeNamespaceData is nil")
+	}
+	shares := make([][]libshare.Share, len(nd.GetShares()))
 
-	for i, shr := range nd.Shares {
+	for i, shr := range nd.GetShares() {
 		shrs, err := SharesFromProto(shr.GetShares())
 		if err != nil {
 			return RangeNamespaceData{}, err
@@ -303,8 +306,8 @@ func RangeNamespaceDataFromProto(nd *pb.RangeNamespaceData) (RangeNamespaceData,
 
 	return RangeNamespaceData{
 		Shares:                  shares,
-		FirstIncompleteRowProof: pbNmtToNmtProof(nd.FirstIncompleteRowProof),
-		LastIncompleteRowProof:  pbNmtToNmtProof(nd.LastIncompleteRowProof),
+		FirstIncompleteRowProof: pbNmtToNmtProof(nd.GetFirstIncompleteRowProof()),
+		LastIncompleteRowProof:  pbNmtToNmtProof(nd.GetLastIncompleteRowProof()),
 	}, nil
 }
 

--- a/share/shwap/range_namespace_data.go
+++ b/share/shwap/range_namespace_data.go
@@ -183,6 +183,11 @@ func (rngdata *RangeNamespaceData) verifyShares(
 	if len(expectedRoots) != len(shares) {
 		return fmt.Errorf("mismatched row roots: expected %d vs got %d", len(shares), len(expectedRoots))
 	}
+	for i, row := range shares {
+		if len(row) == 0 {
+			return fmt.Errorf("empty shares at row %d", i)
+		}
+	}
 	if rngdata.FirstIncompleteRowProof != nil && rngdata.FirstIncompleteRowProof.Start() != from.Col {
 		return fmt.Errorf(
 			"first col share index mismatch: expected %d vs got %d", from.Col, rngdata.FirstIncompleteRowProof.Start(),
@@ -301,6 +306,9 @@ func RangeNamespaceDataFromProto(nd *pb.RangeNamespaceData) (RangeNamespaceData,
 		if err != nil {
 			return RangeNamespaceData{}, err
 		}
+		if len(shrs) == 0 {
+			return RangeNamespaceData{}, fmt.Errorf("empty shares at row %d", i)
+		}
 		shares[i] = shrs
 	}
 
@@ -413,6 +421,10 @@ func ParseNamespace(rawShares [][]libshare.Share, startShare, endShare int) (lib
 		return libshare.Namespace{}, fmt.Errorf(
 			"end share %d cannot be lower or equal to the starting share %d", endShare, startShare,
 		)
+	}
+
+	if len(rawShares) == 0 || len(rawShares[0]) == 0 {
+		return libshare.Namespace{}, errors.New("empty shares")
 	}
 
 	sharesAmount := 0

--- a/share/shwap/row.go
+++ b/share/shwap/row.go
@@ -64,7 +64,10 @@ func RowFromEDS(eds *rsmt2d.ExtendedDataSquare, rowIdx int, side RowSide) (Row, 
 
 // RowFromProto converts a protobuf Row to a Row structure.
 func RowFromProto(r *pb.Row) (Row, error) {
-	shrs, err := SharesFromProto(r.SharesHalf)
+	if r == nil {
+		return Row{}, fmt.Errorf("received nil Row")
+	}
+	shrs, err := SharesFromProto(r.GetSharesHalf())
 	if err != nil {
 		return Row{}, err
 	}

--- a/share/shwap/row_namespace_data.go
+++ b/share/shwap/row_namespace_data.go
@@ -102,6 +102,9 @@ func RowNamespaceDataFromShares(
 
 // RowNamespaceDataFromProto constructs RowNamespaceData out of its protobuf representation.
 func RowNamespaceDataFromProto(row *pb.RowNamespaceData) (RowNamespaceData, error) {
+	if row == nil {
+		return RowNamespaceData{}, errors.New("pb row is nil")
+	}
 	shares, err := SharesFromProto(row.GetShares())
 	if err != nil {
 		return RowNamespaceData{}, err

--- a/share/shwap/sample.go
+++ b/share/shwap/sample.go
@@ -57,6 +57,9 @@ func SampleFromShares(shares []libshare.Share, proofType rsmt2d.Axis, idx Sample
 
 // SampleFromProto converts a protobuf Sample back into its domain model equivalent.
 func SampleFromProto(s *pb.Sample) (Sample, error) {
+	if s == nil {
+		return Sample{}, errors.New("pb sample is nil")
+	}
 	proof := nmt.NewInclusionProof(
 		int(s.GetProof().GetStart()),
 		int(s.GetProof().GetEnd()),

--- a/share/shwap/share.go
+++ b/share/shwap/share.go
@@ -1,6 +1,7 @@
 package shwap
 
 import (
+	"errors"
 	"fmt"
 
 	libshare "github.com/celestiaorg/go-square/v4/share"
@@ -9,11 +10,10 @@ import (
 )
 
 // ShareFromProto converts a protobuf Share object to the application's internal share
-// representation. It returns nil if the input protobuf Share is nil, ensuring safe handling of nil
-// values.
+// representation. Returns an error if the input is nil or contains invalid data
 func ShareFromProto(s *pb.Share) (libshare.Share, error) {
 	if s == nil {
-		return libshare.Share{}, nil
+		return libshare.Share{}, errors.New("pb share is nil")
 	}
 	sh, err := libshare.NewShare(s.Data)
 	if err != nil {

--- a/share/shwap/share_test.go
+++ b/share/shwap/share_test.go
@@ -38,6 +38,11 @@ func TestProtoDecodersRejectMalformedInput(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("SampleFromProto/nil", func(t *testing.T) {
+		_, err := shwap.SampleFromProto(nil)
+		require.Error(t, err)
+	})
+
 	t.Run("SampleFromProto/nil share field", func(t *testing.T) {
 		_, err := shwap.SampleFromProto(&pb.Sample{Share: nil})
 		require.Error(t, err)

--- a/share/shwap/share_test.go
+++ b/share/shwap/share_test.go
@@ -62,6 +62,43 @@ func TestProtoDecodersRejectMalformedInput(t *testing.T) {
 		_, err := shwap.RangeNamespaceDataFromProto(nil)
 		require.Error(t, err)
 	})
+
+	t.Run("RangeNamespaceDataFromProto/empty inner row", func(t *testing.T) {
+		_, err := shwap.RangeNamespaceDataFromProto(&pb.RangeNamespaceData{
+			Shares: []*pb.RowShares{{Shares: nil}},
+		})
+		require.Error(t, err)
+	})
+}
+
+// TestParseNamespaceRejectsEmptyShares guards ParseNamespace against malformed
+// 2D share slices that would otherwise panic at rawShares[0][0]. Even if a
+// decoder one day forgets to enforce non-empty rows, ParseNamespace must not
+// panic on an empty outer slice or an empty first row.
+func TestParseNamespaceRejectsEmptyShares(t *testing.T) {
+	t.Run("empty outer slice", func(t *testing.T) {
+		_, err := shwap.ParseNamespace(nil, 0, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("empty first row", func(t *testing.T) {
+		_, err := shwap.ParseNamespace([][]libshare.Share{nil}, 0, 1)
+		require.Error(t, err)
+	})
+}
+
+// TestVerifyInclusionRejectsEmptyRow guards RangeNamespaceData.VerifyInclusion
+// against manually constructed values with an empty inner row. Even if a future
+// caller bypasses RangeNamespaceDataFromProto, verifyShares must reject the
+// input before any indexing on shares[0][0]-like sites.
+func TestVerifyInclusionRejectsEmptyRow(t *testing.T) {
+	rngdata := shwap.RangeNamespaceData{
+		Shares: [][]libshare.Share{nil},
+	}
+	from := shwap.SampleCoords{Row: 0, Col: 0}
+	to := shwap.SampleCoords{Row: 0, Col: 0}
+	err := rngdata.VerifyInclusion(from, to, 2, [][]byte{{0x00}})
+	require.Error(t, err)
 }
 
 // TestSampleReadFromRejectsNilShare simulates what shrex.Client.Get does after

--- a/share/shwap/share_test.go
+++ b/share/shwap/share_test.go
@@ -1,0 +1,91 @@
+package shwap_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/go-libp2p-messenger/serde"
+	libshare "github.com/celestiaorg/go-square/v4/share"
+
+	"github.com/celestiaorg/celestia-node/share/shwap"
+	"github.com/celestiaorg/celestia-node/share/shwap/pb"
+)
+
+// TestProtoDecodersRejectMalformedInput guards against a class of remote-DoS
+// where a peer sends proto containers with nil/invalid Share fields. Decoders
+// must return an error rather than producing a zero-value libshare.Share, which
+// would panic later when Namespace()/ToBytes() are invoked on it.
+func TestProtoDecodersRejectMalformedInput(t *testing.T) {
+	t.Run("ShareFromProto/nil", func(t *testing.T) {
+		_, err := shwap.ShareFromProto(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("ShareFromProto/empty data", func(t *testing.T) {
+		_, err := shwap.ShareFromProto(&pb.Share{Data: nil})
+		require.Error(t, err)
+	})
+
+	t.Run("ShareFromProto/wrong size", func(t *testing.T) {
+		_, err := shwap.ShareFromProto(&pb.Share{Data: []byte{1, 2, 3}})
+		require.Error(t, err)
+	})
+
+	t.Run("SharesFromProto/nil element", func(t *testing.T) {
+		_, err := shwap.SharesFromProto([]*pb.Share{nil})
+		require.Error(t, err)
+	})
+
+	t.Run("SampleFromProto/nil share field", func(t *testing.T) {
+		_, err := shwap.SampleFromProto(&pb.Sample{Share: nil})
+		require.Error(t, err)
+	})
+
+	t.Run("RowFromProto/nil", func(t *testing.T) {
+		_, err := shwap.RowFromProto(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("RowFromProto/nil share inside", func(t *testing.T) {
+		_, err := shwap.RowFromProto(&pb.Row{SharesHalf: []*pb.Share{nil}})
+		require.Error(t, err)
+	})
+
+	t.Run("RowNamespaceDataFromProto/nil", func(t *testing.T) {
+		_, err := shwap.RowNamespaceDataFromProto(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("RangeNamespaceDataFromProto/nil", func(t *testing.T) {
+		_, err := shwap.RangeNamespaceDataFromProto(nil)
+		require.Error(t, err)
+	})
+}
+
+// TestSampleReadFromRejectsNilShare simulates what shrex.Client.Get does after
+// reading bytes from a malicious peer: serde.Read succeeds because pb.Sample
+// allows the Share field to be unset, but SampleFromProto must reject it. If
+// this regresses, the client will accept the malformed Sample and panic later
+// inside Verify().
+func TestSampleReadFromRejectsNilShare(t *testing.T) {
+	var buf bytes.Buffer
+	_, err := serde.Write(&buf, &pb.Sample{Share: nil})
+	require.NoError(t, err)
+
+	var s shwap.Sample
+	_, err = s.ReadFrom(&buf)
+	require.Error(t, err)
+}
+
+// TestZeroShareDoesNotEscapeDecoders ensures that no decoder hands out a
+// zero-value libshare.Share (data == nil). A zero share panics on Namespace()
+// and ToBytes(), so it must never be produced as a "success" value.
+func TestZeroShareDoesNotEscapeDecoders(t *testing.T) {
+	t.Run("ShareFromProto returns error, never a zero share", func(t *testing.T) {
+		sh, err := shwap.ShareFromProto(nil)
+		require.Error(t, err)
+		require.Equal(t, libshare.Share{}, sh)
+	})
+}


### PR DESCRIPTION
 Tightens input validation in shwap proto decoders: `ShareFromProto`, `RowFromProto`, `RowNamespaceDataFromProto`, and `RangeNamespaceDataFromProto`  now return an explicit error on nil inputs instead of producing zero values. Adds regression tests covering the decoder error paths.