### PR TITLE
fix(shwap/bitswap): return real result from Blockstore.Has

### DIFF
--- a/share/shwap/p2p/bitswap/block_store.go
+++ b/share/shwap/p2p/bitswap/block_store.go
@@ -77,11 +77,11 @@ func (b *Blockstore) Has(ctx context.Context, cid cid.Cid) (bool, error) {
 		return false, err
 	}
 
-	_, err = b.Getter.HasByHeight(ctx, blk.Height())
+	has, err := b.Getter.HasByHeight(ctx, blk.Height())
 	if err != nil {
 		return false, fmt.Errorf("checking EDS Accessor for height %v: %w", blk.Height(), err)
 	}
-	return true, nil
+	return has, nil
 }
 
 func (b *Blockstore) Put(context.Context, blocks.Block) error {

--- a/share/shwap/p2p/bitswap/block_store_test.go
+++ b/share/shwap/p2p/bitswap/block_store_test.go
@@ -1,0 +1,60 @@
+package bitswap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/share/eds"
+)
+
+// hasGetter is a configurable AccessorGetter used to drive Blockstore.Has.
+type hasGetter struct {
+	eds.AccessorStreamer
+	has    bool
+	hasErr error
+}
+
+func (g hasGetter) GetByHeight(context.Context, uint64) (eds.AccessorStreamer, error) {
+	return g.AccessorStreamer, nil
+}
+
+func (g hasGetter) HasByHeight(context.Context, uint64) (bool, error) {
+	return g.has, g.hasErr
+}
+
+// TestBlockstore_Has verifies that Has reflects the real result of
+// HasByHeight instead of unconditionally reporting true. Reporting HAVE for a
+// height the node does not store makes peers send a follow-up WANT-block that
+// fails, delaying their failover to a peer that actually has the data.
+func TestBlockstore_Has(t *testing.T) {
+	ctx := context.Background()
+
+	// a valid Shwap CID so Has reaches HasByHeight.
+	blk, err := NewEmptyRowBlock(1, 0, 4)
+	require.NoError(t, err)
+	cid := blk.CID()
+
+	t.Run("present", func(t *testing.T) {
+		bs := &Blockstore{Getter: hasGetter{has: true}}
+		has, err := bs.Has(ctx, cid)
+		require.NoError(t, err)
+		require.True(t, has)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		bs := &Blockstore{Getter: hasGetter{has: false}}
+		has, err := bs.Has(ctx, cid)
+		require.NoError(t, err)
+		require.False(t, has, "Has must report false when the height is not stored")
+	})
+
+	t.Run("error", func(t *testing.T) {
+		bs := &Blockstore{Getter: hasGetter{hasErr: errors.New("boom")}}
+		has, err := bs.Has(ctx, cid)
+		require.Error(t, err)
+		require.False(t, has)
+	})
+}


### PR DESCRIPTION
## Overview

`Blockstore.Has` discarded the bool from `HasByHeight` and always returned `true` when there was no error. The node then answered HAVE to a Bitswap want-have for a height it does not store; the peer follows up with a want-block that fails with `ipld.ErrNotFound`, wasting a round trip and giving the requester a false positive that delays failover to a peer that actually has the data.

Looks like a regression from #3813 ("use new option for optimized Has check").

## Change

Return the value `HasByHeight` reports instead of a hardcoded `true`.

## Testing

- New `TestBlockstore_Has` covers present / absent / error cases; verified it fails on the pre-fix code.
- `go test ./share/shwap/p2p/bitswap/ -race` - green.

Closes #5076
