### PR TITLE
 fix(share/shwap/p2p/shrex/peers): disconnect peers that fail every request

### DIFF
--- a/share/shwap/p2p/shrex/client.go
+++ b/share/shwap/p2p/shrex/client.go
@@ -19,6 +19,9 @@ import (
 	shrexpb "github.com/celestiaorg/celestia-node/share/shwap/p2p/shrex/pb"
 )
 
+// streamOpenTimeout bounds dialing a peer to a healthy timeout.
+var streamOpenTimeout = 5 * time.Second
+
 // Client implements client side of shrex protocol to obtain data from remote
 // peers.
 type Client struct {
@@ -86,7 +89,7 @@ func (c *Client) doRequest(
 	resp response,
 	peer peer.ID,
 ) (int64, status, error) {
-	streamOpenCtx, cancel := context.WithTimeout(ctx, c.params.ReadTimeout)
+	streamOpenCtx, cancel := context.WithTimeout(ctx, streamOpenTimeout)
 	defer cancel()
 
 	var err error

--- a/share/shwap/p2p/shrex/client_test.go
+++ b/share/shwap/p2p/shrex/client_test.go
@@ -1,0 +1,45 @@
+package shrex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v4/share"
+
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+// TestClient_StreamOpenTimeout tests that a peer stalling on stream open fails
+// fast, freeing the request budget for other peers instead of hanging until the
+// caller's context expires.
+func TestClient_StreamOpenTimeout(t *testing.T) {
+	streamOpenTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { streamOpenTimeout = 5 * time.Second })
+
+	net, err := mocknet.FullMeshLinked(2)
+	require.NoError(t, err)
+	hosts := net.Hosts()
+
+	// Latency well above streamOpenTimeout stalls the stream open.
+	for _, link := range net.LinksBetweenPeers(hosts[0].ID(), hosts[1].ID()) {
+		link.SetOptions(mocknet.LinkOptions{Latency: time.Minute})
+	}
+
+	client, err := NewClient(DefaultClientParameters(), hosts[0])
+	require.NoError(t, err)
+
+	id, err := shwap.NewNamespaceDataID(1, libshare.RandomNamespace())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	err = client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
+	require.ErrorContains(t, err, "open stream")
+	require.Less(t, time.Since(start), 2*time.Second)
+}

--- a/share/shwap/p2p/shrex/peers/manager.go
+++ b/share/shwap/p2p/shrex/peers/manager.go
@@ -312,7 +312,7 @@ func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID, source peerS
 			m.resetStrikes(peerID)
 		case ResultCooldownPeer:
 			if m.strike(peerID) >= peerStrikeLimit {
-				m.kickPeer(peerID)
+				m.kickPeer(peerID, source)
 				return
 			}
 			if source == sourceDiscoveredNodes {
@@ -351,9 +351,10 @@ func (m *Manager) resetStrikes(peerID peer.ID) {
 // kickPeer removes the peer from the nodes pool and disconnects from it. Disconnecting makes
 // discovery drop the peer and back off from redialing it, keeping a peer that fails every
 // request out of rotation for minutes instead of the seconds a cooldown gives.
-func (m *Manager) kickPeer(peerID peer.ID) {
+func (m *Manager) kickPeer(peerID peer.ID, source peerSource) {
 	log.Warnw("disconnecting peer after consecutive failed requests",
-		"peer", peerID.String(), "strikes", peerStrikeLimit)
+		"peer", peerID.String(), "source", source, "strikes", peerStrikeLimit)
+	m.metrics.observeKickPeer(source)
 	m.resetStrikes(peerID)
 	m.nodes.remove(peerID)
 	if err := m.host.Network().ClosePeer(peerID); err != nil {

--- a/share/shwap/p2p/shrex/peers/manager.go
+++ b/share/shwap/p2p/shrex/peers/manager.go
@@ -47,6 +47,14 @@ const (
 	// The blacklist is a best-effort spam filter, so evicting the least-recently-used entries
 	// is acceptable and prevents unbounded growth from a stream of invalid datahashes.
 	blacklistedHashesCacheSize = 1024
+
+	// peerStrikeLimit is the amount of consecutive failed requests after which a peer is
+	// disconnected instead of being put on cooldown. Cooldown only keeps a peer out of
+	// rotation for seconds, which is not enough for a peer that fails every request.
+	peerStrikeLimit = 3
+
+	// peerStrikesCacheSize bounds the number of peers with recorded failures kept in memory.
+	peerStrikesCacheSize = 1024
 )
 
 type result string
@@ -82,6 +90,9 @@ type Manager struct {
 
 	// hashes that are not in the chain, bounded by an LRU to avoid unbounded growth
 	blacklistedHashes *lru.Cache[string, struct{}]
+
+	// strikes counts consecutive failed requests per peer, bounded by an LRU as peers churn
+	strikes *lru.Cache[peer.ID, int]
 
 	metrics *metrics
 
@@ -122,12 +133,18 @@ func NewManager(
 		return nil, fmt.Errorf("shrex/peer-manager: creating blacklisted hashes cache: %w", err)
 	}
 
+	strikes, err := lru.New[peer.ID, int](peerStrikesCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("shrex/peer-manager: creating peer strikes cache: %w", err)
+	}
+
 	s := &Manager{
 		params:                params,
 		connGater:             connGater,
 		host:                  host,
 		pools:                 make(map[string]*syncPool),
 		blacklistedHashes:     blacklistedHashes,
+		strikes:               strikes,
 		headerSubDone:         make(chan struct{}),
 		disconnectedPeersDone: make(chan struct{}),
 		tag:                   tag,
@@ -292,7 +309,12 @@ func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID, source peerS
 		m.metrics.observeDoneResult(source, result)
 		switch result {
 		case ResultNoop:
+			m.resetStrikes(peerID)
 		case ResultCooldownPeer:
+			if m.strike(peerID) >= peerStrikeLimit {
+				m.kickPeer(peerID)
+				return
+			}
 			if source == sourceDiscoveredNodes {
 				m.nodes.putOnCooldown(peerID)
 				return
@@ -306,6 +328,36 @@ func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID, source peerS
 		case ResultBlacklistPeer:
 			m.blacklistPeers(reasonMisbehave, peerID)
 		}
+	}
+}
+
+// strike records a failed request for the peer and reports the amount of consecutive failures.
+func (m *Manager) strike(peerID peer.ID) int {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	strikes, _ := m.strikes.Get(peerID)
+	strikes++
+	m.strikes.Add(peerID, strikes)
+	return strikes
+}
+
+func (m *Manager) resetStrikes(peerID peer.ID) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.strikes.Remove(peerID)
+}
+
+// kickPeer removes the peer from the nodes pool and disconnects from it. Disconnecting makes
+// discovery drop the peer and back off from redialing it, keeping a peer that fails every
+// request out of rotation for minutes instead of the seconds a cooldown gives.
+func (m *Manager) kickPeer(peerID peer.ID) {
+	log.Warnw("disconnecting peer after consecutive failed requests",
+		"peer", peerID.String(), "strikes", peerStrikeLimit)
+	m.resetStrikes(peerID)
+	m.nodes.remove(peerID)
+	if err := m.host.Network().ClosePeer(peerID); err != nil {
+		log.Warnw("failed to close connection with peer", "peer", peerID.String(), "err", err)
 	}
 }
 

--- a/share/shwap/p2p/shrex/peers/manager_test.go
+++ b/share/shwap/p2p/shrex/peers/manager_test.go
@@ -491,6 +491,72 @@ func TestManager_blacklistedHashesBounded(t *testing.T) {
 		"blacklisted hashes cache must stay bounded")
 }
 
+// TestManager_kickPeerAfterStrikes tests that a peer failing peerStrikeLimit consecutive
+// requests is dropped from the nodes pool instead of returning to rotation after each
+// cooldown, and that a successful request in between clears its accumulated failures.
+func TestManager_kickPeerAfterStrikes(t *testing.T) {
+	peerID := peer.ID("peer1")
+
+	t.Run("kicked after limit", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		t.Cleanup(cancel)
+
+		h := testHeader()
+		manager, err := testManager(ctx, newSubLock(h, nil))
+		require.NoError(t, err)
+		manager.UpdateNodePool(peerID, true)
+
+		for range peerStrikeLimit - 1 {
+			failRequest(ctx, t, manager, h, peerID)
+			require.True(t, manager.nodes.has(peerID))
+			// skip the cooldown wait to keep the peer available for the next attempt
+			manager.nodes.afterCooldown(peerID)
+		}
+
+		failRequest(ctx, t, manager, h, peerID)
+		require.False(t, manager.nodes.has(peerID),
+			"peer must be dropped from the pool after %d strikes", peerStrikeLimit)
+		stopManager(t, manager)
+	})
+
+	t.Run("strikes reset on success", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		t.Cleanup(cancel)
+
+		h := testHeader()
+		manager, err := testManager(ctx, newSubLock(h, nil))
+		require.NoError(t, err)
+		manager.UpdateNodePool(peerID, true)
+
+		for range peerStrikeLimit * 2 {
+			failRequest(ctx, t, manager, h, peerID)
+			manager.nodes.afterCooldown(peerID)
+
+			pID, done, err := manager.Peer(ctx, h.DataHash.Bytes(), h.Height())
+			require.NoError(t, err)
+			require.Equal(t, peerID, pID)
+			done(ResultNoop)
+		}
+
+		require.True(t, manager.nodes.has(peerID),
+			"peer with intermittent failures must stay in the pool")
+		stopManager(t, manager)
+	})
+}
+
+func failRequest(
+	ctx context.Context,
+	t *testing.T,
+	manager *Manager,
+	h *header.ExtendedHeader,
+	expected peer.ID,
+) {
+	pID, done, err := manager.Peer(ctx, h.DataHash.Bytes(), h.Height())
+	require.NoError(t, err)
+	require.Equal(t, expected, pID)
+	done(ResultCooldownPeer)
+}
+
 func testManager(ctx context.Context, headerSub libhead.Subscriber[*header.ExtendedHeader]) (*Manager, error) {
 	host, err := mocknet.New().GenPeer()
 	if err != nil {

--- a/share/shwap/p2p/shrex/peers/metrics.go
+++ b/share/shwap/p2p/shrex/peers/metrics.go
@@ -63,6 +63,7 @@ type metrics struct {
 	getPeerPoolSizeHistogram metric.Int64Histogram // attributes: source
 	doneResult               metric.Int64Counter   // attributes: source, done_result
 	validationResult         metric.Int64Counter   // attributes: validation_result
+	kickedPeers              metric.Int64Counter   // attributes: source
 
 	shrexPools               metric.Int64ObservableGauge // attributes: pool_status
 	discoveredPool           metric.Int64ObservableGauge // attributes: pool_status
@@ -107,6 +108,12 @@ func initMetrics(manager *Manager) (*metrics, error) {
 		return nil, err
 	}
 
+	kickedPeers, err := meter.Int64Counter(manager.tag+"_peer_manager_kicked_peers_counter",
+		metric.WithDescription("peers disconnected after consecutive failed requests counter"))
+	if err != nil {
+		return nil, err
+	}
+
 	shrexPools, err := meter.Int64ObservableGauge(manager.tag+"_peer_manager_pools_gauge",
 		metric.WithDescription("pools amount"))
 	if err != nil {
@@ -132,6 +139,7 @@ func initMetrics(manager *Manager) (*metrics, error) {
 		getPeerWaitTimeHistogram: getPeerWaitTimeHistogram,
 		doneResult:               doneResult,
 		validationResult:         validationResult,
+		kickedPeers:              kickedPeers,
 		shrexPools:               shrexPools,
 		discoveredPool:           discoveredPool,
 		getPeerPoolSizeHistogram: getPeerPoolSizeHistogram,
@@ -212,6 +220,17 @@ func (m *metrics) observeDoneResult(source peerSource, result result) {
 		metric.WithAttributes(
 			attribute.String(sourceKey, string(source)),
 			attribute.String(doneResultKey, string(result))))
+}
+
+// observeKickPeer counts peers disconnected for failing peerStrikeLimit consecutive requests
+func (m *metrics) observeKickPeer(source peerSource) {
+	if m == nil {
+		return
+	}
+
+	m.kickedPeers.Add(context.Background(), 1,
+		metric.WithAttributes(
+			attribute.String(sourceKey, string(source))))
 }
 
 // validationObserver is a middleware that observes validation results as metrics


### PR DESCRIPTION
When a peer is put on cooldown, it can re-enter peer rotation almost immediately (3s) after they were put on cooldown, and with a 5-peer pool, this could happen frequently (wasting requests on an less responsive peer).

This PR implements a solution to count consecutive failed requests per peer and, at `peerStrikeLimit`, remove the peer from the nodes pool and close the connection instead of cooling it down. 

Rules:
* A successful request clears the count, so only peers that fail every request are kicked. 
* The disconnect makes discovery discard the peer and back off from redialing it for 10 minutes, while its 1s loop looks for a replacement, so the peer stays out of rotation for minutes rather than
seconds. 
* Strikes are held in a bounded LRU as peers churn.