### PR TITLE
feat(share/shrex): abort in-flight request on parent context cancel

### DIFF
--- a/share/shwap/p2p/shrex/client.go
+++ b/share/shwap/p2p/shrex/client.go
@@ -62,12 +62,7 @@ func (c *Client) Get(
 	)
 	requestTime := time.Now()
 	n, status, err := c.doRequest(ctx, logger, req, resp, peer)
-	// Join ctx.Err() when the request failed after cancellation so the caller
-	// can classify the failure as canceled, without dropping typed shrex errors
-	// like ErrNotFound or ErrResourceExhausted that a late cancel would
-	// otherwise mask. Only join when err is already non-nil so a race between
-	// a successful response and a late cancellation doesn't turn a successful
-	// Get into an error.
+	// Surface ctx.Err() without masking typed wire errors like ErrNotFound.
 	if err != nil && ctx.Err() != nil {
 		err = errors.Join(err, ctx.Err())
 	}
@@ -111,15 +106,8 @@ func (c *Client) doRequest(
 		utils.CloseAndLog(log, "shrex/client stream", stream)
 	}()
 
-	// Reset the stream if ctx is canceled after it is opened, so any in-flight
-	// Read/Write returns immediately instead of blocking until the deadline set
-	// by setStreamDeadlines expires (up to ReadTimeout, 2m by default). Without
-	// this the caller keeps its peer slot even after giving up on the request.
-	//
-	// stopWatch does not wait for an in-flight callback to finish, so the
-	// Reset here can race with the deferred CloseAndLog above. libp2p's stream
-	// Close and Reset are safe under concurrent use, so the race is harmless:
-	// whichever one lands first tears the stream down and the other is a no-op.
+	// Reset on ctx cancel so in-flight Read/Write returns immediately instead
+	// of hanging until the stream deadline.
 	stopWatch := context.AfterFunc(ctx, func() {
 		stream.Reset() //nolint:errcheck
 	})

--- a/share/shwap/p2p/shrex/client.go
+++ b/share/shwap/p2p/shrex/client.go
@@ -61,6 +61,14 @@ func (c *Client) Get(
 	)
 	requestTime := time.Now()
 	n, status, err := c.doRequest(ctx, logger, req, resp, peer)
+	// Prefer ctx.Err() when the request failed after cancellation: without this
+	// the caller sees the libp2p stream-reset error triggered by our own
+	// AfterFunc rather than the actual cause. Only replace when err is already
+	// non-nil so a race between a successful response and a late cancellation
+	// doesn't turn a successful Get into an error.
+	if err != nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
 	if err != nil {
 		logger.Debugw("requesting data from peer failed", "error", err)
 	}
@@ -100,6 +108,15 @@ func (c *Client) doRequest(
 	defer func() {
 		utils.CloseAndLog(log, "shrex/client stream", stream)
 	}()
+
+	// Reset the stream if ctx is canceled after it is opened, so any in-flight
+	// Read/Write returns immediately instead of blocking until the deadline set
+	// by setStreamDeadlines expires (up to ReadTimeout, 2m by default). Without
+	// this the caller keeps its peer slot even after giving up on the request.
+	stopWatch := context.AfterFunc(ctx, func() {
+		stream.Reset() //nolint:errcheck
+	})
+	defer stopWatch()
 
 	c.setStreamDeadlines(ctx, logger, stream)
 

--- a/share/shwap/p2p/shrex/client.go
+++ b/share/shwap/p2p/shrex/client.go
@@ -2,6 +2,7 @@ package shrex
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -61,13 +62,14 @@ func (c *Client) Get(
 	)
 	requestTime := time.Now()
 	n, status, err := c.doRequest(ctx, logger, req, resp, peer)
-	// Prefer ctx.Err() when the request failed after cancellation: without this
-	// the caller sees the libp2p stream-reset error triggered by our own
-	// AfterFunc rather than the actual cause. Only replace when err is already
-	// non-nil so a race between a successful response and a late cancellation
-	// doesn't turn a successful Get into an error.
+	// Join ctx.Err() when the request failed after cancellation so the caller
+	// can classify the failure as canceled, without dropping typed shrex errors
+	// like ErrNotFound or ErrResourceExhausted that a late cancel would
+	// otherwise mask. Only join when err is already non-nil so a race between
+	// a successful response and a late cancellation doesn't turn a successful
+	// Get into an error.
 	if err != nil && ctx.Err() != nil {
-		err = ctx.Err()
+		err = errors.Join(err, ctx.Err())
 	}
 	if err != nil {
 		logger.Debugw("requesting data from peer failed", "error", err)
@@ -113,6 +115,11 @@ func (c *Client) doRequest(
 	// Read/Write returns immediately instead of blocking until the deadline set
 	// by setStreamDeadlines expires (up to ReadTimeout, 2m by default). Without
 	// this the caller keeps its peer slot even after giving up on the request.
+	//
+	// stopWatch does not wait for an in-flight callback to finish, so the
+	// Reset here can race with the deferred CloseAndLog above. libp2p's stream
+	// Close and Reset are safe under concurrent use, so the race is harmless:
+	// whichever one lands first tears the stream down and the other is a no-op.
 	stopWatch := context.AfterFunc(ctx, func() {
 		stream.Reset() //nolint:errcheck
 	})

--- a/share/shwap/p2p/shrex/exchange_test.go
+++ b/share/shwap/p2p/shrex/exchange_test.go
@@ -76,19 +76,21 @@ func TestClient_AbortsOnCtxCancel(t *testing.T) {
 	id, err := shwap.NewNamespaceDataID(1, libshare.RandomNamespace())
 	require.NoError(t, err)
 
-	// Server-side handler holds the stream open without reading or responding,
-	// simulating an unresponsive peer so the client is stuck in serde.Read.
+	// Hold the server handler on a channel that only closes at test cleanup so
+	// the server never reads or writes anything. This keeps the client stuck
+	// in serde.Read waiting for a status response, which is exactly the state
+	// the fix targets — reading a byte instead would race with the client's
+	// WriteTo and let the handler exit before ctx is canceled, so the test
+	// could pass without exercising AfterFunc at all.
 	serverBlocked := make(chan struct{})
-	streamClosed := make(chan struct{})
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
 	hosts[1].SetStreamHandler(
 		ProtocolID(client.params.NetworkID(), id.Name()),
 		func(s network.Stream) {
-			defer close(streamClosed)
-			defer s.Close()
+			defer s.Reset() //nolint:errcheck
 			close(serverBlocked)
-			// Block until the stream is torn down by the client's Reset.
-			buf := make([]byte, 1)
-			_, _ = s.Read(buf)
+			<-unblock
 		},
 	)
 
@@ -115,13 +117,6 @@ func TestClient_AbortsOnCtxCancel(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 	case <-time.After(2 * time.Second):
 		t.Fatal("client did not return promptly after context cancellation")
-	}
-	// The server-side handler should unblock too, once its Read errors out on
-	// the reset stream.
-	select {
-	case <-streamClosed:
-	case <-time.After(2 * time.Second):
-		t.Fatal("server handler did not exit after client reset the stream")
 	}
 }
 

--- a/share/shwap/p2p/shrex/exchange_test.go
+++ b/share/shwap/p2p/shrex/exchange_test.go
@@ -65,9 +65,8 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 	})
 }
 
-// TestClient_AbortsOnCtxCancel is a regression test for #3480: canceling the
-// parent context after the stream is opened must abort the request promptly
-// instead of blocking on the stream deadline (up to ReadTimeout, 2m default).
+// Regression for #3480: canceling ctx mid-request must abort promptly instead
+// of hanging on the stream deadline.
 func TestClient_AbortsOnCtxCancel(t *testing.T) {
 	hosts := createMocknet(t, 2)
 	client, err := NewClient(DefaultClientParameters(), hosts[0])
@@ -76,12 +75,8 @@ func TestClient_AbortsOnCtxCancel(t *testing.T) {
 	id, err := shwap.NewNamespaceDataID(1, libshare.RandomNamespace())
 	require.NoError(t, err)
 
-	// Hold the server handler on a channel that only closes at test cleanup so
-	// the server never reads or writes anything. This keeps the client stuck
-	// in serde.Read waiting for a status response, which is exactly the state
-	// the fix targets — reading a byte instead would race with the client's
-	// WriteTo and let the handler exit before ctx is canceled, so the test
-	// could pass without exercising AfterFunc at all.
+	// Server never reads or writes, so the client stays blocked in serde.Read
+	// until the fix's AfterFunc resets the stream.
 	serverBlocked := make(chan struct{})
 	unblock := make(chan struct{})
 	t.Cleanup(func() { close(unblock) })
@@ -102,8 +97,6 @@ func TestClient_AbortsOnCtxCancel(t *testing.T) {
 		result <- client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
 	}()
 
-	// Wait until the server has accepted the stream so we know the client is
-	// past NewStream and blocked reading the response.
 	select {
 	case <-serverBlocked:
 	case <-time.After(2 * time.Second):

--- a/share/shwap/p2p/shrex/exchange_test.go
+++ b/share/shwap/p2p/shrex/exchange_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	libhost "github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 
@@ -62,6 +63,66 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, data.Flatten())
 	})
+}
+
+// TestClient_AbortsOnCtxCancel is a regression test for #3480: canceling the
+// parent context after the stream is opened must abort the request promptly
+// instead of blocking on the stream deadline (up to ReadTimeout, 2m default).
+func TestClient_AbortsOnCtxCancel(t *testing.T) {
+	hosts := createMocknet(t, 2)
+	client, err := NewClient(DefaultClientParameters(), hosts[0])
+	require.NoError(t, err)
+
+	id, err := shwap.NewNamespaceDataID(1, libshare.RandomNamespace())
+	require.NoError(t, err)
+
+	// Server-side handler holds the stream open without reading or responding,
+	// simulating an unresponsive peer so the client is stuck in serde.Read.
+	serverBlocked := make(chan struct{})
+	streamClosed := make(chan struct{})
+	hosts[1].SetStreamHandler(
+		ProtocolID(client.params.NetworkID(), id.Name()),
+		func(s network.Stream) {
+			defer close(streamClosed)
+			defer s.Close()
+			close(serverBlocked)
+			// Block until the stream is torn down by the client's Reset.
+			buf := make([]byte, 1)
+			_, _ = s.Read(buf)
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
+	}()
+
+	// Wait until the server has accepted the stream so we know the client is
+	// past NewStream and blocked reading the response.
+	select {
+	case <-serverBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never received the stream")
+	}
+
+	cancel()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not return promptly after context cancellation")
+	}
+	// The server-side handler should unblock too, once its Read errors out on
+	// the reset stream.
+	select {
+	case <-streamClosed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server handler did not exit after client reset the stream")
+	}
 }
 
 func createMocknet(t *testing.T, amount int) []libhost.Host {


### PR DESCRIPTION
The shrex client sets the stream deadline once at open and never watches for ctx cancellation, so a canceled request keeps blocking on Read/Write up to 2m.

- Register `context.AfterFunc` to reset the stream on cancel.
- In `Get`, `errors.Join` `ctx.Err()` so typed wire errors like `ErrNotFound` aren't masked.

Regression test: `TestClient_AbortsOnCtxCancel`.

Fixes #3480