### PR TITLE
fix(shrex): keep GetSamples result aligned with requested coords

### DIFF
--- a/share/availability/light/availability_test.go
+++ b/share/availability/light/availability_test.go
@@ -89,6 +89,64 @@ func TestSharesAvailableSuccess(t *testing.T) {
 	require.Len(t, result.Available, int(avail.params.SampleAmount))
 }
 
+// TestSharesAvailablePartialResponse verifies that when a getter returns a
+// length-preserving slice with one not-retrieved (empty) sample, that sample's
+// coordinate is recorded in Remaining and the rest in Available — i.e. results
+// are matched to coords by position. A getter that compacted out empty samples
+// (shorter slice) would misattribute coordinates and silently drop the failed
+// one from Remaining.
+func TestSharesAvailablePartialResponse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	square := edstest.RandEDS(t, 16)
+	roots, err := share.NewAxisRoots(square)
+	require.NoError(t, err)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
+
+	var missing shwap.SampleCoords
+	getter := mock.NewMockGetter(gomock.NewController(t))
+	getter.EXPECT().
+		GetSamples(gomock.Any(), eh, gomock.Any()).
+		DoAndReturn(
+			func(_ context.Context, _ *header.ExtendedHeader, indices []shwap.SampleCoords) ([]shwap.Sample, error) {
+				acc := eds.Rsmt2D{ExtendedDataSquare: square}
+				smpls := make([]shwap.Sample, len(indices))
+				for i, idx := range indices {
+					// leave the first requested coord empty to simulate a
+					// not-retrieved sample, keeping the slice length intact.
+					if i == 0 {
+						missing = idx
+						continue
+					}
+					smpl, err := acc.Sample(ctx, idx)
+					if err != nil {
+						return nil, err
+					}
+					smpls[i] = smpl
+				}
+				return smpls, nil
+			}).
+		AnyTimes()
+
+	ds := datastore.NewMapDatastore()
+	avail := NewShareAvailability(getter, ds, nil)
+
+	// the missing sample makes availability incomplete.
+	err = avail.SharesAvailable(ctx, eh)
+	require.Error(t, err)
+
+	data, err := avail.ds.Get(ctx, datastoreKeyForRoot(roots))
+	require.NoError(t, err)
+	var result SamplingResult
+	require.NoError(t, json.Unmarshal(data, &result))
+
+	// the empty sample's coordinate must be the one recorded as remaining.
+	require.Contains(t, result.Remaining, missing)
+	require.NotContains(t, result.Available, missing)
+	require.Len(t, result.Remaining, 1)
+}
+
 func TestSharesAvailableSkipSampled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -151,10 +150,11 @@ func (sg *Getter) GetSamples(
 	// Callers should check both the returned samples slice and error - a non-nil
 	// error with non-empty samples indicates partial success.
 	err = errGroup.Wait()
-	// Delete empty entries if samples were not found or any other error occurred and return partial response
-	samples = slices.DeleteFunc(samples, func(sample shwap.Sample) bool {
-		return sample.IsEmpty()
-	})
+	// The returned slice is positionally aligned with the requested coords:
+	// samples[i] corresponds to coords[i], and a sample that was not retrieved is
+	// left empty (IsEmpty) rather than removed. Compacting the slice here would
+	// break callers that index results by request position (e.g. light
+	// availability and GetShare), and it matches the bitswap getter's contract.
 	return samples, err
 }
 

--- a/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
@@ -329,14 +329,24 @@ func TestShrexGetter(t *testing.T) {
 		coords := []shwap.SampleCoords{
 			{Row: 0, Col: 1},
 			{Row: 0, Col: 2},
-			{Row: 0, Col: 5},
+			{Row: 0, Col: 5}, // this coord fails to be retrieved
 			{Row: 1, Col: 0},
 		}
+		const failedIdx = 2
 
 		samples, err := getter.GetSamples(ctx, eh, coords)
 		require.Error(t, err)
 		assert.NotNil(t, samples)
-		assert.Len(t, samples, 3)
+		// the result stays positionally aligned with coords: failed entries are
+		// left empty rather than compacted out, so length is preserved.
+		require.Len(t, samples, len(coords))
+		for i, smpl := range samples {
+			if i == failedIdx {
+				assert.True(t, smpl.IsEmpty(), "failed coord must map to an empty sample at its index")
+			} else {
+				assert.False(t, smpl.IsEmpty(), "retrieved coord at index %d must not be empty", i)
+			}
+		}
 	})
 
 	t.Run("Samples_EmptyBlock", func(t *testing.T) {


### PR DESCRIPTION
## Overview

shrex `GetSamples` compacted out empty samples with `slices.DeleteFunc` before returning, producing a slice shorter than the requested coords. Callers that index results by request position then misattribute coordinates:

- **Light availability** (`SharesAvailable`) recorded `Available`/`Remaining` against the wrong coords and silently dropped failed samples from `Remaining` - the corrupted result is persisted and drives pruning. This is the **default light-node path** (`UseShareExchange` defaults to true, shrex is first in the cascade).
- **`module.GetShare`** could index out of range (`smpls[0]`) on an empty compacted result.

The bitswap getter already returns a length-preserving slice with empty placeholders, so the two getters had incompatible contracts.

## Change

Return the slice as-is so `samples[i]` corresponds to `coords[i]`, matching the bitswap contract. Not-retrieved entries are left empty for callers to detect via `IsEmpty()`.

## Testing

- Updated shrex `Samples_partial_response` to assert length is preserved and the failed coord maps to an empty sample at its index (verified it fails on the pre-fix code).
- New `TestSharesAvailablePartialResponse` in light availability: a not-retrieved sample's coord lands in `Remaining`, not lost.
- `go test ./share/shwap/p2p/shrex/shrex_getter/ ./share/availability/light/ -race` - green.
