### PR TITLE
ci(deps): group Dependabot updates and auto-tidy go.mod on bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
         applies-to: version-updates
         update-types:
           - "patch"
-  - package-ecosystem: gomod
+  - package-ecosystem: "gomod"
     directories:
       - "/"
       - "/nodebuilder/tests/tastora"
@@ -22,23 +22,42 @@ updates:
       interval: weekly
       day: monday
       time: "11:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
-      - Wondertan
       - renaynay
+      - vgonkivs
     labels:
       - kind:deps
+    # Major bumps need import-path rewrites, so keep them manual.
     ignore:
-      - dependency-name: "*otel*"
-        update-types: ["version-update:semver-patch"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
-      patch-updates:
+      # Narrow group first: a dep lands in the first group whose pattern matches.
+      # libp2p and its multiformats primitives break far more often than the
+      # rest, so isolate them — a broken libp2p bump must not block the batch.
+      libp2p:
         applies-to: version-updates
-        update-types:
-          - "patch"
-      otel:
         patterns:
-          - "go.opentelemetry.io/otel*"
+          - "github.com/libp2p/*"
+          - "github.com/multiformats/*"
+          - "github.com/celestiaorg/go-libp2p-messenger"
+        update-types:
+          - "minor"
+          - "patch"
+      # exclude-patterns MUST stay identical to the libp2p patterns above,
+      # otherwise those deps get duplicated across both PRs.
+      go-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github.com/libp2p/*"
+          - "github.com/multiformats/*"
+          - "github.com/celestiaorg/go-libp2p-messenger"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot-gomod-tidy.yml
+++ b/.github/workflows/dependabot-gomod-tidy.yml
@@ -1,0 +1,58 @@
+name: Dependabot Go Mod Tidy
+
+# Dependabot edits go.mod/go.sum in place and never runs `go mod tidy`, so
+# indirect requires drift and the go_mod_tidy_check / go_mod_parity_check jobs
+# fail on every bot PR. This workflow runs `go mod tidy` across every module on
+# Dependabot PRs and pushes the fixup back onto the PR branch with the built-in
+# GITHUB_TOKEN (elevated to contents: write below).
+
+on:
+  pull_request:
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  tidy:
+    name: Tidy all Go modules
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Run go mod tidy in every module
+        run: |
+          find . -name go.mod -not -path '*/vendor/*' -print0 | while IFS= read -r -d '' modfile; do
+            dir=$(dirname "$modfile")
+            echo "::group::go mod tidy in $dir"
+            ( cd "$dir" && go mod tidy )
+            echo "::endgroup::"
+          done
+
+      - name: Commit and push fixup if anything changed
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if git diff --quiet; then
+            echo "all modules already tidy — nothing to do"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore(deps): go mod tidy after dependabot bump"
+          git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/dependabot-gomod-tidy.yml
+++ b/.github/workflows/dependabot-gomod-tidy.yml
@@ -5,6 +5,10 @@ name: Dependabot Go Mod Tidy
 # fail on every bot PR. This workflow runs `go mod tidy` across every module on
 # Dependabot PRs and pushes the fixup back onto the PR branch with the built-in
 # GITHUB_TOKEN (elevated to contents: write below).
+#
+# checkout uses persist-credentials: false so the token is never left in
+# .git/config while `go mod tidy` runs; it is supplied explicitly only for the
+# final push.
 
 on:
   pull_request:
@@ -30,6 +34,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
+          persist-credentials: false
 
       - uses: actions/setup-go@v7
         with:
@@ -47,6 +52,8 @@ jobs:
       - name: Commit and push fixup if anything changed
         env:
           HEAD_REF: ${{ github.head_ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           if git diff --quiet; then
             echo "all modules already tidy — nothing to do"
@@ -55,4 +62,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "chore(deps): go mod tidy after dependabot bump"
-          git push origin "HEAD:$HEAD_REF"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:$HEAD_REF"


### PR DESCRIPTION
One more attempt to fix dependabot 😄 

.github/dependabot.yml — switched the gomod ecosystem to grouped version-updates across both modules (/ and /nodebuilder/tests/tastora):
- go-deps group — all minor/patch updates in a single PR;
- libp2p group — github.com/libp2p/*, github.com/multiformats/*, and github.com/celestiaorg/go-libp2p-messenger isolated into their own PR;
- major updates are ignored (kept manual); PR limit 5, weekly.

.github/workflows/dependabot-gomod-tidy.yml (new) — Dependabot never runs go mod tidy, so indirect requires drift (worsened here by the local replace into the tastora module) and the go_mod_tidy_check / go_mod_parity_check jobs fail on every bot PR. This workflow runs go mod tidy across every go.mod on Dependabot PRs and pushes the fixup back onto the PR branch using the built-in GITHUB_TOKEN (elevated to contents: write). After the fixup, the required go-ci checks need a manual re-run (a GITHUB_TOKEN push doesn't re-trigger them) — an accepted trade-off for not requiring a GitHub App token.


Tested locally in my fork.