### PR TITLE
nodebuilder: make Badger ValueThreshold configurable

### DIFF
--- a/nodebuilder/node/config.go
+++ b/nodebuilder/node/config.go
@@ -10,6 +10,15 @@ var defaultLifecycleTimeout = time.Minute * 2
 type Config struct {
 	StartupTimeout  time.Duration
 	ShutdownTimeout time.Duration
+	// BadgerValueThreshold is the byte size above which Badger datastore values
+	// are kept in the value log instead of the LSM tree. 0 = upstream default
+	// (share size, 512B), which forces ExtendedHeaders into the append-only value
+	// log; on long-running nodes that grows `data/` by GBs/hour because deferred
+	// value-log GC cannot reclaim header churn fast enough. Raising it (e.g.
+	// 1048576 = 1 MiB) keeps headers in the LSM tree, where leveled compaction
+	// reclaims overwrites continuously and `data/` stays bounded — at the cost of
+	// more memory during compaction. See nodebuilder/store.go constraintBadgerConfig.
+	BadgerValueThreshold int `toml:",omitempty"`
 }
 
 // DefaultConfig returns the default node configuration for a given node type.

--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -129,7 +129,15 @@ func (f *fsStore) Datastore() (datastore.Batching, error) {
 		return f.data, nil
 	}
 
-	cfg := constraintBadgerConfig()
+	// Read the configured Badger value threshold (0 → upstream default). Lets
+	// disk-constrained operators keep ExtendedHeaders in the LSM tree instead of
+	// the value log, bounding `data/` growth. Falls back to the default if the
+	// node config can't be loaded.
+	valueThreshold := 0
+	if nodeCfg, cfgErr := f.Config(); cfgErr == nil {
+		valueThreshold = nodeCfg.Node.BadgerValueThreshold
+	}
+	cfg := constraintBadgerConfig(valueThreshold)
 	ds, err := dsbadger.NewDatastore(dataPath(f.path), cfg)
 	if err != nil {
 		return nil, fmt.Errorf("node: can't open Badger Datastore: %w", err)
@@ -301,13 +309,24 @@ func dataPath(base string) string {
 //
 // TODO(@Wondertan): Consider alternative less constraint configuration for FN/BN
 // TODO(@Wondertan): Consider dynamic memory allocation based on available RAM
-func constraintBadgerConfig() *dsbadger.Options {
+func constraintBadgerConfig(valueThreshold int) *dsbadger.Options {
 	opts := dsbadger.DefaultOptions // this must be copied
-	// ValueLog:
-	// 2mib default => libshare.ShareSize - makes sure headers and samples are stored in value log
-	// This *tremendously* reduces the amount of memory used by the node, up to 10 times less during
-	// compaction
-	opts.ValueThreshold = libshare.ShareSize
+	// ValueLog / ValueThreshold:
+	// Upstream default is libshare.ShareSize (512B), which forces ExtendedHeaders
+	// (tens of KB each, incl. full validator set + commit) into the append-only value
+	// log. On a long-running node the value log accumulates header churn (head/tail
+	// pointer rewrites every flush + overwrites) that the deferred value-log GC fails to
+	// reclaim, growing `data/` by GBs/hour until it fills the disk (the pruner deletes
+	// nothing for the first PruningWindow=169h, so it is all "live" to GC).
+	// Operators can raise Node.BadgerValueThreshold to keep header values in the LSM
+	// tree instead, where leveled compaction reclaims overwritten versions continuously
+	// and `data/` stays bounded. Trade-off: higher memory during compaction (the reason
+	// upstream keeps it low). Zero preserves the upstream default.
+	if valueThreshold <= 0 {
+		valueThreshold = libshare.ShareSize
+	}
+	log.Infow("badger datastore value threshold", "bytes", valueThreshold)
+	opts.ValueThreshold = int64(valueThreshold)
 	// make sure we don't have any limits for stored headers
 	opts.ValueLogMaxEntries = 100000000
 	// run value log GC more often to spread the work over time


### PR DESCRIPTION
The datastore hardcodes opts.ValueThreshold = libshare.ShareSize (512B), forcing every value above that — notably every ExtendedHeader (RawHeader + Commit with all validator signatures + full ValidatorSet + DAH, tens of KB) — into Badger's append-only value log.

On long-running bridge/full nodes the value log accumulates header write churn (head/tail pointer rewrites on every flush, plus overwrites) that the deferred value-log GC cannot reclaim. Nothing is deleted for the first PruningWindow (>=169h), so it is all live to GC, and the data/ directory grows by GBs/hour until it fills the disk well before pruning ever starts.

Add Node.BadgerValueThreshold (bytes). Default 0 preserves the current behaviour (ShareSize). Setting it above the header size keeps headers in the LSM tree, where leveled compaction reclaims overwritten versions continuously and data/ stays bounded. The trade-off is higher memory during compaction (the reason the threshold is kept low by default, see #2960), so this is strictly opt-in.