### PR TITLE
headertest: unify TestSuite constructors behind functional options

### DIFF
--- a/core/routing_exchange_test.go
+++ b/core/routing_exchange_test.go
@@ -19,7 +19,7 @@ func TestRoutingExchange_GetByHeight_AlwaysUsesCore(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuiteDefaults(t)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -44,7 +44,7 @@ func TestRoutingExchange_GetRangeByHeight_AllInWindow(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuiteDefaults(t)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -71,7 +71,7 @@ func TestRoutingExchange_GetRangeByHeight_AllOutsideWindow(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuiteDefaults(t)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -97,7 +97,7 @@ func TestRoutingExchange_GetRangeByHeight_Split(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuiteDefaults(t)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -129,7 +129,7 @@ func TestRoutingExchange_Head_AlwaysUsesCore(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuiteDefaults(t)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	headers := suite.GenExtendedHeaders(5)
 	coreEx.head = headers[4]
 	p2pEx.head = headers[4]
@@ -155,7 +155,7 @@ func TestRoutingExchange_CalculateCutoffHeight(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuiteDefaults(t)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -203,7 +203,7 @@ func TestRoutingExchange_Get_TriesCoreFirst(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuiteDefaults(t)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	headers := suite.GenExtendedHeaders(5)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -226,7 +226,7 @@ func TestRoutingExchange_Get_FallsBackToP2P(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuiteDefaults(t)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	headers := suite.GenExtendedHeaders(5)
 	// Only add to p2p, not core
 	for _, h := range headers {

--- a/core/routing_exchange_test.go
+++ b/core/routing_exchange_test.go
@@ -19,7 +19,7 @@ func TestRoutingExchange_GetByHeight_AlwaysUsesCore(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -44,7 +44,7 @@ func TestRoutingExchange_GetRangeByHeight_AllInWindow(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -71,7 +71,7 @@ func TestRoutingExchange_GetRangeByHeight_AllOutsideWindow(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -97,7 +97,7 @@ func TestRoutingExchange_GetRangeByHeight_Split(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -129,7 +129,7 @@ func TestRoutingExchange_Head_AlwaysUsesCore(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(5)
 	coreEx.head = headers[4]
 	p2pEx.head = headers[4]
@@ -155,7 +155,7 @@ func TestRoutingExchange_CalculateCutoffHeight(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(10)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -203,7 +203,7 @@ func TestRoutingExchange_Get_TriesCoreFirst(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(5)
 	for _, h := range headers {
 		coreEx.addHeader(h)
@@ -226,7 +226,7 @@ func TestRoutingExchange_Get_FallsBackToP2P(t *testing.T) {
 	coreEx := newMockExchange()
 	p2pEx := newMockExchange()
 
-	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(5)
 	// Only add to p2p, not core
 	for _, h := range headers {

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -168,9 +168,9 @@ func createMockGetterAndSub(
 	numSub int,
 	tail ...*header.ExtendedHeader,
 ) (libhead.Store[*header.ExtendedHeader], libhead.Subscriber[*header.ExtendedHeader]) {
-	hsuite := headertest.NewTestSuiteDefaults(t)
+	hsuite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
 	if len(tail) > 0 {
-		hsuite = headertest.NewTestSuiteWithTail(t, tail[0])
+		hsuite = headertest.NewTestSuite(t, headertest.WithBlockTime(1), headertest.WithTail(tail[0]))
 	}
 
 	store := headertest.NewCustomStore(t, hsuite, numGetter)

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -168,9 +168,9 @@ func createMockGetterAndSub(
 	numSub int,
 	tail ...*header.ExtendedHeader,
 ) (libhead.Store[*header.ExtendedHeader], libhead.Subscriber[*header.ExtendedHeader]) {
-	hsuite := headertest.NewTestSuite(t, headertest.WithBlockTime(1))
+	hsuite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	if len(tail) > 0 {
-		hsuite = headertest.NewTestSuite(t, headertest.WithBlockTime(1), headertest.WithTail(tail[0]))
+		hsuite = headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond), headertest.WithTail(tail[0]))
 	}
 
 	store := headertest.NewCustomStore(t, hsuite, numGetter)

--- a/header/headertest/testing.go
+++ b/header/headertest/testing.go
@@ -45,7 +45,7 @@ type TestSuite struct {
 }
 
 func NewStore(t *testing.T) libhead.Store[*header.ExtendedHeader] {
-	return headertest.NewStore[*header.ExtendedHeader](t, NewTestSuite(t, 3, 0), 10)
+	return headertest.NewStore[*header.ExtendedHeader](t, NewTestSuite(t), 10)
 }
 
 func NewCustomStore(
@@ -56,50 +56,62 @@ func NewCustomStore(
 	return headertest.NewStore[*header.ExtendedHeader](t, generator, numHeaders)
 }
 
-// NewTestSuite setups a new test suite with a given number of validators.
-func NewTestSuite(t *testing.T, numValidators int, blockTime time.Duration) *TestSuite {
-	valSet, vals := RandValidatorSet(numValidators, 10)
-	return &TestSuite{
-		t:         t,
-		vals:      vals,
-		valSet:    valSet,
-		blockTime: blockTime,
-		startTime: time.Now(),
+// defaultNumValidators is the number of validators NewTestSuite generates by
+// default when WithValidators is not provided.
+const defaultNumValidators = 3
+
+// defaultVotingPower is the voting power assigned to every validator generated
+// for a TestSuite.
+const defaultVotingPower = 10
+
+// Option configures a TestSuite.
+type Option func(*TestSuite)
+
+// WithValidators sets the number of validators in the suite's validator set.
+func WithValidators(numValidators int) Option {
+	return func(ts *TestSuite) {
+		ts.valSet, ts.vals = RandValidatorSet(numValidators, defaultVotingPower)
 	}
 }
 
-func NewTestSuiteWithGenesisTime(t *testing.T, startTime time.Time, blockTime time.Duration) *TestSuite {
-	valSet, vals := RandValidatorSet(3, 1)
-	return &TestSuite{
-		t:         t,
-		vals:      vals,
-		valSet:    valSet,
-		blockTime: blockTime,
-		startTime: startTime,
+// WithBlockTime sets the spacing between generated block timestamps. When left
+// at zero (the default), generated headers are timestamped with the current
+// time instead of a fixed interval.
+func WithBlockTime(blockTime time.Duration) Option {
+	return func(ts *TestSuite) {
+		ts.blockTime = blockTime
 	}
 }
 
-func NewTestSuiteDefaults(t *testing.T) *TestSuite {
-	valSet, vals := RandValidatorSet(3, 1)
-	return &TestSuite{
-		t:         t,
-		vals:      vals,
-		valSet:    valSet,
-		blockTime: 1,
-		startTime: time.Now(),
+// WithStartTime sets the genesis timestamp of the suite.
+func WithStartTime(startTime time.Time) Option {
+	return func(ts *TestSuite) {
+		ts.startTime = startTime
 	}
 }
 
-func NewTestSuiteWithTail(t *testing.T, tail *header.ExtendedHeader) *TestSuite {
-	valSet, vals := RandValidatorSet(3, 1)
-	return &TestSuite{
+// WithTail sets the tail header the suite starts generating from.
+func WithTail(tail *header.ExtendedHeader) Option {
+	return func(ts *TestSuite) {
+		ts.tail = tail
+	}
+}
+
+// NewTestSuite sets up a new TestSuite for generating a chain of Headers.
+// By default it uses 3 validators, the current time as genesis and no
+// block-time spacing. Pass Options to override these defaults.
+func NewTestSuite(t *testing.T, opts ...Option) *TestSuite {
+	valSet, vals := RandValidatorSet(defaultNumValidators, defaultVotingPower)
+	ts := &TestSuite{
 		t:         t,
 		vals:      vals,
 		valSet:    valSet,
-		blockTime: 1,
 		startTime: time.Now(),
-		tail:      tail,
 	}
+	for _, opt := range opts {
+		opt(ts)
+	}
+	return ts
 }
 
 func (s *TestSuite) genesis() *header.ExtendedHeader {

--- a/header/headertest/verify_test.go
+++ b/header/headertest/verify_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestVerify(t *testing.T) {
-	h := NewTestSuite(t, 2, 0).GenExtendedHeaders(3)
+	h := NewTestSuite(t, WithValidators(2)).GenExtendedHeaders(3)
 	trusted, untrustedAdj, untrustedNonAdj := h[0], h[1], h[2]
 	tests := []struct {
 		prepare func() *header.ExtendedHeader
@@ -46,7 +46,7 @@ func TestVerify(t *testing.T) {
 		{
 			prepare: func() *header.ExtendedHeader {
 				untrusted := *untrustedNonAdj
-				untrusted.Commit = NewTestSuite(t, 2, 0).Commit(RandRawHeader(t))
+				untrusted.Commit = NewTestSuite(t, WithValidators(2)).Commit(RandRawHeader(t))
 				return &untrusted
 			},
 			err: header.ErrVerifyCommitLightTrustingFailed,

--- a/pruner/service_test.go
+++ b/pruner/service_test.go
@@ -33,7 +33,7 @@ func TestService(t *testing.T) {
 
 	// all headers generated in suite are timestamped to time.Now(), so
 	// they will all be considered "pruneable" within the availability window (
-	suite := headertest.NewTestSuite(t, 1, blockTime)
+	suite := headertest.NewTestSuite(t, headertest.WithValidators(1), headertest.WithBlockTime(blockTime))
 	store := headertest.NewCustomStore(t, suite, 20)
 
 	mp := &mockPruner{}
@@ -73,7 +73,7 @@ func TestService_FailedAreRecorded(t *testing.T) {
 
 	// all headers generated in suite are timestamped to time.Now(), so
 	// they will all be considered "pruneable" within the availability window
-	suite := headertest.NewTestSuite(t, 1, blockTime)
+	suite := headertest.NewTestSuite(t, headertest.WithValidators(1), headertest.WithBlockTime(blockTime))
 	store := headertest.NewCustomStore(t, suite, 100)
 
 	mp := &mockPruner{
@@ -164,7 +164,7 @@ func TestPrune_LargeNumberOfBlocks(t *testing.T) {
 
 	// all headers generated in suite are timestamped to time.Now(), so
 	// they will all be considered "pruneable" within the availability window
-	suite := headertest.NewTestSuite(t, 1, blockTime)
+	suite := headertest.NewTestSuite(t, headertest.WithValidators(1), headertest.WithBlockTime(blockTime))
 	store := headertest.NewCustomStore(t, suite, maxHeadersPerLoop*6) // add small buffer
 
 	mp := &mockPruner{failHeight: make(map[uint64]int, 0)}
@@ -244,7 +244,7 @@ func TestFindPruneableHeaders(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
 
-			suite := headertest.NewTestSuiteWithGenesisTime(t, tc.startTime, tc.blockTime)
+			suite := headertest.NewTestSuite(t, headertest.WithStartTime(tc.startTime), headertest.WithBlockTime(tc.blockTime))
 			store := headertest.NewCustomStore(t, suite, tc.headerAmount)
 
 			mp := &mockPruner{}

--- a/share/availability/full/availability_test.go
+++ b/share/availability/full/availability_test.go
@@ -111,7 +111,7 @@ func TestSharesAvailable_OutsideSamplingWindow_NonArchival(t *testing.T) {
 	store, err := store.NewStore(store.DefaultParameters(), t.TempDir())
 	require.NoError(t, err)
 
-	suite := headertest.NewTestSuite(t, 3, time.Nanosecond)
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
 	headers := suite.GenExtendedHeaders(10)
 
 	avail := NewShareAvailability(store, getter)


### PR DESCRIPTION
Closes #4037.

Unifies the four `TestSuite` constructors (`NewTestSuite`, `NewTestSuiteWithGenesisTime`, `NewTestSuiteDefaults`, `NewTestSuiteWithTail`) into a single variadic `NewTestSuite(t, ...Option)` with `WithValidators`, `WithBlockTime`, `WithStartTime` and `WithTail`, and migrates all call sites.

The migration is behavior-preserving — block-time spacing is retained at the call sites where the removed constructors set it to keep generated header timestamps monotonic. Voting power is standardized (it does not affect test outcomes since every validator signs each commit).

Verified: `header/headertest`, `pruner`, `core`, `das` and `share/availability/full` tests pass.