### PR TITLE
feat(core): multi-source block ingestion for the bridge listener

### DIFF
--- a/cmd/cel-shed/square.go
+++ b/cmd/cel-shed/square.go
@@ -32,10 +32,7 @@ var constructFromCoreCmd = &cobra.Command{
 			panic(err)
 		}
 
-		fetcher, err := core.NewBlockFetcher(conn)
-		if err != nil {
-			panic(err)
-		}
+		fetcher := core.NewBlockFetcher(conn)
 
 		height, err := strconv.Atoi(args[1])
 		if err != nil {

--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -196,8 +196,7 @@ func createCoreFetcher(t *testing.T, cfg *testnode.Config) (*BlockFetcher, *Netw
 	// flakiness with accessing account state)
 	_, err := network.WaitForHeightWithTimeout(2, time.Second*2) // TODO @renaynay: configure?
 	require.NoError(t, err)
-	fetcher, err := NewBlockFetcher(network.GRPCClient)
-	require.NoError(t, err)
+	fetcher := NewBlockFetcher(network.GRPCClient)
 	return fetcher, network
 }
 

--- a/core/exchange_test.go
+++ b/core/exchange_test.go
@@ -245,8 +245,11 @@ func generateNonEmptyBlocks(
 	i := 0
 	for i < 20 {
 		select {
-		case b, ok := <-sub:
+		case ev, ok := <-sub:
 			require.True(t, ok)
+
+			b, err := fetcher.GetSignedBlock(generateCtx, ev.Height)
+			require.NoError(t, err)
 
 			if bytes.Equal(share.EmptyEDSDataHash(), b.Data.Hash()) {
 				continue

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"time"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
@@ -25,6 +24,21 @@ type SignedBlock struct {
 	ValidatorSet *types.ValidatorSet `json:"validator_set"`
 }
 
+// BlockEvent is a new-block notification carrying the height plus which source
+// announced it. The block body is fetched on demand via GetSignedBlockFrom,
+// which prefers the announcing source — the peer fastest to notify this height,
+// a fresh signal that it's the most responsive peer.
+type BlockEvent struct {
+	Height int64
+	// source is the index of the MultiSource source that delivered this height
+	// first. It is internal routing: zero and ignored for a single BlockFetcher.
+	source int
+	// addr is the announcing source's endpoint address, carried so the Listener
+	// can name the offending source if its block is rejected (wrong chain or
+	// inconsistent data) — making "remove the bad source" actionable.
+	addr string
+}
+
 var (
 	log                     = logging.Logger("core")
 	newDataSignedBlockQuery = types.QueryForEvent(types.EventSignedBlock).String()
@@ -32,12 +46,14 @@ var (
 
 type BlockFetcher struct {
 	client coregrpc.BlockAPIClient
+	addr   string
 }
 
 // NewBlockFetcher returns a new `BlockFetcher`.
 func NewBlockFetcher(conn *grpc.ClientConn) *BlockFetcher {
 	return &BlockFetcher{
 		client: coregrpc.NewBlockAPIClient(conn),
+		addr:   conn.Target(),
 	}
 }
 
@@ -101,6 +117,13 @@ func (f *BlockFetcher) GetSignedBlock(ctx context.Context, height int64) (*Signe
 	return f.receiveBlockByHeight(ctx, stream)
 }
 
+// GetSignedBlockFrom fetches the block for the given event. A single
+// BlockFetcher has only one source, so the event's source hint is irrelevant
+// and it simply fetches by height.
+func (f *BlockFetcher) GetSignedBlockFrom(ctx context.Context, ev BlockEvent) (*SignedBlock, error) {
+	return f.GetSignedBlock(ctx, ev.Height)
+}
+
 // Commit queries Core for a `Commit` from the block at
 // the given height.
 // If the height is nil, use the latest height.
@@ -143,13 +166,16 @@ func (f *BlockFetcher) ValidatorSet(ctx context.Context, height int64) (*types.V
 	return validatorSet, nil
 }
 
-// SubscribeNewBlockEvent subscribes to new block events from Core, returning
-// a new block event channel.
-func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan SignedBlock, error) {
-	signedBlockCh := make(chan SignedBlock, 1)
+// SubscribeNewBlockEvent subscribes to new block heights from Core, returning a
+// channel of BlockEvents. The full block is intentionally NOT fetched here: the
+// consumer (Listener) pulls the block on demand via GetSignedBlockFrom, so a
+// MultiSource fanning N endpoints downloads each block once rather than once
+// per source.
+func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan BlockEvent, error) {
+	eventCh := make(chan BlockEvent, 1)
 
 	go func() {
-		defer close(signedBlockCh)
+		defer close(eventCh)
 		for {
 			select {
 			case <-ctx.Done():
@@ -164,7 +190,7 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan SignedB
 			}
 
 			log.Debug("fetcher: subscription created")
-			err = f.receive(ctx, signedBlockCh, subscription)
+			err = f.receive(ctx, eventCh, subscription)
 			if err != nil {
 				log.Warnw("fetcher: error receiving new height", "err", err.Error())
 				_ = subscription.CloseSend() // inform client that the subscription won't be used anymore
@@ -172,37 +198,23 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan SignedB
 			}
 		}
 	}()
-	return signedBlockCh, nil
+	return eventCh, nil
 }
 
 func (f *BlockFetcher) receive(
 	ctx context.Context,
-	signedBlockCh chan SignedBlock,
+	eventCh chan BlockEvent,
 	subscription coregrpc.BlockAPI_SubscribeNewHeightsClient,
 ) error {
-	log.Debug("fetcher: started listening for new blocks")
+	log.Debug("fetcher: started listening for new block heights")
 	for {
 		resp, err := subscription.Recv()
 		if err != nil {
 			return err
 		}
 
-		// TODO(@vgonkivs): make timeout configurable
-		withTimeout, ctxCancel := context.WithTimeout(ctx, 10*time.Second)
-		signedBlock, err := f.GetSignedBlock(withTimeout, resp.Height)
-		ctxCancel()
-		if err != nil {
-			log.Warnw("fetcher: error receiving signed block", "height", resp.Height, "err", err.Error())
-			continue
-		}
-
 		select {
-		case signedBlockCh <- SignedBlock{
-			Header:       signedBlock.Header,
-			Commit:       signedBlock.Commit,
-			ValidatorSet: signedBlock.ValidatorSet,
-			Data:         signedBlock.Data,
-		}:
+		case eventCh <- BlockEvent{Height: resp.Height, addr: f.addr}:
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -218,6 +230,13 @@ func (f *BlockFetcher) IsSyncing(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return resp.SyncInfo.CatchingUp, nil
+}
+
+// IsSyncingFrom reports the sync status for the source that announced the
+// event. A single BlockFetcher has only one source, so the event's source hint
+// is irrelevant and it simply reports its own status.
+func (f *BlockFetcher) IsSyncingFrom(ctx context.Context, _ BlockEvent) (bool, error) {
+	return f.IsSyncing(ctx)
 }
 
 // Verify checks the core endpoint is on the expected network. The expected

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -26,16 +26,16 @@ type SignedBlock struct {
 
 // BlockEvent is a new-block notification carrying the height plus which source
 // announced it. The block body is fetched on demand via GetSignedBlockFrom,
-// which prefers the announcing source — the peer fastest to notify this height,
-// a fresh signal that it's the most responsive peer.
+// which routes to the announcing source — the peer fastest to notify this
+// height, a fresh signal that it's the most responsive peer.
 type BlockEvent struct {
 	Height int64
-	// source is the index of the MultiSource source that delivered this height
-	// first. It is internal routing: zero and ignored for a single BlockFetcher.
-	source int
-	// addr is the announcing source's endpoint address, carried so the Listener
-	// can name the offending source if its block is rejected (wrong chain or
-	// inconsistent data) — making "remove the bad source" actionable.
+	// addr is the announcing source's endpoint address (conn.Target) and doubles
+	// as its id: MultiSource resolves GetSignedBlockFrom/IsSyncingFrom back to the
+	// announcing source by addr, and the Listener uses it to name the offending
+	// source if its block is rejected (wrong chain or inconsistent data) — making
+	// "remove the bad source" actionable. A single BlockFetcher sets it too but
+	// ignores it on fetch, having only one source.
 	addr string
 }
 

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -35,10 +35,10 @@ type BlockFetcher struct {
 }
 
 // NewBlockFetcher returns a new `BlockFetcher`.
-func NewBlockFetcher(conn *grpc.ClientConn) (*BlockFetcher, error) {
+func NewBlockFetcher(conn *grpc.ClientConn) *BlockFetcher {
 	return &BlockFetcher{
 		client: coregrpc.NewBlockAPIClient(conn),
-	}, nil
+	}
 }
 
 // GetBlockInfo queries Core for additional block information, like Commit and ValidatorSet.
@@ -167,6 +167,7 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan SignedB
 			err = f.receive(ctx, signedBlockCh, subscription)
 			if err != nil {
 				log.Warnw("fetcher: error receiving new height", "err", err.Error())
+				_ = subscription.CloseSend() // inform client that the subscription won't be used anymore
 				continue
 			}
 		}
@@ -217,6 +218,22 @@ func (f *BlockFetcher) IsSyncing(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return resp.SyncInfo.CatchingUp, nil
+}
+
+// Verify checks the core endpoint is on the expected network. The expected
+// chain ID must be set: a node must know which network it serves.
+func (f *BlockFetcher) Verify(ctx context.Context, expected string) error {
+	if expected == "" {
+		return fmt.Errorf("core/fetcher: expected chain ID must be configured")
+	}
+	id, err := f.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("core/fetcher: fetching chain ID: %w", err)
+	}
+	if id != expected {
+		return fmt.Errorf("core/fetcher: network mismatch: expected %q, got %q", expected, id)
+	}
+	return nil
 }
 
 // ChainID returns the chain ID (network name) that the Core node is connected to.

--- a/core/fetcher_no_race_test.go
+++ b/core/fetcher_no_race_test.go
@@ -29,8 +29,8 @@ func TestBlockFetcherHeaderValues(t *testing.T) {
 	// read once from channel to generate next block
 	var h int64
 	select {
-	case evt := <-newBlockChan:
-		h = evt.Header.Height
+	case ev := <-newBlockChan:
+		h = ev.Height
 	case <-ctx.Done():
 		require.NoError(t, ctx.Err())
 	}
@@ -41,9 +41,11 @@ func TestBlockFetcherHeaderValues(t *testing.T) {
 	valSet, err := fetcher.ValidatorSet(ctx, h)
 	require.NoError(t, err)
 	// get next block
-	var nextBlock SignedBlock
+	var nextBlock *SignedBlock
 	select {
-	case nextBlock = <-newBlockChan:
+	case nextEv := <-newBlockChan:
+		nextBlock, err = fetcher.GetSignedBlock(ctx, nextEv.Height)
+		require.NoError(t, err)
 	case <-ctx.Done():
 		require.NoError(t, ctx.Err())
 	}

--- a/core/fetcher_no_race_test.go
+++ b/core/fetcher_no_race_test.go
@@ -23,8 +23,7 @@ func TestBlockFetcherHeaderValues(t *testing.T) {
 		require.NoError(t, network.Stop())
 	})
 
-	fetcher, err := NewBlockFetcher(network.GRPCClient)
-	require.NoError(t, err)
+	fetcher := NewBlockFetcher(network.GRPCClient)
 	newBlockChan, err := fetcher.SubscribeNewBlockEvent(ctx)
 	require.NoError(t, err)
 	// read once from channel to generate next block

--- a/core/fetcher_test.go
+++ b/core/fetcher_test.go
@@ -20,8 +20,7 @@ func TestBlockFetcher_GetBlock_and_SubscribeNewBlockEvent(t *testing.T) {
 		require.NoError(t, network.Stop())
 	})
 
-	fetcher, err := NewBlockFetcher(network.GRPCClient)
-	require.NoError(t, err)
+	fetcher := NewBlockFetcher(network.GRPCClient)
 	// generate some blocks
 	newBlockChan, err := fetcher.SubscribeNewBlockEvent(ctx)
 	require.NoError(t, err)
@@ -54,8 +53,7 @@ func TestFetcher_Resubscription(t *testing.T) {
 	host, port, err := net.SplitHostPort(tn.GRPCClient.Target())
 	require.NoError(t, err)
 	client := newTestClient(t, host, port)
-	fetcher, err := NewBlockFetcher(client)
-	require.NoError(t, err)
+	fetcher := NewBlockFetcher(client)
 
 	// subscribe to the channel to get new blocks
 	// and try to get one block

--- a/core/fetcher_test.go
+++ b/core/fetcher_test.go
@@ -27,15 +27,11 @@ func TestBlockFetcher_GetBlock_and_SubscribeNewBlockEvent(t *testing.T) {
 
 	for i := 1; i < 3; i++ {
 		select {
-		case newBlockFromChan := <-newBlockChan:
-			h := newBlockFromChan.Header.Height
-			block, err := fetcher.GetSignedBlock(ctx, h)
+		case ev := <-newBlockChan:
+			block, err := fetcher.GetSignedBlock(ctx, ev.Height)
 			require.NoError(t, err)
-			assert.Equal(t, newBlockFromChan.Data, block.Data)
-			assert.Equal(t, newBlockFromChan.Header, block.Header)
-			assert.Equal(t, newBlockFromChan.Commit, block.Commit)
-			assert.Equal(t, newBlockFromChan.ValidatorSet, block.ValidatorSet)
-			require.GreaterOrEqual(t, newBlockFromChan.Header.Height, int64(i))
+			assert.Equal(t, ev.Height, block.Header.Height)
+			require.GreaterOrEqual(t, ev.Height, int64(i))
 		case <-ctx.Done():
 			require.NoError(t, ctx.Err())
 		}
@@ -60,9 +56,8 @@ func TestFetcher_Resubscription(t *testing.T) {
 	newBlockChan, err := fetcher.SubscribeNewBlockEvent(ctx)
 	require.NoError(t, err)
 	select {
-	case newBlockFromChan := <-newBlockChan:
-		h := newBlockFromChan.Header.Height
-		_, err = fetcher.GetSignedBlock(ctx, h)
+	case ev := <-newBlockChan:
+		_, err = fetcher.GetSignedBlock(ctx, ev.Height)
 		require.NoError(t, err)
 	case <-ctx.Done():
 		t.Fatal("timeout waiting for block subscription")
@@ -88,9 +83,8 @@ func TestFetcher_Resubscription(t *testing.T) {
 		require.NoError(t, tn.Stop())
 	})
 	select {
-	case newBlockFromChan := <-newBlockChan:
-		h := newBlockFromChan.Header.Height
-		_, err = fetcher.GetSignedBlock(ctx, h)
+	case ev := <-newBlockChan:
+		_, err = fetcher.GetSignedBlock(ctx, ev.Height)
 		require.NoError(t, err)
 	case <-ctx.Done():
 		t.Fatal("timeout waiting for block subscription")

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -30,9 +30,9 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 	fetcher := NewBlockFetcher(network.GRPCClient)
 	sub, err := fetcher.SubscribeNewBlockEvent(ctx)
 	require.NoError(t, err)
-	dataBlock := <-sub
+	ev := <-sub
+	height := ev.Height
 
-	height := dataBlock.Header.Height
 	b, err := fetcher.GetBlock(ctx, height)
 	require.NoError(t, err)
 

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -27,8 +27,7 @@ func TestMakeExtendedHeaderForEmptyBlock(t *testing.T) {
 		require.NoError(t, network.Stop())
 	})
 
-	fetcher, err := NewBlockFetcher(network.GRPCClient)
-	require.NoError(t, err)
+	fetcher := NewBlockFetcher(network.GRPCClient)
 	sub, err := fetcher.SubscribeNewBlockEvent(ctx)
 	require.NoError(t, err)
 	dataBlock := <-sub

--- a/core/listener.go
+++ b/core/listener.go
@@ -232,10 +232,12 @@ func (cl *Listener) handleNewBlockEvent(ctx context.Context, ev BlockEvent) erro
 	has, err := cl.store.HasByHeight(ctx, uint64(ev.Height))
 	if err != nil {
 		log.Errorw("listener: error checking block height in store", "height", ev.Height, "err", err)
+		cl.metrics.blockEvent(ctx, ev.addr, "store_error")
 		return nil
 	}
 	if has {
 		log.Debugw("listener: skipping already-processed height", "height", ev.Height)
+		cl.metrics.blockEvent(ctx, ev.addr, "duplicate")
 		return nil
 	}
 
@@ -246,6 +248,7 @@ func (cl *Listener) handleNewBlockEvent(ctx context.Context, ev BlockEvent) erro
 	b, err := cl.fetcher.GetSignedBlockFrom(fetchCtx, ev)
 	cancel()
 	if err != nil {
+		cl.metrics.blockEvent(ctx, ev.addr, "fetch_error")
 		return fmt.Errorf("fetching signed block at height %d: %w", ev.Height, err)
 	}
 
@@ -258,6 +261,7 @@ func (cl *Listener) handleNewBlockEvent(ctx context.Context, ev BlockEvent) erro
 	if !cl.archival && !availability.IsWithinWindow(b.Header.Time, cl.availabilityWindow) {
 		log.Debugw("listener: skipping historic block outside availability window",
 			"height", ev.Height, "source", ev.addr)
+		cl.metrics.blockEvent(ctx, ev.addr, "historic")
 		return nil
 	}
 
@@ -270,10 +274,16 @@ func (cl *Listener) handleNewBlockEvent(ctx context.Context, ev BlockEvent) erro
 	syncing, err := cl.fetcher.IsSyncingFrom(syncCtx, ev)
 	cancel()
 	if err != nil {
+		cl.metrics.blockEvent(ctx, ev.addr, "sync_error")
 		return fmt.Errorf("getting sync state for height %d: %w", ev.Height, err)
 	}
 
-	return cl.handleNewSignedBlock(ctx, ev, b, syncing)
+	if err := cl.handleNewSignedBlock(ctx, ev, b, syncing); err != nil {
+		cl.metrics.blockEvent(ctx, ev.addr, "process_error")
+		return err
+	}
+	cl.metrics.blockEvent(ctx, ev.addr, "processed")
+	return nil
 }
 
 func (cl *Listener) handleNewSignedBlock(ctx context.Context, ev BlockEvent, b *SignedBlock, syncing bool) error {

--- a/core/listener.go
+++ b/core/listener.go
@@ -229,7 +229,12 @@ func (cl *Listener) listen(ctx context.Context, sub <-chan BlockEvent) {
 // skip the expensive processing below; redundant header broadcasts are deduped
 // by gossipsub message IDs.
 func (cl *Listener) handleNewBlockEvent(ctx context.Context, ev BlockEvent) error {
-	if has, err := cl.store.HasByHeight(ctx, uint64(ev.Height)); err == nil && has {
+	has, err := cl.store.HasByHeight(ctx, uint64(ev.Height))
+	if err != nil {
+		log.Errorw("listener: error checking block height in store", "height", ev.Height, "err", err)
+		return nil
+	}
+	if has {
 		log.Debugw("listener: skipping already-processed height", "height", ev.Height)
 		return nil
 	}

--- a/core/listener.go
+++ b/core/listener.go
@@ -19,6 +19,28 @@ import (
 	"github.com/celestiaorg/celestia-node/store"
 )
 
+// Fetcher abstracts the core block source consumed by the Listener. It is
+// satisfied both by a single *BlockFetcher and by a *MultiSource, which fans
+// several core endpoints into one new-block stream for resilience.
+type Fetcher interface {
+	// Verify checks the source is on the expected network before any blocks are
+	// consumed. The expected chain ID must be set — a node must know its network,
+	// so an empty one is an error. A MultiSource may prune sources on the wrong
+	// network here; it errors if none remain usable.
+	Verify(ctx context.Context, expected string) error
+	// SubscribeNewBlockEvent returns a channel of newly produced blocks.
+	SubscribeNewBlockEvent(ctx context.Context) (chan SignedBlock, error)
+	// ChainID returns the network/chain ID of the source.
+	ChainID(ctx context.Context) (string, error)
+	// IsSyncing reports whether the source is still catching up to the head.
+	IsSyncing(ctx context.Context) (bool, error)
+}
+
+var (
+	_ Fetcher = (*BlockFetcher)(nil)
+	_ Fetcher = (*MultiSource)(nil)
+)
+
 // Listener is responsible for listening to Core for
 // new block events and converting new Core blocks into
 // the main data structure used in the Celestia DA network:
@@ -27,7 +49,7 @@ import (
 // broadcasts the new `ExtendedHeader` to the header-sub gossipsub
 // network.
 type Listener struct {
-	fetcher *BlockFetcher
+	fetcher Fetcher
 
 	construct          header.ConstructFn
 	store              *store.Store
@@ -48,7 +70,7 @@ type Listener struct {
 
 func NewListener(
 	bcast libhead.Broadcaster[*header.ExtendedHeader],
-	fetcher *BlockFetcher,
+	fetcher Fetcher,
 	hashBroadcaster shrexsub.BroadcastFn,
 	construct header.ConstructFn,
 	store *store.Store,
@@ -91,7 +113,7 @@ func (cl *Listener) Start(ctx context.Context) error {
 		return fmt.Errorf("listener: already started")
 	}
 
-	if err := cl.verifyChainID(ctx); err != nil {
+	if err := cl.fetcher.Verify(ctx, cl.chainID); err != nil {
 		return err
 	}
 
@@ -105,28 +127,6 @@ func (cl *Listener) Start(ctx context.Context) error {
 	}
 
 	go cl.listen(ctx, subs)
-	return nil
-}
-
-// verifyChainID checks that the core endpoint is on the expected network
-// before starting the listener. This prevents connecting to a wrong network.
-func (cl *Listener) verifyChainID(ctx context.Context) error {
-	if cl.chainID == "" {
-		return nil
-	}
-
-	networkID, err := cl.fetcher.ChainID(ctx)
-	if err != nil {
-		return fmt.Errorf("listener: fetching chain ID from core endpoint: %w", err)
-	}
-
-	if networkID != cl.chainID {
-		return fmt.Errorf(
-			"listener: core endpoint network mismatch: expected %q, got %q",
-			cl.chainID, networkID,
-		)
-	}
-
 	return nil
 }
 
@@ -164,14 +164,6 @@ func (cl *Listener) listen(ctx context.Context, sub <-chan SignedBlock) {
 				return
 			}
 
-			if cl.chainID != "" && b.Header.ChainID != cl.chainID {
-				// stop node if there is a critical issue with the block subscription
-				panic(fmt.Sprintf("listener: received block with unexpected chain ID: expected %s,"+
-					" received %s. blockHeight: %d blockHash: %x.",
-					cl.chainID, b.Header.ChainID, b.Header.Height, b.Header.Hash()),
-				)
-			}
-
 			log.Debugw("listener: new block from core", "height", b.Header.Height)
 
 			err := cl.handleNewSignedBlock(ctx, b)
@@ -201,6 +193,32 @@ func (cl *Listener) handleNewSignedBlock(ctx context.Context, b SignedBlock) err
 	span.SetAttributes(
 		attribute.Int64("height", b.Header.Height),
 	)
+
+	// Multiple core sources (see MultiSource) fan the same height in N times.
+	// Skip a height already in the store. Keying on the store (not an in-memory
+	// watermark) means out-of-order blocks from a lagging source are still
+	// processed, and any failure below returns without storing so another
+	// source's copy retries the height. Historic blocks outside the
+	// availability window are intentionally not stored, so their duplicates are
+	// reprocessed per source; redundant header broadcasts are deduped by
+	// gossipsub message IDs.
+	if has, hasErr := cl.store.HasByHeight(ctx, uint64(b.Header.Height)); hasErr == nil && has {
+		log.Debugw("listener: skipping already-processed height", "height", b.Header.Height)
+		return nil
+	}
+
+	// chainID is checked only after the dedup gate, so a wrong-chain block
+	// reaches it only when this source won the race for a height no other
+	// source has stored yet. A duplicate from a slow misconfigured endpoint is
+	// deduped away above and never panics; we crash only if the *fastest* source
+	// for some height is on the wrong network — a critical misconfiguration we
+	// must not silently ingest.
+	if cl.chainID != "" && b.Header.ChainID != cl.chainID {
+		panic(fmt.Sprintf("listener: received block with unexpected chain ID: expected %s,"+
+			" received %s. blockHeight: %d blockHash: %x.",
+			cl.chainID, b.Header.ChainID, b.Header.Height, b.Header.Hash()),
+		)
+	}
 
 	eds, err := da.ConstructEDS(b.Data.Txs.ToSliceOfBytes(), b.Header.Version.App, -1)
 	if err != nil {

--- a/core/listener.go
+++ b/core/listener.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/libs/utils"
+	"github.com/celestiaorg/celestia-node/share/availability"
 	"github.com/celestiaorg/celestia-node/share/shwap/p2p/shrex/shrexsub"
 	"github.com/celestiaorg/celestia-node/store"
 )
@@ -28,17 +29,49 @@ type Fetcher interface {
 	// so an empty one is an error. A MultiSource may prune sources on the wrong
 	// network here; it errors if none remain usable.
 	Verify(ctx context.Context, expected string) error
-	// SubscribeNewBlockEvent returns a channel of newly produced blocks.
-	SubscribeNewBlockEvent(ctx context.Context) (chan SignedBlock, error)
+	// SubscribeNewBlockEvent returns a channel of new-block events. Each event
+	// carries the height and which source announced it; the block is fetched on
+	// demand via GetSignedBlockFrom, so a MultiSource downloads each block once
+	// instead of once per source.
+	SubscribeNewBlockEvent(ctx context.Context) (chan BlockEvent, error)
+	// GetSignedBlockFrom fetches the full signed block for the event from the
+	// source that announced it — the peer fastest to notify this height. It does
+	// NOT fall back to other sources on failure: an error is just an error.
+	// Resilience is a property of the fan-in — another source announces the same
+	// height, and the Listener retries the fetch from it (the failed attempt
+	// stored nothing, so the duplicate is a store-miss, not a skip).
+	GetSignedBlockFrom(ctx context.Context, ev BlockEvent) (*SignedBlock, error)
 	// ChainID returns the network/chain ID of the source.
 	ChainID(ctx context.Context) (string, error)
-	// IsSyncing reports whether the source is still catching up to the head.
+	// IsSyncingFrom reports whether the source that announced the event is still
+	// catching up to the head. Sync state is per-source: the answer must come
+	// from the same peer that served the block, since another source being
+	// caught up says nothing about whether THIS block is a fresh head or a
+	// replay of an old height from a peer mid-blocksync. Like
+	// GetSignedBlockFrom, it does not fall back to other sources on failure.
+	IsSyncingFrom(ctx context.Context, ev BlockEvent) (bool, error)
+}
+
+// blockSource is a single core endpoint: the leaf a MultiSource fans over. It
+// is deliberately narrower than Fetcher — no GetSignedBlockFrom, since
+// resolving an announced event to a source is the MultiSource's responsibility,
+// not a single endpoint's.
+type blockSource interface {
+	SubscribeNewBlockEvent(ctx context.Context) (chan BlockEvent, error)
+	GetSignedBlock(ctx context.Context, height int64) (*SignedBlock, error)
+	ChainID(ctx context.Context) (string, error)
 	IsSyncing(ctx context.Context) (bool, error)
 }
 
+// blockFetchTimeout bounds a single block fetch made while handling a height
+// announced by a source.
+// TODO(@vgonkivs): make timeout configurable
+const blockFetchTimeout = 10 * time.Second
+
 var (
-	_ Fetcher = (*BlockFetcher)(nil)
-	_ Fetcher = (*MultiSource)(nil)
+	_ Fetcher     = (*BlockFetcher)(nil)
+	_ Fetcher     = (*MultiSource)(nil)
+	_ blockSource = (*BlockFetcher)(nil)
 )
 
 // Listener is responsible for listening to Core for
@@ -151,26 +184,25 @@ func (cl *Listener) Stop(ctx context.Context) error {
 // listen kicks off a loop, listening for new block events from Core,
 // generating ExtendedHeaders and broadcasting them to the header-sub
 // gossipsub network.
-func (cl *Listener) listen(ctx context.Context, sub <-chan SignedBlock) {
+func (cl *Listener) listen(ctx context.Context, sub <-chan BlockEvent) {
 	defer close(cl.closed)
 	defer log.Info("listener: listening stopped")
 	timeout := time.NewTimer(cl.listenerTimeout)
 	defer timeout.Stop()
 	for {
 		select {
-		case b, ok := <-sub:
+		case ev, ok := <-sub:
 			if !ok {
 				log.Error("underlying subscription was closed")
 				return
 			}
 
-			log.Debugw("listener: new block from core", "height", b.Header.Height)
+			log.Debugw("listener: new block height from core", "height", ev.Height)
 
-			err := cl.handleNewSignedBlock(ctx, b)
+			err := cl.handleNewBlockEvent(ctx, ev)
 			if err != nil {
-				log.Errorw("listener: handling new block msg",
-					"height", b.Header.Height,
-					"hash", b.Header.Hash().String(),
+				log.Errorw("listener: handling new block event",
+					"height", ev.Height,
 					"err", err)
 			}
 		case <-timeout.C:
@@ -183,7 +215,63 @@ func (cl *Listener) listen(ctx context.Context, sub <-chan SignedBlock) {
 	}
 }
 
-func (cl *Listener) handleNewSignedBlock(ctx context.Context, b SignedBlock) error {
+// handleNewBlockEvent processes a height announced by a core source. Multiple
+// sources (see MultiSource) announce the same height N times; the store dedup
+// gate here ensures the block is downloaded and processed exactly once. Because
+// events are handled sequentially in listen(), a duplicate height is read only
+// after the first copy has been stored, so it is skipped before any redundant
+// download. Keying on the store (not an in-memory watermark) means out-of-order
+// heights from a lagging source are still processed, and any failure below
+// returns without storing so another source's announcement retries the height.
+// Historic blocks outside the availability window are dropped right after the
+// fetch — never stored — so their duplicates are re-downloaded per source (the
+// event carries only the height; the block time is unknown until fetched), but
+// skip the expensive processing below; redundant header broadcasts are deduped
+// by gossipsub message IDs.
+func (cl *Listener) handleNewBlockEvent(ctx context.Context, ev BlockEvent) error {
+	if has, err := cl.store.HasByHeight(ctx, uint64(ev.Height)); err == nil && has {
+		log.Debugw("listener: skipping already-processed height", "height", ev.Height)
+		return nil
+	}
+
+	// Fetch the full block on demand from the source that announced it first —
+	// the fastest peer to notify this height — so a MultiSource downloads it
+	// once rather than once per source.
+	fetchCtx, cancel := context.WithTimeout(ctx, blockFetchTimeout)
+	b, err := cl.fetcher.GetSignedBlockFrom(fetchCtx, ev)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("fetching signed block at height %d: %w", ev.Height, err)
+	}
+
+	// A source replaying history during catch-up (blocksync) announces heights
+	// the pruned bridge will never keep. Drop them as soon as the block time is
+	// known — before the sync-status query and, crucially, before the
+	// erasure-coding pass in handleNewSignedBlock — or a from-scratch source
+	// would cost a full EDS construction per replayed height just for storeEDS
+	// to throw the result away. Mirrors the storeEDS predicate exactly.
+	if !cl.archival && !availability.IsWithinWindow(b.Header.Time, cl.availabilityWindow) {
+		log.Debugw("listener: skipping historic block outside availability window",
+			"height", ev.Height, "source", ev.addr)
+		return nil
+	}
+
+	// Ask the announcing source — and only it — whether it is still catching
+	// up: that decides if this block is a fresh head (broadcast to the network)
+	// or a catch-up replay (publish locally). Queried before the block is
+	// stored, so a failure here leaves the height unstored and the duplicate
+	// announcement from another source retries it whole.
+	syncCtx, cancel := context.WithTimeout(ctx, blockFetchTimeout)
+	syncing, err := cl.fetcher.IsSyncingFrom(syncCtx, ev)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("getting sync state for height %d: %w", ev.Height, err)
+	}
+
+	return cl.handleNewSignedBlock(ctx, ev, b, syncing)
+}
+
+func (cl *Listener) handleNewSignedBlock(ctx context.Context, ev BlockEvent, b *SignedBlock, syncing bool) error {
 	var err error
 
 	ctx, span := tracer.Start(ctx, "listener/handleNewSignedBlock")
@@ -194,29 +282,17 @@ func (cl *Listener) handleNewSignedBlock(ctx context.Context, b SignedBlock) err
 		attribute.Int64("height", b.Header.Height),
 	)
 
-	// Multiple core sources (see MultiSource) fan the same height in N times.
-	// Skip a height already in the store. Keying on the store (not an in-memory
-	// watermark) means out-of-order blocks from a lagging source are still
-	// processed, and any failure below returns without storing so another
-	// source's copy retries the height. Historic blocks outside the
-	// availability window are intentionally not stored, so their duplicates are
-	// reprocessed per source; redundant header broadcasts are deduped by
-	// gossipsub message IDs.
-	if has, hasErr := cl.store.HasByHeight(ctx, uint64(b.Header.Height)); hasErr == nil && has {
-		log.Debugw("listener: skipping already-processed height", "height", b.Header.Height)
-		return nil
-	}
-
-	// chainID is checked only after the dedup gate, so a wrong-chain block
-	// reaches it only when this source won the race for a height no other
-	// source has stored yet. A duplicate from a slow misconfigured endpoint is
-	// deduped away above and never panics; we crash only if the *fastest* source
-	// for some height is on the wrong network — a critical misconfiguration we
-	// must not silently ingest.
+	// chainID is checked only after the dedup gate (in handleNewBlockEvent), so a
+	// wrong-chain block reaches it only when this source won the race for a height
+	// no other source has stored yet. A duplicate from a slow misconfigured
+	// endpoint is deduped away before fetching and never panics; we crash only if
+	// the *fastest* source for some height is on the wrong network — a critical
+	// misconfiguration we must not silently ingest. The source address is named so
+	// the operator knows which configured endpoint to remove.
 	if cl.chainID != "" && b.Header.ChainID != cl.chainID {
-		panic(fmt.Sprintf("listener: received block with unexpected chain ID: expected %s,"+
+		panic(fmt.Sprintf("listener: source %q served a block on the wrong chain: expected %s,"+
 			" received %s. blockHeight: %d blockHash: %x.",
-			cl.chainID, b.Header.ChainID, b.Header.Height, b.Header.Hash()),
+			ev.addr, cl.chainID, b.Header.ChainID, b.Header.Height, b.Header.Hash()),
 		)
 	}
 
@@ -228,7 +304,8 @@ func (cl *Listener) handleNewSignedBlock(ctx context.Context, b SignedBlock) err
 	// generate extended header
 	eh, err := cl.construct(b.Header, b.Commit, b.ValidatorSet, eds)
 	if err != nil {
-		panic(fmt.Errorf("making extended header: %w", err))
+		panic(fmt.Errorf("listener: source %q served a block with inconsistent data at height %d: "+
+			"making extended header: %w", ev.addr, b.Header.Height, err))
 	}
 	span.AddEvent("listener: constructed extended header",
 		trace.WithAttributes(attribute.Int("square_size", eh.DAH.SquareSize())),
@@ -240,13 +317,8 @@ func (cl *Listener) handleNewSignedBlock(ctx context.Context, b SignedBlock) err
 	}
 	span.AddEvent("listener: stored square")
 
-	syncing, err := cl.fetcher.IsSyncing(ctx)
-	if err != nil {
-		return fmt.Errorf("getting sync state: %w", err)
-	}
-	span.AddEvent("listener: fetched sync state")
-
-	// notify network of new EDS hash only if core is already synced
+	// notify network of new EDS hash only if the announcing source is already
+	// synced (sync state was fetched from it in handleNewBlockEvent)
 	if !syncing {
 		err = cl.hashBroadcaster(ctx, shrexsub.Notification{
 			DataHash: eh.DataHash.Bytes(),

--- a/core/listener_dedup_test.go
+++ b/core/listener_dedup_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	"github.com/celestiaorg/celestia-node/store"
+)
+
+// TestListener_DedupSkipsStoredHeight verifies the multi-source dedup gate in
+// handleNewSignedBlock: a block whose height is already in the store (i.e.
+// already processed) is skipped before any work, so duplicate copies fanned in
+// by MultiSource are dropped cheaply.
+//
+// The skip path is self-validating: blockAt has a nil Data, so if the gate did
+// NOT short-circuit, the subsequent da.ConstructEDS(b.Data.Txs...) would panic
+// and construct would run. A clean nil return with construct untouched can only
+// happen if the gate fired.
+func TestListener_DedupSkipsStoredHeight(t *testing.T) {
+	ctx := t.Context()
+
+	st, err := store.NewStore(store.DefaultParameters(), t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, st.Stop(ctx)) })
+
+	const height = uint64(42)
+	eds := edstest.RandEDS(t, 4)
+	roots, err := share.NewAxisRoots(eds)
+	require.NoError(t, err)
+	require.NoError(t, st.PutODSQ4(ctx, roots, height, eds))
+
+	var constructed atomic.Bool
+	cl := &Listener{
+		store: st,
+		construct: func(
+			*types.Header,
+			*types.Commit,
+			*types.ValidatorSet,
+			*rsmt2d.ExtendedDataSquare,
+		) (*header.ExtendedHeader, error) {
+			constructed.Store(true)
+			return nil, errors.New("construct must not run for an already-stored height")
+		},
+	}
+
+	err = cl.handleNewSignedBlock(ctx, blockAt(int64(height)))
+	require.NoError(t, err)
+	assert.False(t, constructed.Load(), "dedup gate should short-circuit before construct")
+}
+
+// blockAtWithChainID is blockAt with an explicit chain ID, for exercising the
+// chainID guard.
+func blockAtWithChainID(h int64, chainID string) SignedBlock {
+	b := blockAt(h)
+	b.Header.ChainID = chainID
+	return b
+}
+
+// TestListener_ChainIDCheckedAfterDedup verifies the chainID guard sits behind
+// the dedup gate: a wrong-chain duplicate of an already-stored height is deduped
+// away without panicking (a slow misconfigured endpoint is tolerated), while a
+// wrong-chain block for a fresh height — i.e. one whose fastest source is on the
+// wrong network — still panics.
+func TestListener_ChainIDCheckedAfterDedup(t *testing.T) {
+	ctx := t.Context()
+
+	st, err := store.NewStore(store.DefaultParameters(), t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, st.Stop(ctx)) })
+
+	const stored = uint64(42)
+	eds := edstest.RandEDS(t, 4)
+	roots, err := share.NewAxisRoots(eds)
+	require.NoError(t, err)
+	require.NoError(t, st.PutODSQ4(ctx, roots, stored, eds))
+
+	cl := &Listener{store: st, chainID: "expected-chain"}
+
+	t.Run("wrong chain on a stored height is deduped, no panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			err := cl.handleNewSignedBlock(ctx, blockAtWithChainID(int64(stored), "wrong-chain"))
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("wrong chain on a fresh height panics", func(t *testing.T) {
+		assert.Panics(t, func() {
+			_ = cl.handleNewSignedBlock(ctx, blockAtWithChainID(int64(stored)+1, "wrong-chain"))
+		})
+	})
+}

--- a/core/listener_dedup_test.go
+++ b/core/listener_dedup_test.go
@@ -1,31 +1,24 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
-	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/rsmt2d"
-
-	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds/edstest"
 	"github.com/celestiaorg/celestia-node/store"
 )
 
 // TestListener_DedupSkipsStoredHeight verifies the multi-source dedup gate in
-// handleNewSignedBlock: a block whose height is already in the store (i.e.
-// already processed) is skipped before any work, so duplicate copies fanned in
-// by MultiSource are dropped cheaply.
-//
-// The skip path is self-validating: blockAt has a nil Data, so if the gate did
-// NOT short-circuit, the subsequent da.ConstructEDS(b.Data.Txs...) would panic
-// and construct would run. A clean nil return with construct untouched can only
-// happen if the gate fired.
+// handleNewBlockHeight: a height already in the store (i.e. already processed)
+// is skipped before the block is even fetched, so duplicate heights fanned in
+// by MultiSource are dropped without re-downloading the block.
 func TestListener_DedupSkipsStoredHeight(t *testing.T) {
 	ctx := t.Context()
 
@@ -39,38 +32,35 @@ func TestListener_DedupSkipsStoredHeight(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, st.PutODSQ4(ctx, roots, height, eds))
 
-	var constructed atomic.Bool
+	var fetched atomic.Bool
 	cl := &Listener{
 		store: st,
-		construct: func(
-			*types.Header,
-			*types.Commit,
-			*types.ValidatorSet,
-			*rsmt2d.ExtendedDataSquare,
-		) (*header.ExtendedHeader, error) {
-			constructed.Store(true)
-			return nil, errors.New("construct must not run for an already-stored height")
-		},
+		fetcher: &fakeSource{getFn: func(context.Context, int64) (*SignedBlock, error) {
+			fetched.Store(true)
+			return nil, errors.New("must not fetch an already-stored height")
+		}},
 	}
 
-	err = cl.handleNewSignedBlock(ctx, blockAt(int64(height)))
+	err = cl.handleNewBlockEvent(ctx, BlockEvent{Height: int64(height)})
 	require.NoError(t, err)
-	assert.False(t, constructed.Load(), "dedup gate should short-circuit before construct")
+	assert.False(t, fetched.Load(), "dedup gate should short-circuit before fetching the block")
 }
 
-// blockAtWithChainID is blockAt with an explicit chain ID, for exercising the
-// chainID guard.
-func blockAtWithChainID(h int64, chainID string) SignedBlock {
-	b := blockAt(h)
-	b.Header.ChainID = chainID
-	return b
+// wrongChainSource serves a block stamped with the given chain ID at any
+// height, for exercising the chainID guard behind the dedup gate.
+func wrongChainSource(chainID string) *fakeSource {
+	return &fakeSource{getFn: func(_ context.Context, h int64) (*SignedBlock, error) {
+		b := blockAt(h)
+		b.Header.ChainID = chainID
+		return &b, nil
+	}}
 }
 
 // TestListener_ChainIDCheckedAfterDedup verifies the chainID guard sits behind
 // the dedup gate: a wrong-chain duplicate of an already-stored height is deduped
-// away without panicking (a slow misconfigured endpoint is tolerated), while a
-// wrong-chain block for a fresh height — i.e. one whose fastest source is on the
-// wrong network — still panics.
+// away before it is even fetched (a slow misconfigured endpoint is tolerated),
+// while a wrong-chain block for a fresh height — i.e. one whose fastest source
+// is on the wrong network — is fetched and still panics.
 func TestListener_ChainIDCheckedAfterDedup(t *testing.T) {
 	ctx := t.Context()
 
@@ -84,18 +74,78 @@ func TestListener_ChainIDCheckedAfterDedup(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, st.PutODSQ4(ctx, roots, stored, eds))
 
-	cl := &Listener{store: st, chainID: "expected-chain"}
+	cl := &Listener{store: st, fetcher: wrongChainSource("wrong-chain"), chainID: "expected-chain"}
 
 	t.Run("wrong chain on a stored height is deduped, no panic", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			err := cl.handleNewSignedBlock(ctx, blockAtWithChainID(int64(stored), "wrong-chain"))
+			err := cl.handleNewBlockEvent(ctx, BlockEvent{Height: int64(stored)})
 			require.NoError(t, err)
 		})
 	})
 
 	t.Run("wrong chain on a fresh height panics", func(t *testing.T) {
 		assert.Panics(t, func() {
-			_ = cl.handleNewSignedBlock(ctx, blockAtWithChainID(int64(stored)+1, "wrong-chain"))
+			_ = cl.handleNewBlockEvent(ctx, BlockEvent{Height: int64(stored) + 1})
 		})
+	})
+}
+
+// blockAtTime serves a block stamped with the given time at any height, for
+// exercising the availability-window gate.
+func blockAtTime(ts time.Time) *fakeSource {
+	return &fakeSource{getFn: func(_ context.Context, h int64) (*SignedBlock, error) {
+		b := blockAt(h)
+		b.Header.Time = ts
+		return &b, nil
+	}}
+}
+
+// TestListener_HistoricBlockSkippedAfterFetch verifies the availability-window
+// gate sits right after the fetch: a non-archival listener drops a block older
+// than the window before querying sync state (and so before any EDS
+// construction or storage), while a within-window block proceeds past the gate.
+// This is what keeps a source replaying history during catch-up from costing an
+// erasure-coding pass per replayed height.
+func TestListener_HistoricBlockSkippedAfterFetch(t *testing.T) {
+	ctx := t.Context()
+
+	st, err := store.NewStore(store.DefaultParameters(), t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, st.Stop(ctx)) })
+
+	const window = time.Hour
+	// syncingErr poisons IsSyncingFrom: reaching the sync-status query at all
+	// fails the historic case and is the observable proof that a within-window
+	// block passed the gate.
+	src := blockAtTime(time.Now().Add(-2 * window))
+	src.syncingErr = errors.New("sync state must not be queried for a historic block")
+
+	cl := &Listener{store: st, fetcher: src, availabilityWindow: window}
+
+	t.Run("historic block is dropped after fetch, before sync-status query", func(t *testing.T) {
+		err := cl.handleNewBlockEvent(ctx, BlockEvent{Height: 7})
+		require.NoError(t, err)
+
+		has, err := st.HasByHeight(ctx, 7)
+		require.NoError(t, err)
+		assert.False(t, has, "historic block must not be stored")
+	})
+
+	t.Run("within-window block passes the gate", func(t *testing.T) {
+		fresh := blockAtTime(time.Now())
+		fresh.syncingErr = errors.New("queried")
+		cl := &Listener{store: st, fetcher: fresh, availabilityWindow: window}
+
+		err := cl.handleNewBlockEvent(ctx, BlockEvent{Height: 8})
+		require.ErrorContains(t, err, "queried", "a fresh block must reach the sync-status query")
+	})
+
+	t.Run("archival listener keeps historic blocks flowing", func(t *testing.T) {
+		archival := blockAtTime(time.Now().Add(-2 * window))
+		archival.syncingErr = errors.New("queried")
+		cl := &Listener{store: st, fetcher: archival, availabilityWindow: window, archival: true}
+
+		err := cl.handleNewBlockEvent(ctx, BlockEvent{Height: 9})
+		require.ErrorContains(t, err, "queried", "an archival node must process historic blocks")
 	})
 }

--- a/core/listener_metrics.go
+++ b/core/listener_metrics.go
@@ -29,6 +29,8 @@ type listenerMetrics struct {
 
 	headerSubPublishedInst       metric.Int64Counter
 	headerSubPublishDurationInst metric.Float64Histogram
+
+	blockEventsInst metric.Int64Counter
 }
 
 func newListenerMetrics() (*listenerMetrics, error) {
@@ -93,6 +95,19 @@ func newListenerMetrics() (*listenerMetrics, error) {
 		"header_sub_publish_duration_seconds",
 		metric.WithDescription("duration of HeaderSub Broadcast() call (seconds)"),
 		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.blockEventsInst, err = meter.Int64Counter(
+		"core_block_events_total",
+		metric.WithDescription(
+			"new-block events from core sources, labeled by `source` (announcing endpoint) and "+
+				"`result`: duplicate = skipped by store dedup; processed = stored & broadcast; "+
+				"historic = dropped outside availability window; "+
+				"fetch_error/sync_error/process_error/store_error = failed",
+		),
 	)
 	if err != nil {
 		return nil, err
@@ -169,6 +184,21 @@ func (m *listenerMetrics) blockProcessed(ctx context.Context, blockTime time.Tim
 			lag = 0
 		}
 		m.coreToDaLagInst.Record(ctx, lag)
+	})
+}
+
+// blockEvent records the terminal outcome of a single new-block event from a
+// core source. Every BlockEvent funnels into exactly one `result`, so
+// rate(processed) is throughput and rate(duplicate) quantifies the redundant
+// downloads the fan-in dedup saved (≈ N-1 per height with N healthy sources).
+// `source` is the announcing endpoint, so per-source rates expose which
+// configured source actually contributes and which only ever loses the race.
+func (m *listenerMetrics) blockEvent(ctx context.Context, source, result string) {
+	m.observe(ctx, func(ctx context.Context) {
+		m.blockEventsInst.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("source", source),
+			attribute.String("result", result),
+		))
 	})
 }
 

--- a/core/multisource.go
+++ b/core/multisource.go
@@ -9,7 +9,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// taggedSource pairs a source endpoint with its address (conn.Target)
+// taggedSource pairs a source endpoint with its address (conn.Target). It is the
+// constructor input unit; MultiSource itself stores sources keyed by addr.
 type taggedSource struct {
 	fetcher blockSource
 	addr    string
@@ -21,7 +22,12 @@ type taggedSource struct {
 // the others. Duplicate heights across sources are expected and must be deduplicated by
 // the consumer.
 type MultiSource struct {
-	sources []taggedSource
+	// sources keyed by addr (conn.Target). The announcing source's addr travels
+	// on every BlockEvent, so GetSignedBlockFrom/IsSyncingFrom resolve back to it
+	// by addr — no indices that pruning in Verify would shift. Addr is a reliable
+	// id: one addr is one core endpoint, and duplicate endpoints are rejected at
+	// config validation, so the map never silently collapses distinct sources.
+	sources map[string]blockSource
 }
 
 // NewMultiSource builds a MultiSource over the given gRPC connections. With a
@@ -36,7 +42,11 @@ func NewMultiSource(grpcClients ...*grpc.ClientConn) *MultiSource {
 
 // newMultiSource is the internal constructor used by NewMultiSource and tests.
 func newMultiSource(sources ...taggedSource) *MultiSource {
-	return &MultiSource{sources: sources}
+	byAddr := make(map[string]blockSource, len(sources))
+	for _, s := range sources {
+		byAddr[s.addr] = s.fetcher
+	}
+	return &MultiSource{sources: byAddr}
 }
 
 // Verify checks every source against the expected network and keeps only those
@@ -51,43 +61,52 @@ func newMultiSource(sources ...taggedSource) *MultiSource {
 //
 // Verify mutates m.sources and is safe only because Listener.Start calls it
 // synchronously before SubscribeNewBlockEvent spawns goroutines and before
-// ChainID/IsSyncingFrom run. Calling it concurrently with those would race —
-// and pruning after subscription would shift the source indices that in-flight
-// BlockEvents route GetSignedBlockFrom/IsSyncingFrom by.
+// ChainID/IsSyncingFrom run. Pruning is keyed by addr, so it no longer matters
+// that indices would shift — but concurrent mutation would still race the reads.
 func (m *MultiSource) Verify(ctx context.Context, expected string) error {
 	if expected == "" {
 		return fmt.Errorf("multisource: expected chain ID must be configured")
 	}
 
-	// Query every source's chain ID concurrently so a slow or unreachable
-	// endpoint doesn't serialize startup behind it: total latency is the slowest
-	// source rather than the sum. Each goroutine writes its own results slot, so
-	// the wg barrier alone orders the writes before the read below — no mutex.
-	ids := make([]string, len(m.sources))
-	errs := make([]error, len(m.sources))
+	// Snapshot the map into a slice so each goroutine writes its own indexed
+	// result slot (a map can't be range-indexed for that). Query every source's
+	// chain ID concurrently so a slow or unreachable endpoint doesn't serialize
+	// startup behind it: total latency is the slowest source, not the sum. The wg
+	// barrier alone orders the writes before the reads below — no mutex.
+	type entry struct {
+		addr string
+		src  blockSource
+	}
+	entries := make([]entry, 0, len(m.sources))
+	for addr, src := range m.sources {
+		entries = append(entries, entry{addr: addr, src: src})
+	}
+
+	ids := make([]string, len(entries))
+	errs := make([]error, len(entries))
 	var wg sync.WaitGroup
-	for i, src := range m.sources {
+	for i, e := range entries {
 		wg.Add(1)
-		go func(i int, src taggedSource) {
+		go func(i int, e entry) {
 			defer wg.Done()
-			ids[i], errs[i] = src.fetcher.ChainID(ctx)
-		}(i, src)
+			ids[i], errs[i] = e.src.ChainID(ctx)
+		}(i, e)
 	}
 	wg.Wait()
 
-	// Assemble the surviving set sequentially: deterministic and free of shared
-	// mutation now that all goroutines have returned.
-	kept := make([]taggedSource, 0, len(m.sources))
-	for i, src := range m.sources {
+	// Assemble the surviving set sequentially: free of shared mutation now that
+	// all goroutines have returned.
+	kept := make(map[string]blockSource, len(entries))
+	for i, e := range entries {
 		switch {
 		case errs[i] != nil:
 			log.Errorw("multisource: dropping unverifiable source",
-				"source", src.addr, "err", errs[i])
+				"source", e.addr, "err", errs[i])
 		case ids[i] != expected:
 			log.Errorw("multisource: dropping endpoint on wrong network",
-				"source", src.addr, "expected", expected, "received", ids[i])
+				"source", e.addr, "expected", expected, "received", ids[i])
 		default:
-			kept = append(kept, src)
+			kept[e.addr] = e.src
 		}
 	}
 	m.sources = kept
@@ -99,8 +118,8 @@ func (m *MultiSource) Verify(ctx context.Context, expected string) error {
 
 // SubscribeNewBlockEvent fans every source's subscription into one channel,
 // closed once all source goroutines exit (i.e. ctx is canceled). It forwards
-// BlockEvents, not full blocks: each event is tagged with its source so the
-// consumer fetches the block once from the announcing peer via
+// BlockEvents, not full blocks: each event is tagged with its source's addr so
+// the consumer fetches the block once from the announcing peer via
 // GetSignedBlockFrom instead of every source downloading it independently.
 func (m *MultiSource) SubscribeNewBlockEvent(ctx context.Context) (chan BlockEvent, error) {
 	// One buffer slot per source: each can deposit an event without blocking the
@@ -108,12 +127,12 @@ func (m *MultiSource) SubscribeNewBlockEvent(ctx context.Context) (chan BlockEve
 	out := make(chan BlockEvent, len(m.sources))
 
 	var wg sync.WaitGroup
-	for i, src := range m.sources {
+	for addr, src := range m.sources {
 		wg.Add(1)
-		go func(i int, s taggedSource) {
+		go func(addr string, s blockSource) {
 			defer wg.Done()
-			m.subscribe(ctx, i, s, out)
-		}(i, src)
+			m.subscribe(ctx, addr, s, out)
+		}(addr, src)
 	}
 
 	// Close the fan-in channel only after every source goroutine has stopped, so
@@ -127,14 +146,14 @@ func (m *MultiSource) SubscribeNewBlockEvent(ctx context.Context) (chan BlockEve
 }
 
 // subscribe subscribes to a single source and forwards its heights into out,
-// tagging each with the source's index so GetSignedBlockFrom can fetch from the
+// tagging each with the source's addr so GetSignedBlockFrom can fetch from the
 // announcing peer, until the source's channel closes or ctx is canceled.
 // Staying subscribed across transient endpoint errors is the underlying
 // fetcher's responsibility.
-func (m *MultiSource) subscribe(ctx context.Context, idx int, src taggedSource, out chan<- BlockEvent) {
-	sub, err := src.fetcher.SubscribeNewBlockEvent(ctx)
+func (m *MultiSource) subscribe(ctx context.Context, addr string, src blockSource, out chan<- BlockEvent) {
+	sub, err := src.SubscribeNewBlockEvent(ctx)
 	if err != nil {
-		log.Warnw("multisource: subscribe failed", "source", src.addr, "err", err)
+		log.Warnw("multisource: subscribe failed", "source", addr, "err", err)
 		return
 	}
 	for {
@@ -143,11 +162,11 @@ func (m *MultiSource) subscribe(ctx context.Context, idx int, src taggedSource, 
 			return
 		case ev, ok := <-sub:
 			if !ok {
-				log.Debugw("multisource: source subscription closed", "source", src.addr)
+				log.Debugw("multisource: source subscription closed", "source", addr)
 				return
 			}
 			select {
-			case out <- BlockEvent{Height: ev.Height, source: idx, addr: src.addr}:
+			case out <- BlockEvent{Height: ev.Height, addr: addr}:
 			case <-ctx.Done():
 				return
 			}
@@ -163,13 +182,13 @@ func (m *MultiSource) subscribe(ctx context.Context, idx int, src taggedSource, 
 // stores nothing, the Listener re-fetches it from whichever source's duplicate
 // event arrives next.
 func (m *MultiSource) GetSignedBlockFrom(ctx context.Context, ev BlockEvent) (*SignedBlock, error) {
-	if ev.source < 0 || ev.source >= len(m.sources) {
-		return nil, fmt.Errorf("multisource: invalid source index %d for height %d", ev.source, ev.Height)
+	src, ok := m.sources[ev.addr]
+	if !ok {
+		return nil, fmt.Errorf("multisource: unknown source %q for height %d", ev.addr, ev.Height)
 	}
-	src := m.sources[ev.source]
-	blk, err := src.fetcher.GetSignedBlock(ctx, ev.Height)
+	blk, err := src.GetSignedBlock(ctx, ev.Height)
 	if err != nil {
-		return nil, fmt.Errorf("multisource: source %s: %w", src.addr, err)
+		return nil, fmt.Errorf("multisource: source %s: %w", ev.addr, err)
 	}
 	return blk, nil
 }
@@ -179,12 +198,12 @@ func (m *MultiSource) GetSignedBlockFrom(ctx context.Context, ev BlockEvent) (*S
 // against the expected chain ID.
 func (m *MultiSource) ChainID(ctx context.Context) (string, error) {
 	var errs error
-	for _, src := range m.sources {
-		id, err := src.fetcher.ChainID(ctx)
+	for addr, src := range m.sources {
+		id, err := src.ChainID(ctx)
 		if err == nil {
 			return id, nil
 		}
-		errs = errors.Join(errs, fmt.Errorf("%s: %w", src.addr, err))
+		errs = errors.Join(errs, fmt.Errorf("%s: %w", addr, err))
 	}
 	return "", fmt.Errorf("multisource: no source returned chain ID: %w", errs)
 }
@@ -197,13 +216,13 @@ func (m *MultiSource) ChainID(ctx context.Context) (string, error) {
 // calls it before storing the height, so on error the duplicate announcement
 // from another source retries the height whole.
 func (m *MultiSource) IsSyncingFrom(ctx context.Context, ev BlockEvent) (bool, error) {
-	if ev.source < 0 || ev.source >= len(m.sources) {
-		return false, fmt.Errorf("multisource: invalid source index %d for height %d", ev.source, ev.Height)
+	src, ok := m.sources[ev.addr]
+	if !ok {
+		return false, fmt.Errorf("multisource: unknown source %q for height %d", ev.addr, ev.Height)
 	}
-	src := m.sources[ev.source]
-	syncing, err := src.fetcher.IsSyncing(ctx)
+	syncing, err := src.IsSyncing(ctx)
 	if err != nil {
-		return false, fmt.Errorf("multisource: source %s: %w", src.addr, err)
+		return false, fmt.Errorf("multisource: source %s: %w", ev.addr, err)
 	}
 	return syncing, nil
 }

--- a/core/multisource.go
+++ b/core/multisource.go
@@ -1,0 +1,218 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+// taggedSource pairs a source with its endpoint address (conn.Target)
+type taggedSource struct {
+	fetcher Fetcher
+	addr    string
+}
+
+// MultiSource fans several core endpoints into one new-block stream. Each
+// endpoint stays subscribed independently (the underlying BlockFetcher already
+// resubscribes forever on its own), so a single failing endpoint cannot stall
+// the others. Duplicate heights across sources are expected and must be deduplicated by
+// the consumer.
+type MultiSource struct {
+	sources []taggedSource
+}
+
+// NewMultiSource builds a MultiSource over the given gRPC connections. With a
+// single connection it behaves equivalently to a single-source BlockFetcher.
+func NewMultiSource(grpcClients ...*grpc.ClientConn) *MultiSource {
+	sources := make([]taggedSource, len(grpcClients))
+	for i, client := range grpcClients {
+		sources[i] = taggedSource{fetcher: NewBlockFetcher(client), addr: client.Target()}
+	}
+	return newMultiSource(sources...)
+}
+
+// newMultiSource is the internal constructor used by NewMultiSource and tests.
+func newMultiSource(sources ...taggedSource) *MultiSource {
+	return &MultiSource{sources: sources}
+}
+
+// Verify checks every source against the expected network. A source that is
+// definitively on the wrong chain is pruned (and logged with its address); a
+// source that could not be reached is kept, so it may join once it comes up — a
+// wrong-chain block from it later is caught by the Listener's per-block backstop.
+// It errors if no source could be confirmed on the expected network, so a fully
+// misconfigured or unreachable set refuses to start. The expected chain ID must
+// be set: a node must know which network it serves.
+//
+// Verify mutates m.sources and is safe only because Listener.Start calls it
+// synchronously before SubscribeNewBlockEvent spawns goroutines and before
+// ChainID/IsSyncing run. Calling it concurrently with those would race.
+func (m *MultiSource) Verify(ctx context.Context, expected string) error {
+	if expected == "" {
+		return fmt.Errorf("multisource: expected chain ID must be configured")
+	}
+
+	// Query every source's chain ID concurrently so a slow or unreachable
+	// endpoint doesn't serialize startup behind it: total latency is the slowest
+	// source rather than the sum. Each goroutine writes its own results slot, so
+	// the wg barrier alone orders the writes before the read below — no mutex.
+	ids := make([]string, len(m.sources))
+	errs := make([]error, len(m.sources))
+	var wg sync.WaitGroup
+	for i, src := range m.sources {
+		wg.Add(1)
+		go func(i int, src taggedSource) {
+			defer wg.Done()
+			ids[i], errs[i] = src.fetcher.ChainID(ctx)
+		}(i, src)
+	}
+	wg.Wait()
+
+	// Assemble the surviving set sequentially: deterministic and free of shared
+	// mutation now that all goroutines have returned.
+	kept := make([]taggedSource, 0, len(m.sources))
+	confirmed := 0
+	for i, src := range m.sources {
+		switch {
+		case errs[i] != nil:
+			log.Warnw("multisource: could not verify chain ID, keeping source",
+				"source", src.addr, "err", errs[i])
+			kept = append(kept, src)
+		case ids[i] != expected:
+			log.Errorw("multisource: dropping endpoint on wrong network",
+				"source", src.addr, "expected", expected, "received", ids[i])
+		default:
+			confirmed++
+			kept = append(kept, src)
+		}
+	}
+	m.sources = kept
+	if confirmed == 0 {
+		return fmt.Errorf("multisource: no source confirmed on expected network %q", expected)
+	}
+	return nil
+}
+
+// SubscribeNewBlockEvent fans every source's new-block subscription into one
+// channel, closed once all source goroutines exit (i.e. ctx is canceled).
+func (m *MultiSource) SubscribeNewBlockEvent(ctx context.Context) (chan SignedBlock, error) {
+	// One buffer slot per source: each can deposit a block without blocking the
+	// others, beyond which the ctx-guarded send applies backpressure.
+	out := make(chan SignedBlock, len(m.sources))
+
+	var wg sync.WaitGroup
+	for _, src := range m.sources {
+		wg.Add(1)
+		go func(s taggedSource) {
+			defer wg.Done()
+			m.subscribe(ctx, s, out)
+		}(src)
+	}
+
+	// Close the fan-in channel only after every source goroutine has stopped, so
+	// the consumer can detect end-of-stream and we never send on a closed channel.
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out, nil
+}
+
+// subscribe subscribes to a single source and forwards its blocks into out until
+// the source's channel closes or ctx is canceled. Staying subscribed across
+// transient endpoint errors is the underlying fetcher's responsibility.
+func (m *MultiSource) subscribe(ctx context.Context, src taggedSource, out chan<- SignedBlock) {
+	sub, err := src.fetcher.SubscribeNewBlockEvent(ctx)
+	if err != nil {
+		log.Warnw("multisource: subscribe failed", "source", src.addr, "err", err)
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case blk, ok := <-sub:
+			if !ok {
+				log.Debugw("multisource: source subscription closed", "source", src.addr)
+				return
+			}
+			select {
+			case out <- blk:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// ChainID returns the chain ID from the first responsive source. All sources
+// are expected to be on the same network; the Listener verifies the result
+// against the expected chain ID.
+func (m *MultiSource) ChainID(ctx context.Context) (string, error) {
+	var errs error
+	for _, src := range m.sources {
+		id, err := src.fetcher.ChainID(ctx)
+		if err == nil {
+			return id, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("%s: %w", src.addr, err))
+	}
+	return "", fmt.Errorf("multisource: no source returned chain ID: %w", errs)
+}
+
+// IsSyncing reports whether core should be treated as still catching up. All
+// sources are queried concurrently and it returns false (not syncing) as soon
+// as any source reports it is synced — so the Listener broadcasts to the
+// network whenever at least one source is caught up — canceling the rest. If
+// every reachable source reports syncing it returns true; only if no source
+// could be reached does it return an error.
+func (m *MultiSource) IsSyncing(ctx context.Context) (bool, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	type result struct {
+		syncing bool
+		err     error
+	}
+	ch := make(chan result, len(m.sources))
+	for _, src := range m.sources {
+		go func(s taggedSource) {
+			syncing, err := s.fetcher.IsSyncing(ctx)
+			if err != nil {
+				err = fmt.Errorf("%s: %w", s.addr, err)
+			}
+			select {
+			case ch <- result{syncing, err}:
+			case <-ctx.Done():
+			}
+		}(src)
+	}
+
+	var (
+		errs    error
+		anyResp bool
+	)
+	for range m.sources {
+		select {
+		case r := <-ch:
+			if r.err != nil {
+				errs = errors.Join(errs, r.err)
+				continue
+			}
+			anyResp = true
+			if !r.syncing {
+				return false, nil // at least one source is caught up
+			}
+		case <-ctx.Done():
+			return true, ctx.Err()
+		}
+	}
+	if !anyResp {
+		return true, fmt.Errorf("multisource: no source returned sync state: %w", errs)
+	}
+	return true, nil // every reachable source is still syncing
+}

--- a/core/multisource.go
+++ b/core/multisource.go
@@ -9,9 +9,9 @@ import (
 	"google.golang.org/grpc"
 )
 
-// taggedSource pairs a source with its endpoint address (conn.Target)
+// taggedSource pairs a source endpoint with its address (conn.Target)
 type taggedSource struct {
-	fetcher Fetcher
+	fetcher blockSource
 	addr    string
 }
 
@@ -39,17 +39,21 @@ func newMultiSource(sources ...taggedSource) *MultiSource {
 	return &MultiSource{sources: sources}
 }
 
-// Verify checks every source against the expected network. A source that is
-// definitively on the wrong chain is pruned (and logged with its address); a
-// source that could not be reached is kept, so it may join once it comes up — a
-// wrong-chain block from it later is caught by the Listener's per-block backstop.
-// It errors if no source could be confirmed on the expected network, so a fully
-// misconfigured or unreachable set refuses to start. The expected chain ID must
-// be set: a node must know which network it serves.
+// Verify checks every source against the expected network and keeps only those
+// that confirmed the expected chain ID. Both wrong-chain AND unreachable
+// sources are pruned (logged with their address): sources are operator-curated
+// endpoints, so an endpoint that cannot vouch for its network at startup has no
+// business in the active set — letting it join later would defer a wrong-chain
+// failure to a mid-run panic instead of a startup log. The operator restores a
+// pruned endpoint by fixing it and restarting. It errors if no source could be
+// confirmed, so a fully misconfigured or unreachable set refuses to start. The
+// expected chain ID must be set: a node must know which network it serves.
 //
 // Verify mutates m.sources and is safe only because Listener.Start calls it
 // synchronously before SubscribeNewBlockEvent spawns goroutines and before
-// ChainID/IsSyncing run. Calling it concurrently with those would race.
+// ChainID/IsSyncingFrom run. Calling it concurrently with those would race —
+// and pruning after subscription would shift the source indices that in-flight
+// BlockEvents route GetSignedBlockFrom/IsSyncingFrom by.
 func (m *MultiSource) Verify(ctx context.Context, expected string) error {
 	if expected == "" {
 		return fmt.Errorf("multisource: expected chain ID must be configured")
@@ -74,42 +78,42 @@ func (m *MultiSource) Verify(ctx context.Context, expected string) error {
 	// Assemble the surviving set sequentially: deterministic and free of shared
 	// mutation now that all goroutines have returned.
 	kept := make([]taggedSource, 0, len(m.sources))
-	confirmed := 0
 	for i, src := range m.sources {
 		switch {
 		case errs[i] != nil:
-			log.Warnw("multisource: could not verify chain ID, keeping source",
+			log.Errorw("multisource: dropping unverifiable source",
 				"source", src.addr, "err", errs[i])
-			kept = append(kept, src)
 		case ids[i] != expected:
 			log.Errorw("multisource: dropping endpoint on wrong network",
 				"source", src.addr, "expected", expected, "received", ids[i])
 		default:
-			confirmed++
 			kept = append(kept, src)
 		}
 	}
 	m.sources = kept
-	if confirmed == 0 {
+	if len(kept) == 0 {
 		return fmt.Errorf("multisource: no source confirmed on expected network %q", expected)
 	}
 	return nil
 }
 
-// SubscribeNewBlockEvent fans every source's new-block subscription into one
-// channel, closed once all source goroutines exit (i.e. ctx is canceled).
-func (m *MultiSource) SubscribeNewBlockEvent(ctx context.Context) (chan SignedBlock, error) {
-	// One buffer slot per source: each can deposit a block without blocking the
+// SubscribeNewBlockEvent fans every source's subscription into one channel,
+// closed once all source goroutines exit (i.e. ctx is canceled). It forwards
+// BlockEvents, not full blocks: each event is tagged with its source so the
+// consumer fetches the block once from the announcing peer via
+// GetSignedBlockFrom instead of every source downloading it independently.
+func (m *MultiSource) SubscribeNewBlockEvent(ctx context.Context) (chan BlockEvent, error) {
+	// One buffer slot per source: each can deposit an event without blocking the
 	// others, beyond which the ctx-guarded send applies backpressure.
-	out := make(chan SignedBlock, len(m.sources))
+	out := make(chan BlockEvent, len(m.sources))
 
 	var wg sync.WaitGroup
-	for _, src := range m.sources {
+	for i, src := range m.sources {
 		wg.Add(1)
-		go func(s taggedSource) {
+		go func(i int, s taggedSource) {
 			defer wg.Done()
-			m.subscribe(ctx, s, out)
-		}(src)
+			m.subscribe(ctx, i, s, out)
+		}(i, src)
 	}
 
 	// Close the fan-in channel only after every source goroutine has stopped, so
@@ -122,10 +126,12 @@ func (m *MultiSource) SubscribeNewBlockEvent(ctx context.Context) (chan SignedBl
 	return out, nil
 }
 
-// subscribe subscribes to a single source and forwards its blocks into out until
-// the source's channel closes or ctx is canceled. Staying subscribed across
-// transient endpoint errors is the underlying fetcher's responsibility.
-func (m *MultiSource) subscribe(ctx context.Context, src taggedSource, out chan<- SignedBlock) {
+// subscribe subscribes to a single source and forwards its heights into out,
+// tagging each with the source's index so GetSignedBlockFrom can fetch from the
+// announcing peer, until the source's channel closes or ctx is canceled.
+// Staying subscribed across transient endpoint errors is the underlying
+// fetcher's responsibility.
+func (m *MultiSource) subscribe(ctx context.Context, idx int, src taggedSource, out chan<- BlockEvent) {
 	sub, err := src.fetcher.SubscribeNewBlockEvent(ctx)
 	if err != nil {
 		log.Warnw("multisource: subscribe failed", "source", src.addr, "err", err)
@@ -135,18 +141,37 @@ func (m *MultiSource) subscribe(ctx context.Context, src taggedSource, out chan<
 		select {
 		case <-ctx.Done():
 			return
-		case blk, ok := <-sub:
+		case ev, ok := <-sub:
 			if !ok {
 				log.Debugw("multisource: source subscription closed", "source", src.addr)
 				return
 			}
 			select {
-			case out <- blk:
+			case out <- BlockEvent{Height: ev.Height, source: idx, addr: src.addr}:
 			case <-ctx.Done():
 				return
 			}
 		}
 	}
+}
+
+// GetSignedBlockFrom fetches the block for the event from the single source
+// that announced it — the fastest peer to notify this height, a fresh signal
+// it's the most responsive peer. It does ONE thing and does not fall back to
+// other sources: an error is returned as-is. Resilience is the fan-in's job —
+// the same height is announced by other sources, and since a failed fetch
+// stores nothing, the Listener re-fetches it from whichever source's duplicate
+// event arrives next.
+func (m *MultiSource) GetSignedBlockFrom(ctx context.Context, ev BlockEvent) (*SignedBlock, error) {
+	if ev.source < 0 || ev.source >= len(m.sources) {
+		return nil, fmt.Errorf("multisource: invalid source index %d for height %d", ev.source, ev.Height)
+	}
+	src := m.sources[ev.source]
+	blk, err := src.fetcher.GetSignedBlock(ctx, ev.Height)
+	if err != nil {
+		return nil, fmt.Errorf("multisource: source %s: %w", src.addr, err)
+	}
+	return blk, nil
 }
 
 // ChainID returns the chain ID from the first responsive source. All sources
@@ -164,55 +189,21 @@ func (m *MultiSource) ChainID(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("multisource: no source returned chain ID: %w", errs)
 }
 
-// IsSyncing reports whether core should be treated as still catching up. All
-// sources are queried concurrently and it returns false (not syncing) as soon
-// as any source reports it is synced — so the Listener broadcasts to the
-// network whenever at least one source is caught up — canceling the rest. If
-// every reachable source reports syncing it returns true; only if no source
-// could be reached does it return an error.
-func (m *MultiSource) IsSyncing(ctx context.Context) (bool, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	type result struct {
-		syncing bool
-		err     error
+// IsSyncingFrom reports whether the source that announced the event is still
+// catching up. Sync state is per-source: the same peer that announced and
+// served the block answers whether it is a fresh head or a catch-up replay —
+// another source being caught up says nothing about this block. Like
+// GetSignedBlockFrom, it does not fall back to other sources: the Listener
+// calls it before storing the height, so on error the duplicate announcement
+// from another source retries the height whole.
+func (m *MultiSource) IsSyncingFrom(ctx context.Context, ev BlockEvent) (bool, error) {
+	if ev.source < 0 || ev.source >= len(m.sources) {
+		return false, fmt.Errorf("multisource: invalid source index %d for height %d", ev.source, ev.Height)
 	}
-	ch := make(chan result, len(m.sources))
-	for _, src := range m.sources {
-		go func(s taggedSource) {
-			syncing, err := s.fetcher.IsSyncing(ctx)
-			if err != nil {
-				err = fmt.Errorf("%s: %w", s.addr, err)
-			}
-			select {
-			case ch <- result{syncing, err}:
-			case <-ctx.Done():
-			}
-		}(src)
+	src := m.sources[ev.source]
+	syncing, err := src.fetcher.IsSyncing(ctx)
+	if err != nil {
+		return false, fmt.Errorf("multisource: source %s: %w", src.addr, err)
 	}
-
-	var (
-		errs    error
-		anyResp bool
-	)
-	for range m.sources {
-		select {
-		case r := <-ch:
-			if r.err != nil {
-				errs = errors.Join(errs, r.err)
-				continue
-			}
-			anyResp = true
-			if !r.syncing {
-				return false, nil // at least one source is caught up
-			}
-		case <-ctx.Done():
-			return true, ctx.Err()
-		}
-	}
-	if !anyResp {
-		return true, fmt.Errorf("multisource: no source returned sync state: %w", errs)
-	}
-	return true, nil // every reachable source is still syncing
+	return syncing, nil
 }

--- a/core/multisource_integration_test.go
+++ b/core/multisource_integration_test.go
@@ -67,12 +67,13 @@ func TestMultiSource_Integration_Verify(t *testing.T) {
 		require.Error(t, ms.Verify(ctx, "not-"+testChainID))
 	})
 
-	t.Run("unreachable source is kept when another is confirmed", func(t *testing.T) {
+	t.Run("unreachable source is pruned even when another is confirmed", func(t *testing.T) {
 		vctx, vcancel := context.WithTimeout(ctx, 10*time.Second)
 		defer vcancel()
 		ms := NewMultiSource(good, deadGRPCClient(t))
 		require.NoError(t, ms.Verify(vctx, testChainID))
-		assert.Len(t, ms.sources, 2, "unreachable endpoint kept so it can join later")
+		require.Len(t, ms.sources, 1,
+			"an endpoint that cannot vouch for its network must not enter the active set")
 	})
 }
 
@@ -84,7 +85,7 @@ func TestMultiSource_Integration_FanInToleratesDeadSource(t *testing.T) {
 	_, network := createCoreFetcher(t, cfg)
 
 	// One live endpoint, one dead one: the live source must keep delivering real
-	// blocks while the dead source's fetcher retries in the background.
+	// heights while the dead source's fetcher retries in the background.
 	ms := NewMultiSource(network.GRPCClient, deadGRPCClient(t))
 	out, err := ms.SubscribeNewBlockEvent(ctx)
 	require.NoError(t, err)
@@ -92,13 +93,12 @@ func TestMultiSource_Integration_FanInToleratesDeadSource(t *testing.T) {
 	var last int64
 	for range 3 {
 		select {
-		case b := <-out:
-			require.NotNil(t, b.Header)
-			assert.Greater(t, b.Header.Height, int64(0))
-			assert.Greater(t, b.Header.Height, last, "live source delivers heights in order")
-			last = b.Header.Height
+		case ev := <-out:
+			assert.Greater(t, ev.Height, int64(0))
+			assert.Greater(t, ev.Height, last, "live source delivers heights in order")
+			last = ev.Height
 		case <-ctx.Done():
-			t.Fatal("no blocks from the live source while the other endpoint is dead")
+			t.Fatal("no heights from the live source while the other endpoint is dead")
 		}
 	}
 }

--- a/core/multisource_integration_test.go
+++ b/core/multisource_integration_test.go
@@ -39,13 +39,21 @@ func deadGRPCClient(t *testing.T) *grpc.ClientConn {
 	return conn
 }
 
-// secondClientTo opens a second gRPC connection to the same node as conn, so a
-// MultiSource can fan two real subscriptions in from one chain.
+// secondClientTo opens a second gRPC connection to the same backend as conn but
+// under a distinct target string (the passthrough scheme dials the endpoint
+// literally), so MultiSource keys it as a separate source by addr instead of
+// collapsing it into conn. One real node thus stands in for two distinct
+// endpoints fanning the same heights — the realistic shape MultiSource expects,
+// since two connections to one addr are rejected as duplicates upstream.
 func secondClientTo(t *testing.T, conn *grpc.ClientConn) *grpc.ClientConn {
 	t.Helper()
 	host, port, err := net.SplitHostPort(conn.Target())
 	require.NoError(t, err)
-	return newTestClient(t, host, port)
+	target := "passthrough:///" + net.JoinHostPort(host, port)
+	c, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	return c
 }
 
 func TestMultiSource_Integration_Verify(t *testing.T) {

--- a/core/multisource_integration_test.go
+++ b/core/multisource_integration_test.go
@@ -1,0 +1,178 @@
+package core
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/types"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/celestiaorg/go-header/p2p"
+	"github.com/celestiaorg/rsmt2d"
+
+	"github.com/celestiaorg/celestia-node/header"
+	nodep2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	"github.com/celestiaorg/celestia-node/store"
+)
+
+// These tests exercise MultiSource against a real celestia-app + CometBFT
+// node (via createCoreFetcher) over real gRPC, rather than the in-memory
+// fakeSource used by the unit tests. They cover the assumptions that unit tests
+// can't: real chain-ID verification, that a dead endpoint does not stall a live
+// one, and that deduplication holds end-to-end on real blocks delivered twice.
+
+// deadGRPCClient returns a lazily-dialed connection to an address nothing
+// listens on, so any RPC against it fails. It models a configured-but-down
+// endpoint. No retry interceptors, so failures surface promptly.
+func deadGRPCClient(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+	conn, err := grpc.NewClient("127.0.0.1:1", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// secondClientTo opens a second gRPC connection to the same node as conn, so a
+// MultiSource can fan two real subscriptions in from one chain.
+func secondClientTo(t *testing.T, conn *grpc.ClientConn) *grpc.ClientConn {
+	t.Helper()
+	host, port, err := net.SplitHostPort(conn.Target())
+	require.NoError(t, err)
+	return newTestClient(t, host, port)
+}
+
+func TestMultiSource_Integration_Verify(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(cancel)
+
+	cfg := DefaultTestConfig().WithChainID(testChainID)
+	_, network := createCoreFetcher(t, cfg)
+	good := network.GRPCClient
+
+	t.Run("sources on the expected chain are confirmed and kept", func(t *testing.T) {
+		ms := NewMultiSource(good, secondClientTo(t, good))
+		require.NoError(t, ms.Verify(ctx, testChainID))
+		assert.Len(t, ms.sources, 2)
+	})
+
+	t.Run("wrong expected chain ID refuses to start", func(t *testing.T) {
+		ms := NewMultiSource(good)
+		require.Error(t, ms.Verify(ctx, "not-"+testChainID))
+	})
+
+	t.Run("unreachable source is kept when another is confirmed", func(t *testing.T) {
+		vctx, vcancel := context.WithTimeout(ctx, 10*time.Second)
+		defer vcancel()
+		ms := NewMultiSource(good, deadGRPCClient(t))
+		require.NoError(t, ms.Verify(vctx, testChainID))
+		assert.Len(t, ms.sources, 2, "unreachable endpoint kept so it can join later")
+	})
+}
+
+func TestMultiSource_Integration_FanInToleratesDeadSource(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(cancel)
+
+	cfg := DefaultTestConfig().WithChainID(testChainID)
+	_, network := createCoreFetcher(t, cfg)
+
+	// One live endpoint, one dead one: the live source must keep delivering real
+	// blocks while the dead source's fetcher retries in the background.
+	ms := NewMultiSource(network.GRPCClient, deadGRPCClient(t))
+	out, err := ms.SubscribeNewBlockEvent(ctx)
+	require.NoError(t, err)
+
+	var last int64
+	for range 3 {
+		select {
+		case b := <-out:
+			require.NotNil(t, b.Header)
+			assert.Greater(t, b.Header.Height, int64(0))
+			assert.Greater(t, b.Header.Height, last, "live source delivers heights in order")
+			last = b.Header.Height
+		case <-ctx.Done():
+			t.Fatal("no blocks from the live source while the other endpoint is dead")
+		}
+	}
+}
+
+func TestMultiSource_Integration_DedupThroughListener(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	cfg := DefaultTestConfig().WithChainID(testChainID)
+	_, network := createCoreFetcher(t, cfg)
+
+	// Two connections to the same node, so every height is fanned in twice and
+	// the dedup gate is genuinely exercised on real blocks.
+	ms := NewMultiSource(network.GRPCClient, secondClientTo(t, network.GRPCClient))
+
+	ps0, ps1 := createMocknetWithTwoPubsubEndpoints(ctx, t)
+	bcast := newTestSubscriber(ctx, t, ps0)
+	observer := newTestSubscriber(ctx, t, ps1)
+	subs, err := observer.Subscribe()
+	require.NoError(t, err)
+	t.Cleanup(subs.Cancel)
+
+	edsSub := createEdsPubSub(ctx, t)
+	st, err := store.NewStore(store.DefaultParameters(), t.TempDir())
+	require.NoError(t, err)
+
+	// Count construct calls per height: with sequential processing in listen(),
+	// the dedup gate must keep each height to exactly one construction despite
+	// both sources delivering it.
+	var (
+		mu     sync.Mutex
+		counts = map[int64]int{}
+	)
+	construct := func(
+		h *types.Header,
+		c *types.Commit,
+		vs *types.ValidatorSet,
+		eds *rsmt2d.ExtendedDataSquare,
+	) (*header.ExtendedHeader, error) {
+		mu.Lock()
+		counts[h.Height]++
+		mu.Unlock()
+		return header.MakeExtendedHeader(h, c, vs, eds)
+	}
+
+	cl, err := NewListener(bcast, ms, edsSub.Broadcast, construct, st, nodep2p.BlockTime,
+		WithChainID(nodep2p.Network(testChainID)))
+	require.NoError(t, err)
+	require.NoError(t, cl.Start(ctx))
+
+	// Wait until a handful of heights have been processed and broadcast.
+	for range 5 {
+		_, err := subs.NextHeader(ctx)
+		require.NoError(t, err)
+	}
+	require.NoError(t, cl.Stop(ctx))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, counts)
+	for h, n := range counts {
+		assert.Equalf(t, 1, n,
+			"height %d constructed %d times; dedup should build each height once despite two sources", h, n)
+	}
+}
+
+// newTestSubscriber builds and starts a header pubsub subscriber on ps with a
+// pass-through verifier, usable both as a broadcaster and an observer.
+func newTestSubscriber(ctx context.Context, t *testing.T, ps *pubsub.PubSub) *p2p.Subscriber[*header.ExtendedHeader] {
+	t.Helper()
+	sub, err := p2p.NewSubscriber[*header.ExtendedHeader](ps, header.MsgID, p2p.WithSubscriberNetworkID(testChainID))
+	require.NoError(t, err)
+	require.NoError(t, sub.SetVerifier(func(context.Context, *header.ExtendedHeader) error { return nil }))
+	require.NoError(t, sub.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, sub.Stop(ctx)) })
+	return sub
+}

--- a/core/multisource_test.go
+++ b/core/multisource_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,11 +27,14 @@ type fakeSource struct {
 
 	// subFn produces the channel/error for each SubscribeNewBlockEvent call,
 	// indexed by call number, to simulate (re)subscription.
-	subFn    func(call int) (chan SignedBlock, error)
+	subFn    func(call int) (chan BlockEvent, error)
 	subCalls int
+
+	// getFn serves GetSignedBlock.
+	getFn func(ctx context.Context, height int64) (*SignedBlock, error)
 }
 
-func (f *fakeSource) SubscribeNewBlockEvent(context.Context) (chan SignedBlock, error) {
+func (f *fakeSource) SubscribeNewBlockEvent(context.Context) (chan BlockEvent, error) {
 	f.mu.Lock()
 	call := f.subCalls
 	f.subCalls++
@@ -42,6 +46,22 @@ func (f *fakeSource) SubscribeNewBlockEvent(context.Context) (chan SignedBlock, 
 	return fn(call)
 }
 
+func (f *fakeSource) GetSignedBlock(ctx context.Context, height int64) (*SignedBlock, error) {
+	f.mu.Lock()
+	fn := f.getFn
+	f.mu.Unlock()
+	if fn == nil {
+		return nil, errors.New("fakeSource: getFn not set")
+	}
+	return fn(ctx, height)
+}
+
+// GetSignedBlockFrom satisfies the Fetcher interface; a leaf fakeSource has a
+// single source, so it just fetches by height.
+func (f *fakeSource) GetSignedBlockFrom(ctx context.Context, ev BlockEvent) (*SignedBlock, error) {
+	return f.GetSignedBlock(ctx, ev.Height)
+}
+
 func (f *fakeSource) ChainID(context.Context) (string, error) { return f.chainID, f.chainIDErr }
 
 // Verify is unused by MultiSource (which verifies sources via ChainID) but
@@ -50,7 +70,13 @@ func (f *fakeSource) Verify(context.Context, string) error { return nil }
 
 func (f *fakeSource) IsSyncing(context.Context) (bool, error) { return f.syncing, f.syncingErr }
 
-func tagged(addr string, f Fetcher) taggedSource {
+// IsSyncingFrom satisfies the Fetcher interface; a leaf fakeSource has a
+// single source, so it just reports its own status.
+func (f *fakeSource) IsSyncingFrom(ctx context.Context, _ BlockEvent) (bool, error) {
+	return f.IsSyncing(ctx)
+}
+
+func tagged(addr string, f blockSource) taggedSource {
 	return taggedSource{fetcher: f, addr: addr}
 }
 
@@ -58,29 +84,29 @@ func blockAt(h int64) SignedBlock {
 	return SignedBlock{Header: &types.Header{Height: h}}
 }
 
-func recv(t *testing.T, ch <-chan SignedBlock) (SignedBlock, bool) {
+func recv(t *testing.T, ch <-chan BlockEvent) (BlockEvent, bool) {
 	t.Helper()
 	select {
-	case b, ok := <-ch:
-		return b, ok
+	case ev, ok := <-ch:
+		return ev, ok
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting on channel")
-		return SignedBlock{}, false
+		return BlockEvent{}, false
 	}
 }
 
 // neverDelivers returns a channel that is never written to or closed, so a
 // source "stays subscribed" until ctx is canceled.
-func neverDelivers() chan SignedBlock { return make(chan SignedBlock) }
+func neverDelivers() chan BlockEvent { return make(chan BlockEvent) }
 
 func TestMultiSource_SubscribeFanIn(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	chA := make(chan SignedBlock)
-	chB := make(chan SignedBlock)
-	srcA := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return chA, nil }}
-	srcB := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return chB, nil }}
+	chA := make(chan BlockEvent)
+	chB := make(chan BlockEvent)
+	srcA := &fakeSource{subFn: func(int) (chan BlockEvent, error) { return chA, nil }}
+	srcB := &fakeSource{subFn: func(int) (chan BlockEvent, error) { return chB, nil }}
 
 	ms := newMultiSource(tagged("srcA", srcA), tagged("srcB", srcB))
 	out, err := ms.SubscribeNewBlockEvent(ctx)
@@ -88,15 +114,15 @@ func TestMultiSource_SubscribeFanIn(t *testing.T) {
 
 	// Both sources emit the same height (duplicate) plus one extra; MultiSource
 	// forwards everything — dedup is the consumer's job.
-	chA <- blockAt(1)
-	chB <- blockAt(1)
-	chA <- blockAt(2)
+	chA <- BlockEvent{Height: 1}
+	chB <- BlockEvent{Height: 1}
+	chA <- BlockEvent{Height: 2}
 
 	got := make([]int64, 0, 3)
 	for range 3 {
-		b, ok := recv(t, out)
+		ev, ok := recv(t, out)
 		require.True(t, ok)
-		got = append(got, b.Header.Height)
+		got = append(got, ev.Height)
 	}
 	slices.Sort(got)
 	assert.Equal(t, []int64{1, 1, 2}, got)
@@ -110,7 +136,7 @@ func TestMultiSource_SubscribeFanIn(t *testing.T) {
 func TestMultiSource_CancelClosesOut(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
-	src := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return neverDelivers(), nil }}
+	src := &fakeSource{subFn: func(int) (chan BlockEvent, error) { return neverDelivers(), nil }}
 	ms := newMultiSource(tagged("src", src))
 
 	out, err := ms.SubscribeNewBlockEvent(ctx)
@@ -128,10 +154,10 @@ func TestMultiSource_ClosedSourceDoesNotCloseOut(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	dead := make(chan SignedBlock)
-	live := make(chan SignedBlock)
-	deadSrc := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return dead, nil }}
-	liveSrc := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return live, nil }}
+	dead := make(chan BlockEvent)
+	live := make(chan BlockEvent)
+	deadSrc := &fakeSource{subFn: func(int) (chan BlockEvent, error) { return dead, nil }}
+	liveSrc := &fakeSource{subFn: func(int) (chan BlockEvent, error) { return live, nil }}
 
 	ms := newMultiSource(tagged("dead", deadSrc), tagged("live", liveSrc))
 	out, err := ms.SubscribeNewBlockEvent(ctx)
@@ -139,10 +165,10 @@ func TestMultiSource_ClosedSourceDoesNotCloseOut(t *testing.T) {
 
 	// One source ends; the other must keep working and out must stay open.
 	close(dead)
-	live <- blockAt(9)
-	b, ok := recv(t, out)
+	live <- BlockEvent{Height: 9}
+	ev, ok := recv(t, out)
 	require.True(t, ok)
-	assert.Equal(t, int64(9), b.Header.Height)
+	assert.Equal(t, int64(9), ev.Height)
 }
 
 func TestMultiSource_ChainID(t *testing.T) {
@@ -175,47 +201,85 @@ func TestMultiSource_ChainID(t *testing.T) {
 	})
 }
 
-func TestMultiSource_IsSyncing(t *testing.T) {
+func TestMultiSource_GetSignedBlockFrom(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("not syncing if any source is caught up", func(t *testing.T) {
+	// announcing source serves the block at index 1.
+	t.Run("fetches from the announcing source", func(t *testing.T) {
+		wrongSrc := &fakeSource{getFn: func(context.Context, int64) (*SignedBlock, error) {
+			return nil, errors.New("not the announcer; must not be called")
+		}}
+		announcer := &fakeSource{getFn: func(_ context.Context, h int64) (*SignedBlock, error) {
+			b := blockAt(h)
+			return &b, nil
+		}}
+		ms := newMultiSource(tagged("wrong", wrongSrc), tagged("announcer", announcer))
+
+		b, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 7, source: 1})
+		require.NoError(t, err)
+		assert.Equal(t, int64(7), b.Header.Height)
+	})
+
+	// SRP: no fallback. If the announcing source fails, the error propagates and
+	// the OTHER source is NOT tried — the fan-in re-announces the height and the
+	// Listener retries from there.
+	t.Run("announcer failure propagates without trying others", func(t *testing.T) {
+		var otherCalled atomic.Bool
+		other := &fakeSource{getFn: func(context.Context, int64) (*SignedBlock, error) {
+			otherCalled.Store(true)
+			b := blockAt(9)
+			return &b, nil
+		}}
+		down := &fakeSource{getFn: func(context.Context, int64) (*SignedBlock, error) {
+			return nil, errors.New("down")
+		}}
+		ms := newMultiSource(tagged("other", other), tagged("down", down))
+
+		_, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 9, source: 1}) // source 1 = down
+		require.Error(t, err)
+		assert.False(t, otherCalled.Load(), "must not fall back to another source")
+	})
+
+	t.Run("out-of-range source index errors", func(t *testing.T) {
+		ms := newMultiSource(tagged("only", &fakeSource{}))
+		_, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 1, source: 5})
+		require.Error(t, err)
+	})
+}
+
+func TestMultiSource_IsSyncingFrom(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("routes to the announcing source", func(t *testing.T) {
 		ms := newMultiSource(
-			tagged("a", &fakeSource{syncing: true}),
-			tagged("b", &fakeSource{syncing: false}), // caught up
+			tagged("caught-up", &fakeSource{syncing: false}),
+			tagged("catching-up", &fakeSource{syncing: true}),
 		)
-		syncing, err := ms.IsSyncing(ctx)
+
+		// the catching-up source announced: its replayed block must be treated
+		// as syncing even though the other source is caught up.
+		syncing, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 7, source: 1})
+		require.NoError(t, err)
+		assert.True(t, syncing)
+
+		syncing, err = ms.IsSyncingFrom(ctx, BlockEvent{Height: 8, source: 0})
 		require.NoError(t, err)
 		assert.False(t, syncing)
 	})
 
-	t.Run("syncing if every source is syncing", func(t *testing.T) {
+	t.Run("no fallback: announcing source's error surfaces even if another is fine", func(t *testing.T) {
 		ms := newMultiSource(
-			tagged("a", &fakeSource{syncing: true}),
-			tagged("b", &fakeSource{syncing: true}),
+			tagged("healthy", &fakeSource{syncing: false}),
+			tagged("down", &fakeSource{syncingErr: errors.New("down")}),
 		)
-		syncing, err := ms.IsSyncing(ctx)
-		require.NoError(t, err)
-		assert.True(t, syncing)
-	})
-
-	t.Run("a single reachable syncing source wins over an errored one", func(t *testing.T) {
-		ms := newMultiSource(
-			tagged("a", &fakeSource{syncingErr: errors.New("down")}),
-			tagged("b", &fakeSource{syncing: true}),
-		)
-		syncing, err := ms.IsSyncing(ctx)
-		require.NoError(t, err)
-		assert.True(t, syncing)
-	})
-
-	t.Run("errors only when no source is reachable", func(t *testing.T) {
-		ms := newMultiSource(
-			tagged("a", &fakeSource{syncingErr: errors.New("a")}),
-			tagged("b", &fakeSource{syncingErr: errors.New("b")}),
-		)
-		syncing, err := ms.IsSyncing(ctx)
+		_, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 9, source: 1})
 		require.Error(t, err)
-		assert.True(t, syncing, "defaults to syncing when unknown")
+	})
+
+	t.Run("out-of-range source index errors", func(t *testing.T) {
+		ms := newMultiSource(tagged("only", &fakeSource{}))
+		_, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 1, source: 5})
+		require.Error(t, err)
 	})
 }
 
@@ -246,13 +310,15 @@ func TestMultiSource_Verify(t *testing.T) {
 		assert.Equal(t, "good", ms.sources[0].addr)
 	})
 
-	t.Run("unreachable source is kept when another is confirmed good", func(t *testing.T) {
+	t.Run("unreachable source is pruned even when another is confirmed good", func(t *testing.T) {
 		ms := newMultiSource(
 			tagged("good", &fakeSource{chainID: "mocha-4"}),
 			tagged("down", &fakeSource{chainIDErr: errors.New("unreachable")}),
 		)
 		require.NoError(t, ms.Verify(ctx, "mocha-4"))
-		assert.Len(t, ms.sources, 2, "unreachable source kept so it can join later")
+		require.Len(t, ms.sources, 1,
+			"a source that cannot vouch for its network must not enter the active set")
+		assert.Equal(t, "good", ms.sources[0].addr)
 	})
 
 	t.Run("errors when every reachable source is on the wrong chain", func(t *testing.T) {
@@ -277,15 +343,15 @@ func TestMultiSource_Verify(t *testing.T) {
 
 // TestMultiSource_SingleSource pins the contract that a MultiSource wrapping a
 // single endpoint behaves like the bare BlockFetcher the Listener consumed
-// before MultiSource existed: blocks pass through unchanged and in order, and
+// before MultiSource existed: heights pass through unchanged and in order, and
 // ChainID/IsSyncing mirror the one source.
 func TestMultiSource_SingleSource(t *testing.T) {
-	t.Run("forwards every block in order", func(t *testing.T) {
+	t.Run("forwards every height in order", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
-		in := make(chan SignedBlock)
-		src := &fakeSource{subFn: func(call int) (chan SignedBlock, error) {
+		in := make(chan BlockEvent)
+		src := &fakeSource{subFn: func(call int) (chan BlockEvent, error) {
 			if call == 0 {
 				return in, nil
 			}
@@ -300,15 +366,15 @@ func TestMultiSource_SingleSource(t *testing.T) {
 		// exactly as delivered — same as reading the BlockFetcher channel directly.
 		go func() {
 			for h := int64(1); h <= 5; h++ {
-				in <- blockAt(h)
+				in <- BlockEvent{Height: h}
 			}
 		}()
 
 		got := make([]int64, 0, 5)
 		for range 5 {
-			b, ok := recv(t, out)
+			ev, ok := recv(t, out)
 			require.True(t, ok)
-			got = append(got, b.Header.Height)
+			got = append(got, ev.Height)
 		}
 		assert.Equal(t, []int64{1, 2, 3, 4, 5}, got, "single source must preserve delivery order")
 	})
@@ -324,30 +390,27 @@ func TestMultiSource_SingleSource(t *testing.T) {
 		require.Error(t, err, "a failing single source must surface as an error, like the bare fetcher")
 	})
 
-	t.Run("isSyncing passthrough", func(t *testing.T) {
+	t.Run("isSyncingFrom passthrough", func(t *testing.T) {
 		ctx := context.Background()
+		ev := BlockEvent{Height: 1, source: 0}
 
-		syncing, err := newMultiSource(tagged("only", &fakeSource{syncing: true})).IsSyncing(ctx)
+		syncing, err := newMultiSource(tagged("only", &fakeSource{syncing: true})).IsSyncingFrom(ctx, ev)
 		require.NoError(t, err)
 		assert.True(t, syncing)
 
-		syncing, err = newMultiSource(tagged("only", &fakeSource{syncing: false})).IsSyncing(ctx)
+		syncing, err = newMultiSource(tagged("only", &fakeSource{syncing: false})).IsSyncingFrom(ctx, ev)
 		require.NoError(t, err)
 		assert.False(t, syncing)
 
-		// On error the bare BlockFetcher returns (false, err) while MultiSource
-		// returns (true, err); the bool is irrelevant because handleNewSignedBlock
-		// bails on err != nil before reading it. What matters is that the error
-		// still propagates, which it does.
-		_, err = newMultiSource(tagged("only", &fakeSource{syncingErr: errors.New("down")})).IsSyncing(ctx)
-		require.Error(t, err)
+		_, err = newMultiSource(tagged("only", &fakeSource{syncingErr: errors.New("down")})).IsSyncingFrom(ctx, ev)
+		require.Error(t, err, "a failing single source must surface as an error, like the bare fetcher")
 	})
 
 	t.Run("source subscribe error closes out", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
-		src := &fakeSource{subFn: func(int) (chan SignedBlock, error) {
+		src := &fakeSource{subFn: func(int) (chan BlockEvent, error) {
 			return nil, errors.New("subscribe boom")
 		}}
 		ms := newMultiSource(tagged("only", src))

--- a/core/multisource_test.go
+++ b/core/multisource_test.go
@@ -215,7 +215,7 @@ func TestMultiSource_GetSignedBlockFrom(t *testing.T) {
 		}}
 		ms := newMultiSource(tagged("wrong", wrongSrc), tagged("announcer", announcer))
 
-		b, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 7, source: 1})
+		b, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 7, addr: "announcer"})
 		require.NoError(t, err)
 		assert.Equal(t, int64(7), b.Header.Height)
 	})
@@ -235,14 +235,14 @@ func TestMultiSource_GetSignedBlockFrom(t *testing.T) {
 		}}
 		ms := newMultiSource(tagged("other", other), tagged("down", down))
 
-		_, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 9, source: 1}) // source 1 = down
+		_, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 9, addr: "down"})
 		require.Error(t, err)
 		assert.False(t, otherCalled.Load(), "must not fall back to another source")
 	})
 
-	t.Run("out-of-range source index errors", func(t *testing.T) {
+	t.Run("unknown source addr errors", func(t *testing.T) {
 		ms := newMultiSource(tagged("only", &fakeSource{}))
-		_, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 1, source: 5})
+		_, err := ms.GetSignedBlockFrom(ctx, BlockEvent{Height: 1, addr: "nonexistent"})
 		require.Error(t, err)
 	})
 }
@@ -258,11 +258,11 @@ func TestMultiSource_IsSyncingFrom(t *testing.T) {
 
 		// the catching-up source announced: its replayed block must be treated
 		// as syncing even though the other source is caught up.
-		syncing, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 7, source: 1})
+		syncing, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 7, addr: "catching-up"})
 		require.NoError(t, err)
 		assert.True(t, syncing)
 
-		syncing, err = ms.IsSyncingFrom(ctx, BlockEvent{Height: 8, source: 0})
+		syncing, err = ms.IsSyncingFrom(ctx, BlockEvent{Height: 8, addr: "caught-up"})
 		require.NoError(t, err)
 		assert.False(t, syncing)
 	})
@@ -272,13 +272,13 @@ func TestMultiSource_IsSyncingFrom(t *testing.T) {
 			tagged("healthy", &fakeSource{syncing: false}),
 			tagged("down", &fakeSource{syncingErr: errors.New("down")}),
 		)
-		_, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 9, source: 1})
+		_, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 9, addr: "down"})
 		require.Error(t, err)
 	})
 
-	t.Run("out-of-range source index errors", func(t *testing.T) {
+	t.Run("unknown source addr errors", func(t *testing.T) {
 		ms := newMultiSource(tagged("only", &fakeSource{}))
-		_, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 1, source: 5})
+		_, err := ms.IsSyncingFrom(ctx, BlockEvent{Height: 1, addr: "nonexistent"})
 		require.Error(t, err)
 	})
 }
@@ -307,7 +307,8 @@ func TestMultiSource_Verify(t *testing.T) {
 		)
 		require.NoError(t, ms.Verify(ctx, "mocha-4"))
 		require.Len(t, ms.sources, 1)
-		assert.Equal(t, "good", ms.sources[0].addr)
+		_, ok := ms.sources["good"]
+		assert.True(t, ok, "the surviving source must be the good one")
 	})
 
 	t.Run("unreachable source is pruned even when another is confirmed good", func(t *testing.T) {
@@ -318,7 +319,8 @@ func TestMultiSource_Verify(t *testing.T) {
 		require.NoError(t, ms.Verify(ctx, "mocha-4"))
 		require.Len(t, ms.sources, 1,
 			"a source that cannot vouch for its network must not enter the active set")
-		assert.Equal(t, "good", ms.sources[0].addr)
+		_, ok := ms.sources["good"]
+		assert.True(t, ok, "the surviving source must be the good one")
 	})
 
 	t.Run("errors when every reachable source is on the wrong chain", func(t *testing.T) {
@@ -392,7 +394,7 @@ func TestMultiSource_SingleSource(t *testing.T) {
 
 	t.Run("isSyncingFrom passthrough", func(t *testing.T) {
 		ctx := context.Background()
-		ev := BlockEvent{Height: 1, source: 0}
+		ev := BlockEvent{Height: 1, addr: "only"}
 
 		syncing, err := newMultiSource(tagged("only", &fakeSource{syncing: true})).IsSyncingFrom(ctx, ev)
 		require.NoError(t, err)

--- a/core/multisource_test.go
+++ b/core/multisource_test.go
@@ -92,7 +92,7 @@ func TestMultiSource_SubscribeFanIn(t *testing.T) {
 	chB <- blockAt(1)
 	chA <- blockAt(2)
 
-	got := []int64{}
+	got := make([]int64, 0, 3)
 	for range 3 {
 		b, ok := recv(t, out)
 		require.True(t, ok)
@@ -304,7 +304,7 @@ func TestMultiSource_SingleSource(t *testing.T) {
 			}
 		}()
 
-		var got []int64
+		got := make([]int64, 0, 5)
 		for range 5 {
 			b, ok := recv(t, out)
 			require.True(t, ok)

--- a/core/multisource_test.go
+++ b/core/multisource_test.go
@@ -1,0 +1,364 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSource is an in-memory Fetcher used to drive MultiSource without a live
+// gRPC connection.
+type fakeSource struct {
+	mu sync.Mutex
+
+	chainID    string
+	chainIDErr error
+
+	syncing    bool
+	syncingErr error
+
+	// subFn produces the channel/error for each SubscribeNewBlockEvent call,
+	// indexed by call number, to simulate (re)subscription.
+	subFn    func(call int) (chan SignedBlock, error)
+	subCalls int
+}
+
+func (f *fakeSource) SubscribeNewBlockEvent(context.Context) (chan SignedBlock, error) {
+	f.mu.Lock()
+	call := f.subCalls
+	f.subCalls++
+	fn := f.subFn
+	f.mu.Unlock()
+	if fn == nil {
+		return nil, errors.New("fakeSource: subFn not set")
+	}
+	return fn(call)
+}
+
+func (f *fakeSource) ChainID(context.Context) (string, error) { return f.chainID, f.chainIDErr }
+
+// Verify is unused by MultiSource (which verifies sources via ChainID) but
+// required to satisfy the Fetcher interface.
+func (f *fakeSource) Verify(context.Context, string) error { return nil }
+
+func (f *fakeSource) IsSyncing(context.Context) (bool, error) { return f.syncing, f.syncingErr }
+
+func tagged(addr string, f Fetcher) taggedSource {
+	return taggedSource{fetcher: f, addr: addr}
+}
+
+func blockAt(h int64) SignedBlock {
+	return SignedBlock{Header: &types.Header{Height: h}}
+}
+
+func recv(t *testing.T, ch <-chan SignedBlock) (SignedBlock, bool) {
+	t.Helper()
+	select {
+	case b, ok := <-ch:
+		return b, ok
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting on channel")
+		return SignedBlock{}, false
+	}
+}
+
+// neverDelivers returns a channel that is never written to or closed, so a
+// source "stays subscribed" until ctx is canceled.
+func neverDelivers() chan SignedBlock { return make(chan SignedBlock) }
+
+func TestMultiSource_SubscribeFanIn(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	chA := make(chan SignedBlock)
+	chB := make(chan SignedBlock)
+	srcA := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return chA, nil }}
+	srcB := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return chB, nil }}
+
+	ms := newMultiSource(tagged("srcA", srcA), tagged("srcB", srcB))
+	out, err := ms.SubscribeNewBlockEvent(ctx)
+	require.NoError(t, err)
+
+	// Both sources emit the same height (duplicate) plus one extra; MultiSource
+	// forwards everything — dedup is the consumer's job.
+	chA <- blockAt(1)
+	chB <- blockAt(1)
+	chA <- blockAt(2)
+
+	got := []int64{}
+	for range 3 {
+		b, ok := recv(t, out)
+		require.True(t, ok)
+		got = append(got, b.Header.Height)
+	}
+	slices.Sort(got)
+	assert.Equal(t, []int64{1, 1, 2}, got)
+
+	// Canceling drains the sources and closes the fan-in channel.
+	cancel()
+	_, ok := recv(t, out)
+	assert.False(t, ok, "out channel should close after ctx cancel")
+}
+
+func TestMultiSource_CancelClosesOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	src := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return neverDelivers(), nil }}
+	ms := newMultiSource(tagged("src", src))
+
+	out, err := ms.SubscribeNewBlockEvent(ctx)
+	require.NoError(t, err)
+
+	cancel()
+	_, ok := recv(t, out)
+	assert.False(t, ok, "out channel should close after ctx cancel")
+}
+
+// TestMultiSource_ClosedSourceDoesNotCloseOut verifies that one source ending
+// its subscription does not close the fan-in channel: the surviving source
+// keeps delivering, and out closes only once every source goroutine has exited.
+func TestMultiSource_ClosedSourceDoesNotCloseOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	dead := make(chan SignedBlock)
+	live := make(chan SignedBlock)
+	deadSrc := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return dead, nil }}
+	liveSrc := &fakeSource{subFn: func(int) (chan SignedBlock, error) { return live, nil }}
+
+	ms := newMultiSource(tagged("dead", deadSrc), tagged("live", liveSrc))
+	out, err := ms.SubscribeNewBlockEvent(ctx)
+	require.NoError(t, err)
+
+	// One source ends; the other must keep working and out must stay open.
+	close(dead)
+	live <- blockAt(9)
+	b, ok := recv(t, out)
+	require.True(t, ok)
+	assert.Equal(t, int64(9), b.Header.Height)
+}
+
+func TestMultiSource_ChainID(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("first source responds", func(t *testing.T) {
+		ms := newMultiSource(tagged("a", &fakeSource{chainID: "arabica-11"}))
+		id, err := ms.ChainID(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "arabica-11", id)
+	})
+
+	t.Run("falls back past a failing source", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{chainIDErr: errors.New("down")}),
+			tagged("b", &fakeSource{chainID: "mocha-4"}),
+		)
+		id, err := ms.ChainID(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "mocha-4", id)
+	})
+
+	t.Run("errors when all sources fail", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{chainIDErr: errors.New("a")}),
+			tagged("b", &fakeSource{chainIDErr: errors.New("b")}),
+		)
+		_, err := ms.ChainID(ctx)
+		require.Error(t, err)
+	})
+}
+
+func TestMultiSource_IsSyncing(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("not syncing if any source is caught up", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{syncing: true}),
+			tagged("b", &fakeSource{syncing: false}), // caught up
+		)
+		syncing, err := ms.IsSyncing(ctx)
+		require.NoError(t, err)
+		assert.False(t, syncing)
+	})
+
+	t.Run("syncing if every source is syncing", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{syncing: true}),
+			tagged("b", &fakeSource{syncing: true}),
+		)
+		syncing, err := ms.IsSyncing(ctx)
+		require.NoError(t, err)
+		assert.True(t, syncing)
+	})
+
+	t.Run("a single reachable syncing source wins over an errored one", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{syncingErr: errors.New("down")}),
+			tagged("b", &fakeSource{syncing: true}),
+		)
+		syncing, err := ms.IsSyncing(ctx)
+		require.NoError(t, err)
+		assert.True(t, syncing)
+	})
+
+	t.Run("errors only when no source is reachable", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{syncingErr: errors.New("a")}),
+			tagged("b", &fakeSource{syncingErr: errors.New("b")}),
+		)
+		syncing, err := ms.IsSyncing(ctx)
+		require.Error(t, err)
+		assert.True(t, syncing, "defaults to syncing when unknown")
+	})
+}
+
+func TestMultiSource_Verify(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty expected is an error: a node must know its network", func(t *testing.T) {
+		ms := newMultiSource(tagged("a", &fakeSource{chainID: "mocha-4"}))
+		require.Error(t, ms.Verify(ctx, ""))
+	})
+
+	t.Run("all on expected chain are kept", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{chainID: "mocha-4"}),
+			tagged("b", &fakeSource{chainID: "mocha-4"}),
+		)
+		require.NoError(t, ms.Verify(ctx, "mocha-4"))
+		assert.Len(t, ms.sources, 2)
+	})
+
+	t.Run("wrong-chain source is pruned, others kept", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("good", &fakeSource{chainID: "mocha-4"}),
+			tagged("bad", &fakeSource{chainID: "arabica-11"}),
+		)
+		require.NoError(t, ms.Verify(ctx, "mocha-4"))
+		require.Len(t, ms.sources, 1)
+		assert.Equal(t, "good", ms.sources[0].addr)
+	})
+
+	t.Run("unreachable source is kept when another is confirmed good", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("good", &fakeSource{chainID: "mocha-4"}),
+			tagged("down", &fakeSource{chainIDErr: errors.New("unreachable")}),
+		)
+		require.NoError(t, ms.Verify(ctx, "mocha-4"))
+		assert.Len(t, ms.sources, 2, "unreachable source kept so it can join later")
+	})
+
+	t.Run("errors when every reachable source is on the wrong chain", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{chainID: "arabica-11"}),
+			tagged("b", &fakeSource{chainID: "arabica-11"}),
+		)
+		err := ms.Verify(ctx, "mocha-4")
+		require.Error(t, err)
+		assert.Empty(t, ms.sources, "all wrong-chain sources pruned")
+	})
+
+	t.Run("errors when no source could be reached", func(t *testing.T) {
+		ms := newMultiSource(
+			tagged("a", &fakeSource{chainIDErr: errors.New("down")}),
+			tagged("b", &fakeSource{chainIDErr: errors.New("down")}),
+		)
+		err := ms.Verify(ctx, "mocha-4")
+		require.Error(t, err, "cannot start without confirming at least one source")
+	})
+}
+
+// TestMultiSource_SingleSource pins the contract that a MultiSource wrapping a
+// single endpoint behaves like the bare BlockFetcher the Listener consumed
+// before MultiSource existed: blocks pass through unchanged and in order, and
+// ChainID/IsSyncing mirror the one source.
+func TestMultiSource_SingleSource(t *testing.T) {
+	t.Run("forwards every block in order", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		in := make(chan SignedBlock)
+		src := &fakeSource{subFn: func(call int) (chan SignedBlock, error) {
+			if call == 0 {
+				return in, nil
+			}
+			return neverDelivers(), nil
+		}}
+		ms := newMultiSource(tagged("only", src))
+
+		out, err := ms.SubscribeNewBlockEvent(ctx)
+		require.NoError(t, err)
+
+		// A single source has no fan-in interleaving, so order must be preserved
+		// exactly as delivered — same as reading the BlockFetcher channel directly.
+		go func() {
+			for h := int64(1); h <= 5; h++ {
+				in <- blockAt(h)
+			}
+		}()
+
+		var got []int64
+		for range 5 {
+			b, ok := recv(t, out)
+			require.True(t, ok)
+			got = append(got, b.Header.Height)
+		}
+		assert.Equal(t, []int64{1, 2, 3, 4, 5}, got, "single source must preserve delivery order")
+	})
+
+	t.Run("chainID passthrough", func(t *testing.T) {
+		ctx := context.Background()
+
+		id, err := newMultiSource(tagged("only", &fakeSource{chainID: "arabica-11"})).ChainID(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "arabica-11", id)
+
+		_, err = newMultiSource(tagged("only", &fakeSource{chainIDErr: errors.New("down")})).ChainID(ctx)
+		require.Error(t, err, "a failing single source must surface as an error, like the bare fetcher")
+	})
+
+	t.Run("isSyncing passthrough", func(t *testing.T) {
+		ctx := context.Background()
+
+		syncing, err := newMultiSource(tagged("only", &fakeSource{syncing: true})).IsSyncing(ctx)
+		require.NoError(t, err)
+		assert.True(t, syncing)
+
+		syncing, err = newMultiSource(tagged("only", &fakeSource{syncing: false})).IsSyncing(ctx)
+		require.NoError(t, err)
+		assert.False(t, syncing)
+
+		// On error the bare BlockFetcher returns (false, err) while MultiSource
+		// returns (true, err); the bool is irrelevant because handleNewSignedBlock
+		// bails on err != nil before reading it. What matters is that the error
+		// still propagates, which it does.
+		_, err = newMultiSource(tagged("only", &fakeSource{syncingErr: errors.New("down")})).IsSyncing(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("source subscribe error closes out", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		src := &fakeSource{subFn: func(int) (chan SignedBlock, error) {
+			return nil, errors.New("subscribe boom")
+		}}
+		ms := newMultiSource(tagged("only", src))
+
+		out, err := ms.SubscribeNewBlockEvent(ctx)
+		require.NoError(t, err)
+
+		// The lone source can't subscribe, so its goroutine exits and out closes —
+		// the consumer (Listener.listen) then sees the closed channel and stops,
+		// matching the single-fetcher end-of-stream path.
+		_, ok := recv(t, out)
+		assert.False(t, ok, "out should close when the only source cannot subscribe")
+	})
+}

--- a/nodebuilder/core/config.go
+++ b/nodebuilder/core/config.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 
 	"github.com/celestiaorg/celestia-node/libs/utils"
@@ -64,10 +65,23 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 
+	// Reject duplicate endpoints (same ip:port). A duplicate is either a config
+	// typo or a pointless one — two connections to the same node share a failure
+	// domain and add no resilience — and MultiSource keys sources by addr, so a
+	// duplicate would silently collapse into a single source. The primary
+	// endpoint seeds the set so an additional one can't shadow it either.
+	seen := map[string]struct{}{
+		net.JoinHostPort(cfg.IP, cfg.Port): {},
+	}
 	for _, additionalCfg := range cfg.AdditionalCoreEndpoints {
 		if err := additionalCfg.validate(); err != nil {
 			return fmt.Errorf("nodebuilder/core: invalid additional core endpoint configuration: %w", err)
 		}
+		key := net.JoinHostPort(additionalCfg.IP, additionalCfg.Port)
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("nodebuilder/core: duplicate core endpoint %q: endpoints must be distinct nodes", key)
+		}
+		seen[key] = struct{}{}
 	}
 
 	return nil

--- a/nodebuilder/core/config.go
+++ b/nodebuilder/core/config.go
@@ -16,8 +16,16 @@ var MetricsEnabled bool
 // Config combines all configuration fields for managing the relationship with a Core node.
 type Config struct {
 	EndpointConfig
-	// AdditionalCoreEndpoints is a list of additional Celestia-Core endpoints to be used for
-	// transaction submission. Must be provided as `host:port` pairs.
+	// AdditionalCoreEndpoints lists extra Celestia-Core endpoints beyond the primary one.
+	// They serve two purposes: load-balancing transaction submission (see nodebuilder/state),
+	// and acting as additional block sources fanned into a MultiSource so the bridge ingests
+	// new blocks from every endpoint concurrently and tolerates any single one failing
+	// (see core.MultiSource and newCoreFetcher).
+	//
+	// Configurable only via the config file — there is intentionally no CLI flag. Each entry is
+	// a full EndpointConfig (IP, Port, TLSEnabled, XTokenPath): the primary endpoint keeps its
+	// --core.* flags for quick start, while this structured, possibly-secured list belongs in
+	// config rather than being flattened into flags.
 	AdditionalCoreEndpoints []EndpointConfig
 }
 

--- a/nodebuilder/core/config_test.go
+++ b/nodebuilder/core/config_test.go
@@ -106,6 +106,42 @@ func TestValidate(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "duplicate additional endpoints (same ip:port)",
+			cfg: Config{
+				EndpointConfig: EndpointConfig{
+					IP:   "127.0.0.1",
+					Port: DefaultPort,
+				},
+				AdditionalCoreEndpoints: []EndpointConfig{
+					{
+						IP:   "248.249.255.138",
+						Port: "4040",
+					},
+					{
+						IP:   "248.249.255.138",
+						Port: "4040",
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "additional endpoint duplicates the primary",
+			cfg: Config{
+				EndpointConfig: EndpointConfig{
+					IP:   "127.0.0.1",
+					Port: DefaultPort,
+				},
+				AdditionalCoreEndpoints: []EndpointConfig{
+					{
+						IP:   "127.0.0.1",
+						Port: DefaultPort,
+					},
+				},
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/nodebuilder/core/constructors.go
+++ b/nodebuilder/core/constructors.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/celestiaorg/celestia-node/core"
 	"github.com/celestiaorg/celestia-node/libs/utils"
 )
 
@@ -44,6 +45,18 @@ var (
 )
 
 type AdditionalCoreConns []*grpc.ClientConn
+
+// newCoreFetcher builds the block source consumed by the Listener. It combines
+// the primary core endpoint with any AdditionalCoreEndpoints into a MultiSource
+// so the Listener ingests new blocks from all configured endpoints concurrently
+// and tolerates any single endpoint failing. With no additional endpoints it is
+// equivalent to a single-source fetcher.
+func newCoreFetcher(primary *grpc.ClientConn, additional AdditionalCoreConns) core.Fetcher {
+	conns := make([]*grpc.ClientConn, 0, 1+len(additional))
+	conns = append(conns, primary)
+	conns = append(conns, additional...)
+	return core.NewMultiSource(conns...)
+}
 
 // TODO @renaynay: should we make this reusable so we can have all auth + other features
 // for the estimator service too?

--- a/nodebuilder/core/module.go
+++ b/nodebuilder/core/module.go
@@ -40,6 +40,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 		return fx.Module("core",
 			baseComponents,
 			fx.Provide(core.NewBlockFetcher),
+			fx.Provide(newCoreFetcher),
 			fx.Provide(func(
 				fetcher *core.BlockFetcher,
 				store *store.Store,
@@ -74,7 +75,7 @@ func ConstructModule(tp node.Type, cfg *Config, options ...fx.Option) fx.Option 
 			fx.Invoke(fx.Annotate(
 				func(
 					bcast libhead.Broadcaster[*header.ExtendedHeader],
-					fetcher *core.BlockFetcher,
+					fetcher core.Fetcher,
 					pubsub *shrexsub.PubSub,
 					construct header.ConstructFn,
 					store *store.Store,


### PR DESCRIPTION
 The bridge Listener can now ingest new blocks from several Celestia-Core endpoints at once instead of a single connection. The primary endpoint plus any configured AdditionalCoreEndpoints are fanned into one new-block stream  (core.MultiSource), so the bridge keeps making progress as long as at least one endpoint is healthy.

  How it works

  - Fan-in (MultiSource) — each endpoint is subscribed independently and its blocks are forwarded into a single channel. Staying subscribed across  transient errors is the underlying BlockFetcher's job (it already resubscribes internally), so MultiSource is a thin fan-in with no extra  retry/backoff/stall machinery.
  - Deduplication — the same height arrives from N endpoints. handleNewSignedBlock skips a height already present in the store (keyed on the store, not  an in-memory watermark), so duplicates are dropped cheaply while out-of-order blocks from a lagging source are still processed.
  - Startup verification (Fetcher.Verify) — before subscribing, every endpoint's chain ID is checked concurrently. Endpoints on the wrong network are  dropped (logged with their address); unreachable ones are kept (they may come up later). Start fails if no endpoint can be confirmed on the expected  network — or if no expected chain ID is configured at all.
  - Sync state — IsSyncing queries all endpoints concurrently and treats core as caught up as soon as any one reports synced.

  Introducing multiple sources changed how a bad block is handled:

  - Wrong chain ID is now checked after the dedup gate. A duplicate of an already-stored height from a slow/misconfigured endpoint is deduped away and  never panics. The node panics only if a wrong-chain source wins the race for a height no healthy source has stored yet. Combined with Verify pruning  wrong-chain endpoints at startup, this is effectively a backstop.
    - Rationale: configured endpoints are operator-trusted; a wrong chain ID is a static misconfiguration, and we must never ingest blocks from the wrong  network.
  - Header construction failure still panics, as before.
  - The old Listener.verifyChainID (which only checked the first endpoint) was replaced by Fetcher.Verify, which checks and prunes all endpoints.

  Configuring additional endpoints:

Additional endpoints are set only via the config file (config.toml) — there is intentionally no CLI flag. The primary endpoint keeps --core.ip /
  --core.port for quick start; a list of multi-field, possibly TLS/token-secured endpoints belongs in structured config rather than flattened into flags.

```yml
  [Core]
    IP = "primary.example.com"
    Port = "9090"

    [[Core.AdditionalCoreEndpoints]]
      IP = "second.example.com"
      Port = "9090"

    [[Core.AdditionalCoreEndpoints]]
      IP = "third.example.com"
      Port = "9090"
      TLSEnabled = true
      XTokenPath = "/path/to/xtoken-dir"
```

  Each entry is a full EndpointConfig (IP, Port, TLSEnabled, XTokenPath), same fields as the primary. AdditionalCoreEndpoints is also used to  load-balance transaction submission (nodebuilder/state).

Endpoints may sit at different heights, and a faster (ahead-running) endpoint can deliver a height before the heights below it have been seen on the  live subscription (e.g. after a restart when every endpoint is already at the tip). The MultiSource listener handles only the live new-block stream and   deliberately does not backfill historic gaps itself — that is left to the existing machinery:
  - the header Syncer fills any missing ExtendedHeaders between its head and a newly received higher header via the header exchange;
  - the DASer samples and fetches the missing EDSs (for heights within the availability window) via ShareAvailability.

  So a non-contiguous height arriving from an ahead-of-the-pack endpoint is safe: the dedup gate processes/stores what it can locally, and the Syncer +  DASer reconcile the rest. This is also why the dedup gate keys on the store rather than an in-memory high-watermark — it never has to assume heights  arrive in order.