### PR TITLE
chore: bump app to v9.0.0-mocha

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
 	github.com/benbjohnson/clock v1.3.5
-	github.com/celestiaorg/celestia-app/v9 v9.0.0-arabica
+	github.com/celestiaorg/celestia-app/v9 v9.0.0-mocha
 	github.com/celestiaorg/go-header v0.8.5
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2
 	github.com/celestiaorg/go-square/merkle v0.0.0-20240117232118-fd78256df076

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/boxo v0.29.0-fork-4 h1:A202u8w3Iqjw4ZlqSukfiMbefQEN+740GUj1Z3VI960=
 github.com/celestiaorg/boxo v0.29.0-fork-4/go.mod h1:rXql6ncaLZZfLqDG3Cuw9ZYQKd3rMU5bk1TGXF0+ZL0=
-github.com/celestiaorg/celestia-app/v9 v9.0.0-arabica h1:muQoTjaoWVh84A8bRdT5otMpsGQWVEUdjNk9ibzbdnU=
-github.com/celestiaorg/celestia-app/v9 v9.0.0-arabica/go.mod h1:FqrG7EfLCSF4YVAxjnsbB1J2+qPcimtWHbSIatAgreQ=
+github.com/celestiaorg/celestia-app/v9 v9.0.0-mocha h1:dE2V3YpPrhJ5DOE7sfTw/h1mPn/caI8U+3IPVVN0o8Q=
+github.com/celestiaorg/celestia-app/v9 v9.0.0-mocha/go.mod h1:FqrG7EfLCSF4YVAxjnsbB1J2+qPcimtWHbSIatAgreQ=
 github.com/celestiaorg/celestia-core v0.40.2 h1:+8D3anWx0mn0Wyp/Hahml/1ZiyDc5yGbIR/k4iFtqms=
 github.com/celestiaorg/celestia-core v0.40.2/go.mod h1:ZCrmRE1UQzgZfho4Og6tAHtH1KY6s8Jpri5+EKobV5c=
 github.com/celestiaorg/cosmos-sdk v0.52.3 h1:YPMFCycTw77P7tn+HQHTmmdBwXWNMDOrZ6/xVPK9nvM=

--- a/nodebuilder/tests/tastora/go.mod
+++ b/nodebuilder/tests/tastora/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	cosmossdk.io/math v1.5.3
-	github.com/celestiaorg/celestia-app/v9 v9.0.0-arabica
+	github.com/celestiaorg/celestia-app/v9 v9.0.0-mocha
 	github.com/celestiaorg/celestia-node v0.23.3
 	github.com/celestiaorg/go-square/v4 v4.0.0-rc4
 	github.com/celestiaorg/tastora v0.20.0

--- a/nodebuilder/tests/tastora/go.sum
+++ b/nodebuilder/tests/tastora/go.sum
@@ -218,8 +218,8 @@ github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/boxo v0.29.0-fork-4 h1:A202u8w3Iqjw4ZlqSukfiMbefQEN+740GUj1Z3VI960=
 github.com/celestiaorg/boxo v0.29.0-fork-4/go.mod h1:rXql6ncaLZZfLqDG3Cuw9ZYQKd3rMU5bk1TGXF0+ZL0=
-github.com/celestiaorg/celestia-app/v9 v9.0.0-arabica h1:muQoTjaoWVh84A8bRdT5otMpsGQWVEUdjNk9ibzbdnU=
-github.com/celestiaorg/celestia-app/v9 v9.0.0-arabica/go.mod h1:FqrG7EfLCSF4YVAxjnsbB1J2+qPcimtWHbSIatAgreQ=
+github.com/celestiaorg/celestia-app/v9 v9.0.0-mocha h1:dE2V3YpPrhJ5DOE7sfTw/h1mPn/caI8U+3IPVVN0o8Q=
+github.com/celestiaorg/celestia-app/v9 v9.0.0-mocha/go.mod h1:FqrG7EfLCSF4YVAxjnsbB1J2+qPcimtWHbSIatAgreQ=
 github.com/celestiaorg/celestia-core v0.40.2 h1:+8D3anWx0mn0Wyp/Hahml/1ZiyDc5yGbIR/k4iFtqms=
 github.com/celestiaorg/celestia-core v0.40.2/go.mod h1:ZCrmRE1UQzgZfho4Og6tAHtH1KY6s8Jpri5+EKobV5c=
 github.com/celestiaorg/cosmos-sdk v0.52.3 h1:YPMFCycTw77P7tn+HQHTmmdBwXWNMDOrZ6/xVPK9nvM=


### PR DESCRIPTION
Fixes https://linear.app/celestia/issue/PROTOCO-1723/upgrade-node-to-v900-mocha