### PR TITLE
fix(state/core): surface core endpoint in startup timeout error

### DIFF
--- a/libs/utils/ctx.go
+++ b/libs/utils/ctx.go
@@ -5,6 +5,28 @@ import (
 	"time"
 )
 
+// StartupErrorBuffer is how long before a startup deadline a startup hook should
+// abort so its descriptive error is returned before fx masks it with a bare
+// context.DeadlineExceeded. fx's withTimeout prefers ctx.Err() whenever the startup
+// context is already expired at the moment the hook returns, so a hook that only
+// fails exactly at the deadline loses its error; failing slightly earlier keeps it.
+const StartupErrorBuffer = time.Second
+
+// CtxWithStartupBuffer derives a child context whose deadline is StartupErrorBuffer
+// before the parent's deadline. If the parent has no deadline, or the buffered
+// deadline is already in the past, the parent is returned unchanged.
+func CtxWithStartupBuffer(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return context.WithCancel(ctx)
+	}
+	buffered := deadline.Add(-StartupErrorBuffer)
+	if !buffered.After(time.Now()) {
+		return context.WithCancel(ctx)
+	}
+	return context.WithDeadline(ctx, buffered)
+}
+
 // ResetContextOnError returns a fresh context if the given context has an error.
 func ResetContextOnError(ctx context.Context) context.Context {
 	if ctx.Err() != nil {

--- a/libs/utils/startup_test.go
+++ b/libs/utils/startup_test.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtxWithStartupBuffer(t *testing.T) {
+	t.Run("no parent deadline returns parent unchanged", func(t *testing.T) {
+		ctx, cancel := CtxWithStartupBuffer(context.Background())
+		defer cancel()
+		_, ok := ctx.Deadline()
+		assert.False(t, ok)
+	})
+
+	t.Run("far-future deadline is buffered earlier", func(t *testing.T) {
+		parentDL := time.Now().Add(time.Hour)
+		pctx, pcancel := context.WithDeadline(context.Background(), parentDL)
+		defer pcancel()
+
+		bctx, bcancel := CtxWithStartupBuffer(pctx)
+		defer bcancel()
+
+		innerDL, ok := bctx.Deadline()
+		require.True(t, ok)
+		assert.WithinDuration(t, parentDL.Add(-StartupErrorBuffer), innerDL, 10*time.Millisecond)
+	})
+
+	t.Run("deadline within buffer returns parent unchanged", func(t *testing.T) {
+		sctx, scancel := context.WithTimeout(context.Background(), StartupErrorBuffer/2)
+		defer scancel()
+
+		rctx, rcancel := CtxWithStartupBuffer(sctx)
+		defer rcancel()
+
+		sDL, _ := sctx.Deadline()
+		rDL, ok := rctx.Deadline()
+		require.True(t, ok)
+		assert.Equal(t, sDL, rDL)
+	})
+}

--- a/nodebuilder/core/conn_ready_test.go
+++ b/nodebuilder/core/conn_ready_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/connectivity"
+
+	"github.com/celestiaorg/celestia-node/libs/utils"
+)
+
+// fakeConn stubs the subset of *grpc.ClientConn that waitForCoreConnReady uses.
+type fakeConn struct {
+	state connectivity.State
+}
+
+func (f *fakeConn) Connect() {}
+
+func (f *fakeConn) GetState() connectivity.State { return f.state }
+
+func (f *fakeConn) WaitForStateChange(ctx context.Context, _ connectivity.State) bool {
+	// model a never-Ready endpoint: block until the (buffered) context expires
+	<-ctx.Done()
+	return false
+}
+
+// When the endpoint never becomes Ready, waitForCoreConnReady must return a
+// descriptive, DeadlineExceeded-wrapped error naming the endpoint — before the
+// outer startup deadline so fx does not mask it.
+func TestWaitForCoreConnReady_NeverConnects(t *testing.T) {
+	conn := &fakeConn{state: connectivity.TransientFailure}
+
+	timeout := utils.StartupErrorBuffer + 300*time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	err := waitForCoreConnReady(ctx, conn, "1.2.3.4:9090")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "1.2.3.4:9090")
+	assert.Contains(t, err.Error(), "couldn't connect to core endpoint")
+	assert.Less(t, elapsed, timeout, "should return via the buffered inner deadline")
+	assert.NoError(t, ctx.Err(), "outer startup context must not have expired yet")
+}
+
+func TestWaitForCoreConnReady_Ready(t *testing.T) {
+	conn := &fakeConn{state: connectivity.Ready}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := waitForCoreConnReady(ctx, conn, "1.2.3.4:9090")
+
+	require.NoError(t, err)
+	assert.Less(t, time.Since(start), time.Second)
+}

--- a/nodebuilder/core/constructors.go
+++ b/nodebuilder/core/constructors.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -115,24 +114,44 @@ func grpcClient(lc fx.Lifecycle, cfg EndpointConfig) (*grpc.ClientConn, error) {
 		return nil, err
 	}
 
+	endpoint := net.JoinHostPort(cfg.IP, cfg.Port)
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			conn.Connect()
-			for {
-				state := conn.GetState()
-				if state == connectivity.Ready {
-					return nil
-				}
-				if !conn.WaitForStateChange(ctx, state) {
-					return errors.New("couldn't connect to core endpoint")
-				}
-			}
+			return waitForCoreConnReady(ctx, conn, endpoint)
 		},
 		OnStop: func(context.Context) error {
 			return conn.Close()
 		},
 	})
 	return conn, nil
+}
+
+// connReadier is the subset of *grpc.ClientConn used to await connectivity.
+type connReadier interface {
+	Connect()
+	GetState() connectivity.State
+	WaitForStateChange(context.Context, connectivity.State) bool
+}
+
+// waitForCoreConnReady blocks until the gRPC connection reaches connectivity.Ready
+// or the context expires. It aborts a StartupErrorBuffer before the startup deadline
+// so the descriptive error — naming the endpoint — is returned before fx masks it
+// with a bare context.DeadlineExceeded.
+func waitForCoreConnReady(ctx context.Context, conn connReadier, endpoint string) error {
+	ctx, cancel := utils.CtxWithStartupBuffer(ctx)
+	defer cancel()
+	conn.Connect()
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return nil
+		}
+		if !conn.WaitForStateChange(ctx, state) {
+			return fmt.Errorf(
+				"couldn't connect to core endpoint %s; verify --core.ip is correct "+
+					"and the consensus node is reachable: %w", endpoint, ctx.Err())
+		}
+	}
 }
 
 func additionalCoreEndpointGrpcClients(lc fx.Lifecycle, cfg Config) (AdditionalCoreConns, error) {

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -131,7 +131,7 @@ func (ca *CoreAccessor) Start(ctx context.Context) error {
 	ca.feeGrantCli = feegrant.NewQueryClient(ca.coreConn)
 	// create ABCI query client
 	ca.abciQueryCli = tmservice.NewServiceClient(ca.coreConn)
-	resp, err := waitForAppReady(ctx, ca.abciQueryCli)
+	resp, err := waitForAppReady(ctx, ca.abciQueryCli, ca.coreConn.Target())
 	if err != nil {
 		return fmt.Errorf("failed to get node info: %w", err)
 	}
@@ -593,7 +593,13 @@ func convertToSdkTxResponse(resp *user.TxResponse) *TxResponse {
 	}
 }
 
-func waitForAppReady(ctx context.Context, cli tmservice.ServiceClient) (*tmservice.GetNodeInfoResponse, error) {
+func waitForAppReady(
+	ctx context.Context,
+	cli tmservice.ServiceClient,
+	endpoint string,
+) (*tmservice.GetNodeInfoResponse, error) {
+	ctx, cancel := utils.CtxWithStartupBuffer(ctx)
+	defer cancel()
 	for {
 		resp, err := cli.GetNodeInfo(ctx, &tmservice.GetNodeInfoRequest{})
 		if err == nil {
@@ -605,7 +611,9 @@ func waitForAppReady(ctx context.Context, cli tmservice.ServiceClient) (*tmservi
 		select {
 		case <-time.After(p2p.BlockTime):
 		case <-ctx.Done():
-			return nil, fmt.Errorf("celestia-app not ready: %w", err)
+			return nil, fmt.Errorf(
+				"core endpoint %s reachable but celestia-app is not producing blocks "+
+					"(still catching up or halted?): %w", endpoint, ctx.Err())
 		}
 	}
 }

--- a/state/core_access_startup_test.go
+++ b/state/core_access_startup_test.go
@@ -1,0 +1,80 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tmservice "github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/celestiaorg/celestia-node/libs/utils"
+)
+
+// fakeServiceClient stubs tmservice.ServiceClient, overriding only GetNodeInfo.
+// The embedded nil interface panics if any other method is called, which is fine
+// because waitForAppReady only calls GetNodeInfo.
+type fakeServiceClient struct {
+	tmservice.ServiceClient
+	getNodeInfo func(context.Context) (*tmservice.GetNodeInfoResponse, error)
+}
+
+func (f fakeServiceClient) GetNodeInfo(
+	ctx context.Context,
+	_ *tmservice.GetNodeInfoRequest,
+	_ ...grpc.CallOption,
+) (*tmservice.GetNodeInfoResponse, error) {
+	return f.getNodeInfo(ctx)
+}
+
+// When the endpoint is reachable but the app keeps replying "please wait for first
+// block", waitForAppReady must return a descriptive, DeadlineExceeded-wrapped error
+// naming the endpoint — and return before the outer startup deadline so fx does not
+// mask it with a bare context.DeadlineExceeded.
+func TestWaitForAppReady_AppNotProducingBlocks(t *testing.T) {
+	cli := fakeServiceClient{
+		getNodeInfo: func(context.Context) (*tmservice.GetNodeInfoResponse, error) {
+			return nil, status.Error(codes.FailedPrecondition, "please wait for first block")
+		},
+	}
+
+	// Outer deadline is StartupErrorBuffer + a small margin, so the buffered inner
+	// deadline is positive but small and the test stays fast.
+	timeout := utils.StartupErrorBuffer + 300*time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	_, err := waitForAppReady(ctx, cli, "1.2.3.4:9090")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "1.2.3.4:9090")
+	assert.Contains(t, err.Error(), "not producing blocks")
+	assert.Less(t, elapsed, timeout, "should return via the buffered inner deadline")
+	assert.NoError(t, ctx.Err(), "outer startup context must not have expired yet")
+}
+
+// Errors that are not the "please wait for first block" signal (dial refused, wrong
+// network, auth) must still fail fast, unchanged.
+func TestWaitForAppReady_FastFailsOnOtherErrors(t *testing.T) {
+	wantErr := status.Error(codes.Unavailable, "connection refused")
+	cli := fakeServiceClient{
+		getNodeInfo: func(context.Context) (*tmservice.GetNodeInfoResponse, error) {
+			return nil, wantErr
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := waitForAppReady(ctx, cli, "1.2.3.4:9090")
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.Less(t, time.Since(start), time.Second, "non-'not ready' errors must not retry")
+}


### PR DESCRIPTION
## Motivation

When a node's `--core.ip` endpoint is unreachable, or the consensus app isn't producing blocks (halted / still catching up), startup blocks until `StartupTimeout` and then fails with a bare, unattributed error:

```
Error: node: failed to start within timeout(10m0s): context deadline exceeded
```

Nothing points at the core endpoint, so operators (e.g. @mycodecrafting ) repeatedly raise `StartupTimeout` (20s → 120s → 600s), which never helps — the endpoint never becomes ready.

See Slack thread: https://celestia-team.slack.com/archives/C01JZFUPG48/p1783026996137509

## Root cause

Two `OnStart` hooks — the gRPC connection readiness loop (`nodebuilder/core`) and `waitForAppReady` (`state`) — already detect the failure, but fx discards their descriptive errors: `fx`'s `withTimeout` prefers `ctx.Err()` whenever the startup context is already expired at the moment a hook returns.

## Fix

Both hooks now abort a fixed `1s` (`utils.StartupErrorBuffer`) before the startup deadline via `utils.CtxWithStartupBuffer`, returning an endpoint-named error that wraps `context.DeadlineExceeded`. Because they return just before the outer context expires, the real error propagates and `Node.Start` renders e.g.:

```
node: failed to start within timeout(10m0s): couldn't connect to core endpoint 1.2.3.4:9090; verify --core.ip is correct and the consensus node is reachable: context deadline exceeded
```

Distinct messages distinguish "never connected" from "connected but app not producing blocks". Timing behavior is otherwise unchanged (still waits the full window, minus 1s); no new config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHixas2TSuCWi8qffJaz5k