### PR TITLE
fix(core): fetch cutoff height from P2P in RoutingExchange range split

### DIFF
--- a/core/routing_exchange.go
+++ b/core/routing_exchange.go
@@ -107,8 +107,9 @@ func (h *RoutingExchange) GetRangeByHeight(
 		return rng, nil
 	}
 
-	// All headers are outside window - use P2P
-	if to <= cutoff {
+	// All headers are outside window - use P2P.
+	// `to` is exclusive, so the highest requested height is to-1.
+	if to <= cutoff+1 {
 		log.Debugw("requesting full range from p2p network", "from", from.Height(), "to", to)
 		rng, err := h.p2p.GetRangeByHeight(ctx, from, to)
 		if err != nil {
@@ -117,13 +118,14 @@ func (h *RoutingExchange) GetRangeByHeight(
 		return rng, nil
 	}
 
-	// Split: [startHeight, cutoff] from P2P, (cutoff, to] from core
+	// Split: [startHeight, cutoff] from P2P, [cutoff+1, to) from core
 	// cutoff is the last height outside the window (lastPruned), so it should be fetched from P2P
 	var headers []*header.ExtendedHeader
 
-	log.Debugw("requesting partial range from p2p network", "from", from, "to", cutoff)
-	// Get historical headers from P2P (outside window, including cutoff)
-	p2pHeaders, err := h.p2p.GetRangeByHeight(ctx, from, cutoff)
+	log.Debugw("requesting partial range from p2p network", "from", from.Height(), "to", cutoff+1)
+	// Get historical headers from P2P (outside window, including cutoff).
+	// `to` is exclusive, so request up to cutoff+1 to receive cutoff itself.
+	p2pHeaders, err := h.p2p.GetRangeByHeight(ctx, from, cutoff+1)
 	if err != nil {
 		return nil, fmt.Errorf("requesting partial range from p2p network: %w", err)
 	}

--- a/core/routing_exchange_test.go
+++ b/core/routing_exchange_test.go
@@ -120,9 +120,66 @@ func TestRoutingExchange_GetRangeByHeight_Split(t *testing.T) {
 
 	result, err := routingEx.GetRangeByHeight(ctx, fromHeader, 8)
 	require.NoError(t, err)
-	assert.Len(t, result, 5) // heights 4,5,6,7,8
+	require.Len(t, result, 4) // heights 4,5,6,7 (`to` is exclusive)
+	assert.Equal(t, uint64(4), result[0].Height())
+	assert.Equal(t, uint64(7), result[len(result)-1].Height())
 	assert.Equal(t, 1, coreEx.calls)
 	assert.Equal(t, 1, p2pEx.calls)
+}
+
+// TestRoutingExchange_GetRangeByHeight_SplitCutoffUnavailableInCore ensures the
+// split routes the cutoff height itself to P2P. The core exchange serves only
+// heights inside the window (the consensus node has pruned everything at and
+// below the cutoff), so requesting the cutoff from core fails the whole range.
+func TestRoutingExchange_GetRangeByHeight_SplitCutoffUnavailableInCore(t *testing.T) {
+	coreEx := newMockExchange()
+	p2pEx := newMockExchange()
+
+	suite := headertest.NewTestSuite(t, headertest.WithBlockTime(time.Nanosecond))
+	headers := suite.GenExtendedHeaders(10)
+
+	blockTime := time.Second
+	window := 5 * time.Second
+
+	fromHeader := headers[2] // height 3
+	oldTime := time.Now().Add(-window - 2*blockTime)
+	fromHeader.RawHeader.Time = oldTime
+	// cutoff resolves to height 5: heights <= 5 are pruned from core,
+	// heights > 5 are inside the window.
+	const cutoff = 5
+	for _, h := range headers {
+		if h.Height() <= cutoff {
+			p2pEx.addHeader(h)
+		} else {
+			coreEx.addHeader(h)
+		}
+	}
+
+	routingEx, err := NewRoutingExchange(coreEx, p2pEx,
+		window,
+		blockTime,
+	)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	t.Run("split range crossing the cutoff", func(t *testing.T) {
+		result, err := routingEx.GetRangeByHeight(ctx, fromHeader, 8)
+		require.NoError(t, err)
+		require.Len(t, result, 4) // heights 4,5,6,7
+		assert.Equal(t, uint64(4), result[0].Height())
+		assert.Equal(t, uint64(7), result[len(result)-1].Height())
+	})
+
+	t.Run("range ending exactly at the cutoff", func(t *testing.T) {
+		// to = cutoff+1 requests heights 4,5 — entirely outside the window,
+		// so core must not be involved at all.
+		coreCalls := coreEx.calls
+		result, err := routingEx.GetRangeByHeight(ctx, fromHeader, cutoff+1)
+		require.NoError(t, err)
+		require.Len(t, result, 2) // heights 4,5
+		assert.Equal(t, uint64(cutoff), result[len(result)-1].Height())
+		assert.Equal(t, coreCalls, coreEx.calls)
+	})
 }
 
 func TestRoutingExchange_Head_AlwaysUsesCore(t *testing.T) {
@@ -297,7 +354,8 @@ func (m *mockExchange) GetRangeByHeight(
 	to uint64,
 ) ([]*header.ExtendedHeader, error) {
 	var result []*header.ExtendedHeader
-	for i := from.Height() + 1; i <= to; i++ {
+	// `to` is exclusive, matching the libhead.Exchange contract.
+	for i := from.Height() + 1; i < to; i++ {
 		h, ok := m.headers[i]
 		if !ok {
 			return nil, errors.New("not found")


### PR DESCRIPTION
## Overview

`RoutingExchange.GetRangeByHeight` splits requests at the availability-window
cutoff: historical heights go to the P2P exchange, recent heights to core.
The split assumed an inclusive `to`, but `GetRangeByHeight` treats `to` as
exclusive - see the amount calculation in `core.Exchange.GetRangeByHeight`
(`amount := to - (from.Height() + 1)`) and the explicit note in
`pruner/find.go`.

As a result, the P2P request for `[from+1, cutoff]` actually returned only up
to `cutoff-1`, and the follow-up core request started at the cutoff — exactly
the height the consensus node has already pruned. Any range crossing the
pruning-window boundary failed with `requesting partial range from consensus
node: not found`, even though every requested header was available between
the two exchanges. Ranges ending exactly at the cutoff hit the same problem
through the split branch instead of being served entirely by P2P.

The existing tests didn't catch this because the mock exchange implemented an
inclusive `to`, masking the contract mismatch.

## Changes

- request `cutoff+1` from P2P in the split path so the cutoff height itself is
  served by the network, matching the comment right above the call
- route ranges ending exactly at the cutoff (`to == cutoff+1`) entirely to P2P
- align the test mock with the exclusive-`to` contract and fix the `Split`
  test expectations accordingly
- add `TestRoutingExchange_GetRangeByHeight_SplitCutoffUnavailableInCore`,
  where the core exchange only serves heights inside the window - with the
  old code both subtests fail with the exact error above

## Testing

`go test -race ./core/` is green. Reverting the `routing_exchange.go` changes
while keeping the new test makes both subtests fail, reproducing the reported
error.