### PR TITLE
fix(store/file): close ODS file descriptors in ValidateODSSize and Op…

### DIFF
--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -142,6 +142,7 @@ func ValidateODSSize(path string, eds *rsmt2d.ExtendedDataSquare) error {
 	if err != nil {
 		return fmt.Errorf("opening file: %w", err)
 	}
+	defer ods.Close()
 
 	shares, err := filledSharesAmount(eds)
 	if err != nil {
@@ -173,6 +174,7 @@ func OpenODS(path string) (*ODS, error) {
 
 	h, err := readHeader(f)
 	if err != nil {
+		_ = f.Close()
 		return nil, err
 	}
 

--- a/store/file/ods_test.go
+++ b/store/file/ods_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -151,6 +152,59 @@ func TestValidateODSSize(t *testing.T) {
 			})
 		}
 	}
+}
+
+// openFDCount returns the number of file descriptors currently open by the
+// process. It relies on Linux's /proc and skips the test elsewhere.
+func openFDCount(t *testing.T) int {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("file descriptor counting via /proc is only available on Linux")
+	}
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+	return len(entries)
+}
+
+// TestValidateODSSize_NoFDLeak ensures ValidateODSSize does not leak the file
+// descriptor opened by OpenODS. It opened the file but never closed it on any
+// path, leaking one fd per call during store startup validation.
+func TestValidateODSSize_NoFDLeak(t *testing.T) {
+	eds := edstest.RandEDS(t, 8)
+	roots, err := share.NewAxisRoots(eds)
+	require.NoError(t, err)
+	path := t.TempDir() + "ods-fd-leak"
+	require.NoError(t, CreateODS(path, roots, eds))
+
+	// warm up one call so any one-off fds (not per-call leaks) are already open.
+	require.NoError(t, ValidateODSSize(path, eds))
+
+	before := openFDCount(t)
+	for range 50 {
+		require.NoError(t, ValidateODSSize(path, eds))
+	}
+	after := openFDCount(t)
+	require.LessOrEqual(t, after-before, 1, "ValidateODSSize leaked file descriptors")
+}
+
+// TestOpenODS_NoFDLeakOnHeaderError ensures OpenODS closes the underlying file
+// when header parsing fails, instead of leaking the descriptor.
+func TestOpenODS_NoFDLeakOnHeaderError(t *testing.T) {
+	// too short to contain a valid header, so readHeader fails.
+	path := t.TempDir() + "corrupt-ods"
+	require.NoError(t, os.WriteFile(path, []byte{0x00, 0x01, 0x02}, 0o600))
+
+	// warm up so the first-call allocations don't skew the count.
+	_, err := OpenODS(path)
+	require.Error(t, err)
+
+	before := openFDCount(t)
+	for range 50 {
+		_, err := OpenODS(path)
+		require.Error(t, err)
+	}
+	after := openFDCount(t)
+	require.LessOrEqual(t, after-before, 1, "OpenODS leaked a file descriptor on header error")
 }
 
 // BenchmarkAxisFromODSFile/Size:32/ProofType:row/squareHalf:0-16         	  382011	      3104 ns/op


### PR DESCRIPTION
## Overview

Two file-descriptor leaks in `store/file`:

- `ValidateODSSize` opens an ODS via `OpenODS` but never closes it on any path — leaking one fd per call during store startup validation.
- `OpenODS` itself leaks the file when `readHeader` fails (truncated/corrupt file), since the descriptor is never returned to the caller.

Fix: `defer ods.Close()` in `ValidateODSSize`, and close the file in `OpenODS` on the header-error path. The sibling `validateQ4Size` already follows this pattern.

Adds regression tests that count open descriptors (Linux `/proc/self/fd`) and fail on the pre-fix leak.

Closes #5054

