### PR TITLE
test(tastora): add missing tastora tests

### DIFF
--- a/.github/workflows/tastora-weekly.yml
+++ b/.github/workflows/tastora-weekly.yml
@@ -1,0 +1,95 @@
+name: Tastora Weekly
+
+# Weekly bridge-node regression suite. Runs against the newest main commit that has a
+# published celestia-node image, so a regression is localized near the offending PR.
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Monday 07:00 UTC
+  workflow_dispatch:
+    inputs:
+      node_tag:
+        description: "celestia-node image tag to test (blank = newest main commit with a published image)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: tastora-weekly
+  cancel-in-progress: false
+
+jobs:
+  tastora:
+    name: Tastora E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      commit: ${{ steps.resolve.outputs.commit }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 50
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Log in to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Resolve node image tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          image="ghcr.io/celestiaorg/celestia-node"
+
+          override="${{ github.event.inputs.node_tag }}"
+          if [ -n "$override" ]; then
+            echo "Using dispatch-provided tag: $override"
+            echo "tag=$override" >> "$GITHUB_OUTPUT"
+            echo "commit=$override" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Walk back from main HEAD to the newest commit whose 7-char SHA has a published
+          # image (the tag format used by docker-build-publish.yml, e.g. 32627d9).
+          for sha in $(git rev-list -n 50 HEAD); do
+            short="${sha:0:7}"
+            if docker manifest inspect "$image:$short" >/dev/null 2>&1; then
+              echo "Resolved image: $image:$short (commit $sha)"
+              echo "tag=$short" >> "$GITHUB_OUTPUT"
+              echo "commit=$sha" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "no image for $short, walking back..."
+          done
+
+          echo "::error::no published celestia-node image found in the last 50 main commits"
+          exit 1
+
+      - name: Run Tastora suite
+        env:
+          CELESTIA_NODE_TAG: ${{ steps.resolve.outputs.tag }}
+        run: make test-tastora
+
+  # TODO: enable once we ensure tests work correctly
+  # Alerts the channel whenever the weekly regression run fails.
+  # notify-slack-on-failure:
+  #   name: Notify Slack on Failure
+  #   needs: [tastora]
+  #   runs-on: ubuntu-latest
+  #   if: ${{ always() && needs.tastora.result == 'failure' }}
+  #   steps:
+  #     - name: Notify Slack
+  #       uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+  #       with:
+  #         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #         webhook-type: incoming-webhook
+  #         payload: |
+  #           {
+  #             "text": "Tastora weekly regression failed (image tag `${{ needs.tastora.outputs.tag }}`, commit `${{ needs.tastora.outputs.commit }}`). <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+  #           }

--- a/.github/workflows/tastora-weekly.yml
+++ b/.github/workflows/tastora-weekly.yml
@@ -43,11 +43,13 @@ jobs:
 
       - name: Resolve node image tag
         id: resolve
+        env:
+          NODE_TAG: ${{ github.event.inputs.node_tag }}
         run: |
           set -euo pipefail
           image="ghcr.io/celestiaorg/celestia-node"
 
-          override="${{ github.event.inputs.node_tag }}"
+          override="${NODE_TAG:-}"
           if [ -n "$override" ]; then
             echo "Using dispatch-provided tag: $override"
             echo "tag=$override" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tastora-weekly.yml
+++ b/.github/workflows/tastora-weekly.yml
@@ -1,16 +1,13 @@
 name: Tastora Weekly
 
-# Weekly bridge-node regression suite. Runs against the newest main commit that has a
-# published celestia-node image, so a regression is localized near the offending PR.
+# Weekly bridge-node E2E regression suite. Builds the celestia-node image from the current
+# main source and runs the Tastora suite against it, so the node image always matches the
+# test code — tests coupled to node behaviour are validated reliably (unlike testing a
+# separately published image, which lags the source). Release-image validation lives elsewhere.
 on:
   schedule:
     - cron: "0 7 * * 1" # Monday 07:00 UTC
   workflow_dispatch:
-    inputs:
-      node_tag:
-        description: "celestia-node image tag to test (blank = newest main commit with a published image)"
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -26,13 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     outputs:
-      tag: ${{ steps.resolve.outputs.tag }}
-      commit: ${{ steps.resolve.outputs.commit }}
+      commit: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: main
-          fetch-depth: 50
 
       - uses: actions/setup-go@v7
         with:
@@ -41,41 +36,12 @@ jobs:
       - name: Log in to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Resolve node image tag
-        id: resolve
-        env:
-          NODE_TAG: ${{ github.event.inputs.node_tag }}
-        run: |
-          set -euo pipefail
-          image="ghcr.io/celestiaorg/celestia-node"
-
-          override="${NODE_TAG:-}"
-          if [ -n "$override" ]; then
-            echo "Using dispatch-provided tag: $override"
-            echo "tag=$override" >> "$GITHUB_OUTPUT"
-            echo "commit=$override" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Walk back from main HEAD to the newest commit whose 7-char SHA has a published
-          # image (the tag format used by docker-build-publish.yml, e.g. 32627d9).
-          for sha in $(git rev-list -n 50 HEAD); do
-            short="${sha:0:7}"
-            if docker manifest inspect "$image:$short" >/dev/null 2>&1; then
-              echo "Resolved image: $image:$short (commit $sha)"
-              echo "tag=$short" >> "$GITHUB_OUTPUT"
-              echo "commit=$sha" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "no image for $short, walking back..."
-          done
-
-          echo "::error::no published celestia-node image found in the last 50 main commits"
-          exit 1
+      - name: Build node image from source
+        run: docker build -t ghcr.io/celestiaorg/celestia-node:tastora-ci .
 
       - name: Run Tastora suite
         env:
-          CELESTIA_NODE_TAG: ${{ steps.resolve.outputs.tag }}
+          CELESTIA_NODE_TAG: tastora-ci
         run: make test-tastora
 
   # TODO: enable once we ensure tests work correctly
@@ -93,5 +59,5 @@ jobs:
   #         webhook-type: incoming-webhook
   #         payload: |
   #           {
-  #             "text": "Tastora weekly regression failed (image tag `${{ needs.tastora.outputs.tag }}`, commit `${{ needs.tastora.outputs.commit }}`). <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+  #             "text": "Tastora weekly regression failed (commit `${{ needs.tastora.outputs.commit }}`). <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
   #           }

--- a/.github/workflows/tastora-weekly.yml
+++ b/.github/workflows/tastora-weekly.yml
@@ -1,9 +1,10 @@
 name: Tastora Weekly
 
-# Weekly bridge-node E2E regression suite. Builds the celestia-node image from the current
-# main source and runs the Tastora suite against it, so the node image always matches the
-# test code — tests coupled to node behaviour are validated reliably (unlike testing a
-# separately published image, which lags the source). Release-image validation lives elsewhere.
+# Weekly bridge-node E2E regression suite. Builds the celestia-node image once from the current
+# main source, then fans every Tastora suite out across a matrix so each runs in parallel against
+# that image and reports its own pass/fail. Keeping the node image matched to the test code means
+# tests coupled to node behaviour are validated reliably (unlike testing a separately published
+# image, which lags the source). Release-image validation lives elsewhere.
 on:
   schedule:
     - cron: "0 7 * * 1" # Monday 07:00 UTC
@@ -17,13 +18,53 @@ concurrency:
   group: tastora-weekly
   cancel-in-progress: false
 
+env:
+  NODE_TAG: tastora-ci
+
 jobs:
-  tastora:
-    name: Tastora E2E
+  build-image:
+    name: Build node image
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-    outputs:
-      commit: ${{ github.sha }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Build node image from source
+        run: docker build -t ghcr.io/celestiaorg/celestia-node:${NODE_TAG} .
+
+      - name: Export image
+        run: docker save ghcr.io/celestiaorg/celestia-node:${NODE_TAG} | gzip > /tmp/node-image.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tastora-node-image
+          path: /tmp/node-image.tar.gz
+          retention-days: 1
+
+  test:
+    name: ${{ matrix.suite }}
+    needs: build-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - TestArchivalTestSuite
+          - TestBlobInclusionTestSuite
+          - TestBlobTestSuite
+          - TestCatchupTestSuite
+          - TestCoreControlTestSuite
+          - TestCoreFailoverTestSuite
+          - TestDASTestSuite
+          - TestE2ESanityTestSuite
+          - TestHeaderP2PSyncTestSuite
+          - TestHeaderTestSuite
+          - TestLightRestartTestSuite
+          - TestP2PTestSuite
+          - TestRestartTestSuite
     steps:
       - uses: actions/checkout@v7
         with:
@@ -33,31 +74,15 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Log in to ghcr.io
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - uses: actions/download-artifact@v4
+        with:
+          name: tastora-node-image
+          path: /tmp
 
-      - name: Build node image from source
-        run: docker build -t ghcr.io/celestiaorg/celestia-node:tastora-ci .
+      - name: Load node image
+        run: docker load --input /tmp/node-image.tar.gz
 
-      - name: Run Tastora suite
+      - name: Run ${{ matrix.suite }}
         env:
-          CELESTIA_NODE_TAG: tastora-ci
-        run: make test-tastora
-
-  # TODO: enable once we ensure tests work correctly
-  # Alerts the channel whenever the weekly regression run fails.
-  # notify-slack-on-failure:
-  #   name: Notify Slack on Failure
-  #   needs: [tastora]
-  #   runs-on: ubuntu-latest
-  #   if: ${{ always() && needs.tastora.result == 'failure' }}
-  #   steps:
-  #     - name: Notify Slack
-  #       uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
-  #       with:
-  #         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #         webhook-type: incoming-webhook
-  #         payload: |
-  #           {
-  #             "text": "Tastora weekly regression failed (commit `${{ needs.tastora.outputs.commit }}`). <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-  #           }
+          CELESTIA_NODE_TAG: ${{ env.NODE_TAG }}
+        run: make test-tastora RUN=${{ matrix.suite }} TIMEOUT=30m

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ test-e2e-sanity:
 ## test-tastora: Run all Tastora framework tests.
 test-tastora:
 	@echo "--> Running all Tastora tests"
-	cd nodebuilder/tests/tastora && go test ${LDFLAGS} -v -tags integration ./...
+	cd nodebuilder/tests/tastora && go test ${LDFLAGS} -v -tags integration -timeout 60m ./...
 
 ## benchmark: Run all benchmarks.
 benchmark:

--- a/Makefile
+++ b/Makefile
@@ -193,10 +193,10 @@ test-e2e-sanity:
 	@echo "--> Running E2ESanityTestSuite"
 	cd nodebuilder/tests/tastora && go test -v -tags integration -run TestE2ESanityTestSuite -timeout 10m
 
-## test-tastora: Run all Tastora framework tests.
+## test-tastora: Run Tastora framework tests. Use RUN=TestXxxTestSuite for a single suite and TIMEOUT to override the 60m default.
 test-tastora:
-	@echo "--> Running all Tastora tests"
-	cd nodebuilder/tests/tastora && go test ${LDFLAGS} -v -tags integration -timeout 60m ./...
+	@echo "--> Running Tastora tests $(if $(RUN),($(RUN)),(all))"
+	cd nodebuilder/tests/tastora && go test ${LDFLAGS} -v -tags integration -timeout $(or $(TIMEOUT),60m) $(if $(RUN),-run '^$(RUN)$$') ./...
 
 ## benchmark: Run all benchmarks.
 benchmark:

--- a/nodebuilder/pruner/module.go
+++ b/nodebuilder/pruner/module.go
@@ -56,7 +56,9 @@ func ConstructModule(tp node.Type) fx.Option {
 		// LNs enforce pruning by default
 		return fx.Module("prune",
 			baseComponents,
-			fx.Supply(modshare.Window(availability.SamplingWindow)),
+			fx.Provide(func() modshare.Window {
+				return modshare.Window(availability.ResolveWindow(availability.SamplingWindow))
+			}),
 			// TODO(@walldiss @renaynay): remove conversion after Availability and Pruner interfaces are merged
 			//  note this provide exists in pruner module to avoid cyclical imports
 			fx.Provide(func(la *light.ShareAvailability) pruner.Pruner { return la }),
@@ -71,7 +73,9 @@ func ConstructModule(tp node.Type) fx.Option {
 				return []core.Option{core.WithArchivalMode()}, []fullavail.Option{fullavail.WithArchivalMode()}
 			}),
 			fx.Provide(func(fa *fullavail.ShareAvailability) pruner.Pruner { return fa }),
-			fx.Supply(modshare.Window(availability.StorageWindow)),
+			fx.Provide(func() modshare.Window {
+				return modshare.Window(availability.ResolveWindow(availability.StorageWindow))
+			}),
 			fx.Invoke(convertToPruned),
 		)
 	default:

--- a/nodebuilder/tests/tastora/archival_test.go
+++ b/nodebuilder/tests/tastora/archival_test.go
@@ -44,8 +44,8 @@ func (s *ArchivalTestSuite) TearDownSuite() {
 	}
 }
 
-// TestArchivalNodeKeepsData submits a blob at an early height and wait untill it will be
-// outside AvalaibilityWindow to ensure that the whole data is servable
+// TestArchivalNodeKeepsData submits a blob at an early height and waits until it is
+// outside the availability window to ensure the whole data stays servable.
 func (s *ArchivalTestSuite) TestArchivalNodeKeepsData() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/nodebuilder/tests/tastora/archival_test.go
+++ b/nodebuilder/tests/tastora/archival_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package tastora
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/celestiaorg/go-square/v4/share"
+
+	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
+	nodeblob "github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/state"
+)
+
+// ArchivalTestSuite runs a bridge node started with `--archival`, so it must retain
+// block data past the storage window.
+type ArchivalTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestArchivalTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping archival integration tests in short mode")
+	}
+	suite.Run(t, &ArchivalTestSuite{})
+}
+
+func (s *ArchivalTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(0), WithArchivalBridge())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+}
+
+func (s *ArchivalTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestArchivalNodeKeepsData submits a blob at an early height and wait untill it will be
+// outside AvalaibilityWindow to ensure that the whole data is servable
+func (s *ArchivalTestSuite) TestArchivalNodeKeepsData() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	bridge := s.framework.GetBridgeNodes()[0]
+	client := s.framework.GetNodeRPCClient(ctx, bridge)
+
+	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x05}, 10))
+	s.Require().NoError(err, "should create namespace")
+
+	blobData := []byte("TestArchivalNodeKeepsData: archival retention test data")
+	nodeBlobs := s.createBlob(ctx, client, namespace, blobData)
+
+	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
+	earlyHeight, err := client.Blob.Submit(ctx, nodeBlobs, txConfig)
+	s.Require().NoError(err, "should submit blob")
+	s.Require().NotZero(earlyHeight)
+
+	_, err = client.Header.WaitForHeight(ctx, earlyHeight)
+	s.Require().NoError(err, "should reach submit height")
+
+	earlyHdr, err := client.Header.GetByHeight(ctx, earlyHeight)
+	s.Require().NoError(err, "should get early header")
+
+	_, err = client.Header.WaitForHeight(ctx, earlyHeight+30)
+	s.Require().NoError(err, "chain should advance well past the early height")
+
+	postHdr, err := client.Header.GetByHeight(ctx, earlyHeight)
+	s.Require().NoError(err, "early header should still be served after advancing")
+	s.Assert().Equal(earlyHdr.Hash(), postHdr.Hash(), "early header should be unchanged")
+	s.Assert().Equal(earlyHdr.DAH.Hash(), postHdr.DAH.Hash(), "early DAH should be unchanged")
+
+	s.Require().NoError(client.Share.SharesAvailable(ctx, earlyHeight),
+		"early-height shares should stay available on an archival node")
+
+	eds, err := client.Share.GetEDS(ctx, earlyHeight)
+	s.Require().NoError(err, "early-height EDS should stay retrievable")
+	s.Require().NotNil(eds)
+
+	got, err := client.Blob.Get(ctx, earlyHeight, namespace, nodeBlobs[0].Commitment)
+	s.Require().NoError(err, "early-height blob should stay retrievable")
+	s.Require().NotNil(got)
+	s.Assert().Equal(blobData, bytes.TrimRight(got.Data(), "\x00"), "blob should round-trip")
+}
+
+func (s *ArchivalTestSuite) createBlob(
+	ctx context.Context,
+	client *rpcclient.Client,
+	namespace share.Namespace,
+	data []byte,
+) []*nodeblob.Blob {
+	nodeAddr, err := client.State.AccountAddress(ctx)
+	s.Require().NoError(err, "should get node address")
+
+	libBlob, err := share.NewV1Blob(namespace, data, nodeAddr.Bytes())
+	s.Require().NoError(err, "should create libshare blob")
+
+	nodeBlobs, err := nodeblob.ToNodeBlobs(libBlob)
+	s.Require().NoError(err, "should convert to node blobs")
+	return nodeBlobs
+}

--- a/nodebuilder/tests/tastora/archival_test.go
+++ b/nodebuilder/tests/tastora/archival_test.go
@@ -17,9 +17,8 @@ import (
 	"github.com/celestiaorg/celestia-node/state"
 )
 
-// archivalAvailabilityWindow is the shrunk availability window for the archival node, so
-// a height submitted early ages out of the window within the test's runtime. It must stay
-// large enough that the node's own head remains "recent" and its syncer doesn't stall.
+// archivalAvailabilityWindow shrinks the window so an early height ages out during the test,
+// but stays large enough that the node's head stays recent and the syncer doesn't stall.
 const archivalAvailabilityWindow = 2 * time.Minute
 
 // ArchivalTestSuite runs a bridge node started with `--archival` and a shrunk availability
@@ -50,11 +49,9 @@ func (s *ArchivalTestSuite) TearDownSuite() {
 	}
 }
 
-// TestArchivalNodeKeepsData submits a blob at an early height, lets the chain advance
-// until that height is outside the (shrunk) availability window, and asserts the archival
-// node still serves the header, shares and blob. On an archival node SharesAvailable
-// bypasses the window gate, whereas a non-archival node would reject an out-of-window
-// height and prune its data — so this exercises the archival retention guarantee.
+// TestArchivalNodeKeepsData submits a blob, advances past the shrunk availability window,
+// and asserts the archival node still serves the header, shares and blob — a non-archival
+// node would reject the out-of-window height and prune its data.
 func (s *ArchivalTestSuite) TestArchivalNodeKeepsData() {
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()

--- a/nodebuilder/tests/tastora/archival_test.go
+++ b/nodebuilder/tests/tastora/archival_test.go
@@ -56,7 +56,7 @@ func (s *ArchivalTestSuite) TestArchivalNodeKeepsData() {
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
-	bridge := s.framework.GetBridgeNodes()[0]
+	bridge := s.framework.GetArchivalNode()
 	client := s.framework.GetNodeRPCClient(ctx, bridge)
 
 	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x05}, 10))

--- a/nodebuilder/tests/tastora/archival_test.go
+++ b/nodebuilder/tests/tastora/archival_test.go
@@ -17,8 +17,13 @@ import (
 	"github.com/celestiaorg/celestia-node/state"
 )
 
-// ArchivalTestSuite runs a bridge node started with `--archival`, so it must retain
-// block data past the storage window.
+// archivalAvailabilityWindow is the shrunk availability window for the archival node, so
+// a height submitted early ages out of the window within the test's runtime. It must stay
+// large enough that the node's own head remains "recent" and its syncer doesn't stall.
+const archivalAvailabilityWindow = 2 * time.Minute
+
+// ArchivalTestSuite runs a bridge node started with `--archival` and a shrunk availability
+// window, so it must retain and serve block data even after it falls outside that window.
 type ArchivalTestSuite struct {
 	suite.Suite
 	framework *Framework
@@ -32,7 +37,8 @@ func TestArchivalTestSuite(t *testing.T) {
 }
 
 func (s *ArchivalTestSuite) SetupSuite() {
-	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(0), WithArchivalBridge())
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(0),
+		WithArchivalBridge(), WithAvailabilityWindow(archivalAvailabilityWindow))
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	s.Require().NoError(s.framework.SetupNetwork(ctx))
@@ -44,10 +50,13 @@ func (s *ArchivalTestSuite) TearDownSuite() {
 	}
 }
 
-// TestArchivalNodeKeepsData submits a blob at an early height and waits until it is
-// outside the availability window to ensure the whole data stays servable.
+// TestArchivalNodeKeepsData submits a blob at an early height, lets the chain advance
+// until that height is outside the (shrunk) availability window, and asserts the archival
+// node still serves the header, shares and blob. On an archival node SharesAvailable
+// bypasses the window gate, whereas a non-archival node would reject an out-of-window
+// height and prune its data — so this exercises the archival retention guarantee.
 func (s *ArchivalTestSuite) TestArchivalNodeKeepsData() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	bridge := s.framework.GetBridgeNodes()[0]
@@ -70,8 +79,10 @@ func (s *ArchivalTestSuite) TestArchivalNodeKeepsData() {
 	earlyHdr, err := client.Header.GetByHeight(ctx, earlyHeight)
 	s.Require().NoError(err, "should get early header")
 
-	_, err = client.Header.WaitForHeight(ctx, earlyHeight+30)
-	s.Require().NoError(err, "chain should advance well past the early height")
+	// Advance well past the availability window (block time ~1s, window 2m) so the early
+	// height is firmly outside it.
+	_, err = client.Header.WaitForHeight(ctx, earlyHeight+140)
+	s.Require().NoError(err, "chain should advance past the availability window")
 
 	postHdr, err := client.Header.GetByHeight(ctx, earlyHeight)
 	s.Require().NoError(err, "early header should still be served after advancing")

--- a/nodebuilder/tests/tastora/blob_inclusion_test.go
+++ b/nodebuilder/tests/tastora/blob_inclusion_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package tastora
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/celestiaorg/go-square/v4/share"
+
+	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
+	nodeblob "github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/state"
+)
+
+// BlobInclusionTestSuite verifies blob inclusion.
+type BlobInclusionTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestBlobInclusionTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping blob inclusion integration tests in short mode")
+	}
+	suite.Run(t, &BlobInclusionTestSuite{})
+}
+
+func (s *BlobInclusionTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(0))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+}
+
+func (s *BlobInclusionTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestBlobInclusion submits a blob under a namespace and verifies it is included.
+func (s *BlobInclusionTestSuite) TestBlobInclusion() {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	bridge := s.framework.GetBridgeNodes()[0]
+	client := s.framework.GetNodeRPCClient(ctx, bridge)
+
+	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x0A}, 10))
+	s.Require().NoError(err, "should create namespace")
+
+	blobData := []byte("TestBlobInclusion: included blob")
+	nodeBlobs := s.createBlob(ctx, client, namespace, blobData)
+
+	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
+	height, err := client.Blob.Submit(ctx, nodeBlobs, txConfig)
+	s.Require().NoError(err, "should submit blob")
+	s.Require().NotZero(height)
+
+	_, err = client.Header.WaitForHeight(ctx, height)
+	s.Require().NoError(err, "should reach the blob height")
+
+	commitment := nodeBlobs[0].Commitment
+
+	// The inclusion proof verifies against the committed blob.
+	proof, err := client.Blob.GetProof(ctx, height, namespace, commitment)
+	s.Require().NoError(err, "should get inclusion proof")
+	s.Require().NotNil(proof)
+
+	included, err := client.Blob.Included(ctx, height, namespace, proof, commitment)
+	s.Require().NoError(err, "should verify inclusion")
+	s.Require().True(included, "blob should be proven included at height %d", height)
+
+	// The blob round-trips through Get.
+	got, err := client.Blob.Get(ctx, height, namespace, commitment)
+	s.Require().NoError(err, "should get the included blob")
+	s.Require().Equal(blobData, bytes.TrimRight(got.Data(), "\x00"), "blob should round-trip")
+}
+
+// TestBlobNonInclusion submits a blob under one namespace then asserts a different
+// namespace has no blob at that height.
+func (s *BlobInclusionTestSuite) TestBlobNonInclusion() {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	bridge := s.framework.GetBridgeNodes()[0]
+	client := s.framework.GetNodeRPCClient(ctx, bridge)
+
+	present, err := share.NewV0Namespace(bytes.Repeat([]byte{0x0B}, 10))
+	s.Require().NoError(err, "should create present namespace")
+	nodeBlobs := s.createBlob(ctx, client, present, []byte("TestBlobNonInclusion: present blob"))
+
+	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
+	height, err := client.Blob.Submit(ctx, nodeBlobs, txConfig)
+	s.Require().NoError(err, "should submit blob")
+	s.Require().NotZero(height)
+
+	_, err = client.Header.WaitForHeight(ctx, height)
+	s.Require().NoError(err, "should reach the blob height")
+
+	// A different namespace has no blob at that height.
+	absent, err := share.NewV0Namespace(bytes.Repeat([]byte{0x0C}, 10))
+	s.Require().NoError(err, "should create absent namespace")
+
+	_, err = client.Blob.Get(ctx, height, absent, nodeBlobs[0].Commitment)
+	s.Require().ErrorContains(err, nodeblob.ErrBlobNotFound.Error(), "absent namespace should report no blob")
+
+	all, err := client.Blob.GetAll(ctx, height, []share.Namespace{absent})
+	if err != nil {
+		s.Require().ErrorContains(err, nodeblob.ErrBlobNotFound.Error(),
+			"GetAll on an absent namespace should not error otherwise")
+	}
+	s.Require().Empty(all, "absent namespace should yield no blobs")
+}
+
+func (s *BlobInclusionTestSuite) createBlob(
+	ctx context.Context,
+	client *rpcclient.Client,
+	namespace share.Namespace,
+	data []byte,
+) []*nodeblob.Blob {
+	nodeAddr, err := client.State.AccountAddress(ctx)
+	s.Require().NoError(err, "should get node address")
+
+	libBlob, err := share.NewV1Blob(namespace, data, nodeAddr.Bytes())
+	s.Require().NoError(err, "should create libshare blob")
+
+	nodeBlobs, err := nodeblob.ToNodeBlobs(libBlob)
+	s.Require().NoError(err, "should convert to node blobs")
+	return nodeBlobs
+}

--- a/nodebuilder/tests/tastora/catchup_test.go
+++ b/nodebuilder/tests/tastora/catchup_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package tastora
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/celestiaorg/go-square/v4/share"
+
+	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
+	nodeblob "github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/share/availability"
+	"github.com/celestiaorg/celestia-node/state"
+)
+
+// catchupWindow is the shrunk availability window given to the catching-up bridge
+const catchupWindow = 10 * time.Second
+
+// CatchupTestSuite runs a 2-bridge topology where bridge[0] (A) is archival and bridge[1] (B) is a
+// non-archival node started with a shrunk availability window.
+type CatchupTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestCatchupTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping catchup integration tests in short mode")
+	}
+	suite.Run(t, &CatchupTestSuite{})
+}
+
+func (s *CatchupTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(),
+		WithValidators(1), WithBridgeNodes(2), WithLightNodes(0), WithArchivalBridge())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+}
+
+func (s *CatchupTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+func (s *CatchupTestSuite) TestBridgeCatchupViaShrex() {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	archival := s.framework.GetBridgeNodes()[0]
+	clientA := s.framework.GetNodeRPCClient(ctx, archival)
+
+	// Bring B up with a small window, let it catch up to the current head, then take it offline.
+	bridgeB := s.framework.StartBridgeNodeWithSmallWindow(ctx, catchupWindow)
+	clientB := s.framework.GetNodeRPCClient(ctx, bridgeB)
+	headB, err := clientB.Header.LocalHead(ctx)
+	s.Require().NoError(err, "B should report a local head before going offline")
+	s.Require().NoError(bridgeB.Stop(ctx), "should stop B")
+
+	// While B is offline, submit a blob to A at a height above B's last-seen head.
+	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x07}, 10))
+	s.Require().NoError(err, "should create namespace")
+	nodeAddr, err := clientA.State.AccountAddress(ctx)
+	s.Require().NoError(err, "should get A account address")
+	libBlob, err := share.NewV1Blob(namespace, []byte("catch me over shrex"), nodeAddr.Bytes())
+	s.Require().NoError(err, "should build blob")
+	nodeBlobs, err := nodeblob.ToNodeBlobs(libBlob)
+	s.Require().NoError(err, "should convert blob")
+
+	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
+	gapHeight, err := clientA.Blob.Submit(ctx, nodeBlobs, txConfig)
+	s.Require().NoError(err, "A should submit the gap blob")
+	s.Require().Greater(gapHeight, headB.Height(), "gap blob must land above B's pre-offline head")
+
+	// Age the gap block past B's window (block time ~1s) with margin, and advance the chain beyond it.
+	time.Sleep(catchupWindow + 5*time.Second)
+	_, err = clientA.Header.WaitForHeight(ctx, gapHeight+15)
+	s.Require().NoError(err, "chain should advance past the gap height")
+
+	// Restart B: it backfills the missed headers, but holds the gap header without its EDS.
+	s.Require().NoError(bridgeB.Start(ctx), "should restart B")
+	clientB = s.framework.GetNodeRPCClient(ctx, bridgeB)
+	s.waitNodeUp(ctx, clientB)
+	_, err = clientB.Header.WaitForHeight(ctx, gapHeight)
+	s.Require().NoError(err, "B should backfill the header at the gap height")
+
+	// The gap height is outside B's sampling window: the DASer skips it and the local availability
+	// check refuses it — confirming B neither sampled nor stored it locally.
+	err = clientB.Share.SharesAvailable(ctx, gapHeight)
+	s.Require().ErrorContains(err, availability.ErrOutsideSamplingWindow.Error(),
+		"gap height should be outside B's sampling window")
+
+	// A (archival) serves the canonical square.
+	edsA, err := clientA.Share.GetEDS(ctx, gapHeight)
+	s.Require().NoError(err, "archival A should serve the gap EDS")
+
+	// GetEDS bypasses the sampling-window gate so the request goes to the A node over shrex
+	fetchCtx, fetchCancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer fetchCancel()
+	edsB, err := clientB.Share.GetEDS(fetchCtx, gapHeight)
+	s.Require().NoError(err, "B should fetch the out-of-window EDS from archival A over shrex")
+	s.Assert().Equal(edsA.Flattened(), edsB.Flattened(), "B's shrex-fetched square should match A's")
+}
+
+func (s *CatchupTestSuite) waitNodeUp(ctx context.Context, client *rpcclient.Client) {
+	s.Require().Eventually(func() bool {
+		_, err := client.Header.LocalHead(ctx)
+		return err == nil
+	}, 90*time.Second, 2*time.Second, "B RPC should become reachable after restart")
+}

--- a/nodebuilder/tests/tastora/catchup_test.go
+++ b/nodebuilder/tests/tastora/catchup_test.go
@@ -21,8 +21,9 @@ import (
 // catchupWindow is the shrunk availability window given to the catching-up bridge
 const catchupWindow = 10 * time.Second
 
-// CatchupTestSuite runs a 2-bridge topology where bridge[0] (A) is archival and bridge[1] (B) is a
-// non-archival node started with a shrunk availability window.
+// CatchupTestSuite runs a 2-bridge topology: an archival node A (see Framework.GetArchivalNode)
+// and a non-archival node B started with a shrunk availability window (see
+// Framework.StartBridgeNodeWithSmallWindow).
 type CatchupTestSuite struct {
 	suite.Suite
 	framework *Framework
@@ -53,7 +54,7 @@ func (s *CatchupTestSuite) TestBridgeCatchupViaShrex() {
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
-	archival := s.framework.GetBridgeNodes()[0]
+	archival := s.framework.GetArchivalNode()
 	clientA := s.framework.GetNodeRPCClient(ctx, archival)
 
 	// Bring B up with a small window, let it catch up to the current head, then take it offline.

--- a/nodebuilder/tests/tastora/config.go
+++ b/nodebuilder/tests/tastora/config.go
@@ -5,6 +5,8 @@ type Config struct {
 	NumValidators   int
 	BridgeNodeCount int
 	LightNodeCount  int
+	ArchivalBridge  bool
+	MultiSource     bool
 }
 
 // Option for modifying Tastora's Config.
@@ -37,5 +39,20 @@ func WithBridgeNodes(count int) Option {
 func WithLightNodes(count int) Option {
 	return func(c *Config) {
 		c.LightNodeCount = count
+	}
+}
+
+// WithArchivalBridge starts bridge nodes in archival mode with disabled pruner
+func WithArchivalBridge() Option {
+	return func(c *Config) {
+		c.ArchivalBridge = true
+	}
+}
+
+// WithMultiSource starts each bridge with a second core endpoint added to its
+// config.toml
+func WithMultiSource() Option {
+	return func(c *Config) {
+		c.MultiSource = true
 	}
 }

--- a/nodebuilder/tests/tastora/config.go
+++ b/nodebuilder/tests/tastora/config.go
@@ -60,9 +60,8 @@ func WithMultiSource() Option {
 	}
 }
 
-// WithAvailabilityWindow shrinks the availability window of the DA nodes via the
-// CELESTIA_OVERRIDE_AVAILABILITY_WINDOW env var, so heights age out of the window
-// within a test's runtime.
+// WithAvailabilityWindow shrinks the DA nodes' availability window (via
+// CELESTIA_OVERRIDE_AVAILABILITY_WINDOW) so heights age out within a test.
 func WithAvailabilityWindow(window time.Duration) Option {
 	return func(c *Config) {
 		c.AvailabilityWindow = window

--- a/nodebuilder/tests/tastora/config.go
+++ b/nodebuilder/tests/tastora/config.go
@@ -4,12 +4,13 @@ import "time"
 
 // Config represents configuration options for the Tastora testing framework.
 type Config struct {
-	NumValidators      int
-	BridgeNodeCount    int
-	LightNodeCount     int
-	ArchivalBridge     bool
-	MultiSource        bool
-	AvailabilityWindow time.Duration
+	NumValidators       int
+	BridgeNodeCount     int
+	LightNodeCount      int
+	ArchivalBridge      bool
+	MultiSource         bool
+	AvailabilityWindow  time.Duration
+	ConsensusRetainBlks uint64
 }
 
 // Option for modifying Tastora's Config.
@@ -65,5 +66,14 @@ func WithMultiSource() Option {
 func WithAvailabilityWindow(window time.Duration) Option {
 	return func(c *Config) {
 		c.AvailabilityWindow = window
+	}
+}
+
+// WithPrunedConsensus makes the consensus node retain only the last `blocks` blocks
+// (app.toml min-retain-blocks), so older blocks are pruned from its store and a bridge
+// must source them from an archival peer over p2p.
+func WithPrunedConsensus(blocks uint64) Option {
+	return func(c *Config) {
+		c.ConsensusRetainBlks = blocks
 	}
 }

--- a/nodebuilder/tests/tastora/config.go
+++ b/nodebuilder/tests/tastora/config.go
@@ -1,12 +1,15 @@
 package tastora
 
+import "time"
+
 // Config represents configuration options for the Tastora testing framework.
 type Config struct {
-	NumValidators   int
-	BridgeNodeCount int
-	LightNodeCount  int
-	ArchivalBridge  bool
-	MultiSource     bool
+	NumValidators      int
+	BridgeNodeCount    int
+	LightNodeCount     int
+	ArchivalBridge     bool
+	MultiSource        bool
+	AvailabilityWindow time.Duration
 }
 
 // Option for modifying Tastora's Config.
@@ -54,5 +57,14 @@ func WithArchivalBridge() Option {
 func WithMultiSource() Option {
 	return func(c *Config) {
 		c.MultiSource = true
+	}
+}
+
+// WithAvailabilityWindow shrinks the availability window of the DA nodes via the
+// CELESTIA_OVERRIDE_AVAILABILITY_WINDOW env var, so heights age out of the window
+// within a test's runtime.
+func WithAvailabilityWindow(window time.Duration) Option {
+	return func(c *Config) {
+		c.AvailabilityWindow = window
 	}
 }

--- a/nodebuilder/tests/tastora/core_failover_test.go
+++ b/nodebuilder/tests/tastora/core_failover_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package tastora
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
+)
+
+// CoreFailoverTestSuite runs one bridge fed by two core endpoints (validator[0] as the primary
+// and validator[1] as an additional endpoint in config.toml). Helps to test that network will not
+// be halted if at least one core endpoint is healthy.
+type CoreFailoverTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestCoreFailoverTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping core-failover integration tests in short mode")
+	}
+
+	suite.Run(t, &CoreFailoverTestSuite{})
+}
+
+func (s *CoreFailoverTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(),
+		WithValidators(4), WithBridgeNodes(1), WithLightNodes(0), WithMultiSource())
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+}
+
+func (s *CoreFailoverTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestBridgeCoreFailover verifies that a bridge configured with a primary plus one additional
+// core endpoint keeps ingesting new blocks when either endpoint dies in both directions.
+func (s *CoreFailoverTestSuite) TestBridgeCoreFailover() {
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	bridge := s.framework.GetBridgeNodes()[0]
+	client := s.framework.GetNodeRPCClient(ctx, bridge)
+
+	// both endpoints up the bridge ingests normally.
+	s.requireHeadAdvances(ctx, client, 3, 90*time.Second, "baseline: bridge should ingest with both core endpoints up")
+
+	// kill the primary. The chain stays live - the head continue growing from the additional endpoint
+	s.framework.StopValidator(ctx, 0)
+	s.requireHeadAdvances(ctx, client, 3, 4*time.Minute,
+		"bridge should keep ingesting from the additional endpoint after the primary dies")
+
+	// restore the primary and once it is caught up and re-joined as a source - kill the
+	// additional. Continued head growth now can only come from the primary.
+	s.framework.StartValidator(ctx, 0)
+	s.framework.WaitValidatorSynced(ctx, 0, 2*time.Minute)
+	// Give the bridge's fetcher time to resubscribe to the recovered primary
+	s.requireHeadAdvances(ctx, client, 2, 90*time.Second, "bridge should still ingest after the primary recovers")
+
+	s.framework.StopValidator(ctx, 1)
+	s.requireHeadAdvances(ctx, client, 3, 4*time.Minute,
+		"bridge should ingest from the recovered primary after the additional dies")
+}
+
+// requireHeadAdvances asserts the bridge's local head grows by at least `by` heights within timeout.
+func (s *CoreFailoverTestSuite) requireHeadAdvances(
+	ctx context.Context,
+	client *rpcclient.Client,
+	by uint64,
+	timeout time.Duration,
+	msg string,
+) {
+	head, err := client.Header.LocalHead(ctx)
+	s.Require().NoError(err, "should read bridge local head")
+	target := head.Height() + by
+	s.Require().Eventually(func() bool {
+		h, err := client.Header.LocalHead(ctx)
+		return err == nil && h.Height() >= target
+	}, timeout, 2*time.Second, msg)
+}

--- a/nodebuilder/tests/tastora/core_test.go
+++ b/nodebuilder/tests/tastora/core_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package tastora
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// CoreControlTestSuite runs a healthy bridge (which proves the chain is up) alongside an extra bridge
+// started against an unreachable core to reach the core-unreachable startup path.
+type CoreControlTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestCoreControlTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping core-control integration tests in short mode")
+	}
+	suite.Run(t, &CoreControlTestSuite{})
+}
+
+func (s *CoreControlTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(2), WithLightNodes(0))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+}
+
+func (s *CoreControlTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestBridgeCoreUnreachable starts a bridge pointed at an unreachable core and asserts the observable
+// startup contract: the node does not hang forever.
+func (s *CoreControlTestSuite) TestBridgeCoreUnreachable() {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	node := s.framework.StartBridgeNodeWithBrokenCore(ctx)
+
+	// Bridge StartupTimeout defaults to 2m; poll well past it to catch a hang without flaking on a
+	// slow container/store startup.
+	s.Require().Eventually(func() bool {
+		return !s.framework.bridgeContainerRunning(ctx, node)
+	}, 4*time.Minute, 5*time.Second, "bridge with an unreachable core must terminate, not hang indefinitely")
+
+	exitCode, logs := s.framework.bridgeContainerExit(ctx, node)
+	s.Assert().NotZero(exitCode, "a failed startup must exit non-zero")
+	s.Assert().Contains(strings.ToLower(logs), "failed to start",
+		"logs should carry a clear startup failure, got:\n%s", logs)
+}

--- a/nodebuilder/tests/tastora/das_test.go
+++ b/nodebuilder/tests/tastora/das_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package tastora
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/celestiaorg/go-square/v4/share"
+
+	nodeblob "github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/state"
+)
+
+// DASTestSuite runs verifies that sampling works correctly.
+type DASTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestDASTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping DAS integration tests in short mode")
+	}
+	suite.Run(t, &DASTestSuite{})
+}
+
+func (s *DASTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(1))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+	s.framework.NewLightNodeBitswapOff(ctx)
+}
+
+func (s *DASTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestBasicDASFlow asserts the data-availability sampling pipeline over shrex
+func (s *DASTestSuite) TestBasicDASFlow() {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	bridge := s.framework.GetBridgeNodes()[0]
+	light := s.framework.GetLightNodes()[0]
+	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridge)
+	lightClient := s.framework.GetNodeRPCClient(ctx, light)
+
+	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x09}, 10))
+	s.Require().NoError(err, "should create namespace")
+
+	nodeAddr, err := bridgeClient.State.AccountAddress(ctx)
+	s.Require().NoError(err, "should get bridge account address")
+
+	libBlob, err := share.NewV1Blob(namespace, []byte("sample me over shrex"), nodeAddr.Bytes())
+	s.Require().NoError(err, "should build blob")
+
+	nodeBlobs, err := nodeblob.ToNodeBlobs(libBlob)
+	s.Require().NoError(err, "should convert blob")
+
+	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
+	blobHeight, err := bridgeClient.Blob.Submit(ctx, nodeBlobs, txConfig)
+	s.Require().NoError(err, "bridge should submit blob")
+	s.Require().NotZero(blobHeight, "blob submission should return a valid height")
+
+	_, err = bridgeClient.Header.WaitForHeight(ctx, blobHeight+5)
+	s.Require().NoError(err, "chain should advance past the blob height")
+
+	// wait until it has the blob height, then sample.
+	_, err = lightClient.Header.WaitForHeight(ctx, blobHeight)
+	s.Require().NoError(err, "light node should sync the header at the blob height")
+
+	catchupCtx, catchupCancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer catchupCancel()
+	s.Require().NoError(lightClient.DAS.WaitCatchUp(catchupCtx), "light node DASer should catch up")
+
+	stats, err := lightClient.DAS.SamplingStats(ctx)
+	s.Require().NoError(err, "should get light node sampling stats")
+	s.T().Logf("light DAS stats: sampledChainHead=%d catchupHead=%d networkHead=%d failed=%d isRunning=%v catchUpDone=%v",
+		stats.SampledChainHead, stats.CatchupHead, stats.NetworkHead, len(stats.Failed), stats.IsRunning, stats.CatchUpDone)
+	s.Assert().True(stats.IsRunning, "DASer should be running")
+	s.Assert().True(stats.CatchUpDone, "DASer should have finished catching up")
+	s.Assert().Empty(stats.Failed, "no sampled height should have failed")
+	s.Assert().GreaterOrEqual(stats.SampledChainHead, blobHeight,
+		"sampled chain head should reach at least the blob height %d", blobHeight)
+
+	// sample the non-empty blob square over shrex.
+	s.Require().NoError(lightClient.Share.SharesAvailable(ctx, blobHeight),
+		"blob square shares should be available to the light node at height %d", blobHeight)
+
+	// the light node does not store squares, so GetEDS forces a shrex to get it
+	// from the bridge.
+	edsBridge, err := bridgeClient.Share.GetEDS(ctx, blobHeight)
+	s.Require().NoError(err, "bridge should serve the blob EDS")
+	fetchCtx, fetchCancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer fetchCancel()
+	edsLight, err := lightClient.Share.GetEDS(fetchCtx, blobHeight)
+	s.Require().NoError(err, "light node should reconstruct the EDS from the bridge over shrex")
+	s.Assert().Equal(edsBridge.Flattened(), edsLight.Flattened(),
+		"light node's shrex-fetched square should match the bridge's")
+}

--- a/nodebuilder/tests/tastora/das_test.go
+++ b/nodebuilder/tests/tastora/das_test.go
@@ -16,7 +16,8 @@ import (
 	"github.com/celestiaorg/celestia-node/state"
 )
 
-// DASTestSuite runs verifies that sampling works correctly.
+// DASTestSuite verifies a light node samples a blob square and reconstructs its EDS
+// from the bridge over shrex (bitswap disabled).
 type DASTestSuite struct {
 	suite.Suite
 	framework *Framework
@@ -43,7 +44,8 @@ func (s *DASTestSuite) TearDownSuite() {
 	}
 }
 
-// TestBasicDASFlow asserts the data-availability sampling pipeline over shrex
+// TestBasicDASFlow submits a blob, verifies the light node samples it, then reconstructs
+// its EDS over shrex.
 func (s *DASTestSuite) TestBasicDASFlow() {
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()

--- a/nodebuilder/tests/tastora/e2e_sanity_test.go
+++ b/nodebuilder/tests/tastora/e2e_sanity_test.go
@@ -59,6 +59,7 @@ func (s *E2ESanityTestSuite) TestBlobSubscribe() {
 	bridgeNode := s.framework.GetBridgeNodes()[0]
 	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridgeNode)
 	wsClient := s.framework.GetNodeRPCClientWS(ctx, bridgeNode)
+	defer wsClient.Close()
 
 	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x03}, 10))
 	s.Require().NoError(err, "should create namespace")

--- a/nodebuilder/tests/tastora/e2e_sanity_test.go
+++ b/nodebuilder/tests/tastora/e2e_sanity_test.go
@@ -14,12 +14,11 @@ import (
 
 	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
 	nodeblob "github.com/celestiaorg/celestia-node/blob"
-	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/state"
 )
 
-// E2ESanityTestSuite provides E2E sanity testing of basic functionality flows.
-// Focuses on core functionality validation with minimal setup (1 BN + 1 LN).
+// E2ESanityTestSuite provides E2E sanity testing of basic bridge-node flows that don't
+// warrant a dedicated suite: blob subscription, large blocks, and out-of-range errors.
 type E2ESanityTestSuite struct {
 	suite.Suite
 	framework *Framework
@@ -30,16 +29,7 @@ func TestE2ESanityTestSuite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E sanity integration tests in short mode")
 	}
-	suite.Run(t, &E2ESanityTestSuite{
-		timeout: 2 * time.Minute, // Default timeout
-	})
-}
-
-// NewE2ESanityTestSuite creates a new test suite with custom timeout
-func NewE2ESanityTestSuite(timeout time.Duration) *E2ESanityTestSuite {
-	return &E2ESanityTestSuite{
-		timeout: timeout,
-	}
+	suite.Run(t, &E2ESanityTestSuite{timeout: 2 * time.Minute})
 }
 
 // withTimeout creates a context with the suite's configured timeout
@@ -48,46 +38,16 @@ func (s *E2ESanityTestSuite) withTimeout() (context.Context, context.CancelFunc)
 }
 
 func (s *E2ESanityTestSuite) SetupSuite() {
-	// Setup with minimal topology: 1 Bridge Node + 1 Light Node
-	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(1))
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(0))
 	ctx, cancel := s.withTimeout()
 	defer cancel()
 	s.Require().NoError(s.framework.SetupNetwork(ctx))
-
-	// Start the light node after network setup
-	s.framework.NewLightNode(ctx)
 }
 
 func (s *E2ESanityTestSuite) TearDownSuite() {
 	if s.framework != nil {
 		s.framework.Cleanup()
 	}
-}
-
-// TestBasicDASFlow validates basic Data Availability Sampling functionality on a single bridge node
-func (s *E2ESanityTestSuite) TestBasicDASFlow() {
-	ctx, cancel := s.withTimeout()
-	defer cancel()
-
-	bridgeNode := s.framework.GetBridgeNodes()[0]
-	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridgeNode)
-
-	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x01}, 10))
-	s.Require().NoError(err, "should create namespace")
-
-	blobData := []byte("TestBasicDASFlow: Basic DAS functionality test data")
-	nodeBlobs := s.createBlobsForSubmission(ctx, bridgeClient, namespace, blobData)
-
-	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
-	height, err := bridgeClient.Blob.Submit(ctx, nodeBlobs, txConfig)
-	s.Require().NoError(err, "bridge node should be able to submit blob")
-	s.Require().NotZero(height, "blob submission should return valid height")
-
-	_, err = bridgeClient.Header.WaitForHeight(ctx, height)
-	s.Require().NoError(err, "bridge node should be able to wait for block inclusion")
-
-	err = bridgeClient.Share.SharesAvailable(ctx, height)
-	s.Require().NoError(err, "bridge node should have shares available at height %d", height)
 }
 
 // TestBlobSubscribe subscribes to a namespace, submits a blob to it and wait
@@ -129,7 +89,7 @@ func (s *E2ESanityTestSuite) TestBlobSubscribe() {
 	}
 }
 
-// TestLargeBlock submits a large blob that will span mlutiple rows.
+// TestLargeBlock submits a large blob that spans multiple rows.
 func (s *E2ESanityTestSuite) TestLargeBlock() {
 	ctx, cancel := s.withTimeout()
 	defer cancel()
@@ -210,8 +170,12 @@ func (s *E2ESanityTestSuite) TestErrorPaths() {
 	}
 }
 
-// Helper function to create blobs for submission
-func (s *E2ESanityTestSuite) createBlobsForSubmission(ctx context.Context, client *rpcclient.Client, namespace share.Namespace, data []byte) []*nodeblob.Blob {
+func (s *E2ESanityTestSuite) createBlobsForSubmission(
+	ctx context.Context,
+	client *rpcclient.Client,
+	namespace share.Namespace,
+	data []byte,
+) []*nodeblob.Blob {
 	nodeAddr, err := client.State.AccountAddress(ctx)
 	s.Require().NoError(err, "should get node address")
 
@@ -222,213 +186,4 @@ func (s *E2ESanityTestSuite) createBlobsForSubmission(ctx context.Context, clien
 	s.Require().NoError(err, "should convert to node blobs")
 
 	return nodeBlobs
-}
-
-// TestBasicBlobLifecycle tests the complete blob lifecycle workflow on a bridge node
-func (s *E2ESanityTestSuite) TestBasicBlobLifecycle() {
-	ctx, cancel := s.withTimeout()
-	defer cancel()
-
-	bridgeNode := s.framework.GetBridgeNodes()[0]
-	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridgeNode)
-
-	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x02}, 10))
-	s.Require().NoError(err, "should create namespace")
-
-	blobData := []byte("TestBasicBlobLifecycle: Complete blob lifecycle test data")
-	nodeBlobs := s.createBlobsForSubmission(ctx, bridgeClient, namespace, blobData)
-
-	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
-	height, err := bridgeClient.Blob.Submit(ctx, nodeBlobs, txConfig)
-	s.Require().NoError(err, "bridge node should be able to submit blob")
-	s.Require().NotZero(height, "blob submission should return valid height")
-
-	_, err = bridgeClient.Header.WaitForHeight(ctx, height)
-	s.Require().NoError(err, "bridge node should be able to wait for block inclusion")
-
-	retrievedBlob, err := bridgeClient.Blob.Get(ctx, height, namespace, nodeBlobs[0].Commitment)
-	s.Require().NoError(err, "bridge node should be able to retrieve blob within timeout")
-	s.Require().NotNil(retrievedBlob, "bridge node should return valid blob")
-
-	retrievedData := bytes.TrimRight(retrievedBlob.Data(), "\x00")
-	s.Assert().Equal(blobData, retrievedData, "bridge node should return correct data")
-
-	proof, err := bridgeClient.Blob.GetProof(ctx, height, namespace, nodeBlobs[0].Commitment)
-	s.Require().NoError(err, "bridge node should be able to get blob proof")
-	s.Require().NotNil(proof, "blob proof should not be nil")
-
-	included, err := bridgeClient.Blob.Included(ctx, height, namespace, proof, nodeBlobs[0].Commitment)
-	s.Require().NoError(err, "bridge node should be able to verify blob inclusion")
-	s.Assert().True(included, "blob should be included at height %d", height)
-
-	blobs, err := bridgeClient.Blob.GetAll(ctx, height, []share.Namespace{namespace})
-	s.Require().NoError(err, "bridge node should be able to get all blobs")
-	s.Require().NotEmpty(blobs, "should return at least one blob")
-
-	found := false
-	for _, blob := range blobs {
-		if bytes.Equal(blob.Commitment, nodeBlobs[0].Commitment) {
-			found = true
-			break
-		}
-	}
-	s.Assert().True(found, "submitted blob should be found in GetAll results")
-}
-
-// TestHeaderSyncSanity tests end-to-end header synchronization workflow
-func (s *E2ESanityTestSuite) TestHeaderSyncSanity() {
-	ctx, cancel := s.withTimeout()
-	defer cancel()
-
-	// Get nodes
-	bridgeNode := s.framework.GetBridgeNodes()[0]
-	lightNode := s.framework.GetLightNodes()[0]
-
-	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridgeNode)
-	lightClient := s.framework.GetNodeRPCClient(ctx, lightNode)
-
-	bridgeSyncState, err := bridgeClient.Header.SyncState(ctx)
-	s.Require().NoError(err, "bridge node should be able to provide sync state")
-	s.Require().NotNil(bridgeSyncState, "bridge sync state should not be nil")
-
-	lightSyncState, err := lightClient.Header.SyncState(ctx)
-	s.Require().NoError(err, "light node should be able to provide sync state")
-	s.Require().NotNil(lightSyncState, "light sync state should not be nil")
-
-	bridgeHead, err := bridgeClient.Header.LocalHead(ctx)
-	s.Require().NoError(err, "bridge node should be able to provide local head")
-	s.Require().NotNil(bridgeHead, "bridge head should not be nil")
-
-	lightHead, err := lightClient.Header.LocalHead(ctx)
-	s.Require().NoError(err, "light node should be able to provide local head")
-	s.Require().NotNil(lightHead, "light head should not be nil")
-
-	// Verify both nodes have the same head (they should be synced)
-	s.Assert().Equal(bridgeHead.Height(), lightHead.Height(), "both nodes should have same head height")
-	s.Assert().Equal(bridgeHead.Hash(), lightHead.Hash(), "both nodes should have same head hash")
-
-	// Store current height for later use
-	currentHeight := bridgeHead.Height()
-	targetHeight := currentHeight + 3
-
-	// Wait for new blocks on bridge node
-	bridgeHeader, err := bridgeClient.Header.WaitForHeight(ctx, targetHeight)
-	s.Require().NoError(err, "bridge node should be able to wait for new height")
-	s.Require().NotNil(bridgeHeader, "bridge header should not be nil")
-
-	// Verify light node also syncs to the same height
-	lightHeader, err := lightClient.Header.WaitForHeight(ctx, targetHeight)
-	s.Require().NoError(err, "light node should be able to wait for new height")
-	s.Require().NotNil(lightHeader, "light header should not be nil")
-
-	// Verify both nodes have identical headers
-	s.Assert().Equal(bridgeHeader.Hash(), lightHeader.Hash(), "both nodes should have identical headers")
-	s.Assert().Equal(bridgeHeader.Height(), lightHeader.Height(), "both nodes should have same height")
-
-	startHeight := currentHeight - 2
-	endHeight := currentHeight
-
-	bridgeHeaders := make([]*header.ExtendedHeader, 0)
-	for h := startHeight; h <= endHeight; h++ {
-		header, err := bridgeClient.Header.GetByHeight(ctx, h)
-		s.Require().NoError(err, "bridge should be able to get header at height %d", h)
-		s.Require().NotNil(header, "bridge header at height %d should not be nil", h)
-		bridgeHeaders = append(bridgeHeaders, header)
-	}
-
-	lightHeaders := make([]*header.ExtendedHeader, 0)
-	for h := startHeight; h <= endHeight; h++ {
-		header, err := lightClient.Header.GetByHeight(ctx, h)
-		s.Require().NoError(err, "light should be able to get header at height %d", h)
-		s.Require().NotNil(header, "light header at height %d should not be nil", h)
-		lightHeaders = append(lightHeaders, header)
-	}
-
-	s.Assert().Equal(len(bridgeHeaders), len(lightHeaders), "should have same number of headers")
-	for i := 0; i < len(bridgeHeaders); i++ {
-		s.Assert().Equal(bridgeHeaders[i].Hash(), lightHeaders[i].Hash(), "headers at index %d should match", i)
-	}
-}
-
-// TestP2PConnectivity tests end-to-end P2P network connectivity workflow
-func (s *E2ESanityTestSuite) TestP2PConnectivity() {
-	ctx, cancel := s.withTimeout()
-	defer cancel()
-
-	bridgeNode := s.framework.GetBridgeNodes()[0]
-	lightNode := s.framework.GetLightNodes()[0]
-
-	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridgeNode)
-	lightClient := s.framework.GetNodeRPCClient(ctx, lightNode)
-
-	bridgeInfo, err := bridgeClient.P2P.Info(ctx)
-	s.Require().NoError(err, "bridge node should be able to provide P2P info")
-	s.Require().NotNil(bridgeInfo, "bridge P2P info should not be nil")
-
-	lightInfo, err := lightClient.P2P.Info(ctx)
-	s.Require().NoError(err, "light node should be able to provide P2P info")
-	s.Require().NotNil(lightInfo, "light P2P info should not be nil")
-
-	// Verify initial connectivity
-	bridgeConnectivity, err := bridgeClient.P2P.Connectedness(ctx, lightInfo.ID)
-	s.Require().NoError(err, "bridge node should be able to check connectivity")
-	s.Assert().Equal(1, int(bridgeConnectivity), "bridge node should be connected to light node initially")
-
-	lightConnectivity, err := lightClient.P2P.Connectedness(ctx, bridgeInfo.ID)
-	s.Require().NoError(err, "light node should be able to check connectivity")
-	s.Assert().Equal(1, int(lightConnectivity), "light node should be connected to bridge node initially")
-
-	// Test disconnect operation - close connection from bridge to light node
-	s.T().Log("Testing P2P disconnect operation")
-	err = bridgeClient.P2P.ClosePeer(ctx, lightInfo.ID)
-	s.Require().NoError(err, "bridge node should be able to close connection to light node")
-
-	// Wait a moment for the disconnect to propagate
-	time.Sleep(3 * time.Second)
-
-	// Verify disconnect was successful (or at least attempted)
-	bridgeConnectivity, err = bridgeClient.P2P.Connectedness(ctx, lightInfo.ID)
-	s.Require().NoError(err, "bridge node should be able to check connectivity after disconnect")
-
-	// Note: In some P2P configurations, connections may auto-reconnect
-	// We'll test that the ClosePeer operation succeeds and then test Connect
-	s.T().Logf("Bridge connectivity after ClosePeer: %d", int(bridgeConnectivity))
-
-	// Test connect operation - ensure we can explicitly connect
-	s.T().Log("Testing P2P connect operation")
-	err = bridgeClient.P2P.Connect(ctx, lightInfo)
-	s.Require().NoError(err, "bridge node should be able to connect to light node")
-
-	// Wait a moment for the connection to establish
-	time.Sleep(3 * time.Second)
-
-	// Verify connect operation was successful
-	bridgeConnectivity, err = bridgeClient.P2P.Connectedness(ctx, lightInfo.ID)
-	s.Require().NoError(err, "bridge node should be able to check connectivity after connect")
-	s.Assert().Equal(1, int(bridgeConnectivity), "bridge node should be connected to light node after explicit connect")
-
-	lightConnectivity, err = lightClient.P2P.Connectedness(ctx, bridgeInfo.ID)
-	s.Require().NoError(err, "light node should be able to check connectivity after connect")
-	s.Assert().Equal(1, int(lightConnectivity), "light node should be connected to bridge node after explicit connect")
-
-	// Verify peer information exchange still works after connect
-	bridgePeerInfo, err := bridgeClient.P2P.PeerInfo(ctx, lightInfo.ID)
-	s.Require().NoError(err, "bridge node should be able to exchange peer information after connect")
-	s.Require().NotNil(bridgePeerInfo, "bridge should receive valid peer info after connect")
-
-	lightPeerInfo, err := lightClient.P2P.PeerInfo(ctx, bridgeInfo.ID)
-	s.Require().NoError(err, "light node should be able to exchange peer information after connect")
-	s.Require().NotNil(lightPeerInfo, "light should receive valid peer info after connect")
-
-	// Verify peers are listed correctly
-	bridgePeers, err := bridgeClient.P2P.Peers(ctx)
-	s.Require().NoError(err, "bridge node should be able to discover peers after connect")
-	s.Require().NotNil(bridgePeers, "bridge peer list should not be nil after connect")
-
-	lightPeers, err := lightClient.P2P.Peers(ctx)
-	s.Require().NoError(err, "light node should be able to discover peers after connect")
-	s.Require().NotNil(lightPeers, "light peer list should not be nil after connect")
-
-	s.Assert().GreaterOrEqual(len(bridgePeers), 1, "bridge node should have discovered at least one peer after connect")
-	s.Assert().GreaterOrEqual(len(lightPeers), 1, "light node should have discovered at least one peer after connect")
 }

--- a/nodebuilder/tests/tastora/e2e_sanity_test.go
+++ b/nodebuilder/tests/tastora/e2e_sanity_test.go
@@ -90,6 +90,126 @@ func (s *E2ESanityTestSuite) TestBasicDASFlow() {
 	s.Require().NoError(err, "bridge node should have shares available at height %d", height)
 }
 
+// TestBlobSubscribe subscribes to a namespace, submits a blob to it and wait
+// until blob appears in the chain
+func (s *E2ESanityTestSuite) TestBlobSubscribe() {
+	ctx, cancel := s.withTimeout()
+	defer cancel()
+
+	bridgeNode := s.framework.GetBridgeNodes()[0]
+	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridgeNode)
+	wsClient := s.framework.GetNodeRPCClientWS(ctx, bridgeNode)
+
+	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x03}, 10))
+	s.Require().NoError(err, "should create namespace")
+
+	sub, err := wsClient.Blob.Subscribe(ctx, namespace)
+	s.Require().NoError(err, "should subscribe to blobs")
+
+	blobData := []byte("TestBlobSubscribe: blob subscription test data")
+	nodeBlobs := s.createBlobsForSubmission(ctx, bridgeClient, namespace, blobData)
+
+	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
+	height, err := bridgeClient.Blob.Submit(ctx, nodeBlobs, txConfig)
+	s.Require().NoError(err, "bridge node should be able to submit blob")
+	s.Require().NotZero(height, "blob submission should return valid height")
+
+	for {
+		select {
+		case resp := <-sub:
+			s.Require().NotNil(resp)
+			for _, b := range resp.Blobs {
+				if bytes.Equal(b.Commitment, nodeBlobs[0].Commitment) {
+					return
+				}
+			}
+		case <-ctx.Done():
+			s.FailNowf("timed out waiting for blob subscription event", "blob at height %d never delivered", height)
+		}
+	}
+}
+
+// TestLargeBlock submits a large blob that will span mlutiple rows.
+func (s *E2ESanityTestSuite) TestLargeBlock() {
+	ctx, cancel := s.withTimeout()
+	defer cancel()
+
+	bridgeNode := s.framework.GetBridgeNodes()[0]
+	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridgeNode)
+
+	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x04}, 10))
+	s.Require().NoError(err, "should create namespace")
+
+	blobData := bytes.Repeat([]byte("celestia-large-block"), 12_800) // ~256 KiB
+	nodeBlobs := s.createBlobsForSubmission(ctx, bridgeClient, namespace, blobData)
+
+	txConfig := state.NewTxConfig(state.WithGasPrice(0.1))
+	height, err := bridgeClient.Blob.Submit(ctx, nodeBlobs, txConfig)
+	s.Require().NoError(err, "bridge node should be able to submit large blob")
+	s.Require().NotZero(height, "blob submission should return valid height")
+
+	_, err = bridgeClient.Header.WaitForHeight(ctx, height)
+	s.Require().NoError(err, "bridge node should be able to wait for block inclusion")
+
+	err = bridgeClient.Share.SharesAvailable(ctx, height)
+	s.Require().NoError(err, "large-block shares should be available at height %d", height)
+
+	hdr, err := bridgeClient.Header.GetByHeight(ctx, height)
+	s.Require().NoError(err, "should get header at height %d", height)
+	s.Assert().Greater(len(hdr.DAH.RowRoots), share.MinSquareSize*2,
+		"large blob should grow the EDS past the minimum empty-square width")
+
+	retrievedBlob, err := bridgeClient.Blob.Get(ctx, height, namespace, nodeBlobs[0].Commitment)
+	s.Require().NoError(err, "bridge node should be able to retrieve large blob")
+	s.Require().NotNil(retrievedBlob, "bridge node should return valid blob")
+
+	retrievedData := bytes.TrimRight(retrievedBlob.Data(), "\x00")
+	s.Assert().Equal(blobData, retrievedData, "retrieved large blob should round-trip the payload")
+}
+
+// TestErrorPaths asserts the RPC surface returns a clean and bounded error for out-of-range height
+func (s *E2ESanityTestSuite) TestErrorPaths() {
+	ctx, cancel := s.withTimeout()
+	defer cancel()
+
+	bridgeNode := s.framework.GetBridgeNodes()[0]
+	bridgeClient := s.framework.GetNodeRPCClient(ctx, bridgeNode)
+
+	head, err := bridgeClient.Header.LocalHead(ctx)
+	s.Require().NoError(err, "should get local head")
+
+	cases := []struct {
+		name   string
+		height uint64
+	}{
+		{"FutureHeight", head.Height() + 1_000_000},
+		{"BelowGenesis", 0},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			// set timeout for each probe far under the suite timeout
+			probe := func(name string, call func(context.Context) error) {
+				probeCtx, probeCancel := context.WithTimeout(ctx, 15*time.Second)
+				defer probeCancel()
+
+				callErr := call(probeCtx)
+				s.Require().Error(callErr, "%s(%d) should return an error", name, tc.height)
+				s.Require().NoError(probeCtx.Err(), "%s(%d) should return promptly, not hang", name, tc.height)
+				s.T().Logf("%s(%d) error: %v", name, tc.height, callErr)
+			}
+
+			probe("GetByHeight", func(c context.Context) error {
+				_, err := bridgeClient.Header.GetByHeight(c, tc.height)
+				return err
+			})
+			probe("SharesAvailable", func(c context.Context) error {
+				return bridgeClient.Share.SharesAvailable(c, tc.height)
+			})
+		})
+	}
+}
+
 // Helper function to create blobs for submission
 func (s *E2ESanityTestSuite) createBlobsForSubmission(ctx context.Context, client *rpcclient.Client, namespace share.Namespace, data []byte) []*nodeblob.Blob {
 	nodeAddr, err := client.State.AccountAddress(ctx)

--- a/nodebuilder/tests/tastora/framework.go
+++ b/nodebuilder/tests/tastora/framework.go
@@ -222,7 +222,7 @@ func (f *Framework) StartBridgeNodeWithSmallWindow(ctx context.Context, window t
 	require.NoError(f.t, err, "failed to start small-window bridge node")
 
 	f.fundNodeAccount(ctx, bridgeNode, f.defaultFundingAmount)
-	f.verifyNodeBalance(ctx, bridgeNode, f.defaultFundingAmount, "small-window bridge node")
+	f.verifyNodeBalance(ctx, bridgeNode, f.defaultFundingAmount)
 
 	f.bridgeNodes = append(f.bridgeNodes, bridgeNode)
 	return bridgeNode
@@ -273,7 +273,7 @@ func (f *Framework) NewLightNode(ctx context.Context) *dataavailability.Node {
 	f.t.Logf("Light node created and funded with %d utia", f.defaultFundingAmount)
 
 	// Verify funds are available by checking balance
-	f.verifyNodeBalance(ctx, lightNode, f.defaultFundingAmount, "light node")
+	f.verifyNodeBalance(ctx, lightNode, f.defaultFundingAmount)
 
 	f.lightNodes = append(f.lightNodes, lightNode)
 	return lightNode
@@ -285,7 +285,7 @@ func (f *Framework) NewLightNodeBitswapOff(ctx context.Context) *dataavailabilit
 	lightNode := f.startLightNode(ctx, bridgeNode, f.celestia,
 		dataavailability.WithConfigModifications(bitswapOffMod()))
 	f.fundNodeAccount(ctx, lightNode, f.defaultFundingAmount)
-	f.verifyNodeBalance(ctx, lightNode, f.defaultFundingAmount, "light node (bitswap off)")
+	f.verifyNodeBalance(ctx, lightNode, f.defaultFundingAmount)
 
 	f.lightNodes = append(f.lightNodes, lightNode)
 	return lightNode
@@ -365,7 +365,7 @@ func (f *Framework) newBridgeNode(ctx context.Context) *dataavailability.Node {
 	f.t.Logf("Bridge node created and funded with %d utia", f.defaultFundingAmount)
 
 	// Verify funds are available by checking balance
-	f.verifyNodeBalance(ctx, bridgeNode, f.defaultFundingAmount, "bridge node")
+	f.verifyNodeBalance(ctx, bridgeNode, f.defaultFundingAmount)
 
 	return bridgeNode
 }
@@ -418,7 +418,8 @@ func (f *Framework) fundWallet(ctx context.Context, fromWallet *types.Wallet, to
 // verifyNodeBalance verifies that a DA node has the expected balance after funding.
 // This function provides deterministic balance verification with retries and waiting.
 // It should be called after fundNodeAccount to ensure funding was successful.
-func (f *Framework) verifyNodeBalance(ctx context.Context, daNode *dataavailability.Node, expectedAmount int64, nodeType string) {
+func (f *Framework) verifyNodeBalance(ctx context.Context, daNode *dataavailability.Node, expectedAmount int64) {
+	nodeType := daNode.GetType()
 	nodeClient := f.GetNodeRPCClient(ctx, daNode)
 	nodeAddr, err := nodeClient.State.AccountAddress(ctx)
 	require.NoError(f.t, err, "failed to get %s account address", nodeType)
@@ -670,7 +671,9 @@ func (f *Framework) startLightNode(
 
 	startOpts := append([]dataavailability.StartOption{
 		dataavailability.WithChainID(testChainID),
-		dataavailability.WithAdditionalStartArguments("--p2p.network", testChainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0"),
+		dataavailability.WithAdditionalStartArguments(
+			"--p2p.network", testChainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0",
+		),
 		dataavailability.WithEnvironmentVariables(
 			map[string]string{
 				"CELESTIA_CUSTOM": types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, p2pAddr),

--- a/nodebuilder/tests/tastora/framework.go
+++ b/nodebuilder/tests/tastora/framework.go
@@ -3,7 +3,6 @@ package tastora
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -16,6 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/moby/moby/api/pkg/stdcopy"
 	dockerclient "github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -251,8 +251,10 @@ func (f *Framework) bridgeContainerExit(ctx context.Context, node *dataavailabil
 	require.NoError(f.t, err, "failed to read container logs")
 	defer logs.Close()
 
+	// ContainerLogs returns Docker's multiplexed stream (8-byte header per frame); demux it
+	// so the returned logs are clean text, not binary-prefixed.
 	var sb strings.Builder
-	_, err = io.Copy(&sb, logs)
+	_, err = stdcopy.StdCopy(&sb, &sb, logs)
 	require.NoError(f.t, err, "failed to copy container logs")
 
 	return inspect.Container.State.ExitCode, sb.String()

--- a/nodebuilder/tests/tastora/framework.go
+++ b/nodebuilder/tests/tastora/framework.go
@@ -3,6 +3,7 @@ package tastora
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -29,6 +30,7 @@ import (
 	"github.com/celestiaorg/tastora/framework/docker/dataavailability"
 	"github.com/celestiaorg/tastora/framework/testutil/config"
 	"github.com/celestiaorg/tastora/framework/testutil/sdkacc"
+	tomlutil "github.com/celestiaorg/tastora/framework/testutil/toml"
 	"github.com/celestiaorg/tastora/framework/testutil/wait"
 	"github.com/celestiaorg/tastora/framework/testutil/wallet"
 	"github.com/celestiaorg/tastora/framework/types"
@@ -41,11 +43,14 @@ const (
 	defaultCelestiaTag = "v5.0.1"
 	nodeImage          = "ghcr.io/celestiaorg/celestia-node"
 	testChainID        = "test"
+
+	// brokenCoreIP is a valid but unroutable address.
+	brokenCoreIP = "192.0.2.1"
 )
 
 // defaultNodeTag can be overridden at build time using ldflags
 // Example: go build -ldflags "-X github.com/celestiaorg/celestia-node/nodebuilder/tests/tastora.defaultNodeTag=v1.2.3"
-var defaultNodeTag = "37c99f2" // fallback if not set via ldflags
+var defaultNodeTag = "32627d9" // fallback if not set via ldflags
 
 // Framework represents the main testing infrastructure for Tastora-based tests.
 // It provides Docker-based chain and node setup, similar to how Swamp provides
@@ -70,6 +75,9 @@ type Framework struct {
 	// Private funding infrastructure (not exposed to tests)
 	fundingWallet        *types.Wallet
 	defaultFundingAmount int64
+
+	archivalBridge bool
+	multisource    bool
 }
 
 // NewFramework creates a new Tastora testing framework instance.
@@ -86,6 +94,8 @@ func NewFramework(t *testing.T, options ...Option) *Framework {
 	for _, opt := range options {
 		opt(cfg)
 	}
+	f.archivalBridge = cfg.ArchivalBridge
+	f.multisource = cfg.MultiSource
 
 	f.logger.Info("Setting up Tastora framework", zap.String("test", t.Name()))
 	f.client, f.network = docker.Setup(t)
@@ -143,6 +153,111 @@ func (f *Framework) NewBridgeNode(ctx context.Context) *dataavailability.Node {
 	return bridgeNode
 }
 
+// RestartNode restarts any DA node's container keeping all the data
+func (f *Framework) RestartNode(ctx context.Context, node *dataavailability.Node) {
+	require.NoError(f.t, node.Stop(ctx), "failed to stop node")
+	require.NoError(f.t, node.Start(ctx), "failed to restart node")
+}
+
+func (f *Framework) RestartBridgeNode(ctx context.Context, node *dataavailability.Node) {
+	f.RestartNode(ctx, node)
+}
+
+// StartBridgeNodeWithBrokenCore starts a bridge pointed at an unreachable core
+func (f *Framework) StartBridgeNodeWithBrokenCore(ctx context.Context) *dataavailability.Node {
+	genesisHash := f.getGenesisHash(ctx, f.celestia)
+
+	bridgeNodes := f.daNetwork.GetBridgeNodes()
+	idx := len(f.bridgeNodes)
+	if idx >= len(bridgeNodes) {
+		f.t.Fatalf("Cannot create more bridge nodes: already have %d, max is %d", idx, len(bridgeNodes))
+	}
+	bridgeNode := bridgeNodes[idx]
+
+	startArgs := []string{"--p2p.network", testChainID, "--core.ip", brokenCoreIP, "--rpc.addr", "0.0.0.0"}
+	err := bridgeNode.Start(ctx,
+		dataavailability.WithChainID(testChainID),
+		dataavailability.WithAdditionalStartArguments(startArgs...),
+		dataavailability.WithEnvironmentVariables(
+			map[string]string{
+				"CELESTIA_CUSTOM": types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, ""),
+				"P2P_NETWORK":     testChainID,
+			},
+		),
+	)
+	require.NoError(f.t, err, "container should start even with an unreachable core")
+
+	f.bridgeNodes = append(f.bridgeNodes, bridgeNode)
+	return bridgeNode
+}
+
+// StartBridgeNodeWithSmallWindow starts a non-archival bridge with a tiny availability window
+func (f *Framework) StartBridgeNodeWithSmallWindow(ctx context.Context, window time.Duration) *dataavailability.Node {
+	genesisHash := f.getGenesisHash(ctx, f.celestia)
+
+	bridgeNodes := f.daNetwork.GetBridgeNodes()
+	idx := len(f.bridgeNodes)
+	if idx >= len(bridgeNodes) {
+		f.t.Fatalf("Cannot create more bridge nodes: already have %d, max is %d", idx, len(bridgeNodes))
+	}
+	require.Positive(f.t, idx, "small-window bridge must be peered to an existing bridge[0]")
+	bridgeNode := bridgeNodes[idx]
+
+	trustedPeer := f.nodeP2PAddr(ctx, f.bridgeNodes[0])
+	networkInfo, err := f.celestia.GetNodes()[0].GetNetworkInfo(ctx)
+	require.NoError(f.t, err, "failed to get network info")
+	hostname := networkInfo.Internal.Hostname
+
+	startArgs := []string{"--p2p.network", testChainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0"}
+	err = bridgeNode.Start(ctx,
+		dataavailability.WithChainID(testChainID),
+		dataavailability.WithAdditionalStartArguments(startArgs...),
+		dataavailability.WithEnvironmentVariables(map[string]string{
+			"CELESTIA_CUSTOM":                       types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, trustedPeer),
+			"P2P_NETWORK":                           testChainID,
+			"CELESTIA_OVERRIDE_AVAILABILITY_WINDOW": window.String(),
+		}),
+		dataavailability.WithConfigModifications(bitswapOffMod()),
+	)
+	require.NoError(f.t, err, "failed to start small-window bridge node")
+
+	f.fundNodeAccount(ctx, bridgeNode, f.defaultFundingAmount)
+	f.verifyNodeBalance(ctx, bridgeNode, f.defaultFundingAmount, "small-window bridge node")
+
+	f.bridgeNodes = append(f.bridgeNodes, bridgeNode)
+	return bridgeNode
+}
+
+func bitswapOffMod() map[string]tomlutil.Toml {
+	return map[string]tomlutil.Toml{
+		"config.toml": {
+			"RPC":   tomlutil.Toml{"SkipAuth": true},
+			"Share": tomlutil.Toml{"UseBitswap": false},
+		},
+	}
+}
+
+func (f *Framework) bridgeContainerRunning(ctx context.Context, node *dataavailability.Node) bool {
+	return node.ContainerLifecycle.Running(ctx) == nil
+}
+
+func (f *Framework) bridgeContainerExit(ctx context.Context, node *dataavailability.Node) (int, string) {
+	id := node.ContainerLifecycle.ContainerID()
+
+	inspect, err := f.client.ContainerInspect(ctx, id, dockerclient.ContainerInspectOptions{})
+	require.NoError(f.t, err, "failed to inspect container")
+
+	logs, err := f.client.ContainerLogs(ctx, id, dockerclient.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
+	require.NoError(f.t, err, "failed to read container logs")
+	defer logs.Close()
+
+	var sb strings.Builder
+	_, err = io.Copy(&sb, logs)
+	require.NoError(f.t, err, "failed to copy container logs")
+
+	return inspect.Container.State.ExitCode, sb.String()
+}
+
 // NewLightNode creates, starts and appends a new light node.
 func (f *Framework) NewLightNode(ctx context.Context) *dataavailability.Node {
 	// Get the next available light node from the DA network
@@ -164,6 +279,18 @@ func (f *Framework) NewLightNode(ctx context.Context) *dataavailability.Node {
 	return lightNode
 }
 
+// NewLightNodeBitswapOff starts a light node connected  to bridge with bitswap disabled
+func (f *Framework) NewLightNodeBitswapOff(ctx context.Context) *dataavailability.Node {
+	bridgeNode := f.bridgeNodes[0]
+	lightNode := f.startLightNode(ctx, bridgeNode, f.celestia,
+		dataavailability.WithConfigModifications(bitswapOffMod()))
+	f.fundNodeAccount(ctx, lightNode, f.defaultFundingAmount)
+	f.verifyNodeBalance(ctx, lightNode, f.defaultFundingAmount, "light node (bitswap off)")
+
+	f.lightNodes = append(f.lightNodes, lightNode)
+	return lightNode
+}
+
 // GetCelestiaChain returns the Celestia chain instance.
 func (f *Framework) GetCelestiaChain() *cosmos.Chain {
 	return f.celestia
@@ -171,6 +298,20 @@ func (f *Framework) GetCelestiaChain() *cosmos.Chain {
 
 // GetNodeRPCClient retrieves an RPC client for the provided DA node.
 func (f *Framework) GetNodeRPCClient(ctx context.Context, daNode *dataavailability.Node) *rpcclient.Client {
+	rpcClient, err := rpcclient.NewClient(ctx, "http://"+f.nodeRPCAddr(ctx, daNode), "")
+	require.NoError(f.t, err)
+	return rpcClient
+}
+
+// GetNodeRPCClientWS is like GetNodeRPCClient but dials over WebSocket, which
+// go-jsonrpc requires for subscription methods (e.g. Header.Subscribe).
+func (f *Framework) GetNodeRPCClientWS(ctx context.Context, daNode *dataavailability.Node) *rpcclient.Client {
+	rpcClient, err := rpcclient.NewClient(ctx, "ws://"+f.nodeRPCAddr(ctx, daNode), "")
+	require.NoError(f.t, err)
+	return rpcClient
+}
+
+func (f *Framework) nodeRPCAddr(ctx context.Context, daNode *dataavailability.Node) string {
 	networkInfo, err := daNode.GetNetworkInfo(ctx)
 	require.NoError(f.t, err, "failed to get network info")
 	rpcAddr := fmt.Sprintf("%s:%s", networkInfo.External.Hostname, networkInfo.External.Ports.RPC)
@@ -180,10 +321,7 @@ func (f *Framework) GetNodeRPCClient(ctx context.Context, daNode *dataavailabili
 	if strings.HasPrefix(rpcAddr, "0.0.0.0:") {
 		rpcAddr = "127.0.0.1:" + strings.TrimPrefix(rpcAddr, "0.0.0.0:")
 	}
-
-	rpcClient, err := rpcclient.NewClient(ctx, "http://"+rpcAddr, "")
-	require.NoError(f.t, err)
-	return rpcClient
+	return rpcAddr
 }
 
 // CreateTestWallet creates a new test wallet on the chain, funding it with the specified amount.
@@ -423,34 +561,97 @@ func (f *Framework) startBridgeNode(ctx context.Context, chain *cosmos.Chain) *d
 	}
 	bridgeNode := bridgeNodes[bridgeNodeIndex]
 
+	var trustedPeer string
+	if bridgeNodeIndex > 0 {
+		trustedPeer = f.nodeP2PAddr(ctx, f.bridgeNodes[0])
+	}
+
 	networkInfo, err := chain.GetNodes()[0].GetNetworkInfo(ctx)
 	require.NoError(f.t, err, "failed to get network info")
 	hostname := networkInfo.Internal.Hostname
 
-	err = bridgeNode.Start(ctx,
+	startArgs := []string{"--p2p.network", testChainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0"}
+	if f.archivalBridge {
+		startArgs = append(startArgs, "--archival")
+	}
+
+	startOpts := []dataavailability.StartOption{
 		dataavailability.WithChainID(testChainID),
-		dataavailability.WithAdditionalStartArguments("--p2p.network", testChainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0"),
+		dataavailability.WithAdditionalStartArguments(startArgs...),
 		dataavailability.WithEnvironmentVariables(
 			map[string]string{
-				"CELESTIA_CUSTOM":       types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, ""),
+				"CELESTIA_CUSTOM":       types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, trustedPeer),
 				"P2P_NETWORK":           testChainID,
 				"CELESTIA_BOOTSTRAPPER": "true", // Make bridge node act as DHT bootstrapper
 			},
 		),
-	)
+	}
+	if f.multisource {
+		startOpts = append(startOpts, dataavailability.WithConfigModifications(f.additionalCoreEndpointMod(ctx, chain)))
+	}
+
+	err = bridgeNode.Start(ctx, startOpts...)
 	require.NoError(f.t, err, "failed to start bridge node")
 	return bridgeNode
 }
 
+func (f *Framework) additionalCoreEndpointMod(ctx context.Context, chain *cosmos.Chain) map[string]tomlutil.Toml {
+	require.GreaterOrEqual(f.t, len(chain.Validators), 2, "failover core requires at least two validators")
+	info, err := chain.Validators[1].GetNetworkInfo(ctx)
+	require.NoError(f.t, err, "failed to get additional core endpoint network info")
+
+	port := info.Internal.Ports.GRPC
+	if port == "" {
+		port = "9090" // celestia-core default gRPC port
+	}
+
+	return map[string]tomlutil.Toml{
+		"config.toml": {
+			"RPC": tomlutil.Toml{
+				"SkipAuth": true,
+			},
+			"Core": tomlutil.Toml{
+				"AdditionalCoreEndpoints": []map[string]any{
+					{"IP": info.Internal.Hostname, "Port": port, "TLSEnabled": false, "XTokenPath": ""},
+				},
+			},
+		},
+	}
+}
+
+// StopValidator stops the container of the validator at idx to simulating a core endpoint going down.
+func (f *Framework) StopValidator(ctx context.Context, idx int) {
+	require.Less(f.t, idx, len(f.celestia.Validators), "validator index %d out of range", idx)
+	require.NoError(f.t, f.celestia.Validators[idx].StopContainer(ctx), "failed to stop validator %d", idx)
+}
+
+// StartValidator restarts the previously stopped container of the validator at idx.
+func (f *Framework) StartValidator(ctx context.Context, idx int) {
+	require.Less(f.t, idx, len(f.celestia.Validators), "validator index %d out of range", idx)
+	require.NoError(f.t, f.celestia.Validators[idx].StartContainer(ctx), "failed to start validator %d", idx)
+}
+
+// WaitValidatorSynced blocks until the validator at idx reports it is up to date
+func (f *Framework) WaitValidatorSynced(ctx context.Context, idx int, timeout time.Duration) {
+	require.Less(f.t, idx, len(f.celestia.Validators), "validator index %d out of range", idx)
+	rpc, err := f.celestia.Validators[idx].GetRPCClient()
+	require.NoError(f.t, err, "failed to get validator %d rpc client", idx)
+	require.Eventually(f.t, func() bool {
+		st, err := rpc.Status(ctx)
+		return err == nil && !st.SyncInfo.CatchingUp
+	}, timeout, 2*time.Second, "validator %d should catch up after restart", idx)
+}
+
 // startLightNode initializes and starts a light node.
-func (f *Framework) startLightNode(ctx context.Context, bridgeNode *dataavailability.Node, chain *cosmos.Chain) *dataavailability.Node {
+func (f *Framework) startLightNode(
+	ctx context.Context,
+	bridgeNode *dataavailability.Node,
+	chain *cosmos.Chain,
+	extraOpts ...dataavailability.StartOption,
+) *dataavailability.Node {
 	genesisHash := f.getGenesisHash(ctx, chain)
 
-	p2pInfo, err := bridgeNode.GetP2PInfo(ctx)
-	require.NoError(f.t, err, "failed to get bridge node p2p info")
-
-	p2pAddr, err := p2pInfo.GetP2PAddress()
-	require.NoError(f.t, err, "failed to get bridge node p2p address")
+	p2pAddr := f.nodeP2PAddr(ctx, bridgeNode)
 
 	// Get the core node hostname for state access
 	networkInfo, err := chain.GetNodes()[0].GetNetworkInfo(ctx)
@@ -467,19 +668,21 @@ func (f *Framework) startLightNode(ctx context.Context, bridgeNode *dataavailabi
 
 	lightNode := f.daNetwork.GetLightNodes()[lightNodeIndex]
 
-	// Try starting the light node, with a retry to avoid occasional docker flakiness
+	startOpts := append([]dataavailability.StartOption{
+		dataavailability.WithChainID(testChainID),
+		dataavailability.WithAdditionalStartArguments("--p2p.network", testChainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0"),
+		dataavailability.WithEnvironmentVariables(
+			map[string]string{
+				"CELESTIA_CUSTOM": types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, p2pAddr),
+				"P2P_NETWORK":     testChainID,
+			},
+		),
+	}, extraOpts...)
+
+	// Try starting the light node with a retry to avoid docker flakiness
 	var lastErr error
 	for attempt := 1; attempt <= 2; attempt++ {
-		err = lightNode.Start(ctx,
-			dataavailability.WithChainID(testChainID),
-			dataavailability.WithAdditionalStartArguments("--p2p.network", testChainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0"),
-			dataavailability.WithEnvironmentVariables(
-				map[string]string{
-					"CELESTIA_CUSTOM": types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, p2pAddr),
-					"P2P_NETWORK":     testChainID,
-				},
-			),
-		)
+		err = lightNode.Start(ctx, startOpts...)
 		if err == nil {
 			return lightNode
 		}
@@ -494,6 +697,14 @@ func (f *Framework) startLightNode(ctx context.Context, bridgeNode *dataavailabi
 	}
 	require.NoError(f.t, lastErr, "failed to start light node after retries")
 	return nil
+}
+
+func (f *Framework) nodeP2PAddr(ctx context.Context, node *dataavailability.Node) string {
+	p2pInfo, err := node.GetP2PInfo(ctx)
+	require.NoError(f.t, err, "failed to get node p2p info")
+	p2pAddr, err := p2pInfo.GetP2PAddress()
+	require.NoError(f.t, err, "failed to get node p2p address")
+	return p2pAddr
 }
 
 // getGenesisHash returns the genesis hash of the chain.

--- a/nodebuilder/tests/tastora/framework.go
+++ b/nodebuilder/tests/tastora/framework.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -46,6 +47,10 @@ const (
 
 	// brokenCoreIP is a valid but unroutable address.
 	brokenCoreIP = "192.0.2.1"
+
+	// prunedEvidenceMaxAgeBlocks shrinks the genesis evidence window well below the 3000-block
+	// min-retain floor so that min-retain-blocks governs pruning (see shrinkEvidenceWindow).
+	prunedEvidenceMaxAgeBlocks = 100
 )
 
 // defaultNodeTag can be overridden at build time using ldflags
@@ -76,9 +81,14 @@ type Framework struct {
 	fundingWallet        *types.Wallet
 	defaultFundingAmount int64
 
-	archivalBridge     bool
-	multisource        bool
-	availabilityWindow time.Duration
+	archivalBridge      bool
+	multisource         bool
+	availabilityWindow  time.Duration
+	consensusRetainBlks uint64
+
+	// genesisHash is memoized on first computation; a pruned consensus node discards block 1,
+	// from which it is derived, once the chain advances past its retain window.
+	genesisHash string
 }
 
 // NewFramework creates a new Tastora testing framework instance.
@@ -98,6 +108,7 @@ func NewFramework(t *testing.T, options ...Option) *Framework {
 	f.archivalBridge = cfg.ArchivalBridge
 	f.multisource = cfg.MultiSource
 	f.availabilityWindow = cfg.AvailabilityWindow
+	f.consensusRetainBlks = cfg.ConsensusRetainBlks
 
 	f.logger.Info("Setting up Tastora framework", zap.String("test", t.Name()))
 	f.client, f.network = docker.Setup(t)
@@ -211,14 +222,18 @@ func (f *Framework) StartBridgeNodeWithSmallWindow(ctx context.Context, window t
 	hostname := networkInfo.Internal.Hostname
 
 	startArgs := []string{"--p2p.network", testChainID, "--core.ip", hostname, "--rpc.addr", "0.0.0.0"}
+	env := map[string]string{
+		"CELESTIA_CUSTOM": types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, trustedPeer),
+		"P2P_NETWORK":     testChainID,
+	}
+	// window == 0 leaves the default availability window (a plain non-archival bridge).
+	if window > 0 {
+		env["CELESTIA_OVERRIDE_AVAILABILITY_WINDOW"] = window.String()
+	}
 	err = bridgeNode.Start(ctx,
 		dataavailability.WithChainID(testChainID),
 		dataavailability.WithAdditionalStartArguments(startArgs...),
-		dataavailability.WithEnvironmentVariables(map[string]string{
-			"CELESTIA_CUSTOM":                       types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, trustedPeer),
-			"P2P_NETWORK":                           testChainID,
-			"CELESTIA_OVERRIDE_AVAILABILITY_WINDOW": window.String(),
-		}),
+		dataavailability.WithEnvironmentVariables(env),
 		dataavailability.WithConfigModifications(bitswapOffMod()),
 	)
 	require.NoError(f.t, err, "failed to start small-window bridge node")
@@ -482,27 +497,53 @@ func (f *Framework) createBuilders(cfg *Config) (*cosmos.ChainBuilder, *dataavai
 		UIDGID:     "10001:10001",
 	}
 
+	// Fast commit so a single validator clears the ~3000-block retain floor within the test.
+	commitTimeout := "1s"
+	if cfg.ConsensusRetainBlks > 0 {
+		commitTimeout = "10ms"
+	}
+	consensusArgs := []string{
+		"--force-no-bbr",
+		"--grpc.enable",
+		"--grpc.address", "0.0.0.0:9090",
+		"--rpc.grpc_laddr", "tcp://0.0.0.0:9098",
+		"--timeout-commit", commitTimeout,
+	}
+	if cfg.ConsensusRetainBlks > 0 {
+		consensusArgs = append(consensusArgs, "--min-retain-blocks", strconv.FormatUint(cfg.ConsensusRetainBlks, 10))
+	}
+
 	chainBuilder := cosmos.NewChainBuilderWithTestName(f.t, f.t.Name()).
 		WithDockerClient(f.client).
 		WithDockerNetworkID(f.network).
 		WithImage(chainImage).
 		WithEncodingConfig(&enc).
-		WithAdditionalStartArgs(
-			"--force-no-bbr",
-			"--grpc.enable",
-			"--grpc.address", "0.0.0.0:9090",
-			"--rpc.grpc_laddr", "tcp://0.0.0.0:9098",
-			"--timeout-commit", "1s",
-		).
+		WithAdditionalStartArgs(consensusArgs...).
 		WithPostInit(func(ctx context.Context, node *cosmos.ChainNode) error {
-			if err := config.Modify(ctx, node, "config/config.toml", func(cfg *cometcfg.Config) {
-				cfg.TxIndex.Indexer = "kv"
+			if err := config.Modify(ctx, node, "config/config.toml", func(cometCfg *cometcfg.Config) {
+				cometCfg.TxIndex.Indexer = "kv"
 			}); err != nil {
 				return err
 			}
-			return config.Modify(ctx, node, "config/app.toml", func(cfg *servercfg.Config) {
-				cfg.GRPC.Enable = true
-			})
+			if err := config.Modify(ctx, node, "config/app.toml", func(appCfg *servercfg.Config) {
+				appCfg.GRPC.Enable = true
+			}); err != nil {
+				return err
+			}
+			if cfg.ConsensusRetainBlks == 0 {
+				return nil
+			}
+			// CometBFT keeps max(min-retain-blocks, evidence.max_age_num_blocks) blocks; the
+			// default evidence window dwarfs min-retain, so it must be shrunk here (PostInit
+			// runs after the final genesis is written, before consensus starts) for pruning
+			// to ever kick in within a test.
+			var patchErr error
+			if err := config.Modify(ctx, node, "config/genesis.json", func(genesis *map[string]any) {
+				patchErr = shrinkEvidenceWindow(*genesis, prunedEvidenceMaxAgeBlocks)
+			}); err != nil {
+				return err
+			}
+			return patchErr
 		})
 
 	// Add validator nodes based on config
@@ -540,6 +581,27 @@ func (f *Framework) createBuilders(cfg *Config) (*cosmos.ChainBuilder, *dataavai
 		WithNodes(nodeConfigs...)
 
 	return chainBuilder, daNetworkBuilder
+}
+
+// shrinkEvidenceWindow sets consensus.params.evidence.max_age_num_blocks in a decoded genesis
+// map, erroring loudly if the expected structure is absent so a genesis-format change can't
+// silently disable pruning.
+func shrinkEvidenceWindow(genesis map[string]any, maxAgeBlocks int64) error {
+	consensus, ok := genesis["consensus"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("genesis: consensus not found or of unexpected type")
+	}
+	params, ok := consensus["params"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("genesis: consensus.params not found or of unexpected type")
+	}
+	ev, ok := params["evidence"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("genesis: consensus.params.evidence not found or of unexpected type")
+	}
+	// cosmos-sdk's AppGenesis reader requires int64 consensus params to be string-encoded.
+	ev["max_age_num_blocks"] = strconv.FormatInt(maxAgeBlocks, 10)
+	return nil
 }
 
 // createAndStartCelestiaChain initializes and starts the Celestia chain.
@@ -717,8 +779,15 @@ func (f *Framework) nodeP2PAddr(ctx context.Context, node *dataavailability.Node
 	return p2pAddr
 }
 
-// getGenesisHash returns the genesis hash of the chain.
+// getGenesisHash returns the genesis hash of the chain. It memoizes the result because it is
+// derived from block height 1, which a pruned consensus node discards once the chain advances
+// past its retain window — so later callers (e.g. a bridge started mid-test) must reuse the
+// value captured while block 1 was still available.
 func (f *Framework) getGenesisHash(ctx context.Context, chain *cosmos.Chain) string {
+	if f.genesisHash != "" {
+		return f.genesisHash
+	}
+
 	node := chain.GetNodes()[0]
 	c, err := node.GetRPCClient()
 	require.NoError(f.t, err, "failed to get node client")
@@ -729,6 +798,7 @@ func (f *Framework) getGenesisHash(ctx context.Context, chain *cosmos.Chain) str
 
 	genesisHash := block.Block.Header.Hash().String()
 	require.NotEmpty(f.t, genesisHash, "genesis hash is empty")
+	f.genesisHash = genesisHash
 	return genesisHash
 }
 

--- a/nodebuilder/tests/tastora/framework.go
+++ b/nodebuilder/tests/tastora/framework.go
@@ -76,8 +76,9 @@ type Framework struct {
 	fundingWallet        *types.Wallet
 	defaultFundingAmount int64
 
-	archivalBridge bool
-	multisource    bool
+	archivalBridge     bool
+	multisource        bool
+	availabilityWindow time.Duration
 }
 
 // NewFramework creates a new Tastora testing framework instance.
@@ -96,6 +97,7 @@ func NewFramework(t *testing.T, options ...Option) *Framework {
 	}
 	f.archivalBridge = cfg.ArchivalBridge
 	f.multisource = cfg.MultiSource
+	f.availabilityWindow = cfg.AvailabilityWindow
 
 	f.logger.Info("Setting up Tastora framework", zap.String("test", t.Name()))
 	f.client, f.network = docker.Setup(t)
@@ -578,16 +580,19 @@ func (f *Framework) startBridgeNode(ctx context.Context, chain *cosmos.Chain) *d
 		startArgs = append(startArgs, "--archival")
 	}
 
+	env := map[string]string{
+		"CELESTIA_CUSTOM":       types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, trustedPeer),
+		"P2P_NETWORK":           testChainID,
+		"CELESTIA_BOOTSTRAPPER": "true",
+	}
+	if f.availabilityWindow > 0 {
+		env["CELESTIA_OVERRIDE_AVAILABILITY_WINDOW"] = f.availabilityWindow.String()
+	}
+
 	startOpts := []dataavailability.StartOption{
 		dataavailability.WithChainID(testChainID),
 		dataavailability.WithAdditionalStartArguments(startArgs...),
-		dataavailability.WithEnvironmentVariables(
-			map[string]string{
-				"CELESTIA_CUSTOM":       types.BuildCelestiaCustomEnvVar(testChainID, genesisHash, trustedPeer),
-				"P2P_NETWORK":           testChainID,
-				"CELESTIA_BOOTSTRAPPER": "true", // Make bridge node act as DHT bootstrapper
-			},
-		),
+		dataavailability.WithEnvironmentVariables(env),
 	}
 	if f.multisource {
 		startOpts = append(startOpts, dataavailability.WithConfigModifications(f.additionalCoreEndpointMod(ctx, chain)))

--- a/nodebuilder/tests/tastora/framework.go
+++ b/nodebuilder/tests/tastora/framework.go
@@ -159,6 +159,14 @@ func (f *Framework) GetLightNodes() []*dataavailability.Node {
 	return f.lightNodes
 }
 
+// GetArchivalNode returns the archival bridge node. It requires the framework to have been
+// configured with WithArchivalBridge; the archival node is always the primary bridge (index 0).
+func (f *Framework) GetArchivalNode() *dataavailability.Node {
+	require.True(f.t, f.archivalBridge, "framework was not configured with WithArchivalBridge")
+	require.NotEmpty(f.t, f.bridgeNodes, "no bridge nodes have been started")
+	return f.bridgeNodes[0]
+}
+
 // NewBridgeNode creates, starts and appends a new bridge node.
 func (f *Framework) NewBridgeNode(ctx context.Context) *dataavailability.Node {
 	bridgeNode := f.newBridgeNode(ctx)

--- a/nodebuilder/tests/tastora/go.mod
+++ b/nodebuilder/tests/tastora/go.mod
@@ -181,7 +181,7 @@ require (
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.3.0 // indirect
-	github.com/libp2p/go-libp2p v0.49.0 // indirect
+	github.com/libp2p/go-libp2p v0.49.0
 	github.com/libp2p/go-libp2p-asn-util v0.4.1 // indirect
 	github.com/libp2p/go-libp2p-kad-dht v0.42.1 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.9.0 // indirect

--- a/nodebuilder/tests/tastora/go.mod
+++ b/nodebuilder/tests/tastora/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cometbft/cometbft v1.0.1
 	github.com/containerd/errdefs v1.0.0
 	github.com/cosmos/cosmos-sdk v0.50.13
+	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
 	github.com/stretchr/testify v1.12.0
 	go.uber.org/zap v1.28.0
@@ -374,7 +375,6 @@ require (
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.72 // indirect
 	github.com/ingonyama-zk/icicle-gnark/v3 v3.2.2 // indirect
 	github.com/minio/minlz v1.0.1-0.20250507153514-87eb42fe8882 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/pion/transport/v4 v4.0.2 // indirect
 	github.com/ronanh/intcomp v1.1.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect

--- a/nodebuilder/tests/tastora/header_p2p_sync_test.go
+++ b/nodebuilder/tests/tastora/header_p2p_sync_test.go
@@ -54,7 +54,7 @@ func (s *HeaderP2PSyncTestSuite) TestBridgeArchivalHeaderSyncViaP2P() {
 	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
 	defer cancel()
 
-	archival := s.framework.GetBridgeNodes()[0]
+	archival := s.framework.GetArchivalNode()
 	clientA := s.framework.GetNodeRPCClient(ctx, archival)
 
 	// Advance past the retain window so early blocks (incl. prunedHeight) are pruned from

--- a/nodebuilder/tests/tastora/header_p2p_sync_test.go
+++ b/nodebuilder/tests/tastora/header_p2p_sync_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package tastora
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// archivalHeaderWindow is the shrunk availability window given to the catching-up
+// bridge.
+const archivalHeaderWindow = 2 * time.Minute
+
+// historyHeight is how much chain the archival bridge builds before the small-window
+// bridge joins.
+const historyHeight = 150
+
+// HeaderP2PSyncTestSuite runs a 2-bridge topology where bridge[0] (A) is archival and
+// bridge[1] (B) is non-archival with a small availability window.
+type HeaderP2PSyncTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestHeaderP2PSyncTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping header p2p sync integration tests in short mode")
+	}
+	suite.Run(t, &HeaderP2PSyncTestSuite{})
+}
+
+func (s *HeaderP2PSyncTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(),
+		WithValidators(1), WithBridgeNodes(2), WithLightNodes(0), WithArchivalBridge())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+}
+
+func (s *HeaderP2PSyncTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestBridgeArchivalHeaderSyncViaP2P asserts a non-archival bridge fetches headers that
+// are older than its availability window from an archival bridge over p2p.
+func (s *HeaderP2PSyncTestSuite) TestBridgeArchivalHeaderSyncViaP2P() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	archival := s.framework.GetBridgeNodes()[0]
+	clientA := s.framework.GetNodeRPCClient(ctx, archival)
+
+	_, err := clientA.Header.WaitForHeight(ctx, historyHeight)
+	s.Require().NoError(err, "chain should build enough history before B joins")
+
+	// the early out-of-window heights route to the p2p header exchange and
+	// the recent ones to core.
+	bridgeB := s.framework.StartBridgeNodeWithSmallWindow(ctx, archivalHeaderWindow)
+	clientB := s.framework.GetNodeRPCClient(ctx, bridgeB)
+
+	headA, err := clientA.Header.LocalHead(ctx)
+	s.Require().NoError(err, "should get A's head")
+	_, err = clientB.Header.WaitForHeight(ctx, headA.Height())
+	s.Require().NoError(err, "B should sync to the head")
+
+	_, logs := s.framework.bridgeContainerExit(ctx, bridgeB)
+	s.Require().Contains(logs, "range from p2p network",
+		"B's logs should show it fetched out-of-window headers over p2p")
+	s.T().Log("confirmed: B fetched archival headers via the p2p route")
+}

--- a/nodebuilder/tests/tastora/header_p2p_sync_test.go
+++ b/nodebuilder/tests/tastora/header_p2p_sync_test.go
@@ -10,16 +10,15 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// archivalHeaderWindow is the shrunk availability window given to the catching-up
-// bridge.
-const archivalHeaderWindow = 2 * time.Minute
+// consensusRetainBlocks is how many recent blocks the consensus node keeps; older blocks
+// are pruned from its store, so a bridge must source them from the archival peer over p2p.
+// celestia-app floors min-retain-blocks at 3000, so this is the smallest usable value;
+// the framework pairs it with fast blocks so the chain clears it within the test.
+const consensusRetainBlocks = 3000
 
-// historyHeight is how much chain the archival bridge builds before the small-window
-// bridge joins.
-const historyHeight = 150
-
-// HeaderP2PSyncTestSuite runs a 2-bridge topology where bridge[0] (A) is archival and
-// bridge[1] (B) is non-archival with a small availability window.
+// HeaderP2PSyncTestSuite runs a pruned consensus node, an archival bridge (A) that retains
+// every block, and a fresh non-archival bridge (B). B must backfill blocks the consensus
+// node has already pruned, which it can only obtain from A over the p2p header exchange.
 type HeaderP2PSyncTestSuite struct {
 	suite.Suite
 	framework *Framework
@@ -34,7 +33,8 @@ func TestHeaderP2PSyncTestSuite(t *testing.T) {
 
 func (s *HeaderP2PSyncTestSuite) SetupSuite() {
 	s.framework = NewFramework(s.T(),
-		WithValidators(1), WithBridgeNodes(2), WithLightNodes(0), WithArchivalBridge())
+		WithValidators(1), WithBridgeNodes(2), WithLightNodes(0),
+		WithArchivalBridge(), WithPrunedConsensus(consensusRetainBlocks))
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	s.Require().NoError(s.framework.SetupNetwork(ctx))
@@ -46,30 +46,43 @@ func (s *HeaderP2PSyncTestSuite) TearDownSuite() {
 	}
 }
 
-// TestBridgeArchivalHeaderSyncViaP2P asserts a non-archival bridge fetches headers that
-// are older than its availability window from an archival bridge over p2p.
+// TestBridgeArchivalHeaderSyncViaP2P asserts a bridge backfills headers the consensus node
+// has pruned from an archival bridge over p2p. The consensus node keeps only the last few
+// blocks (min-retain-blocks), so when B fetches an early height core has no block and
+// core.Exchange falls back to the p2p header exchange (archival A) — logged at INFO.
 func (s *HeaderP2PSyncTestSuite) TestBridgeArchivalHeaderSyncViaP2P() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
 	defer cancel()
 
 	archival := s.framework.GetBridgeNodes()[0]
 	clientA := s.framework.GetNodeRPCClient(ctx, archival)
 
-	_, err := clientA.Header.WaitForHeight(ctx, historyHeight)
-	s.Require().NoError(err, "chain should build enough history before B joins")
+	// Advance past the retain window so early blocks (incl. prunedHeight) are pruned from
+	// the consensus node while archival A keeps them.
+	_, err := clientA.Header.WaitForHeight(ctx, consensusRetainBlocks+100)
+	s.Require().NoError(err, "chain should advance past the consensus retain window")
 
-	// the early out-of-window heights route to the p2p header exchange and
-	// the recent ones to core.
-	bridgeB := s.framework.StartBridgeNodeWithSmallWindow(ctx, archivalHeaderWindow)
+	// Fresh non-archival bridge B, peered to archival A (window 0 = no override).
+	bridgeB := s.framework.StartBridgeNodeWithSmallWindow(ctx, 0)
 	clientB := s.framework.GetNodeRPCClient(ctx, bridgeB)
 
 	headA, err := clientA.Header.LocalHead(ctx)
 	s.Require().NoError(err, "should get A's head")
 	_, err = clientB.Header.WaitForHeight(ctx, headA.Height())
-	s.Require().NoError(err, "B should sync to the head")
+	s.Require().NoError(err, "B should sync to the head, backfilling pruned blocks from A over p2p")
 
+	// An early height was pruned from the consensus node, so B could only get its header
+	// from archival A over p2p; it must match A's canonical header.
+	const prunedHeight = 5
+	hdrB, err := clientB.Header.GetByHeight(ctx, prunedHeight)
+	s.Require().NoError(err, "B should hold the pruned-from-core header at %d", prunedHeight)
+	hdrA, err := clientA.Header.GetByHeight(ctx, prunedHeight)
+	s.Require().NoError(err, "archival A should hold the header at %d", prunedHeight)
+	s.Assert().Equal(hdrA.Hash(), hdrB.Hash(), "B's p2p-fetched header should match A's")
+
+	// B's own logs are the direct evidence the header came from p2p rather than core.
 	_, logs := s.framework.bridgeContainerExit(ctx, bridgeB)
-	s.Require().Contains(logs, "range from p2p network",
-		"B's logs should show it fetched out-of-window headers over p2p")
-	s.T().Log("confirmed: B fetched archival headers via the p2p route")
+	s.Require().Contains(logs, "fetched extended header from p2p (core unavailable)",
+		"B should have fetched pruned headers from p2p")
+	s.T().Log("confirmed: B fetched pruned-from-core headers via the p2p fallback")
 }

--- a/nodebuilder/tests/tastora/header_test.go
+++ b/nodebuilder/tests/tastora/header_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package tastora
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// HeaderTestSuite provides testing of the Header module APIs against a live network.
+type HeaderTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestHeaderTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Header module integration tests in short mode")
+	}
+	suite.Run(t, &HeaderTestSuite{})
+}
+
+func (s *HeaderTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+}
+
+func (s *HeaderTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestHeaderLiveSync subscribes to the bridge's header stream and asserts that
+// it produces a live chain.
+func (s *HeaderTestSuite) TestHeaderLiveSync() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	bridgeNode := s.framework.GetBridgeNodes()[0]
+	client := s.framework.GetNodeRPCClientWS(ctx, bridgeNode)
+
+	sub, err := client.Header.Subscribe(ctx)
+	s.Require().NoError(err)
+
+	const want = 5
+	var prev uint64
+	for i := 0; i < want; i++ {
+		select {
+		case eh := <-sub:
+			s.Require().NotNil(eh)
+			s.Assert().Greater(eh.Height(), prev, "heights should strictly increase")
+			s.Assert().NotEmpty(eh.DAH.RowRoots, "header at height %d should carry a non-empty DAH", eh.Height())
+			prev = eh.Height()
+		case <-ctx.Done():
+			s.FailNowf("timed out waiting for header events", "received %d of %d", i, want)
+		}
+	}
+}
+
+// TestHeaderSubscribe asserts that the subscription delivers canonical, retrievable
+// headers
+func (s *HeaderTestSuite) TestHeaderSubscribe() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	bridgeNode := s.framework.GetBridgeNodes()[0]
+	client := s.framework.GetNodeRPCClientWS(ctx, bridgeNode)
+
+	sub, err := client.Header.Subscribe(ctx)
+	s.Require().NoError(err)
+
+	const want = 5
+	for i := 0; i < want; i++ {
+		select {
+		case eh := <-sub:
+			s.Require().NotNil(eh)
+			got, err := client.Header.GetByHeight(ctx, eh.Height())
+			s.Require().NoError(err)
+			s.Assert().Equal(eh.Hash(), got.Hash(), "streamed header at height %d should match GetByHeight", eh.Height())
+		case <-ctx.Done():
+			s.FailNowf("timed out waiting for header events", "received %d of %d", i, want)
+		}
+	}
+}

--- a/nodebuilder/tests/tastora/header_test.go
+++ b/nodebuilder/tests/tastora/header_test.go
@@ -44,6 +44,7 @@ func (s *HeaderTestSuite) TestHeaderLiveSync() {
 
 	bridgeNode := s.framework.GetBridgeNodes()[0]
 	client := s.framework.GetNodeRPCClientWS(ctx, bridgeNode)
+	defer client.Close()
 
 	sub, err := client.Header.Subscribe(ctx)
 	s.Require().NoError(err)
@@ -71,6 +72,7 @@ func (s *HeaderTestSuite) TestHeaderSubscribe() {
 
 	bridgeNode := s.framework.GetBridgeNodes()[0]
 	client := s.framework.GetNodeRPCClientWS(ctx, bridgeNode)
+	defer client.Close()
 
 	sub, err := client.Header.Subscribe(ctx)
 	s.Require().NoError(err)

--- a/nodebuilder/tests/tastora/light_restart_test.go
+++ b/nodebuilder/tests/tastora/light_restart_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+package tastora
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
+)
+
+// LightRestartTestSuite verifies a light node resumes data-availability sampling.
+type LightRestartTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestLightRestartTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping light-restart integration tests in short mode")
+	}
+	suite.Run(t, &LightRestartTestSuite{})
+}
+
+func (s *LightRestartTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(1))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+	s.framework.NewLightNode(ctx)
+}
+
+func (s *LightRestartTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestLightNodeResumesSamplingAfterRestart samples the chain on a light node, restarts its container,
+// and asserts the light node comes back, keeps its header store, resumes sampling from where it left
+// off and keeps advancing.
+func (s *LightRestartTestSuite) TestLightNodeResumesSamplingAfterRestart() {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	light := s.framework.GetLightNodes()[0]
+	client := s.framework.GetNodeRPCClient(ctx, light)
+
+	head, err := client.Header.LocalHead(ctx)
+	s.Require().NoError(err, "should get light local head before restart")
+	h0 := head.Height()
+	preHdr, err := client.Header.GetByHeight(ctx, h0)
+	s.Require().NoError(err, "should get header at height %d before restart", h0)
+
+	s.Require().NoError(client.DAS.WaitCatchUp(ctx), "light DASer should catch up before restart")
+	preStats, err := client.DAS.SamplingStats(ctx)
+	s.Require().NoError(err, "should get sampling stats before restart")
+	s.Require().Empty(preStats.Failed, "no height should have failed before restart")
+	s.T().Logf("pre-restart: head=%d sampledChainHead=%d networkHead=%d",
+		h0, preStats.SampledChainHead, preStats.NetworkHead)
+
+	s.framework.RestartNode(ctx, light)
+
+	client = s.framework.GetNodeRPCClient(ctx, light)
+	s.waitNodeUp(ctx, client)
+
+	postHdr, err := client.Header.GetByHeight(ctx, h0)
+	s.Require().NoError(err, "should get header at height %d after restart", h0)
+	s.Assert().Equal(preHdr.Hash(), postHdr.Hash(), "header hash at height %d should survive restart", h0)
+
+	immStats, err := client.DAS.SamplingStats(ctx)
+	s.Require().NoError(err, "should get sampling stats after restart")
+	s.T().Logf("post-restart (immediate): sampledChainHead=%d networkHead=%d isRunning=%v",
+		immStats.SampledChainHead, immStats.NetworkHead, immStats.IsRunning)
+
+	s.Require().NoError(client.DAS.WaitCatchUp(ctx), "light DASer should catch up again after restart")
+	postStats, err := client.DAS.SamplingStats(ctx)
+	s.Require().NoError(err, "should get sampling stats after catch up")
+	s.T().Logf("post-restart (caught up): sampledChainHead=%d networkHead=%d",
+		postStats.SampledChainHead, postStats.NetworkHead)
+	s.Assert().Empty(postStats.Failed, "no height should have failed after restart")
+	s.Assert().GreaterOrEqual(postStats.SampledChainHead, preStats.SampledChainHead,
+		"sampled chain head should not regress across restart")
+
+	// the light node keeps sampling new blocks after the restart.
+	newHead := postStats.NetworkHead + 3
+	_, err = client.Header.WaitForHeight(ctx, newHead)
+	s.Require().NoError(err, "light node should keep syncing headers after restart")
+	s.Require().NoError(client.DAS.WaitCatchUp(ctx), "light DASer should sample past the restart")
+	finalStats, err := client.DAS.SamplingStats(ctx)
+	s.Require().NoError(err, "should get final sampling stats")
+	s.Assert().GreaterOrEqual(finalStats.SampledChainHead, newHead,
+		"light node should sample blocks produced after the restart")
+	s.Assert().Empty(finalStats.Failed, "no height should have failed while sampling past the restart")
+}
+
+func (s *LightRestartTestSuite) waitNodeUp(ctx context.Context, client *rpcclient.Client) {
+	s.Require().Eventually(func() bool {
+		_, err := client.Header.LocalHead(ctx)
+		return err == nil
+	}, 90*time.Second, 2*time.Second, "light node RPC should become reachable after restart")
+}

--- a/nodebuilder/tests/tastora/p2p_test.go
+++ b/nodebuilder/tests/tastora/p2p_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package tastora
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/suite"
+
+	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
+)
+
+// P2PTestSuite runs a 2-bridge topology where bridge[1] is connected to bridge[0]
+type P2PTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestP2PTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping p2p integration tests in short mode")
+	}
+	suite.Run(t, &P2PTestSuite{})
+}
+
+func (s *P2PTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(2), WithLightNodes(0))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+	s.framework.NewBridgeNode(ctx)
+}
+
+func (s *P2PTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestP2PBridgeToBridge brings up two bridges and asserts they are mutually connected: bridge[1] is
+// wired to bridge[0] as a trusted peer, so each must see the other in its peer set and report a
+// Connected state in both directions.
+func (s *P2PTestSuite) TestP2PBridgeToBridge() {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	bridges := s.framework.GetBridgeNodes()
+	s.Require().Len(bridges, 2, "suite must run with two bridge nodes")
+
+	client0 := s.framework.GetNodeRPCClient(ctx, bridges[0])
+	client1 := s.framework.GetNodeRPCClient(ctx, bridges[1])
+
+	info0, err := client0.P2P.Info(ctx)
+	s.Require().NoError(err, "bridge[0] should provide P2P info")
+
+	info1, err := client1.P2P.Info(ctx)
+	s.Require().NoError(err, "bridge[1] should provide P2P info")
+	s.Require().NotEqual(info0.ID, info1.ID, "bridges must have distinct peer IDs")
+
+	s.waitConnected(ctx, client1, info0.ID, "bridge[1] -> bridge[0]")
+	s.waitConnected(ctx, client0, info1.ID, "bridge[0] -> bridge[1]")
+
+	peers0, err := client0.P2P.Peers(ctx)
+	s.Require().NoError(err, "bridge[0] should list peers")
+	s.Assert().Contains(peerIDs(peers0), info1.ID, "bridge[0] peer set should include bridge[1]")
+
+	peers1, err := client1.P2P.Peers(ctx)
+	s.Require().NoError(err, "bridge[1] should list peers")
+	s.Assert().Contains(peerIDs(peers1), info0.ID, "bridge[1] peer set should include bridge[0]")
+}
+
+func (s *P2PTestSuite) waitConnected(ctx context.Context, client *rpcclient.Client, id peer.ID, dir string) {
+	s.Require().Eventually(func() bool {
+		c, err := client.P2P.Connectedness(ctx, id)
+		return err == nil && c == network.Connected
+	}, 60*time.Second, time.Second, "%s should reach Connected", dir)
+}
+
+func peerIDs(peers []peer.ID) map[peer.ID]struct{} {
+	set := make(map[peer.ID]struct{}, len(peers))
+	for _, p := range peers {
+		set[p] = struct{}{}
+	}
+	return set
+}

--- a/nodebuilder/tests/tastora/restart_test.go
+++ b/nodebuilder/tests/tastora/restart_test.go
@@ -54,11 +54,11 @@ func (s *RestartTestSuite) TestRestartPersistence() {
 	preHdr, err := client.Header.GetByHeight(ctx, h0)
 	s.Require().NoError(err, "should get header at height %d before restart", h0)
 
-	preStats, dasErr := client.DAS.SamplingStats(ctx)
+	_, dasErr := client.DAS.SamplingStats(ctx)
 	s.Require().NoError(dasErr, "DAS not available", dasErr)
 
 	s.Require().NoError(client.DAS.WaitCatchUp(ctx), "DASer should catch up before restart")
-	preStats, err = client.DAS.SamplingStats(ctx)
+	preStats, err := client.DAS.SamplingStats(ctx)
 	s.Require().NoError(err, "should get sampling stats before restart")
 	s.T().Logf("pre-restart: head=%d sampledChainHead=%d catchupHead=%d networkHead=%d",
 		h0, preStats.SampledChainHead, preStats.CatchupHead, preStats.NetworkHead)
@@ -76,20 +76,18 @@ func (s *RestartTestSuite) TestRestartPersistence() {
 	s.Require().NoError(client.Share.SharesAvailable(ctx, h0),
 		"shares at height %d should stay available after restart", h0)
 
-	if dasEnabled {
-		immStats, err := client.DAS.SamplingStats(ctx)
-		s.Require().NoError(err, "should get sampling stats after restart")
-		s.T().Logf("post-restart (immediate): sampledChainHead=%d catchupHead=%d networkHead=%d isRunning=%v",
-			immStats.SampledChainHead, immStats.CatchupHead, immStats.NetworkHead, immStats.IsRunning)
+	immStats, err := client.DAS.SamplingStats(ctx)
+	s.Require().NoError(err, "should get sampling stats after restart")
+	s.T().Logf("post-restart (immediate): sampledChainHead=%d catchupHead=%d networkHead=%d isRunning=%v",
+		immStats.SampledChainHead, immStats.CatchupHead, immStats.NetworkHead, immStats.IsRunning)
 
-		s.Require().NoError(client.DAS.WaitCatchUp(ctx), "DASer should catch up again after restart")
-		postStats, err := client.DAS.SamplingStats(ctx)
-		s.Require().NoError(err, "should get sampling stats after catch up")
-		s.T().Logf("post-restart (caught up): sampledChainHead=%d catchupHead=%d networkHead=%d",
-			postStats.SampledChainHead, postStats.CatchupHead, postStats.NetworkHead)
-		s.Assert().GreaterOrEqual(postStats.SampledChainHead, preStats.SampledChainHead,
-			"sampled chain head should not regress across restart")
-	}
+	s.Require().NoError(client.DAS.WaitCatchUp(ctx), "DASer should catch up again after restart")
+	postStats, err := client.DAS.SamplingStats(ctx)
+	s.Require().NoError(err, "should get sampling stats after catch up")
+	s.T().Logf("post-restart (caught up): sampledChainHead=%d catchupHead=%d networkHead=%d",
+		postStats.SampledChainHead, postStats.CatchupHead, postStats.NetworkHead)
+	s.Assert().GreaterOrEqual(postStats.SampledChainHead, preStats.SampledChainHead,
+		"sampled chain head should not regress across restart")
 
 	// the node keeps advancing after the restart.
 	_, err = client.Header.WaitForHeight(ctx, h0+3)

--- a/nodebuilder/tests/tastora/restart_test.go
+++ b/nodebuilder/tests/tastora/restart_test.go
@@ -68,7 +68,7 @@ func (s *RestartTestSuite) TestRestartPersistence() {
 	client = s.framework.GetNodeRPCClient(ctx, bridge)
 	s.waitNodeUp(ctx, client)
 
-	// verify that store is survived after restsart
+	// verify that store survived after restart
 	postHdr, err := client.Header.GetByHeight(ctx, h0)
 	s.Require().NoError(err, "should get header at height %d after restart", h0)
 	s.Assert().Equal(preHdr.Hash(), postHdr.Hash(), "header hash at height %d should survive restart", h0)

--- a/nodebuilder/tests/tastora/restart_test.go
+++ b/nodebuilder/tests/tastora/restart_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+package tastora
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
+)
+
+// RestartTestSuite verifies a bridge node survives a container restart on a single-bridge
+// topology
+type RestartTestSuite struct {
+	suite.Suite
+	framework *Framework
+}
+
+func TestRestartTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping restart integration tests in short mode")
+	}
+	suite.Run(t, &RestartTestSuite{})
+}
+
+func (s *RestartTestSuite) SetupSuite() {
+	s.framework = NewFramework(s.T(), WithValidators(1), WithBridgeNodes(1), WithLightNodes(0))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s.Require().NoError(s.framework.SetupNetwork(ctx))
+}
+
+func (s *RestartTestSuite) TearDownSuite() {
+	if s.framework != nil {
+		s.framework.Cleanup()
+	}
+}
+
+// TestRestartPersistence asserts a bridge node keeps its state across a container restart.
+func (s *RestartTestSuite) TestRestartPersistence() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	bridge := s.framework.GetBridgeNodes()[0]
+	client := s.framework.GetNodeRPCClient(ctx, bridge)
+
+	head, err := client.Header.LocalHead(ctx)
+	s.Require().NoError(err, "should get local head before restart")
+	h0 := head.Height()
+
+	preHdr, err := client.Header.GetByHeight(ctx, h0)
+	s.Require().NoError(err, "should get header at height %d before restart", h0)
+
+	preStats, dasErr := client.DAS.SamplingStats(ctx)
+	s.Require().NoError(dasErr, "DAS not available", dasErr)
+
+	s.Require().NoError(client.DAS.WaitCatchUp(ctx), "DASer should catch up before restart")
+	preStats, err = client.DAS.SamplingStats(ctx)
+	s.Require().NoError(err, "should get sampling stats before restart")
+	s.T().Logf("pre-restart: head=%d sampledChainHead=%d catchupHead=%d networkHead=%d",
+		h0, preStats.SampledChainHead, preStats.CatchupHead, preStats.NetworkHead)
+
+	s.framework.RestartBridgeNode(ctx, bridge)
+
+	client = s.framework.GetNodeRPCClient(ctx, bridge)
+	s.waitNodeUp(ctx, client)
+
+	// verify that store is survived after restsart
+	postHdr, err := client.Header.GetByHeight(ctx, h0)
+	s.Require().NoError(err, "should get header at height %d after restart", h0)
+	s.Assert().Equal(preHdr.Hash(), postHdr.Hash(), "header hash at height %d should survive restart", h0)
+	s.Assert().Equal(preHdr.DAH.Hash(), postHdr.DAH.Hash(), "DAH at height %d should survive restart", h0)
+	s.Require().NoError(client.Share.SharesAvailable(ctx, h0),
+		"shares at height %d should stay available after restart", h0)
+
+	if dasEnabled {
+		immStats, err := client.DAS.SamplingStats(ctx)
+		s.Require().NoError(err, "should get sampling stats after restart")
+		s.T().Logf("post-restart (immediate): sampledChainHead=%d catchupHead=%d networkHead=%d isRunning=%v",
+			immStats.SampledChainHead, immStats.CatchupHead, immStats.NetworkHead, immStats.IsRunning)
+
+		s.Require().NoError(client.DAS.WaitCatchUp(ctx), "DASer should catch up again after restart")
+		postStats, err := client.DAS.SamplingStats(ctx)
+		s.Require().NoError(err, "should get sampling stats after catch up")
+		s.T().Logf("post-restart (caught up): sampledChainHead=%d catchupHead=%d networkHead=%d",
+			postStats.SampledChainHead, postStats.CatchupHead, postStats.NetworkHead)
+		s.Assert().GreaterOrEqual(postStats.SampledChainHead, preStats.SampledChainHead,
+			"sampled chain head should not regress across restart")
+	}
+
+	// the node keeps advancing after the restart.
+	_, err = client.Header.WaitForHeight(ctx, h0+3)
+	s.Require().NoError(err, "node should keep advancing after restart")
+}
+
+func (s *RestartTestSuite) waitNodeUp(ctx context.Context, client *rpcclient.Client) {
+	s.Require().Eventually(func() bool {
+		_, err := client.Header.LocalHead(ctx)
+		return err == nil
+	}, 90*time.Second, 2*time.Second, "node RPC should become reachable after restart")
+}

--- a/nodebuilder/tests/tastora/shrex_test.go
+++ b/nodebuilder/tests/tastora/shrex_test.go
@@ -1,0 +1,152 @@
+//go:build integration
+
+package tastora
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/da"
+	"github.com/celestiaorg/go-square/v4/share"
+
+	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
+	nodeblob "github.com/celestiaorg/celestia-node/blob"
+	"github.com/celestiaorg/celestia-node/state"
+)
+
+// TestBridgeServesSharesOverShrex submits a blob to bridge[0] (A) and exercises the full Share API
+// surface against it:
+//   - GetShare,
+//   - GetEDS,
+//   - GetRow,
+//   - GetRange,
+//   - GetNamespaceData,
+//
+// proving A serves every share-retrieval path for a real, non-empty square.
+func (s *P2PTestSuite) TestBridgeServesSharesOverShrex() {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	bridges := s.framework.GetBridgeNodes()
+	s.Require().Len(bridges, 2, "suite must run with two bridge nodes")
+
+	clientA := s.framework.GetNodeRPCClient(ctx, bridges[0])
+	clientB := s.framework.GetNodeRPCClient(ctx, bridges[1])
+
+	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{0x05}, 10))
+	s.Require().NoError(err, "should create namespace")
+
+	blobData := []byte("TestBridgeServesSharesOverShrex: share API over the network")
+	nodeAddr, err := clientA.State.AccountAddress(ctx)
+	s.Require().NoError(err, "should get bridge[0] account address")
+
+	libBlob, err := share.NewV1Blob(namespace, blobData, nodeAddr.Bytes())
+	s.Require().NoError(err, "should create libshare blob")
+
+	nodeBlobs, err := nodeblob.ToNodeBlobs(libBlob)
+	s.Require().NoError(err, "should convert to node blobs")
+
+	txConfig := state.NewTxConfig(state.WithGas(300_000), state.WithGasPrice(5000))
+
+	height, err := clientA.Blob.Submit(ctx, nodeBlobs, txConfig)
+	s.Require().NoError(err, "bridge[0] should submit blob")
+	s.Require().NotZero(height, "blob submission should return valid height")
+
+	_, err = clientA.Header.WaitForHeight(ctx, height)
+	s.Require().NoError(err, "bridge[0] should reach the submitted height")
+
+	hdr, err := clientA.Header.GetByHeight(ctx, height)
+	s.Require().NoError(err, "bridge[0] should serve the header at height %d", height)
+
+	err = clientA.Share.SharesAvailable(ctx, height)
+	s.Require().NoError(err, "bridge[0] shares should be available at height %d", height)
+
+	edsA, err := clientA.Share.GetEDS(ctx, height)
+	s.Require().NoError(err, "bridge[0] should serve the EDS")
+	s.Require().NotNil(edsA, "EDS should not be nil")
+	width := int(edsA.Width())
+	s.Require().Positive(width, "EDS width should be positive")
+
+	shareA, err := clientA.Share.GetShare(ctx, height, 0, 0)
+	s.Require().NoError(err, "bridge[0] should serve share (0,0)")
+
+	dah, err := da.NewDataAvailabilityHeader(edsA)
+	s.Require().NoError(err, "err building DAH")
+
+	row, err := clientA.Share.GetRow(ctx, height, 0)
+	s.Require().NoError(err, "bridge[0] should serve row 0")
+	rowShares, err := row.Shares()
+	s.Require().NoError(err, "row should reconstruct its shares")
+	s.Assert().Len(rowShares, width, "row 0 should hold a full EDS-width row of shares")
+	s.Require().NoError(row.Verify(dah, 0), "bridge[0] invalid row at index 0")
+
+	rng, err := clientA.Share.GetRange(ctx, height, 0, 1)
+	s.Require().NoError(err, "bridge[0] should serve a share range")
+	s.Require().NotEmpty(rng.Shares, "range should contain shares")
+	s.Require().NotNil(rng.Proof, "range should carry an inclusion proof")
+	s.Require().NoError(rng.Verify(hdr.DataHash), "range proof should validate against the data root")
+
+	nsDataA, err := clientA.Share.GetNamespaceData(ctx, height, namespace)
+	s.Require().NoError(err, "bridge[0] should serve namespace data")
+	s.Require().NotEmpty(nsDataA.Flatten(), "namespace data should contain the submitted blob shares")
+	s.Require().NoError(nsDataA.Verify(dah, namespace), "bridge[0] proof veirification failed")
+
+	// same height retrieved on B (peered to A) returns byte-identical shares.
+	_, err = clientB.Header.WaitForHeight(ctx, height)
+	s.Require().NoError(err, "bridge[1] should reach the submitted height")
+
+	err = clientB.Share.SharesAvailable(ctx, height)
+	s.Require().NoError(err, "bridge[1] shares should be available at height %d", height)
+
+	edsB, err := clientB.Share.GetEDS(ctx, height)
+	s.Require().NoError(err, "bridge[1] should serve the EDS")
+	// the RPC-decoded square loses its NMT constructor, so compare by content, not recomputed roots.
+	s.Assert().Equal(edsA.Flattened(), edsB.Flattened(), "both bridges should serve the same square")
+
+	shareB, err := clientB.Share.GetShare(ctx, height, 0, 0)
+	s.Require().NoError(err, "bridge[1] should serve share (0,0)")
+	s.Assert().Equal(shareA, shareB, "share (0,0) should match across bridges")
+
+	nsDataB, err := clientB.Share.GetNamespaceData(ctx, height, namespace)
+	s.Require().NoError(err, "bridge[1] should serve namespace data")
+	s.Assert().Equal(nsDataA.Flatten(), nsDataB.Flatten(), "namespace data should match across bridges")
+	s.Require().NoError(nsDataB.Verify(dah, namespace), "bridge[1] proof veirification failed")
+}
+
+func (s *P2PTestSuite) TestNoPeerHasData() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	bridges := s.framework.GetBridgeNodes()
+	s.Require().Len(bridges, 2, "suite must run with two bridge nodes")
+
+	clientA := s.framework.GetNodeRPCClient(ctx, bridges[0])
+	clientB := s.framework.GetNodeRPCClient(ctx, bridges[1])
+
+	absentNs, err := share.NewV0Namespace(bytes.Repeat([]byte{0xAB}, 10))
+	s.Require().NoError(err, "should create absent namespace")
+
+	head, err := clientB.Header.LocalHead(ctx)
+	s.Require().NoError(err, "bridge[1] should report its local head")
+	height := head.Height()
+	_, err = clientA.Header.WaitForHeight(ctx, height)
+	s.Require().NoError(err, "bridge[0] should reach height %d", height)
+
+	for _, tc := range []struct {
+		name   string
+		client *rpcclient.Client
+	}{{"bridge[0]", clientA}, {"bridge[1]", clientB}} {
+		nsData, err := tc.client.Share.GetNamespaceData(ctx, height, absentNs)
+		s.Require().NoError(err, "%s GetNamespaceData should not error for an absent namespace", tc.name)
+		s.Assert().True(nsData.IsEmpty(), "%s should return empty namespace data for an absent namespace", tc.name)
+
+		blobs, err := tc.client.Blob.GetAll(ctx, height, []share.Namespace{absentNs})
+		s.Require().NoError(err, "%s Blob.GetAll should not error for an absent namespace", tc.name)
+		s.Assert().Empty(blobs, "%s Blob.GetAll should return no blobs for an absent namespace", tc.name)
+
+		_, err = tc.client.Blob.Get(ctx, height, absentNs, bytes.Repeat([]byte{0xFF}, 32))
+		s.Require().Error(err, "%s Blob.Get should error for an absent blob", tc.name)
+		s.Assert().Contains(err.Error(), nodeblob.ErrBlobNotFound.Error(), "%s should report blob-not-found", tc.name)
+	}
+}

--- a/nodebuilder/tests/tastora/shrex_test.go
+++ b/nodebuilder/tests/tastora/shrex_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/celestiaorg/celestia-app/v9/pkg/da"
 	"github.com/celestiaorg/go-square/v4/share"
 
 	rpcclient "github.com/celestiaorg/celestia-node/api/rpc/client"
@@ -71,15 +70,12 @@ func (s *P2PTestSuite) TestBridgeServesSharesOverShrex() {
 	shareA, err := clientA.Share.GetShare(ctx, height, 0, 0)
 	s.Require().NoError(err, "bridge[0] should serve share (0,0)")
 
-	dah, err := da.NewDataAvailabilityHeader(edsA)
-	s.Require().NoError(err, "err building DAH")
-
 	row, err := clientA.Share.GetRow(ctx, height, 0)
 	s.Require().NoError(err, "bridge[0] should serve row 0")
 	rowShares, err := row.Shares()
 	s.Require().NoError(err, "row should reconstruct its shares")
 	s.Assert().Len(rowShares, width, "row 0 should hold a full EDS-width row of shares")
-	s.Require().NoError(row.Verify(dah, 0), "bridge[0] invalid row at index 0")
+	s.Require().NoError(row.Verify(hdr.DAH, 0), "bridge[0] invalid row at index 0")
 
 	rng, err := clientA.Share.GetRange(ctx, height, 0, 1)
 	s.Require().NoError(err, "bridge[0] should serve a share range")
@@ -90,7 +86,7 @@ func (s *P2PTestSuite) TestBridgeServesSharesOverShrex() {
 	nsDataA, err := clientA.Share.GetNamespaceData(ctx, height, namespace)
 	s.Require().NoError(err, "bridge[0] should serve namespace data")
 	s.Require().NotEmpty(nsDataA.Flatten(), "namespace data should contain the submitted blob shares")
-	s.Require().NoError(nsDataA.Verify(dah, namespace), "bridge[0] proof veirification failed")
+	s.Require().NoError(nsDataA.Verify(hdr.DAH, namespace), "bridge[0] proof verification failed")
 
 	// same height retrieved on B (peered to A) returns byte-identical shares.
 	_, err = clientB.Header.WaitForHeight(ctx, height)
@@ -111,7 +107,7 @@ func (s *P2PTestSuite) TestBridgeServesSharesOverShrex() {
 	nsDataB, err := clientB.Share.GetNamespaceData(ctx, height, namespace)
 	s.Require().NoError(err, "bridge[1] should serve namespace data")
 	s.Assert().Equal(nsDataA.Flatten(), nsDataB.Flatten(), "namespace data should match across bridges")
-	s.Require().NoError(nsDataB.Verify(dah, namespace), "bridge[1] proof veirification failed")
+	s.Require().NoError(nsDataB.Verify(hdr.DAH, namespace), "bridge[1] proof verification failed")
 }
 
 func (s *P2PTestSuite) TestNoPeerHasData() {

--- a/share/availability/window.go
+++ b/share/availability/window.go
@@ -37,7 +37,7 @@ func ResolveWindow(window time.Duration) time.Duration {
 		return window
 	}
 	overrideLogOnce.Do(func() {
-		log.Infow("availability window overridden by", "env", overrideWindowEnv, "window", duration)
+		log.Infow("availability window overridden", "env", overrideWindowEnv, "window", duration)
 	})
 	return duration
 }

--- a/share/availability/window.go
+++ b/share/availability/window.go
@@ -3,7 +3,10 @@ package availability
 import (
 	"errors"
 	"os"
+	"sync"
 	"time"
+
+	logging "github.com/ipfs/go-log/v2"
 )
 
 const (
@@ -12,18 +15,38 @@ const (
 	StorageWindow  = RequestWindow + time.Hour
 )
 
-var ErrOutsideSamplingWindow = errors.New("timestamp outside sampling window")
+// overrideWindowEnv shrinks (or grows) the availability window for every consumer:
+// sampling, header routing and pruning.
+const overrideWindowEnv = "CELESTIA_OVERRIDE_AVAILABILITY_WINDOW"
+
+var (
+	log                      = logging.Logger("share/availability")
+	overrideLogOnce          sync.Once
+	ErrOutsideSamplingWindow = errors.New("timestamp outside sampling window")
+)
+
+// ResolveWindow returns window or the CELESTIA_OVERRIDE_AVAILABILITY_WINDOW value
+// when that env var is set to a valid duration.
+func ResolveWindow(window time.Duration) time.Duration {
+	durationRaw, ok := os.LookupEnv(overrideWindowEnv)
+	if !ok {
+		return window
+	}
+	duration, err := time.ParseDuration(durationRaw)
+	if err != nil {
+		return window
+	}
+	overrideLogOnce.Do(func() {
+		log.Infow("availability window overridden by", "env", overrideWindowEnv, "window", duration)
+	})
+	return duration
+}
 
 // IsWithinWindow checks whether the given timestamp is within the
 // given AvailabilityWindow. If the window is disabled (0), it returns true for
 // every timestamp.
 func IsWithinWindow(t time.Time, window time.Duration) bool {
-	// check for environment variable override
-	if durationRaw, ok := os.LookupEnv("CELESTIA_OVERRIDE_AVAILABILITY_WINDOW"); ok {
-		if duration, err := time.ParseDuration(durationRaw); err == nil {
-			window = duration
-		}
-	}
+	window = ResolveWindow(window)
 	if window == time.Duration(0) {
 		return true
 	}


### PR DESCRIPTION
Added the following tests:

- TestRestartPersistence — checks that a bridge survives a container restart: the store returns byte-identical header+DAH, SharesAvailable still hits the local EDS, the DASer resumes without regressing SampledChainHead, and the chain keeps advancing.
- TestArchivalNodeKeepsData — verifies an archival bridge (--archival, pruner off) retains data past the availability window: an early height still serves header+DAH, SharesAvailable, GetEDS, and a Blob.Get round-trip 30 blocks later.
- TestBridgeCoreUnreachable — ensures a bridge with an unroutable --core.ip (192.0.2.1) terminates within ≤4 min (not an infinite hang), with a non-zero exit code and failed to start in its logs.
- TestHeaderLiveSync — verifies WS Header.Subscribe produces a live chain: 5 events, strictly increasing heights, non-empty DAH in each.
- TestHeaderSubscribe — checks that every header from the subscription matches GetByHeight by hash at the same height (canonical, retrievable).
- TestBlobSubscribe — ensures WS Blob.Subscribe delivers the submitted blob (matched by commitment).
- TestLargeBlock — verifies a large blob (~256 KiB) grows the EDS across multiple rows (RowRoots > MinSquareSize*2), SharesAvailable passes, and Blob.Get round-trips the payload.
- TestErrorPaths — checks that RPC for a future height and height 0 returns a clean, bounded error immediately (no hang).
- TestBasicDASFlow — verifies "core-less, shrex-only DAS": a light node (bitswap off) samples over shrex only; WaitCatchUp + SamplingStats confirm CatchUpDone, zero Failed, SampledChainHead ≥ blob height; plus an explicit SharesAvailable and a GetEDS content-match against the bridge.
- TestLightNodeResumesSamplingAfterRestart — ensures the light DASer resumes from its checkpoint after a container restart: the header store survives, SampledChainHead does not regress to genesis, zero Failed, and it keeps sampling blocks produced after the restart.
- TestP2PBridgeToBridge — checks that two bridges are mutually Connected and present in each other's peer set (both directions).
- TestBridgeServesSharesOverShrex — verifies bridge A's full Share API (GetShare/GetEDS/GetRow/GetRange+proof/GetNamespaceData), and that the peered bridge B returns byte-identical shares (cross-node consistency).
- TestNoPeerHasData — checks the "no data" contracts: a never-written namespace → empty NamespaceData (IsEmpty), empty Blob.GetAll, Blob.Get → blob: not found error; all return instantly, no hang.
- TestBridgeCatchupViaShrex — verifies the shrex-as-client path: a small-window bridge B backfills an out-of-window gap block whose EDS storeEDS drops locally, so SharesAvailable(gap) → ErrOutsideSamplingWindow while GetEDS(gap) content-matches archival peer A (a forced shrex fetch).
- TestBridgeCoreFailover (4 validators / 1 bridge) — verifies two-way multi-source failover: kill the primary core → head advances from the additional endpoint; restore the primary + kill the additional → head advances from the recovered primary.
- BlobTestSuite (7 tests) — covers the Blob module

Resolves https://linear.app/celestia/issue/PROTOCO-2091/testing-add-missing-e2e-tests