### PR TITLE
fix(node): surface real hook error on Start/Stop timeout

### DIFF
--- a/nodebuilder/core/constructors.go
+++ b/nodebuilder/core/constructors.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -115,6 +114,8 @@ func grpcClient(lc fx.Lifecycle, cfg EndpointConfig) (*grpc.ClientConn, error) {
 		return nil, err
 	}
 
+	endpoint := net.JoinHostPort(cfg.IP, cfg.Port)
+
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
 			conn.Connect()
@@ -124,7 +125,10 @@ func grpcClient(lc fx.Lifecycle, cfg EndpointConfig) (*grpc.ClientConn, error) {
 					return nil
 				}
 				if !conn.WaitForStateChange(ctx, state) {
-					return errors.New("couldn't connect to core endpoint")
+					return fmt.Errorf(
+						"couldn't connect to core endpoint %s; verify --core.ip is correct "+
+							"and the consensus node is reachable", endpoint,
+					)
 				}
 			}
 		},

--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cristalhq/jwt/v5"
 	"github.com/ipfs/boxo/blockservice"
@@ -172,11 +173,15 @@ func (n *Node) Stop(ctx context.Context) error {
 // Light, unless we decide to give package users the ability to create custom node types themselves.
 func newNode(opts ...fx.Option) (*Node, error) {
 	node := new(Node)
+	// startErr/stopErr receive the real error of a lifecycle hook that hung past
+	// its deadline. Buffered to not blocked the fx pipeline
+	startErr := make(chan error, 1)
+	stopErr := make(chan error, 1)
 	app := fx.New(
 		fx.WithLogger(func() fxevent.Logger {
 			zl := &fxevent.ZapLogger{Logger: fxLog.Desugar()}
 			zl.UseLogLevel(zapcore.DebugLevel)
-			return zl
+			return &hookErrCapturer{next: zl, onStart: startErr, onStop: stopErr}
 		}),
 		fx.Populate(node),
 		fx.Options(opts...),
@@ -185,9 +190,59 @@ func newNode(opts ...fx.Option) (*Node, error) {
 		return nil, err
 	}
 
-	node.start, node.stop = app.Start, app.Stop
+	node.start = withHookCause(app.Start, startErr)
+	node.stop = withHookCause(app.Stop, stopErr)
 	return node, nil
 }
 
 // lifecycleFunc defines a type for common lifecycle funcs.
 type lifecycleFunc func(context.Context) error
+
+// hookErrCapturer wraps an fxevent.Logger and forwards the real error of a
+// failed lifecycle hook to the channel matching its phase.
+type hookErrCapturer struct {
+	next    fxevent.Logger
+	onStart chan<- error
+	onStop  chan<- error
+}
+
+func (l *hookErrCapturer) LogEvent(e fxevent.Event) {
+	l.next.LogEvent(e)
+
+	switch e := e.(type) {
+	case *fxevent.OnStartExecuted:
+		l.capture(l.onStart, e.Err)
+	case *fxevent.OnStopExecuted:
+		l.capture(l.onStop, e.Err)
+	}
+}
+
+func (l *hookErrCapturer) capture(ch chan<- error, err error) {
+	if err == nil { //skip non-error cases
+		return
+	}
+	select {
+	case ch <- err:
+	default:
+	}
+}
+
+// withHookCause wraps fx lifecycle func so that on a timeout it returns the
+// offending hook's real error instead of a bare context.DeadlineExceeded. When
+// the phase times out the hung hook keeps unwinding in the background and, once
+// it fails - hookErrCapturer forwards its error to pending.
+func withHookCause(fn lifecycleFunc, pending <-chan error) lifecycleFunc {
+	return func(ctx context.Context) error {
+		err := fn(ctx)
+		if errors.Is(err, context.DeadlineExceeded) {
+			select {
+			case cause := <-pending:
+				if cause != nil {
+					return errors.Join(err, cause)
+				}
+			case <-time.After(time.Second):
+			}
+		}
+		return err
+	}
+}

--- a/nodebuilder/node.go
+++ b/nodebuilder/node.go
@@ -218,7 +218,7 @@ func (l *hookErrCapturer) LogEvent(e fxevent.Event) {
 }
 
 func (l *hookErrCapturer) capture(ch chan<- error, err error) {
-	if err == nil { //skip non-error cases
+	if err == nil { // skip non-error cases
 		return
 	}
 	select {

--- a/state/core_access.go
+++ b/state/core_access.go
@@ -131,7 +131,7 @@ func (ca *CoreAccessor) Start(ctx context.Context) error {
 	ca.feeGrantCli = feegrant.NewQueryClient(ca.coreConn)
 	// create ABCI query client
 	ca.abciQueryCli = tmservice.NewServiceClient(ca.coreConn)
-	resp, err := waitForAppReady(ctx, ca.abciQueryCli)
+	resp, err := waitForAppReady(ctx, ca.abciQueryCli, ca.coreConn.Target())
 	if err != nil {
 		return fmt.Errorf("failed to get node info: %w", err)
 	}
@@ -593,7 +593,10 @@ func convertToSdkTxResponse(resp *user.TxResponse) *TxResponse {
 	}
 }
 
-func waitForAppReady(ctx context.Context, cli tmservice.ServiceClient) (*tmservice.GetNodeInfoResponse, error) {
+func waitForAppReady(
+	ctx context.Context,
+	cli tmservice.ServiceClient, endpoint string,
+) (*tmservice.GetNodeInfoResponse, error) {
 	for {
 		resp, err := cli.GetNodeInfo(ctx, &tmservice.GetNodeInfoRequest{})
 		if err == nil {
@@ -605,7 +608,9 @@ func waitForAppReady(ctx context.Context, cli tmservice.ServiceClient) (*tmservi
 		select {
 		case <-time.After(p2p.BlockTime):
 		case <-ctx.Done():
-			return nil, fmt.Errorf("celestia-app not ready: %w", err)
+			return nil, fmt.Errorf(
+				"core endpoint %s reachable but celestia-app is not producing blocks "+
+					"(still catching up or halted?): %w", endpoint, ctx.Err())
 		}
 	}
 }


### PR DESCRIPTION
Does the same as https://github.com/celestiaorg/celestia-node/pull/5097 but using native fx logic and cover all possible errors.

```
Error: node: failed to start within timeout(20s): context deadline exceeded
couldn't connect to core endpoint rpc.celestia.pops.one:9090; verify --core.ip is correct and the consensus node is reachable.
```