### PR TITLE
mics(metrics): add metrics to improve observability

### DIFF
--- a/api/rpc/metrics.go
+++ b/api/rpc/metrics.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"reflect"
 	"sync/atomic"
-	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -15,34 +14,27 @@ import (
 
 var meter = otel.Meter("rpc")
 
-// rpcMetrics holds the JSON-RPC server instruments. HTTP-layer metrics are
-// recorded by the `instrument` middleware (no method label, since the HTTP
-// middleware can't see the parsed JSON-RPC method without buffering bodies).
-// Method-keyed call counts are recorded by `traceMethod`, hooked into
-// jsonrpc.WithTracer so go-jsonrpc supplies the already-parsed method name.
+// rpcMetrics holds the JSON-RPC server instruments that live outside otelhttp's
+// scope. HTTP request-level metrics (duration, sizes, active requests, status)
+// are recorded by otelhttp wrapping the handler (see Server.newHandlerStack);
+// here we keep only what otelhttp can't see:
+//   - method-keyed call counts, via go-jsonrpc's Tracer hook (traceMethod),
+//   - connection-lifecycle signals from http.Server.ConnState (onConnState).
 type rpcMetrics struct {
-	// HTTP-layer instruments, no method label.
-	requestsTotal   metric.Int64Counter
-	requestDuration metric.Float64Histogram
-	requestSize     metric.Int64Histogram
-	responseSize    metric.Int64Histogram
-
-	// methodCalls is method-keyed (via go-jsonrpc Tracer hook) with a
-	// boolean error attribute. No duration: the Tracer signature doesn't
-	// carry it, see go-jsonrpc handler.Tracer.
+	// methodCalls is method-keyed (via go-jsonrpc Tracer hook) with a boolean
+	// error attribute. No duration: the Tracer signature doesn't carry it, see
+	// go-jsonrpc handler.Tracer.
 	methodCalls metric.Int64Counter
 
 	// websocketUpgrades counts StateHijacked transitions. net/http emits
-	// StateHijacked once per upgrade and does not emit a matching close,
-	// so this is intrinsically cumulative — a counter, not a gauge.
+	// StateHijacked once per upgrade and does not emit a matching close, so this
+	// is intrinsically cumulative — a counter, not a gauge.
 	websocketUpgrades metric.Int64Counter
 
-	// active requests + open HTTP connections — atomic counters surfaced
-	// via observable gauges. Single consistent pattern, one atomic load
-	// per collection cycle, no per-request SDK calls.
-	activeRequests      atomic.Int64
+	// connectionsOpen tracks currently-open HTTP connections, surfaced via an
+	// observable gauge. Connection lifecycle is invisible to otelhttp (it only
+	// sees individual requests), so it stays instrumented here.
 	connectionsOpen     atomic.Int64
-	activeRequestsInst  metric.Int64ObservableGauge
 	connectionsOpenInst metric.Int64ObservableGauge
 	gaugeReg            metric.Registration
 }
@@ -51,44 +43,6 @@ func newMetrics() (*rpcMetrics, error) {
 	m := &rpcMetrics{}
 
 	var err error
-	m.requestsTotal, err = meter.Int64Counter(
-		"rpc_requests_total",
-		metric.WithDescription("total number of JSON-RPC requests served, labeled by HTTP status"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	m.requestDuration, err = meter.Float64Histogram(
-		"rpc_request_duration_seconds",
-		metric.WithDescription("duration of JSON-RPC request handling"),
-		metric.WithUnit("s"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	m.responseSize, err = meter.Int64Histogram(
-		"rpc_response_size_bytes",
-		metric.WithDescription("size of JSON-RPC response payload"),
-		metric.WithUnit("By"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	m.requestSize, err = meter.Int64Histogram(
-		"rpc_request_size_bytes",
-		metric.WithDescription(
-			"size of JSON-RPC request payload; only recorded when Content-Length>0 "+
-				"(chunked transfer and empty-body GETs are skipped to keep quantiles meaningful)",
-		),
-		metric.WithUnit("By"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	m.methodCalls, err = meter.Int64Counter(
 		"rpc_method_calls_total",
 		metric.WithDescription(
@@ -108,13 +62,6 @@ func newMetrics() (*rpcMetrics, error) {
 		return nil, err
 	}
 
-	m.activeRequestsInst, err = meter.Int64ObservableGauge(
-		"rpc_active_requests",
-		metric.WithDescription("number of JSON-RPC requests currently being served"),
-	)
-	if err != nil {
-		return nil, err
-	}
 	m.connectionsOpenInst, err = meter.Int64ObservableGauge(
 		"rpc_connections_open",
 		metric.WithDescription("number of HTTP connections currently open to the RPC server"),
@@ -122,11 +69,7 @@ func newMetrics() (*rpcMetrics, error) {
 	if err != nil {
 		return nil, err
 	}
-	m.gaugeReg, err = meter.RegisterCallback(
-		m.observeGauges,
-		m.activeRequestsInst,
-		m.connectionsOpenInst,
-	)
+	m.gaugeReg, err = meter.RegisterCallback(m.observeGauges, m.connectionsOpenInst)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +78,6 @@ func newMetrics() (*rpcMetrics, error) {
 }
 
 func (m *rpcMetrics) observeGauges(_ context.Context, obs metric.Observer) error {
-	obs.ObserveInt64(m.activeRequestsInst, m.activeRequests.Load())
 	obs.ObserveInt64(m.connectionsOpenInst, m.connectionsOpen.Load())
 	return nil
 }
@@ -171,61 +113,4 @@ func (m *rpcMetrics) traceMethod(method string, _, _ []reflect.Value, err error)
 		attribute.String("method", method),
 		attribute.Bool("error", err != nil),
 	))
-}
-
-// instrument wraps the next handler with HTTP-layer RPC metrics. The HTTP
-// middleware has no visibility into the JSON-RPC method (extracting it would
-// require buffering the entire request body — see traceMethod for the
-// method-keyed signal sourced from go-jsonrpc instead).
-func (m *rpcMetrics) instrument(next http.Handler) http.Handler {
-	if m == nil {
-		return next
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-
-		m.activeRequests.Add(1)
-		defer m.activeRequests.Add(-1)
-
-		// Only record when Content-Length is a real size. -1 means chunked
-		// (unknown length); 0 means no body. Both would distort quantiles.
-		if r.ContentLength > 0 {
-			m.requestSize.Record(r.Context(), r.ContentLength)
-		}
-
-		rec := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
-		next.ServeHTTP(rec, r)
-
-		statusAttr := attribute.Int("status", rec.status)
-		m.requestsTotal.Add(r.Context(), 1, metric.WithAttributes(statusAttr))
-		m.requestDuration.Record(r.Context(), time.Since(start).Seconds())
-		if rec.bytesWritten > 0 {
-			m.responseSize.Record(r.Context(), rec.bytesWritten)
-		}
-	})
-}
-
-// responseRecorder captures status code and bytes written for metrics.
-type responseRecorder struct {
-	http.ResponseWriter
-	status       int
-	bytesWritten int64
-	wroteHeader  bool
-}
-
-func (r *responseRecorder) WriteHeader(code int) {
-	if !r.wroteHeader {
-		r.status = code
-		r.wroteHeader = true
-	}
-	r.ResponseWriter.WriteHeader(code)
-}
-
-func (r *responseRecorder) Write(b []byte) (int, error) {
-	if !r.wroteHeader {
-		r.wroteHeader = true
-	}
-	n, err := r.ResponseWriter.Write(b)
-	r.bytesWritten += int64(n)
-	return n, err
 }

--- a/api/rpc/metrics.go
+++ b/api/rpc/metrics.go
@@ -1,0 +1,231 @@
+package rpc
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"reflect"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var meter = otel.Meter("rpc")
+
+// rpcMetrics holds the JSON-RPC server instruments. HTTP-layer metrics are
+// recorded by the `instrument` middleware (no method label, since the HTTP
+// middleware can't see the parsed JSON-RPC method without buffering bodies).
+// Method-keyed call counts are recorded by `traceMethod`, hooked into
+// jsonrpc.WithTracer so go-jsonrpc supplies the already-parsed method name.
+type rpcMetrics struct {
+	// HTTP-layer instruments, no method label.
+	requestsTotal   metric.Int64Counter
+	requestDuration metric.Float64Histogram
+	requestSize     metric.Int64Histogram
+	responseSize    metric.Int64Histogram
+
+	// methodCalls is method-keyed (via go-jsonrpc Tracer hook) with a
+	// boolean error attribute. No duration: the Tracer signature doesn't
+	// carry it, see go-jsonrpc handler.Tracer.
+	methodCalls metric.Int64Counter
+
+	// websocketUpgrades counts StateHijacked transitions. net/http emits
+	// StateHijacked once per upgrade and does not emit a matching close,
+	// so this is intrinsically cumulative — a counter, not a gauge.
+	websocketUpgrades metric.Int64Counter
+
+	// active requests + open HTTP connections — atomic counters surfaced
+	// via observable gauges. Single consistent pattern, one atomic load
+	// per collection cycle, no per-request SDK calls.
+	activeRequests      atomic.Int64
+	connectionsOpen     atomic.Int64
+	activeRequestsInst  metric.Int64ObservableGauge
+	connectionsOpenInst metric.Int64ObservableGauge
+	gaugeReg            metric.Registration
+}
+
+func newMetrics() (*rpcMetrics, error) {
+	m := &rpcMetrics{}
+
+	var err error
+	m.requestsTotal, err = meter.Int64Counter(
+		"rpc_requests_total",
+		metric.WithDescription("total number of JSON-RPC requests served, labeled by HTTP status"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.requestDuration, err = meter.Float64Histogram(
+		"rpc_request_duration_seconds",
+		metric.WithDescription("duration of JSON-RPC request handling"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.responseSize, err = meter.Int64Histogram(
+		"rpc_response_size_bytes",
+		metric.WithDescription("size of JSON-RPC response payload"),
+		metric.WithUnit("By"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.requestSize, err = meter.Int64Histogram(
+		"rpc_request_size_bytes",
+		metric.WithDescription(
+			"size of JSON-RPC request payload; only recorded when Content-Length>0 "+
+				"(chunked transfer and empty-body GETs are skipped to keep quantiles meaningful)",
+		),
+		metric.WithUnit("By"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.methodCalls, err = meter.Int64Counter(
+		"rpc_method_calls_total",
+		metric.WithDescription(
+			"JSON-RPC method invocations, labeled by `method` and `error` "+
+				"(true if the handler returned an error). Sourced from go-jsonrpc's Tracer hook.",
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.websocketUpgrades, err = meter.Int64Counter(
+		"rpc_websocket_upgrades_total",
+		metric.WithDescription("HTTP connections hijacked by websocket upgrades"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.activeRequestsInst, err = meter.Int64ObservableGauge(
+		"rpc_active_requests",
+		metric.WithDescription("number of JSON-RPC requests currently being served"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	m.connectionsOpenInst, err = meter.Int64ObservableGauge(
+		"rpc_connections_open",
+		metric.WithDescription("number of HTTP connections currently open to the RPC server"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	m.gaugeReg, err = meter.RegisterCallback(
+		m.observeGauges,
+		m.activeRequestsInst,
+		m.connectionsOpenInst,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (m *rpcMetrics) observeGauges(_ context.Context, obs metric.Observer) error {
+	obs.ObserveInt64(m.activeRequestsInst, m.activeRequests.Load())
+	obs.ObserveInt64(m.connectionsOpenInst, m.connectionsOpen.Load())
+	return nil
+}
+
+// onConnState is intended to be installed as http.Server.ConnState. Connection
+// lifecycle: New → Active/Idle → (Closed | Hijacked). open = New − (Closed + Hijacked).
+// StateHijacked also bumps the cumulative websocket-upgrade counter, since
+// net/http never emits a matching close for hijacked connections.
+func (m *rpcMetrics) onConnState(_ net.Conn, state http.ConnState) {
+	if m == nil {
+		return
+	}
+	switch state {
+	case http.StateNew:
+		m.connectionsOpen.Add(1)
+	case http.StateHijacked:
+		m.connectionsOpen.Add(-1)
+		m.websocketUpgrades.Add(context.Background(), 1)
+	case http.StateClosed:
+		m.connectionsOpen.Add(-1)
+	}
+}
+
+// traceMethod is installed via jsonrpc.WithTracer. go-jsonrpc invokes it after
+// every RPC dispatch with the already-parsed method name and the handler's
+// error (nil on success). No body sniffing, no extra JSON parsing on the
+// hot path.
+func (m *rpcMetrics) traceMethod(method string, _, _ []reflect.Value, err error) {
+	if m == nil {
+		return
+	}
+	m.methodCalls.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("method", method),
+		attribute.Bool("error", err != nil),
+	))
+}
+
+// instrument wraps the next handler with HTTP-layer RPC metrics. The HTTP
+// middleware has no visibility into the JSON-RPC method (extracting it would
+// require buffering the entire request body — see traceMethod for the
+// method-keyed signal sourced from go-jsonrpc instead).
+func (m *rpcMetrics) instrument(next http.Handler) http.Handler {
+	if m == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		m.activeRequests.Add(1)
+		defer m.activeRequests.Add(-1)
+
+		// Only record when Content-Length is a real size. -1 means chunked
+		// (unknown length); 0 means no body. Both would distort quantiles.
+		if r.ContentLength > 0 {
+			m.requestSize.Record(r.Context(), r.ContentLength)
+		}
+
+		rec := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+
+		statusAttr := attribute.Int("status", rec.status)
+		m.requestsTotal.Add(r.Context(), 1, metric.WithAttributes(statusAttr))
+		m.requestDuration.Record(r.Context(), time.Since(start).Seconds())
+		if rec.bytesWritten > 0 {
+			m.responseSize.Record(r.Context(), rec.bytesWritten)
+		}
+	})
+}
+
+// responseRecorder captures status code and bytes written for metrics.
+type responseRecorder struct {
+	http.ResponseWriter
+	status       int
+	bytesWritten int64
+	wroteHeader  bool
+}
+
+func (r *responseRecorder) WriteHeader(code int) {
+	if !r.wroteHeader {
+		r.status = code
+		r.wroteHeader = true
+	}
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		r.wroteHeader = true
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytesWritten += int64(n)
+	return n, err
+}

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -74,6 +74,8 @@ type Server struct {
 
 	signer   jwt.Signer
 	verifier jwt.Verifier
+
+	metrics *rpcMetrics
 }
 
 type TLSConfig struct {
@@ -91,12 +93,7 @@ func NewServer(
 	signer jwt.Signer,
 	verifier jwt.Verifier,
 ) *Server {
-	rpc := jsonrpc.NewServer(
-		jsonrpc.WithMaxRequestSize(maxRequestSize),
-	)
-
 	srv := &Server{
-		rpc:          rpc,
 		signer:       signer,
 		verifier:     verifier,
 		authDisabled: authDisabled,
@@ -107,9 +104,19 @@ func NewServer(
 		tlsKeyPath:   tlsConfig.KeyPath,
 	}
 
+	// The tracer closure reads srv.metrics lazily: WithMetrics may run after
+	// NewServer, and traceMethod is nil-safe. So we wire the hook now once
+	// and let metrics get populated later.
+	srv.rpc = jsonrpc.NewServer(
+		jsonrpc.WithMaxRequestSize(maxRequestSize),
+		jsonrpc.WithTracer(func(method string, params, results []reflect.Value, err error) {
+			srv.metrics.traceMethod(method, params, results, err)
+		}),
+	)
+
 	srv.srv = &http.Server{
 		Addr:    net.JoinHostPort(address, port),
-		Handler: srv.newHandlerStack(rpc),
+		Handler: srv.newHandlerStack(srv.rpc),
 		// the amount of time allowed to read request headers. set to the default 2 seconds
 		ReadHeaderTimeout: 2 * time.Second,
 		ReadTimeout:       30 * time.Second,
@@ -122,17 +129,19 @@ func NewServer(
 }
 
 // newHandlerStack returns wrapped rpc related handlers.
-// Middleware order (outermost first): rate-limit (opt-in) → conn-limit → CORS/auth → RPC handler.
+// Middleware order (outermost first): rate-limit (opt-in) → conn-limit → CORS/auth → metrics → RPC handler.
 func (s *Server) newHandlerStack(core http.Handler) http.Handler {
-	var h http.Handler
+	// metrics middleware wraps the innermost handler so it observes every
+	// request that reaches the RPC layer. s.metrics may be nil (no-op).
+	h := s.metrics.instrument(core)
 	switch {
 	case s.authDisabled:
 		log.Warn("auth disabled, allowing all origins, methods and headers for CORS")
-		h = s.corsAny(core)
+		h = s.corsAny(h)
 	case s.corsConfig.Enabled:
-		h = s.corsWithConfig(s.authHandler(core))
+		h = s.corsWithConfig(s.authHandler(h))
 	default:
-		h = s.authHandler(core)
+		h = s.authHandler(h)
 	}
 
 	h = connLimit(maxConcurrentConns, h)
@@ -142,6 +151,20 @@ func (s *Server) newHandlerStack(core http.Handler) http.Handler {
 		h = rateLimit(s.rateLimitCfg.RequestsPerSec, s.rateLimitCfg.Burst, s.rateLimitCfg.CacheSize, h)
 	}
 	return h
+}
+
+// WithMetrics enables OTel metrics on the RPC server. Must be called before
+// Start, since it rebuilds the handler stack to install the metrics middleware
+// and registers an http.Server.ConnState hook for connection-level gauges.
+func (s *Server) WithMetrics() error {
+	m, err := newMetrics()
+	if err != nil {
+		return err
+	}
+	s.metrics = m
+	s.srv.Handler = s.newHandlerStack(s.rpc)
+	s.srv.ConnState = m.onConnState
+	return nil
 }
 
 // verifyAuth is the RPC server's auth middleware. This middleware is only

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -14,6 +14,8 @@ import (
 	"github.com/filecoin-project/go-jsonrpc/auth"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/rs/cors"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
 
@@ -131,9 +133,18 @@ func NewServer(
 // newHandlerStack returns wrapped rpc related handlers.
 // Middleware order (outermost first): rate-limit (opt-in) → conn-limit → CORS/auth → metrics → RPC handler.
 func (s *Server) newHandlerStack(core http.Handler) http.Handler {
-	// metrics middleware wraps the innermost handler so it observes every
-	// request that reaches the RPC layer. s.metrics may be nil (no-op).
-	h := s.metrics.instrument(core)
+	// otelhttp records HTTP request-level metrics (duration, request/response
+	// sizes, active requests, status) and — unlike a hand-rolled wrapper —
+	// preserves the http.Hijacker that websocket upgrades rely on (it wraps the
+	// writer via httpsnoop). Connection- and method-level signals live in
+	// rpcMetrics. s.metrics may be nil (metrics disabled) → no wrapping.
+	h := core
+	if s.metrics != nil {
+		h = otelhttp.NewHandler(core, "rpc",
+			// metrics only: suppress the per-request span otelhttp would emit.
+			otelhttp.WithTracerProvider(noop.NewTracerProvider()),
+		)
+	}
 	switch {
 	case s.authDisabled:
 		log.Warn("auth disabled, allowing all origins, methods and headers for CORS")

--- a/api/rpc/server_test.go
+++ b/api/rpc/server_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cristalhq/jwt/v5"
+	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-jsonrpc/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -411,6 +412,63 @@ func TestServer_NoTLS_PlainHTTP(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.NotNil(t, resp)
+}
+
+// wsTestService is a minimal RPC service. Its channel-returning method forces a
+// websocket upgrade, exercising the http.Hijacker path.
+type wsTestService struct{}
+
+func (wsTestService) Ping(context.Context) (string, error) { return "pong", nil }
+
+func (wsTestService) Updates(ctx context.Context) (<-chan int, error) {
+	ch := make(chan int, 1)
+	ch <- 7
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch, nil
+}
+
+// TestServer_WithMetrics_WebSocketSubscription guards the regression where the
+// metrics middleware wrapped the ResponseWriter without promoting http.Hijacker,
+// so every websocket subscription 500'd once WithMetrics was enabled. The
+// subscription must still work with metrics on.
+func TestServer_WithMetrics_WebSocketSubscription(t *testing.T) {
+	signer, verifier := createTestJWT(t)
+	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, signer, verifier)
+	srv.RegisterService("test", wsTestService{}, nil)
+	require.NoError(t, srv.WithMetrics())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, srv.Stop(context.Background())) })
+
+	var client struct {
+		Ping    func(context.Context) (string, error)
+		Updates func(context.Context) (<-chan int, error)
+	}
+	closer, err := jsonrpc.NewClient(ctx, "ws://"+srv.ListenAddr(), "test", &client, nil)
+	require.NoError(t, err)
+	t.Cleanup(closer)
+
+	// Unary call over the websocket transport.
+	got, err := client.Ping(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "pong", got)
+
+	// Subscription: this is the path that hijacks the connection — broken before
+	// the switch to otelhttp, which preserves http.Hijacker.
+	ch, err := client.Updates(ctx)
+	require.NoError(t, err, "websocket subscription must work with WithMetrics enabled")
+	select {
+	case v, ok := <-ch:
+		require.True(t, ok)
+		assert.Equal(t, 7, v)
+	case <-ctx.Done():
+		t.Fatal("no value received from websocket subscription")
+	}
 }
 
 func generateSelfSignedCert(t *testing.T) (certPath, keyPath string) {

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -159,9 +159,15 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan SignedB
 
 			subscription, err := f.client.SubscribeNewHeights(ctx, &coregrpc.SubscribeNewHeightsRequest{})
 			if err != nil {
-				// try re-subscribe in case of any errors that can come during subscription. gRPC
-				// retry mechanism has a back off on retries, so we don't need timers anymore.
+				// try re-subscribe in case of any errors. gRPC retry interceptor has its
+				// own backoff for transient codes, but we still need a guard here to avoid
+				// a hot loop on persistent failures (e.g. core fully down).
 				log.Warnw("fetcher: failed to subscribe to new block events", "err", err)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Second):
+				}
 				continue
 			}
 
@@ -169,6 +175,11 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan SignedB
 			err = f.receive(ctx, signedBlockCh, subscription)
 			if err != nil {
 				log.Warnw("fetcher: error receiving new height", "err", err.Error())
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Second):
+				}
 				continue
 			}
 		}

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -159,15 +159,7 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan SignedB
 
 			subscription, err := f.client.SubscribeNewHeights(ctx, &coregrpc.SubscribeNewHeightsRequest{})
 			if err != nil {
-				// try re-subscribe in case of any errors. gRPC retry interceptor has its
-				// own backoff for transient codes, but we still need a guard here to avoid
-				// a hot loop on persistent failures (e.g. core fully down).
 				log.Warnw("fetcher: failed to subscribe to new block events", "err", err)
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(time.Second):
-				}
 				continue
 			}
 
@@ -175,11 +167,6 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan SignedB
 			err = f.receive(ctx, signedBlockCh, subscription)
 			if err != nil {
 				log.Warnw("fetcher: error receiving new height", "err", err.Error())
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(time.Second):
-				}
 				continue
 			}
 		}

--- a/core/listener.go
+++ b/core/listener.go
@@ -242,11 +242,15 @@ func (cl *Listener) handleNewSignedBlock(ctx context.Context, b SignedBlock) err
 	}
 
 	// broadcast new ExtendedHeader, but if core is still syncing, notify only local subscribers
+	bcastStart := time.Now()
 	err = cl.headerBroadcaster.Broadcast(ctx, eh, pubsub.WithLocalPublication(syncing))
+	cl.metrics.headerPublished(ctx, time.Since(bcastStart), syncing, err)
 	if err != nil && !errors.Is(err, context.Canceled) {
 		log.Errorw("listener: broadcasting next header",
 			"height", b.Header.Height,
 			"err", err)
 	}
+
+	cl.metrics.blockProcessed(ctx, b.Header.Time)
 	return nil
 }

--- a/core/listener_metrics.go
+++ b/core/listener_metrics.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/celestiaorg/celestia-node/libs/utils"
@@ -18,6 +20,15 @@ type listenerMetrics struct {
 	lastTimeSubscriptionStuckReg  metric.Registration
 
 	subscriptionStuckInst metric.Int64Counter
+
+	lastProcessedBlockTs     time.Time
+	lastProcessedBlockTsInst metric.Int64ObservableGauge
+	lastProcessedBlockTsReg  metric.Registration
+
+	coreToDaLagInst metric.Float64Histogram
+
+	headerSubPublishedInst       metric.Int64Counter
+	headerSubPublishDurationInst metric.Float64Histogram
 }
 
 func newListenerMetrics() (*listenerMetrics, error) {
@@ -47,6 +58,46 @@ func newListenerMetrics() (*listenerMetrics, error) {
 		return nil, err
 	}
 
+	m.lastProcessedBlockTsInst, err = meter.Int64ObservableGauge(
+		"core_listener_last_processed_block_ts",
+		metric.WithDescription("unix timestamp (seconds) of the last block successfully processed and broadcast"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	m.lastProcessedBlockTsReg, err = meter.RegisterCallback(
+		m.observeLastProcessedBlockTsCallback,
+		m.lastProcessedBlockTsInst,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.coreToDaLagInst, err = meter.Float64Histogram(
+		"core_to_da_lag_seconds",
+		metric.WithDescription("seconds between core block consensus time and DA broadcast"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.headerSubPublishedInst, err = meter.Int64Counter(
+		"header_sub_published_total",
+		metric.WithDescription("number of ExtendedHeaders published to HeaderSub by this bridge"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.headerSubPublishDurationInst, err = meter.Float64Histogram(
+		"header_sub_publish_duration_seconds",
+		metric.WithDescription("duration of HeaderSub Broadcast() call (seconds)"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return m, nil
 }
 
@@ -68,8 +119,57 @@ func (m *listenerMetrics) subscriptionStuck(ctx context.Context) {
 }
 
 func (m *listenerMetrics) observeLastTimeStuckCallback(_ context.Context, obs metric.Observer) error {
+	if m.lastTimeSubscriptionStuck.IsZero() {
+		// Never stuck — don't emit a value, otherwise dashboards interpret
+		// time.Time{}.Unix() as a timestamp ~2025 years in the past.
+		return nil
+	}
 	obs.ObserveInt64(m.lastTimeSubscriptionStuckInst, m.lastTimeSubscriptionStuck.Unix())
 	return nil
+}
+
+func (m *listenerMetrics) observeLastProcessedBlockTsCallback(_ context.Context, obs metric.Observer) error {
+	if m.lastProcessedBlockTs.IsZero() {
+		return nil
+	}
+	obs.ObserveInt64(m.lastProcessedBlockTsInst, m.lastProcessedBlockTs.Unix())
+	return nil
+}
+
+// headerPublished records a HeaderSub Broadcast() outcome. `local` distinguishes
+// catch-up broadcasts (delivered only to local subscribers, no network propagation)
+// from steady-state network broadcasts. Errors are tagged with result=error.
+func (m *listenerMetrics) headerPublished(ctx context.Context, dur time.Duration, local bool, err error) {
+	m.observe(ctx, func(ctx context.Context) {
+		result := "ok"
+		switch {
+		case errors.Is(err, context.Canceled):
+			result = "canceled"
+		case err != nil:
+			result = "error"
+		}
+		attrs := metric.WithAttributes(
+			attribute.String("result", result),
+			attribute.Bool("local_only", local),
+		)
+		m.headerSubPublishedInst.Add(ctx, 1, attrs)
+		m.headerSubPublishDurationInst.Record(ctx, dur.Seconds(), attrs)
+	})
+}
+
+// blockProcessed records a successfully processed block: updates the last-processed
+// timestamp and records the core->DA lag (consensus block time -> broadcast).
+func (m *listenerMetrics) blockProcessed(ctx context.Context, blockTime time.Time) {
+	m.observe(ctx, func(ctx context.Context) {
+		m.lastProcessedBlockTs = time.Now()
+		lag := time.Since(blockTime).Seconds()
+		if lag < 0 {
+			// clock skew between core and node; clamp rather than skip so the
+			// metric remains continuous and visible in dashboards.
+			lag = 0
+		}
+		m.coreToDaLagInst.Record(ctx, lag)
+	})
 }
 
 func (m *listenerMetrics) Close() error {
@@ -77,5 +177,8 @@ func (m *listenerMetrics) Close() error {
 		return nil
 	}
 
-	return m.lastTimeSubscriptionStuckReg.Unregister()
+	return errors.Join(
+		m.lastTimeSubscriptionStuckReg.Unregister(),
+		m.lastProcessedBlockTsReg.Unregister(),
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/bridges/prometheus v0.69.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
@@ -357,7 +358,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0 // indirect
 	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/mock v0.5.2 // indirect

--- a/nodebuilder/node/metrics.go
+++ b/nodebuilder/node/metrics.go
@@ -18,10 +18,7 @@ var meter = otel.Meter("node")
 
 // WithMetrics registers node metrics.
 func WithMetrics(lc fx.Lifecycle) error {
-	var (
-		timeStarted time.Time
-		nodeStarted bool
-	)
+	timeStarted := time.Now()
 
 	nodeStartTS, err := meter.Int64ObservableGauge(
 		"node_start_ts",
@@ -48,13 +45,10 @@ func WithMetrics(lc fx.Lifecycle) error {
 	}
 
 	callback := func(_ context.Context, observer metric.Observer) error {
-		if !nodeStarted {
-			// Observe node start timestamp
-			timeStarted = time.Now()
-			observer.ObserveInt64(nodeStartTS, timeStarted.Unix())
-			nodeStarted = true
-		}
-
+		// Re-observe the start timestamp every cycle: OTel only exports
+		// instruments observed in the current collection, so a once-only
+		// observation goes stale in Prometheus after ~5m.
+		observer.ObserveInt64(nodeStartTS, timeStarted.Unix())
 		observer.ObserveFloat64(totalNodeRunTime, time.Since(timeStarted).Seconds())
 
 		// Observe build info with labels

--- a/nodebuilder/rpc/opts.go
+++ b/nodebuilder/rpc/opts.go
@@ -1,0 +1,11 @@
+package rpc
+
+import (
+	"github.com/celestiaorg/celestia-node/api/rpc"
+)
+
+// WithMetrics enables OTel metrics on the RPC server. Intended to be invoked
+// by the fx lifecycle.
+func WithMetrics(server *rpc.Server) error {
+	return server.WithMetrics()
+}

--- a/nodebuilder/settings.go
+++ b/nodebuilder/settings.go
@@ -31,6 +31,7 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	modprune "github.com/celestiaorg/celestia-node/nodebuilder/pruner"
+	modrpc "github.com/celestiaorg/celestia-node/nodebuilder/rpc"
 	"github.com/celestiaorg/celestia-node/nodebuilder/share"
 	"github.com/celestiaorg/celestia-node/state/txclient"
 )
@@ -114,6 +115,7 @@ func WithMetrics(metricOpts []otlpmetrichttp.Option, nodeType node.Type) fx.Opti
 		fx.Invoke(node.WithMetrics),
 		fx.Invoke(share.WithDiscoveryMetrics),
 		fx.Invoke(share.WithBlockStoreMetrics),
+		fx.Invoke(modrpc.WithMetrics),
 	)
 
 	samplingMetrics := fx.Options(

--- a/pruner/metrics.go
+++ b/pruner/metrics.go
@@ -70,7 +70,7 @@ func (m *metrics) close() error {
 	return m.clientReg.Unregister()
 }
 
-func (m *metrics) observePrune(ctx context.Context, failed bool) {
+func (m *metrics) observePrune(ctx context.Context, edsSize int, failed bool) {
 	if m == nil {
 		return
 	}
@@ -78,5 +78,6 @@ func (m *metrics) observePrune(ctx context.Context, failed bool) {
 		ctx = context.Background()
 	}
 	m.prunedCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.Bool("failed", failed)))
+		attribute.Bool("failed", failed),
+		attribute.Int("eds_size", edsSize)))
 }

--- a/pruner/service.go
+++ b/pruner/service.go
@@ -199,7 +199,7 @@ func (s *Service) prune(ctx context.Context) {
 
 		for _, eh := range headers {
 			err = s.pruner.Prune(ctx, eh)
-			s.metrics.observePrune(ctx, err != nil)
+			s.metrics.observePrune(ctx, eh.DAH.SquareSize(), err != nil)
 			if err != nil {
 				log.Errorw("failed to prune block", "height", eh.Height(), "err", err)
 				failedSet[eh.Height()] = struct{}{}
@@ -240,6 +240,7 @@ func (s *Service) retryFailed(ctx context.Context) {
 			log.Errorw("failed to prune block from failed map", "height", failed, "err", err)
 			continue
 		}
+		s.metrics.observePrune(ctx, h.DAH.SquareSize(), false)
 		delete(s.checkpoint.FailedHeaders, failed)
 	}
 }
@@ -281,7 +282,7 @@ func (s *Service) pruneOnHeaderDelete(ctx context.Context, height uint64) error 
 	}
 
 	err = s.pruner.Prune(ctx, eh)
-	s.metrics.observePrune(ctx, err != nil)
+	s.metrics.observePrune(ctx, eh.DAH.SquareSize(), err != nil)
 	if err != nil {
 		return fmt.Errorf("pruning height %d: %w", height, err)
 	}

--- a/store/metrics.go
+++ b/store/metrics.go
@@ -17,18 +17,20 @@ const (
 	failedKey = "failed"
 	withQ4Key = "with_q4"
 	sizeKey   = "eds_size"
+	layoutKey = "layout"
 )
 
 var meter = otel.Meter("store")
 
 type metrics struct {
-	put         metric.Float64Histogram
-	putExists   metric.Int64Counter
-	get         metric.Float64Histogram
-	has         metric.Float64Histogram
-	removeODSQ4 metric.Float64Histogram
-	removeQ4    metric.Float64Histogram
-	unreg       func() error
+	put            metric.Float64Histogram
+	putExists      metric.Int64Counter
+	get            metric.Float64Histogram
+	has            metric.Float64Histogram
+	removeODSQ4    metric.Float64Histogram
+	removeQ4       metric.Float64Histogram
+	bytesReclaimed metric.Int64Counter
+	unreg          func() error
 }
 
 func (s *Store) WithMetrics() error {
@@ -73,13 +75,24 @@ func (s *Store) WithMetrics() error {
 		return err
 	}
 
+	bytesReclaimed, err := meter.Int64Counter("eds_store_bytes_reclaimed_total",
+		metric.WithDescription(
+			"bytes reclaimed from disk by EDS file removal, labeled by `layout` "+
+				"(odsq4 = ODS+Q4 pair, q4 = Q4 only)",
+		),
+		metric.WithUnit("By"))
+	if err != nil {
+		return err
+	}
+
 	s.metrics = &metrics{
-		put:         put,
-		putExists:   putExists,
-		get:         get,
-		has:         has,
-		removeODSQ4: removeODSQ4,
-		removeQ4:    removeQ4,
+		put:            put,
+		putExists:      putExists,
+		get:            get,
+		has:            has,
+		removeODSQ4:    removeODSQ4,
+		removeQ4:       removeQ4,
+		bytesReclaimed: bytesReclaimed,
 	}
 	return s.metrics.addCacheMetrics(s.cache)
 }
@@ -146,7 +159,7 @@ func (m *metrics) observeHas(ctx context.Context, dur time.Duration, failed bool
 		attribute.Bool(failedKey, failed)))
 }
 
-func (m *metrics) observeRemoveODSQ4(ctx context.Context, dur time.Duration, failed bool) {
+func (m *metrics) observeRemoveODSQ4(ctx context.Context, dur time.Duration, bytes int64, failed bool) {
 	if m == nil {
 		return
 	}
@@ -154,9 +167,13 @@ func (m *metrics) observeRemoveODSQ4(ctx context.Context, dur time.Duration, fai
 
 	m.removeODSQ4.Record(ctx, dur.Seconds(), metric.WithAttributes(
 		attribute.Bool(failedKey, failed)))
+	if !failed && bytes > 0 {
+		m.bytesReclaimed.Add(ctx, bytes, metric.WithAttributes(
+			attribute.String(layoutKey, "odsq4")))
+	}
 }
 
-func (m *metrics) observeRemoveQ4(ctx context.Context, dur time.Duration, failed bool) {
+func (m *metrics) observeRemoveQ4(ctx context.Context, dur time.Duration, bytes int64, failed bool) {
 	if m == nil {
 		return
 	}
@@ -164,10 +181,14 @@ func (m *metrics) observeRemoveQ4(ctx context.Context, dur time.Duration, failed
 
 	m.removeQ4.Record(ctx, dur.Seconds(), metric.WithAttributes(
 		attribute.Bool(failedKey, failed)))
+	if !failed && bytes > 0 {
+		m.bytesReclaimed.Add(ctx, bytes, metric.WithAttributes(
+			attribute.String(layoutKey, "q4")))
+	}
 }
 
 func (m *metrics) close() error {
-	if m == nil {
+	if m == nil || m.unreg == nil {
 		return nil
 	}
 	return m.unreg()

--- a/store/store.go
+++ b/store/store.go
@@ -455,9 +455,19 @@ func (s *Store) RemoveODSQ4(ctx context.Context, height uint64, datahash share.D
 	lock.lock()
 	defer lock.unlock()
 
+	// Size the files before removal so the bytes-reclaimed metric reflects
+	// what actually left the filesystem. The hardlink in heights/ shares an
+	// inode with the ODS file in blocks/, so we size only the canonical
+	// blocks/ paths to avoid double-counting.
+	var bytes int64
+	if !datahash.IsEmptyEDS() {
+		bytes = fileSize(s.hashToPath(datahash, odsFileExt)) +
+			fileSize(s.hashToPath(datahash, q4FileExt))
+	}
+
 	tNow := time.Now()
 	err := s.removeODSQ4(height, datahash)
-	s.metrics.observeRemoveODSQ4(ctx, time.Since(tNow), err != nil)
+	s.metrics.observeRemoveODSQ4(ctx, time.Since(tNow), bytes, err != nil)
 	return err
 }
 
@@ -498,9 +508,14 @@ func (s *Store) RemoveQ4(ctx context.Context, height uint64, datahash share.Data
 	lock.lock()
 	defer lock.unlock()
 
+	var bytes int64
+	if !datahash.IsEmptyEDS() {
+		bytes = fileSize(s.hashToPath(datahash, q4FileExt))
+	}
+
 	tNow := time.Now()
 	err := s.removeQ4(height, datahash)
-	s.metrics.observeRemoveQ4(ctx, time.Since(tNow), err != nil)
+	s.metrics.observeRemoveQ4(ctx, time.Since(tNow), bytes, err != nil)
 	return err
 }
 
@@ -591,4 +606,14 @@ func remove(path string) error {
 		return fmt.Errorf("removing file '%s': %w", path, err)
 	}
 	return nil
+}
+
+// fileSize returns the on-disk size of a file, or 0 if it's missing/unstatable.
+// Used purely for the bytes-reclaimed metric — best-effort, not load-bearing.
+func fileSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
 }


### PR DESCRIPTION
List of added metrics:


 | Metric | Type | Why it was added |
  |---|---|---|
  | `http_server_request_duration_seconds` | histogram | HTTP request latency **and** count (via `otelhttp`). Buckets drive p50/p95/p99;
  `_count{http_response_status_code}` drives QPS and HTTP error-rate dashboards. |
  | `http_server_request_body_size_bytes` | histogram | Request payload size (via `otelhttp`). Surfaces oversized `blob.Submit` and batch requests. |
  | `http_server_response_body_size_bytes` | histogram | Response payload size (via `otelhttp`). Highlights heavy reads such as namespace queries /
  `blob.Get`. |
  | `http_server_active_requests` | updown counter | In-flight HTTP requests (via `otelhttp`). Concurrency and saturation signal. |
  | `rpc_method_calls_total` | counter | JSON-RPC invocations labelled by `method` and `error`, sourced from go-jsonrpc's Tracer hook. Per-method QPS +
  handler error-rate (the HTTP layer can't see the JSON-RPC method without buffering the body). |
  | `rpc_connections_open` | observable gauge | Currently-open HTTP connections. Early warning before hitting `maxConcurrentConns`. |
  | `rpc_websocket_upgrades_total` | counter | Cumulative websocket upgrades (hijacked connections). net/http emits no close for hijacked connections, so
   it is a counter, not a gauge. Separates long-lived subscriptions from regular HTTP load. |
  | `core_listener_last_processed_block_ts` | observable gauge | Unix timestamp of last block broadcast by bridge listener. Drives a "bridge is alive"
  liveness alert. |
  | `core_to_da_lag_seconds` | histogram | Seconds between a block's consensus time and its DA broadcast. Measures how far DA trails consensus
  end-to-end. |
  | `header_sub_published_total` | counter | ExtendedHeaders broadcast on HeaderSub, labelled by `result` and `local_only`. Distinguishes catch-up vs
  steady-state publishes. |
  | `header_sub_publish_duration_seconds` | histogram | Duration of `pubsub.Publish()` inside the listener. Detects pubsub backpressure and slow
  subscribers. |
  | `eds_store_bytes_reclaimed_total` | counter | Bytes reclaimed from disk by EDS file removal, labelled by `layout` (which file layout was removed).
  Recorded at the store layer where the removed layout is known. Quantifies pruning effectiveness. |
