### PR TITLE
nodebuilder/rpc: Make maxConcurrentConns configurable

### DIFF
--- a/api/rpc/server.go
+++ b/api/rpc/server.go
@@ -30,8 +30,10 @@ const (
 	// to cover base64 + JSON envelope overhead (~1.5×) on a worst-case blob.Submit,
 	// which packs all blobs into a single PFB tx capped at MaxTxSize.
 	maxRequestSize = int64(appconsts.MaxTxSize * 2)
-	// maxConcurrentConns caps simultaneous connections to bound goroutine/FD usage.
-	maxConcurrentConns = 500
+	// DefaultMaxConcurrentConns is the default cap on simultaneous connections
+	// to bound goroutine/FD usage. Operators can override via config; websocket
+	// subscriptions count against this limit for the lifetime of the connection.
+	DefaultMaxConcurrentConns = 500
 )
 
 // RateLimitConfig configures per-IP rate limiting based on the connection's
@@ -70,6 +72,11 @@ type Server struct {
 	corsConfig   CORSConfig
 	rateLimitCfg RateLimitConfig
 
+	// maxConcurrentConns caps simultaneous HTTP connections. Websocket
+	// subscriptions count against this for the lifetime of the connection,
+	// so operators exposing many long-lived subscribers should raise it.
+	maxConcurrentConns int
+
 	tlsEnabled  bool
 	tlsCertPath string
 	tlsKeyPath  string
@@ -92,18 +99,23 @@ func NewServer(
 	corsConfig CORSConfig,
 	tlsConfig TLSConfig,
 	rateLimitCfg RateLimitConfig,
+	maxConcurrentConns int,
 	signer jwt.Signer,
 	verifier jwt.Verifier,
 ) *Server {
+	if maxConcurrentConns <= 0 {
+		maxConcurrentConns = DefaultMaxConcurrentConns
+	}
 	srv := &Server{
-		signer:       signer,
-		verifier:     verifier,
-		authDisabled: authDisabled,
-		corsConfig:   corsConfig,
-		rateLimitCfg: rateLimitCfg,
-		tlsEnabled:   tlsConfig.Enabled,
-		tlsCertPath:  tlsConfig.CertPath,
-		tlsKeyPath:   tlsConfig.KeyPath,
+		signer:             signer,
+		verifier:           verifier,
+		authDisabled:       authDisabled,
+		corsConfig:         corsConfig,
+		rateLimitCfg:       rateLimitCfg,
+		maxConcurrentConns: maxConcurrentConns,
+		tlsEnabled:         tlsConfig.Enabled,
+		tlsCertPath:        tlsConfig.CertPath,
+		tlsKeyPath:         tlsConfig.KeyPath,
 	}
 
 	// The tracer closure reads srv.metrics lazily: WithMetrics may run after
@@ -155,7 +167,7 @@ func (s *Server) newHandlerStack(core http.Handler) http.Handler {
 		h = s.authHandler(h)
 	}
 
-	h = connLimit(maxConcurrentConns, h)
+	h = connLimit(s.maxConcurrentConns, h)
 	// Per-IP rate limiting is opt-in: behind a reverse proxy all clients share
 	// one bucket (RemoteAddr == proxy), so the limit is best applied there.
 	if s.rateLimitCfg.Enabled {

--- a/api/rpc/server_test.go
+++ b/api/rpc/server_test.go
@@ -70,7 +70,10 @@ func TestServer_HandlerStackSelection(t *testing.T) {
 				AllowedHeaders: []string{"Content-Type"},
 			}
 
-			server := NewServer("localhost", "0", tt.authDisabled, corsConfig, TLSConfig{}, RateLimitConfig{}, signer, verifier)
+			server := NewServer(
+				"localhost", "0", tt.authDisabled, corsConfig,
+				TLSConfig{}, RateLimitConfig{}, 0, signer, verifier,
+			)
 
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -114,7 +117,7 @@ func TestServer_AuthDisabledOverridesCORS(t *testing.T) {
 		AllowedHeaders: []string{"Content-Type"},
 	}
 
-	server := NewServer("localhost", "0", true, restrictiveCORS, TLSConfig{}, RateLimitConfig{}, signer, verifier)
+	server := NewServer("localhost", "0", true, restrictiveCORS, TLSConfig{}, RateLimitConfig{}, 0, signer, verifier)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -180,7 +183,7 @@ func TestServer_CORSConfigurationPassing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewServer("localhost", "0", false, tt.corsConfig, TLSConfig{}, RateLimitConfig{}, signer, verifier)
+			server := NewServer("localhost", "0", false, tt.corsConfig, TLSConfig{}, RateLimitConfig{}, 0, signer, verifier)
 
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -242,6 +245,7 @@ func TestServer_AuthMiddleware(t *testing.T) {
 				CORSConfig{},
 				TLSConfig{},
 				RateLimitConfig{},
+				0,
 				signer,
 				verifier,
 			)
@@ -307,6 +311,7 @@ func TestServer_VerifyAuth(t *testing.T) {
 				CORSConfig{},
 				TLSConfig{},
 				RateLimitConfig{},
+				0,
 				signer,
 				verifier,
 			)
@@ -326,7 +331,7 @@ func TestServer_VerifyAuth(t *testing.T) {
 // TestServer_StartStop tests server lifecycle
 func TestServer_StartStop(t *testing.T) {
 	signer, verifier := createTestJWT(t)
-	server := NewServer("localhost", "0", false, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, signer, verifier)
+	server := NewServer("localhost", "0", false, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, 0, signer, verifier)
 
 	ctx := context.Background()
 
@@ -358,7 +363,7 @@ func TestServer_TLS(t *testing.T) {
 		Enabled:  true,
 		CertPath: certFile,
 		KeyPath:  keyFile,
-	}, RateLimitConfig{}, signer, verifier)
+	}, RateLimitConfig{}, 0, signer, verifier)
 
 	ctx := context.Background()
 	err := srv.Start(ctx)
@@ -397,7 +402,7 @@ func TestServer_TLS(t *testing.T) {
 func TestServer_NoTLS_PlainHTTP(t *testing.T) {
 	signer, verifier := createTestJWT(t)
 
-	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, signer, verifier)
+	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, 0, signer, verifier)
 
 	ctx := context.Background()
 	err := srv.Start(ctx)
@@ -436,7 +441,7 @@ func (wsTestService) Updates(ctx context.Context) (<-chan int, error) {
 // subscription must still work with metrics on.
 func TestServer_WithMetrics_WebSocketSubscription(t *testing.T) {
 	signer, verifier := createTestJWT(t)
-	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, signer, verifier)
+	srv := NewServer("127.0.0.1", "0", true, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, 0, signer, verifier)
 	srv.RegisterService("test", wsTestService{}, nil)
 	require.NoError(t, srv.WithMetrics())
 
@@ -469,6 +474,55 @@ func TestServer_WithMetrics_WebSocketSubscription(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("no value received from websocket subscription")
 	}
+}
+
+// TestServer_MaxConcurrentConns_Configurable verifies that a non-zero
+// maxConcurrentConns passed to NewServer flows through to connLimit,
+// so operators can raise the cap when many long-lived websocket
+// subscribers would otherwise exhaust the default 500 slots.
+func TestServer_MaxConcurrentConns_Configurable(t *testing.T) {
+	signer, verifier := createTestJWT(t)
+	srv := NewServer("localhost", "0", true, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, 1, signer, verifier)
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Block") == "true" {
+			close(blocked)
+			<-release
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	stack := srv.newHandlerStack(inner)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-Block", "true")
+		w := httptest.NewRecorder()
+		stack.ServeHTTP(w, req)
+	}()
+
+	<-blocked
+
+	// Second concurrent request must be rejected — the single slot is held.
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	stack.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	close(release)
+	<-done
+}
+
+// TestServer_MaxConcurrentConns_ZeroFallsBackToDefault verifies that passing
+// 0 falls back to DefaultMaxConcurrentConns, so callers that leave the field
+// unset get the same behavior as before this became configurable.
+func TestServer_MaxConcurrentConns_ZeroFallsBackToDefault(t *testing.T) {
+	signer, verifier := createTestJWT(t)
+	srv := NewServer("localhost", "0", true, CORSConfig{}, TLSConfig{}, RateLimitConfig{}, 0, signer, verifier)
+	assert.Equal(t, DefaultMaxConcurrentConns, srv.maxConcurrentConns)
 }
 
 func generateSelfSignedCert(t *testing.T) (certPath, keyPath string) {

--- a/nodebuilder/rpc/config.go
+++ b/nodebuilder/rpc/config.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/celestiaorg/celestia-node/api/rpc"
 	"github.com/celestiaorg/celestia-node/libs/utils"
 )
 
@@ -43,16 +44,22 @@ type Config struct {
 	TLSCertPath string
 	TLSKeyPath  string
 	RateLimit   RateLimitConfig
+	// MaxConcurrentConns caps simultaneous HTTP connections to bound
+	// goroutine/FD usage. Websocket subscriptions count against this limit
+	// for the lifetime of the connection, so operators exposing many
+	// long-lived subscribers should raise this. Must be > 0.
+	MaxConcurrentConns int
 }
 
 func DefaultConfig() Config {
 	return Config{
 		Address: defaultBindAddress,
 		// do NOT expose the same port as celestia-core by default so that both can run on the same machine
-		Port:      defaultPort,
-		SkipAuth:  false,
-		CORS:      DefaultCORSConfig(),
-		RateLimit: DefaultRateLimitConfig(),
+		Port:               defaultPort,
+		SkipAuth:           false,
+		CORS:               DefaultCORSConfig(),
+		RateLimit:          DefaultRateLimitConfig(),
+		MaxConcurrentConns: rpc.DefaultMaxConcurrentConns,
 	}
 }
 
@@ -121,6 +128,10 @@ func (cfg *Config) Validate() error {
 		if cfg.RateLimit.CacheSize <= 0 {
 			return fmt.Errorf("service/rpc: rate limit CacheSize must be > 0")
 		}
+	}
+
+	if cfg.MaxConcurrentConns <= 0 {
+		return fmt.Errorf("service/rpc: MaxConcurrentConns must be > 0")
 	}
 
 	return nil

--- a/nodebuilder/rpc/config.go
+++ b/nodebuilder/rpc/config.go
@@ -130,8 +130,11 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
+	// A missing MaxConcurrentConns in an older config.toml decodes to 0. Fall
+	// back to the default instead of rejecting so binary upgrades don't require
+	// the operator to run `celestia config update` before the node can start.
 	if cfg.MaxConcurrentConns <= 0 {
-		return fmt.Errorf("service/rpc: MaxConcurrentConns must be > 0")
+		cfg.MaxConcurrentConns = rpc.DefaultMaxConcurrentConns
 	}
 
 	return nil

--- a/nodebuilder/rpc/config_test.go
+++ b/nodebuilder/rpc/config_test.go
@@ -4,7 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/celestiaorg/celestia-node/api/rpc"
 )
+
+const testAddr = "127.0.0.1"
 
 // TestDefaultConfig tests that the default rpc config is correct.
 func TestDefaultConfig(t *testing.T) {
@@ -18,7 +22,8 @@ func TestDefaultConfig(t *testing.T) {
 			AllowedHeaders: []string{},
 			AllowedMethods: []string{},
 		},
-		RateLimit: DefaultRateLimitConfig(),
+		RateLimit:          DefaultRateLimitConfig(),
+		MaxConcurrentConns: rpc.DefaultMaxConcurrentConns,
 	}
 
 	assert.Equal(t, expected, DefaultConfig())
@@ -33,24 +38,45 @@ func TestConfigValidate(t *testing.T) {
 		{
 			name: "valid config",
 			cfg: Config{
-				Address: "127.0.0.1",
-				Port:    "8080",
+				Address:            testAddr,
+				Port:               "8080",
+				MaxConcurrentConns: rpc.DefaultMaxConcurrentConns,
 			},
 			err: false,
 		},
 		{
 			name: "invalid address",
 			cfg: Config{
-				Address: "999.999.999.999",
-				Port:    "8080",
+				Address:            "999.999.999.999",
+				Port:               "8080",
+				MaxConcurrentConns: rpc.DefaultMaxConcurrentConns,
 			},
 			err: true,
 		},
 		{
 			name: "invalid port",
 			cfg: Config{
-				Address: "127.0.0.1",
-				Port:    "invalid",
+				Address:            testAddr,
+				Port:               "invalid",
+				MaxConcurrentConns: rpc.DefaultMaxConcurrentConns,
+			},
+			err: true,
+		},
+		{
+			name: "MaxConcurrentConns zero rejected",
+			cfg: Config{
+				Address:            testAddr,
+				Port:               "8080",
+				MaxConcurrentConns: 0,
+			},
+			err: true,
+		},
+		{
+			name: "MaxConcurrentConns negative rejected",
+			cfg: Config{
+				Address:            testAddr,
+				Port:               "8080",
+				MaxConcurrentConns: -1,
 			},
 			err: true,
 		},

--- a/nodebuilder/rpc/config_test.go
+++ b/nodebuilder/rpc/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-node/api/rpc"
 )
@@ -62,24 +63,6 @@ func TestConfigValidate(t *testing.T) {
 			},
 			err: true,
 		},
-		{
-			name: "MaxConcurrentConns zero rejected",
-			cfg: Config{
-				Address:            testAddr,
-				Port:               "8080",
-				MaxConcurrentConns: 0,
-			},
-			err: true,
-		},
-		{
-			name: "MaxConcurrentConns negative rejected",
-			cfg: Config{
-				Address:            testAddr,
-				Port:               "8080",
-				MaxConcurrentConns: -1,
-			},
-			err: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -88,6 +71,30 @@ func TestConfigValidate(t *testing.T) {
 			if (err != nil) != tt.err {
 				t.Errorf("Config.Validate() error = %v, err %v", err, tt.err)
 			}
+		})
+	}
+}
+
+// TestConfigValidate_MaxConcurrentConnsFallback covers the upgrade path where
+// an older config.toml lacks the field: it decodes to 0, and Validate must
+// backfill the default instead of failing the node's startup.
+func TestConfigValidate_MaxConcurrentConnsFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+	}{
+		{name: "zero (missing from old config.toml)", in: 0},
+		{name: "negative", in: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Address:            testAddr,
+				Port:               "8080",
+				MaxConcurrentConns: tt.in,
+			}
+			require.NoError(t, cfg.Validate())
+			assert.Equal(t, rpc.DefaultMaxConcurrentConns, cfg.MaxConcurrentConns)
 		})
 	}
 }

--- a/nodebuilder/rpc/constructors.go
+++ b/nodebuilder/rpc/constructors.go
@@ -54,5 +54,5 @@ func server(cfg *Config, signer jwt.Signer, verifier jwt.Verifier) *rpc.Server {
 		RequestsPerSec: cfg.RateLimit.RequestsPerSec,
 		Burst:          cfg.RateLimit.Burst,
 		CacheSize:      cfg.RateLimit.CacheSize,
-	}, signer, verifier)
+	}, cfg.MaxConcurrentConns, signer, verifier)
 }

--- a/nodebuilder/rpc/flags.go
+++ b/nodebuilder/rpc/flags.go
@@ -22,6 +22,7 @@ var (
 	tlsCertPathFlag        = "rpc.tls-cert"
 	tlsKeyPathFlag         = "rpc.tls-key"
 	rateLimitFlag          = "rpc.rate-limit"
+	maxConcurrentConnsFlag = "rpc.max-concurrent-conns"
 )
 
 // Flags gives a set of hardcoded node/rpc package flags.
@@ -90,6 +91,13 @@ func Flags() *flag.FlagSet {
 		rateLimitFlag,
 		false,
 		"Enable per-IP rate limiting on RPC server. Leave disabled when running behind a reverse proxy",
+	)
+
+	flags.Int(
+		maxConcurrentConnsFlag,
+		0,
+		"Cap on simultaneous RPC connections; websocket subscriptions count for their lifetime. "+
+			"0 keeps the config file value (default 500)",
 	)
 
 	return flags
@@ -195,6 +203,12 @@ func ParseFlags(cmd *cobra.Command, cfg *Config) error {
 	} else if val {
 		log.Info("RPC rate limiting enabled (--rpc.rate-limit)")
 		cfg.RateLimit.Enabled = true
+	}
+
+	if val, err := cmd.Flags().GetInt(maxConcurrentConnsFlag); err != nil {
+		return err
+	} else if val > 0 {
+		cfg.MaxConcurrentConns = val
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fixes #5071. After the RPC hardening in #4909 shipped in v0.31.3, the `connLimit` middleware caps all incoming HTTP connections at a hardcoded 500. Websocket subscriptions occupy a slot for the lifetime of the connection, so a bridge with many long-lived subscribers exhausts the pool; the next WS upgrade gets HTTP 503 back, which surfaces client-side as `websocket: bad handshake`. Operators had no way to raise the cap without a custom build.

This PR:

- Adds `MaxConcurrentConns` to `nodebuilder/rpc.Config` (default 500, must be `> 0`).
- Adds `--rpc.max-concurrent-conns` flag (0 = fall back to config value).
- Threads the value through `api/rpc.NewServer` into `connLimit`. A zero value passed to `NewServer` falls back to `DefaultMaxConcurrentConns` so callers that leave the field unset keep the pre-change behavior.
- Tests: a wiring test that constructs the server with `limit=1`, blocks one request, and asserts the second gets 503; a fallback test for the zero-value path; validation-rejection tests for `≤ 0`.

Out of scope (issue questions Q3 and Q5): a separate WS-only limit / exempting WS upgrades from the shared cap, and surfacing the HTTP reject reason on failed upgrades. Both are worth doing as follow-ups but are larger design changes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (no new warnings introduced)
- [x] `golangci-lint run --new-from-rev=origin/main` — 0 new issues
- [x] `go test ./api/rpc/... ./nodebuilder/rpc/...`
- [x] `go test -short ./nodebuilder/...` — full nodebuilder suite passes
- [ ] Manual: set `MaxConcurrentConns` to a low value in `config.toml`, confirm the new cap is honored and default value still works when unset