### PR TITLE
fix(blob): guard against nil proof in Service.Included

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -382,6 +382,11 @@ func (s *Service) Included(
 		attribute.Int64("height", int64(height)),
 		attribute.String("namespace", namespace.String()),
 	)
+
+	if proof == nil {
+		return false, errors.New("blob: proof cannot be nil")
+	}
+
 	log.Infow("included",
 		"height", height,
 		"namespace", namespace.String(),

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -296,6 +296,22 @@ func TestBlobService_Get(t *testing.T) {
 			},
 		},
 		{
+			name: "nil proof returns an error instead of panicking",
+			doFn: func() (any, error) {
+				return service.Included(ctx, 1,
+					blobsWithDiffNamespaces[0].Namespace(),
+					nil,
+					blobsWithDiffNamespaces[0].Commitment,
+				)
+			},
+			expectedResult: func(res any, err error) {
+				require.Error(t, err)
+				included, ok := res.(bool)
+				require.True(t, ok)
+				require.False(t, included)
+			},
+		},
+		{
 			name: "not included",
 			doFn: func() (any, error) {
 				libBlob, err := libshare.GenerateV0Blobs([]int{10}, false)


### PR DESCRIPTION
## Overview

`Service.Included` is exposed over RPC (`perm:"read"`) and dereferenced the caller-supplied `proof` pointer with no nil check: `proof.Len()` in the log line and `*proof` in the final comparison. A client passing `null` for the proof parameter unmarshals to a nil `*Proof` and panics the node.

## Change

Return an error when `proof` is nil, before any dereference.

## Testing

- New `nil proof` case in `TestBlobService_Get`; verified it panics on the pre-fix code (nil-deref at `service.go:390`) and returns a clean error after the fix.
- `go test ./blob/ -race` - green.

Closes #5078
