### PR TITLE
chore: remove stray .claude worktree gitlink breaking CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ coverage.txt
 go.work
 go.work.sum
 .claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
A Claude worktree dir was committed as a gitlink (mode 160000) in #4853; with no .gitmodules entry it breaks actions/checkout submodule cleanup. Drop it and ignore .claude/worktrees/ to prevent recurrence.