### PR TITLE
feat(api): add gauge to track active ws connections

### DIFF
--- a/api/rpc/metrics.go
+++ b/api/rpc/metrics.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"strings"
 	"sync/atomic"
 
 	"go.opentelemetry.io/otel"
@@ -36,7 +37,17 @@ type rpcMetrics struct {
 	// sees individual requests), so it stays instrumented here.
 	connectionsOpen     atomic.Int64
 	connectionsOpenInst metric.Int64ObservableGauge
-	gaugeReg            metric.Registration
+
+	// websocketConnsOpen tracks currently-open websocket connections. It can't
+	// live in onConnState like connectionsOpen: net/http emits StateHijacked on
+	// upgrade but never a matching close for hijacked conns, so the gauge is
+	// bracketed around the (blocking) ws ServeHTTP in trackWebsocket instead.
+	// Live slot usage against maxConcurrentConns is connectionsOpen +
+	// websocketConnsOpen (hijacked conns leave connectionsOpen on upgrade).
+	websocketConnsOpen     atomic.Int64
+	websocketConnsOpenInst metric.Int64ObservableGauge
+
+	gaugeReg metric.Registration
 }
 
 func newMetrics() (*rpcMetrics, error) {
@@ -69,7 +80,17 @@ func newMetrics() (*rpcMetrics, error) {
 	if err != nil {
 		return nil, err
 	}
-	m.gaugeReg, err = meter.RegisterCallback(m.observeGauges, m.connectionsOpenInst)
+	m.websocketConnsOpenInst, err = meter.Int64ObservableGauge(
+		"rpc_websocket_connections_open",
+		metric.WithDescription("number of websocket connections currently open to the RPC server"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.gaugeReg, err = meter.RegisterCallback(
+		m.observeGauges, m.connectionsOpenInst, m.websocketConnsOpenInst,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -79,6 +100,7 @@ func newMetrics() (*rpcMetrics, error) {
 
 func (m *rpcMetrics) observeGauges(_ context.Context, obs metric.Observer) error {
 	obs.ObserveInt64(m.connectionsOpenInst, m.connectionsOpen.Load())
+	obs.ObserveInt64(m.websocketConnsOpenInst, m.websocketConnsOpen.Load())
 	return nil
 }
 
@@ -113,4 +135,30 @@ func (m *rpcMetrics) traceMethod(method string, _, _ []reflect.Value, err error)
 		attribute.String("method", method),
 		attribute.Bool("error", err != nil),
 	))
+}
+
+// isWebsocketUpgrade reports whether r is a websocket handshake. Such a request
+// is served by a single ServeHTTP call that blocks for the whole connection
+// lifetime, so bracketing it yields an accurate live count — unlike ConnState,
+// which sees StateHijacked but never a matching close.
+func isWebsocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+}
+
+// trackWebsocket brackets each websocket connection with the websocketConnsOpen
+// gauge. The inner ServeHTTP blocks until the socket closes, so the deferred
+// decrement fires exactly on close — the close signal net/http withholds for
+// hijacked connections. A handshake that fails to upgrade returns immediately,
+// leaving the gauge net-zero.
+func (m *rpcMetrics) trackWebsocket(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m == nil || !isWebsocketUpgrade(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		m.websocketConnsOpen.Add(1)
+		defer m.websocketConnsOpen.Add(-1)
+		next.ServeHTTP(w, r)
+	})
 }

--- a/api/rpc/middleware_test.go
+++ b/api/rpc/middleware_test.go
@@ -155,6 +155,79 @@ func TestRateLimit_EvictedIPGetsFreshBurst(t *testing.T) {
 	assert.Equal(t, http.StatusOK, do("1.1.1.1:1"))
 }
 
+func TestIsWebsocketUpgrade(t *testing.T) {
+	tests := []struct {
+		name       string
+		upgrade    string
+		connection string
+		want       bool
+	}{
+		{"standard handshake", "websocket", "Upgrade", true},
+		{"case-insensitive, listed connection", "WebSocket", "keep-alive, upgrade", true},
+		{"plain http", "", "", false},
+		{"upgrade header only", "websocket", "", false},
+		{"connection header only", "", "Upgrade", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			if tt.upgrade != "" {
+				r.Header.Set("Upgrade", tt.upgrade)
+			}
+			if tt.connection != "" {
+				r.Header.Set("Connection", tt.connection)
+			}
+			assert.Equal(t, tt.want, isWebsocketUpgrade(r))
+		})
+	}
+}
+
+// TestTrackWebsocket_BracketsConnection verifies the live-ws gauge is +1 while
+// the (blocking) ws handler runs and back to 0 once it returns — the close
+// signal net/http never delivers for hijacked connections.
+func TestTrackWebsocket_BracketsConnection(t *testing.T) {
+	m := &rpcMetrics{}
+
+	inHandler := make(chan struct{})
+	release := make(chan struct{})
+	handler := m.trackWebsocket(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		close(inHandler)
+		<-release // mimic a ws read-loop blocking for the connection lifetime
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	<-inHandler
+	assert.Equal(t, int64(1), m.websocketConnsOpen.Load(), "gauge should be incremented while ws is open")
+
+	close(release)
+	wg.Wait()
+	assert.Equal(t, int64(0), m.websocketConnsOpen.Load(), "gauge should be decremented after ws closes")
+}
+
+func TestTrackWebsocket_IgnoresPlainHTTP(t *testing.T) {
+	m := &rpcMetrics{}
+	handler := m.trackWebsocket(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		assert.Equal(t, int64(0), m.websocketConnsOpen.Load(), "plain HTTP must not touch the ws gauge")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), m.websocketConnsOpen.Load())
+}
+
 func TestExtractIP(t *testing.T) {
 	tests := []struct {
 		remoteAddr string

--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -140,7 +140,10 @@ func (s *Server) newHandlerStack(core http.Handler) http.Handler {
 	// rpcMetrics. s.metrics may be nil (metrics disabled) → no wrapping.
 	h := core
 	if s.metrics != nil {
-		h = otelhttp.NewHandler(core, "rpc",
+		// trackWebsocket wraps core directly so its bracket is the tightest
+		// possible around the (blocking) ws ServeHTTP; otelhttp then wraps that.
+		h = s.metrics.trackWebsocket(h)
+		h = otelhttp.NewHandler(h, "rpc",
 			// metrics only: suppress the per-request span otelhttp would emit.
 			otelhttp.WithTracerProvider(noop.NewTracerProvider()),
 		)


### PR DESCRIPTION
Adding a metric to track active ws connection since `rpc_connections_open` does not show hijacked connections. 


Tested Locally: create a tool establishes 5 ws connection

<img width="1117" height="190" alt="Screenshot 2026-07-15 at 15 40 13" src="https://github.com/user-attachments/assets/5d318fbe-2d3b-4b68-80b5-dbf48f78c01c" />

