### PR TITLE
ci: notify #protocol-ci Slack channel on CI failures

### DIFF
--- a/.github/workflows/notify-protocol-ci.yml
+++ b/.github/workflows/notify-protocol-ci.yml
@@ -1,0 +1,33 @@
+name: Notify protocol-ci on failure
+
+# Posts a message to the #protocol-ci Slack channel when a CI workflow fails on
+# main (post-merge) or on a scheduled run. A single workflow_run-triggered file
+# watches several workflows so we don't have to add a notify job to each one.
+# The repo name is included in the message so #protocol-ci can aggregate
+# failures from celestia-app, celestia-core, and celestia-node.
+on:
+  workflow_run:
+    workflows:
+      - "CI and Release"
+      - "Docker Build & Publish"
+      - "Bootstrapper Health Check"
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.PROTOCOL_CI_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ github.repository }} | ${{ github.event.workflow_run.name }} failed on ${{ github.event.workflow_run.head_branch }}: ${{ github.event.workflow_run.html_url }}"
+            }

--- a/.github/workflows/notify-protocol-ci.yml
+++ b/.github/workflows/notify-protocol-ci.yml
@@ -16,6 +16,10 @@ on:
     branches:
       - main
 
+# The notifier only calls an external Slack webhook; it needs no GITHUB_TOKEN
+# scopes.
+permissions: {}
+
 jobs:
   notify:
     name: Notify Slack
@@ -23,7 +27,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: Slack Notification
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.PROTOCOL_CI_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Overview

Routes celestia-node CI failures into the new **#protocol-ci** Slack channel so failures from celestia-app, celestia-core, and celestia-node can be monitored in one place. Each message is prefixed with the repo name, e.g.:

> `celestiaorg/celestia-node | CI and Release failed on main: <link>`

## Changes

- Add `.github/workflows/notify-protocol-ci.yml`: a single `workflow_run`-triggered notifier that watches `CI and Release`, `Docker Build & Publish`, and the scheduled `Bootstrapper Health Check`, and posts to #protocol-ci when any fails on `main` (post-merge) or on a scheduled run.

## Notes

- Uses a new repo secret `PROTOCOL_CI_SLACK_WEBHOOK_URL` (incoming webhook for #protocol-ci), so existing notifications to other channels are untouched. The secret has been configured.

## Security hardening

Addresses CodeQL `actions/unpinned-tag` and `actions/missing-workflow-permissions` alerts:
- Pinned `slackapi/slack-github-action` to its v3.0.3 commit SHA (`45a88b9`).
- Set an empty `permissions: {}` block (the notifier only calls an external Slack webhook).

Closes [PROTOCO-1891](https://linear.app/celestia/issue/PROTOCO-1891/route-ci-failures-from-celestia-appcorenode-to-protocol-ci-slack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
