### PR TITLE
 fix(share/shrex): fail fast(er) on unreachable peers

### DIFF
--- a/share/shwap/p2p/shrex/client.go
+++ b/share/shwap/p2p/shrex/client.go
@@ -19,6 +19,9 @@ import (
 	shrexpb "github.com/celestiaorg/celestia-node/share/shwap/p2p/shrex/pb"
 )
 
+// streamOpenTimeout bounds dialing a peer to a healthy timeout.
+var streamOpenTimeout = 5 * time.Second
+
 // Client implements client side of shrex protocol to obtain data from remote
 // peers.
 type Client struct {
@@ -86,7 +89,7 @@ func (c *Client) doRequest(
 	resp response,
 	peer peer.ID,
 ) (int64, status, error) {
-	streamOpenCtx, cancel := context.WithTimeout(ctx, c.params.ReadTimeout)
+	streamOpenCtx, cancel := context.WithTimeout(ctx, streamOpenTimeout)
 	defer cancel()
 
 	var err error

--- a/share/shwap/p2p/shrex/client_test.go
+++ b/share/shwap/p2p/shrex/client_test.go
@@ -1,0 +1,45 @@
+package shrex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v4/share"
+
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+// TestClient_StreamOpenTimeout tests that a peer stalling on stream open fails
+// fast, freeing the request budget for other peers instead of hanging until the
+// caller's context expires.
+func TestClient_StreamOpenTimeout(t *testing.T) {
+	streamOpenTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { streamOpenTimeout = 5 * time.Second })
+
+	net, err := mocknet.FullMeshLinked(2)
+	require.NoError(t, err)
+	hosts := net.Hosts()
+
+	// Latency well above streamOpenTimeout stalls the stream open.
+	for _, link := range net.LinksBetweenPeers(hosts[0].ID(), hosts[1].ID()) {
+		link.SetOptions(mocknet.LinkOptions{Latency: time.Minute})
+	}
+
+	client, err := NewClient(DefaultClientParameters(), hosts[0])
+	require.NoError(t, err)
+
+	id, err := shwap.NewNamespaceDataID(1, libshare.RandomNamespace())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	err = client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
+	require.ErrorContains(t, err, "open stream")
+	require.Less(t, time.Since(start), 2*time.Second)
+}


### PR DESCRIPTION
Stream open (dial) was deadlined off `ClientParams.ReadTimeout` (2m), a dial to a dead peer took 60s and consumed the getter's entire ~80s request budget, leaving ~1 attempt per request. 

**This PR gives stream open its own 5s deadline**;  but `ReadTimeout` still applies to the body read.

First low-hanging fruit item of V1 in [PROTOCO-2120](https://linear.app/celestia/issue/PROTOCO-2120/speed-up-eds-sync).

**TODO**
- [ ] run tastora tests