### PR TITLE
ci: re-enable unit tests with race detector

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -162,27 +162,33 @@ jobs:
           file: ./coverage.txt
           name: coverage-ubuntu-latest
 
-  # @ramin - Temporarily removed while we figure out getting
-  # these unit tests consistently running on ubuntu-latest
-  # and then enabled for macos-latest. We aren't requiring
-  # unit_race_test to pass for PRs so lets remove and reintroduce
-  # once green
-  #
-  # unit_test_race:
-  #   needs: [lint, go_mod_tidy_check]
-  #   name: Unit Tests with Race Detector (ubuntu-latest)
-  #   runs-on: ubuntu-latest
+  unit_test_race:
+    needs: [lint, go_mod_tidy_check]
+    name: Unit Tests with Race Detector (ubuntu-latest)
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v7
+    steps:
+      - uses: actions/checkout@v7
 
-  #     - name: set up go
-  #       uses: actions/setup-go@v6
-  #       with:
-  #         go-version: ${{ inputs.go-version }}
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/*.go') }}
+          restore-keys: |
+            go-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+            go-race-${{ runner.os }}-
 
-  #     - name: execute test run
-  #       run: make test-unit-race ENABLE_VERBOSE=${{ runner.debug == '1' && 'true' || 'false' }}
+      - name: set up go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          cache: false
+
+      - name: execute test run
+        run: make test-unit-race ENABLE_VERBOSE=${{ runner.debug == '1' && 'true' || 'false' }}
 
   integration_test:
     name: Integration Tests


### PR DESCRIPTION
## Overview

The race-detector CI job was disabled in #3147 (Jan 2024) while a handful of
test-side data races were sorted out. Two years later those are fixed, so this
re-enables the job and closes out #5059.

The test-side races that blocked it are now fixed on `main`:

- `libs/utils`: atomic `maxActive` - #5060
- `shrex_getter`: per-manager header subscriber - #5074
- `share/eds`: warm EDS roots before parallel subtests - #5075

## Changes

- Uncomment the `unit_test_race` job and wire it like the current `unit_tests`
  job (Go module cache + `setup-go`), running `make test-unit-race`.

## Testing

Verified locally that the previously-racy packages pass under `-race`:
`libs/utils`, `share/shwap/p2p/shrex/shrex_getter`, `store/file`, `share/eds`.
CI will exercise the full suite.

## Question for maintainers

Would you prefer this to be a **required** check straight away, or bake it in as
non-blocking for a few runs first to confirm it's stable across the full suite?

Closes #3147
Closes #5059
