### PR TITLE
test(shrex_getter): give each peer manager its own header subscriber

### DIFF
--- a/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
@@ -50,12 +50,12 @@ func TestShrexGetter(t *testing.T) {
 	edsStore := newWrappedStore(st)
 	client, _ := newShrexClientServer(ctx, t, edsStore, srvHost, clHost)
 
-	// create shrex Getter
-	sub := new(headertest.Subscriber)
-
-	fullPeerManager, err := testManager(ctx, clHost, sub)
+	// create shrex Getter. Each manager gets its own subscriber: the headertest
+	// Subscriber mock is not safe for concurrent NextHeader calls, and in
+	// production every manager has its own header subscription anyway.
+	fullPeerManager, err := testManager(ctx, clHost, new(headertest.Subscriber))
 	require.NoError(t, err)
-	archivalPeerManager, err := testManager(ctx, clHost, sub)
+	archivalPeerManager, err := testManager(ctx, clHost, new(headertest.Subscriber))
 	require.NoError(t, err)
 
 	getter := NewGetter(client, fullPeerManager, archivalPeerManager, availability.RequestWindow)


### PR DESCRIPTION
## Overview

Fixes a test-side data race in `TestShrexGetter`, one of the blockers for re-enabling the `-race` CI job (#5059).

The test shared a single `headertest.Subscriber` mock between two peer managers (`fullPeerManager` and `archivalPeerManager`). Both managers call `NextHeader` concurrently, but the mock is not safe for concurrent use, so `-race` flags it.

## Change

Give each manager its own `headertest.Subscriber`. This matches production, where every manager has its own header subscription.

## Testing

- `go test ./share/shwap/p2p/shrex/shrex_getter/ -race` - green.

Part of #5059.
