### PR TITLE
fix(api/client): close already-opened clients on partial init failure

### DIFF
--- a/api/client/read_client.go
+++ b/api/client/read_client.go
@@ -14,6 +14,10 @@ import (
 	shareapi "github.com/celestiaorg/celestia-node/nodebuilder/share"
 )
 
+// newJSONRPCClient opens a json-rpc client. It is a package-level variable so
+// tests can simulate a mid-initialization failure.
+var newJSONRPCClient = jsonrpc.NewClient
+
 // Bridge node json-rpc connection config
 type ReadConfig struct {
 	// BridgeDAAddr is the address of the bridge node
@@ -61,37 +65,54 @@ func NewReadClient(ctx context.Context, cfg ReadConfig) (*ReadClient, error) {
 		}
 	}
 
+	// Track every client opened so far and, unless construction succeeds, close
+	// them on return. Otherwise a NewClient failure on a later client would leak
+	// the connections already opened for the earlier ones.
+	var closers []jsonrpc.ClientCloser
+	success := false
+	defer func() {
+		if !success {
+			for _, closer := range closers {
+				closer()
+			}
+		}
+	}()
+
 	// Initialize share client
 	shareAPI := shareapi.API{}
-	shareCloser, err := jsonrpc.NewClient(
+	shareCloser, err := newJSONRPCClient(
 		ctx, cfg.BridgeDAAddr, "share", &shareAPI.Internal, cfg.HTTPHeader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize share client: %w", err)
 	}
+	closers = append(closers, shareCloser)
 
 	// Initialize blobstream client
 	blobstreamAPI := blobstreamapi.API{}
-	blobstreamCloser, err := jsonrpc.NewClient(
+	blobstreamCloser, err := newJSONRPCClient(
 		ctx, cfg.BridgeDAAddr, "blobstream", &blobstreamAPI.Internal, cfg.HTTPHeader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize blobstream client: %w", err)
 	}
+	closers = append(closers, blobstreamCloser)
 
 	// Initialize header client
 	headerAPI := headerapi.API{}
-	headerCloser, err := jsonrpc.NewClient(
+	headerCloser, err := newJSONRPCClient(
 		ctx, cfg.BridgeDAAddr, "header", &headerAPI.Internal, cfg.HTTPHeader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize header client: %w", err)
 	}
+	closers = append(closers, headerCloser)
 
 	// Initialize blob read client
 	blobAPI := blobapi.API{}
-	blobCloser, err := jsonrpc.NewClient(
+	blobCloser, err := newJSONRPCClient(
 		ctx, cfg.BridgeDAAddr, "blob", &blobAPI.Internal, cfg.HTTPHeader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize blob client: %w", err)
 	}
+	closers = append(closers, blobCloser)
 
 	// pass prev func as value to avoid recursive call during unwrap
 	closer := func() error {
@@ -101,6 +122,7 @@ func NewReadClient(ctx context.Context, cfg ReadConfig) (*ReadClient, error) {
 		blobCloser()
 		return nil
 	}
+	success = true
 
 	return &ReadClient{
 		Share:      &shareAPI,

--- a/api/client/read_client_test.go
+++ b/api/client/read_client_test.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/filecoin-project/go-jsonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewReadClient_ClosesClientsOnPartialInitFailure verifies that when one of
+// the json-rpc clients fails to initialize, the clients opened before it are
+// closed instead of leaked.
+func TestNewReadClient_ClosesClientsOnPartialInitFailure(t *testing.T) {
+	// Restore the real client constructor after the test.
+	orig := newJSONRPCClient
+	t.Cleanup(func() { newJSONRPCClient = orig })
+
+	var opened, closed int
+	// Fail on the 3rd client (header); the first two (share, blobstream) must be
+	// closed by the rollback.
+	const failOn = 3
+	newJSONRPCClient = func(
+		_ context.Context, _, _ string, _ interface{}, _ http.Header,
+	) (jsonrpc.ClientCloser, error) {
+		opened++
+		if opened == failOn {
+			return nil, errors.New("boom")
+		}
+		return func() { closed++ }, nil
+	}
+
+	c, err := NewReadClient(context.Background(), ReadConfig{BridgeDAAddr: "http://localhost:1"})
+	require.Error(t, err)
+	require.Nil(t, c)
+
+	require.Equal(t, failOn, opened, "should have attempted clients up to the failing one")
+	require.Equal(t, failOn-1, closed, "all clients opened before the failure must be closed")
+}
+
+// TestNewReadClient_NoCloseOnSuccess verifies the rollback does not fire when
+// all clients initialize successfully.
+func TestNewReadClient_NoCloseOnSuccess(t *testing.T) {
+	orig := newJSONRPCClient
+	t.Cleanup(func() { newJSONRPCClient = orig })
+
+	var closed int
+	newJSONRPCClient = func(
+		_ context.Context, _, _ string, _ interface{}, _ http.Header,
+	) (jsonrpc.ClientCloser, error) {
+		return func() { closed++ }, nil
+	}
+
+	c, err := NewReadClient(context.Background(), ReadConfig{BridgeDAAddr: "http://localhost:1"})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	require.Zero(t, closed, "clients must not be closed on the success path")
+
+	// the assembled closer should still close all of them on demand.
+	require.NoError(t, c.Close())
+	require.Equal(t, 4, closed)
+}


### PR DESCRIPTION
## Overview

NewReadClient opens four json-rpc clients sequentially (share, blobstream, header, blob). If a later NewClient call failed, the function returned the error without closing the clients opened before it, leaking their connections and goroutines. This is a common case when the bridge endpoint is flaky and a later dial fails after earlier ones succeeded.

Distinct from #4520 (which fixed a nil-close ordering bug on the submission client) - that change did not address the partial-init leak here.

## Change

Track the opened clients and close them on any early return via a deferred rollback that only no-ops once construction fully succeeds.

## Testing

- New read_client_test.go: a partial-init case asserts the clients opened before the failure are closed (verified it fails without the rollback), plus a success case asserting no premature close and that Close() still closes all four.
- go test ./api/client/ -race - green.