### PR TITLE
test(share/eds): warm EDS roots before parallel accessor subtests

### DIFF
--- a/share/eds/testing.go
+++ b/share/eds/testing.go
@@ -91,6 +91,17 @@ func testEDSes(t *testing.T, sizes ...int) map[string]*rsmt2d.ExtendedDataSquare
 	}
 
 	testEDSes["EmptyODS"] = share.EmptyEDS()
+
+	// rsmt2d lazily computes and caches the row/col roots on first access without
+	// locking. The accessor subtests below run in parallel on the same shared EDS,
+	// so letting them trigger that computation concurrently is a data race. Warm
+	// the cache once here, single-threaded, before the parallel subtests run.
+	for _, eds := range testEDSes {
+		_, err := eds.RowRoots()
+		require.NoError(t, err)
+		_, err = eds.ColRoots()
+		require.NoError(t, err)
+	}
 	return testEDSes
 }
 


### PR DESCRIPTION
## Overview

Fixes a test-side data race that affects both `share/eds` and `store/file`, one of the blockers for re-enabling the `-race` CI job (#5059).

`TestSuiteAccessor` runs accessor subtests in parallel over the same shared `*rsmt2d.ExtendedDataSquare`. rsmt2d computes and caches row/col roots lazily on first access **without locking**, so letting parallel subtests trigger that computation concurrently is a data race.

## Change

Warm the root cache once, single-threaded, in `testEDSes` before the parallel subtests run, so the lazy computation happens before any concurrency.

## Testing

- `go test ./share/eds/ -race` - green.
- `go test ./store/file/ -race` - green.

Part of #5059.
