### PR TITLE
fix(shwap): bind sample coordinate in Sample.Verify

### DIFF
--- a/share/shwap/sample.go
+++ b/share/shwap/sample.go
@@ -140,6 +140,18 @@ func (s Sample) Verify(roots *share.AxisRoots, rowIdx, colIdx int) error {
 	if s.ProofType != rsmt2d.Row && s.ProofType != rsmt2d.Col {
 		return fmt.Errorf("invalid SampleProofType: %d", s.ProofType)
 	}
+	switch s.ProofType {
+	case rsmt2d.Row:
+		if s.Proof.Start() != colIdx || s.Proof.End() != colIdx+1 {
+			return fmt.Errorf("%w: row proof Start/End = %d/%d, want %d/%d",
+				ErrFailedVerification, s.Proof.Start(), s.Proof.End(), colIdx, colIdx+1)
+		}
+	case rsmt2d.Col:
+		if s.Proof.Start() != rowIdx || s.Proof.End() != rowIdx+1 {
+			return fmt.Errorf("%w: col proof Start/End = %d/%d, want %d/%d",
+				ErrFailedVerification, s.Proof.Start(), s.Proof.End(), rowIdx, rowIdx+1)
+		}
+	}
 	if !s.verifyInclusion(roots, rowIdx, colIdx) {
 		return ErrFailedVerification
 	}

--- a/share/shwap/sample_test.go
+++ b/share/shwap/sample_test.go
@@ -77,6 +77,35 @@ func TestSampleNegativeVerifyInclusion(t *testing.T) {
 	require.ErrorIs(t, err, shwap.ErrFailedVerification)
 }
 
+// TestSampleColumnSubstitution demonstrates PROTOCO-1823: Sample.Verify does not
+// bind the proof's column to the requested column. A sample built for (row 0, col 1)
+// is accepted when the caller requested (row 0, col 0). Both coordinates live in the
+// same row and the same (non-parity) quadrant, so the row root and namespace selection
+// still match. This test asserts the CORRECT behavior (rejection) and therefore fails
+// on current code, proving the vulnerability.
+func TestSampleColumnSubstitution(t *testing.T) {
+	const odsSize = 8
+	randEDS := edstest.RandEDS(t, odsSize)
+	root, err := share.NewAxisRoots(randEDS)
+	require.NoError(t, err)
+	inMem := eds.Rsmt2D{ExtendedDataSquare: randEDS}
+
+	const requestedRow, requestedCol = 0, 0
+	const servedCol = 1 // attacker substitutes a different column in the same row
+
+	// Build a valid sample+proof for a DIFFERENT column in the same row.
+	served, err := inMem.SampleForProofAxis(shwap.SampleCoords{Row: requestedRow, Col: servedCol}, rsmt2d.Row)
+	require.NoError(t, err)
+
+	// The proof genuinely opens column 1, not the requested column 0.
+	require.Equal(t, servedCol, served.Proof.Start())
+
+	// Verifying against the REQUESTED coordinate (row 0, col 0) must be rejected.
+	err = served.Verify(root, requestedRow, requestedCol)
+	require.ErrorIs(t, err, shwap.ErrFailedVerification,
+		"Sample.Verify accepted a proof for col %d when col %d was requested", servedCol, requestedCol)
+}
+
 func TestSampleProtoEncoding(t *testing.T) {
 	const odsSize = 8
 	randEDS := edstest.RandEDS(t, odsSize)


### PR DESCRIPTION
## Overview

Adds coordinate binding to `Sample.Verify` so that a sample's inclusion proof must open at the requested coordinate, not merely under the requested axis root. Mirrors the existing binding in `range_namespace_data.go`. The `Start`/`End` fields are already on the wire, so there is no protocol cost.

Includes a regression test (`TestSampleColumnSubstitution`).

Closes PROTOCO-1823 (see Linear for details).

🤖 Generated with [Claude Code](https://claude.com/claude-code)