### PR TITLE
fix(shwap/bitswap): release hasher mutex on error path

### DIFF
--- a/share/shwap/p2p/bitswap/block_fetch.go
+++ b/share/shwap/p2p/bitswap/block_fetch.go
@@ -218,11 +218,11 @@ func (h *hasher) write(data []byte) error {
 	// NOTE: Bitswap may call hasher.Write concurrently, which may call unmarshall concurrently
 	// this we need this synchronization.
 	entry.Lock()
+	defer entry.Unlock()
 	err = entry.UnmarshalFn(container, id)
 	if err != nil {
 		return fmt.Errorf("verifying and unmarshalling container data: %w", err)
 	}
-	entry.Unlock()
 
 	// set the id as resulting sum
 	// it's required for the sum to match the requested ID

--- a/share/shwap/p2p/bitswap/block_fetch_deadlock_test.go
+++ b/share/shwap/p2p/bitswap/block_fetch_deadlock_test.go
@@ -1,0 +1,40 @@
+package bitswap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHasher_MutexReleasedOnUnmarshalError is a regression test ensuring
+// hasher.write releases the per-entry mutex on the error path.
+//
+// When an UnmarshalFn returns an error (e.g. a peer sends a block with a valid
+// CID and proto envelope but corrupted/invalid container data), hasher.write
+// must still release entry.Lock(). The entry lives in the global unmarshalFns
+// map, so a leaked lock is observable by every subsequent goroutine that loads
+// the same entry, causing them to block forever on entry.Lock().
+func TestHasher_MutexReleasedOnUnmarshalError(t *testing.T) {
+	blk := newTestBlock(0xBEEF & 0xFFFF)
+	protoData, err := marshalProto(blk)
+	require.NoError(t, err)
+
+	entry := &unmarshalEntry{
+		UnmarshalFn: func(_, _ []byte) error {
+			return fmt.Errorf("simulated invalid share data / forged proof")
+		},
+	}
+	unmarshalFns.Store(blk.CID(), entry)
+	defer unmarshalFns.Delete(blk.CID())
+
+	h := &hasher{IDSize: testIDSize}
+	_, writeErr := h.Write(protoData)
+	require.Error(t, writeErr, "hasher.Write must reject invalid data")
+
+	// After the error path, the entry mutex must NOT be held. TryLock returns
+	// false if the mutex is still locked (the leak); true if it is free.
+	free := entry.TryLock()
+	require.True(t, free, "entry mutex still held after UnmarshalFn error — lock leaked")
+	entry.Unlock()
+}


### PR DESCRIPTION
## Overview

`hasher.write` in `share/shwap/p2p/bitswap/block_fetch.go` acquired the per-entry mutex (`entry.Lock()`) but only released it on the success path. On the error return path the lock was leaked. This moves the unlock to a `defer` so it runs on every exit path (success, error, panic), and adds a regression test.

This addresses a security report. Bug details are tracked privately in the Linear issue.

Closes PROTOCO-1830

## Testing

- Added `TestHasher_MutexReleasedOnUnmarshalError` (fails before the fix, passes after).
- `go test -race ./share/shwap/p2p/bitswap/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)