### PR TITLE
fix(state/txclient): honor an explicitly-set zero MaxGasPrice

### DIFF
--- a/state/txclient/tx_config.go
+++ b/state/txclient/tx_config.go
@@ -74,6 +74,8 @@ type TxConfig struct {
 	isGasPriceSet bool
 	// specifies the max gas price that user expects to pay for the transaction.
 	maxGasPrice float64
+	// since maxGasPrice can be 0, it is necessary to understand that user explicitly set it.
+	isMaxGasPriceSet bool
 	// 0 gas means users want us to calculate it for them.
 	gas uint64
 	// priority is the priority level of the requested gas price.
@@ -101,7 +103,7 @@ func (cfg *TxConfig) IsGasPriceSet() bool {
 // MaxGasPrice will return the max gas price that the user set
 // in the TxConfig. If no value was set, it will return the default value.
 func (cfg *TxConfig) MaxGasPrice() float64 {
-	if cfg.maxGasPrice == 0 {
+	if !cfg.isMaxGasPriceSet {
 		return DefaultMaxGasPrice
 	}
 
@@ -118,6 +120,7 @@ type jsonTxConfig struct {
 	GasPrice          float64 `json:"gas_price,omitempty"`
 	IsGasPriceSet     bool    `json:"is_gas_price_set,omitempty"`
 	MaxGasPrice       float64 `json:"max_gas_price"`
+	IsMaxGasPriceSet  bool    `json:"is_max_gas_price_set,omitempty"`
 	Gas               uint64  `json:"gas,omitempty"`
 	TxPriority        int     `json:"tx_priority,omitempty"`
 	KeyName           string  `json:"key_name,omitempty"`
@@ -130,6 +133,7 @@ func (cfg *TxConfig) MarshalJSON() ([]byte, error) {
 		GasPrice:          cfg.gasPrice,
 		IsGasPriceSet:     cfg.isGasPriceSet,
 		MaxGasPrice:       cfg.maxGasPrice,
+		IsMaxGasPriceSet:  cfg.isMaxGasPriceSet,
 		Gas:               cfg.gas,
 		TxPriority:        int(cfg.priority),
 		KeyName:           cfg.keyName,
@@ -149,6 +153,7 @@ func (cfg *TxConfig) UnmarshalJSON(data []byte) error {
 	cfg.gasPrice = jsonOpts.GasPrice
 	cfg.isGasPriceSet = jsonOpts.IsGasPriceSet
 	cfg.maxGasPrice = jsonOpts.MaxGasPrice
+	cfg.isMaxGasPriceSet = jsonOpts.IsMaxGasPriceSet
 	cfg.gas = jsonOpts.Gas
 	cfg.priority = TxPriority(jsonOpts.TxPriority)
 	cfg.keyName = jsonOpts.KeyName
@@ -218,6 +223,7 @@ func WithFeeGranterAddress(granter string) ConfigOption {
 func WithMaxGasPrice(gasPrice float64) ConfigOption {
 	return func(cfg *TxConfig) {
 		cfg.maxGasPrice = gasPrice
+		cfg.isMaxGasPriceSet = true
 	}
 }
 

--- a/state/txclient/tx_config_test.go
+++ b/state/txclient/tx_config_test.go
@@ -24,3 +24,30 @@ func TestMarshallingOptions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, opts, newOpts)
 }
+
+func TestMaxGasPrice(t *testing.T) {
+	t.Run("unset returns default", func(t *testing.T) {
+		cfg := NewTxConfig()
+		require.Equal(t, DefaultMaxGasPrice, cfg.MaxGasPrice())
+	})
+
+	t.Run("explicit zero is honored, not replaced by default", func(t *testing.T) {
+		cfg := NewTxConfig(WithMaxGasPrice(0))
+		require.Equal(t, float64(0), cfg.MaxGasPrice())
+	})
+
+	t.Run("explicit non-zero is honored", func(t *testing.T) {
+		cfg := NewTxConfig(WithMaxGasPrice(1.5))
+		require.Equal(t, 1.5, cfg.MaxGasPrice())
+	})
+
+	t.Run("explicit zero survives JSON round-trip", func(t *testing.T) {
+		cfg := NewTxConfig(WithMaxGasPrice(0))
+		data, err := json.Marshal(cfg)
+		require.NoError(t, err)
+
+		out := &TxConfig{}
+		require.NoError(t, json.Unmarshal(data, out))
+		require.Equal(t, float64(0), out.MaxGasPrice())
+	})
+}


### PR DESCRIPTION
## Overview

MaxGasPrice() returned DefaultMaxGasPrice whenever maxGasPrice == 0, so a caller that explicitly set WithMaxGasPrice(0) (or unmarshaled a config with max_gas_price: 0) had their cap silently replaced by the default. The tx then passed the gas-price guard (estimateGasPrice / estimateGasPriceAndUsage) and paid a real fee instead of being rejected.

This mirrors the existing gasPrice handling, which already distinguishes an explicit 0 from "unset" via isGasPriceSet - maxGasPrice was missing the same treatment.

## Change

Track whether the value was explicitly set with an isMaxGasPriceSet flag (mirroring isGasPriceSet); only fall back to the default when unset. The flag is set in WithMaxGasPrice and persisted across JSON round-trips.

## Testing

- New TestMaxGasPrice: unset -  default, explicit zero - honored (not default), explicit non-zero - honored, and explicit zero survives a JSON round-trip. Verified the explicit-zero cases fail on the pre-fix code.
- go test ./state/txclient/ -race - green.