### PR TITLE
perf(nodebuilder/config): Increase `PeersLimit` based on DASer `ConcurrencyLimit`

### DIFF
--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -38,7 +38,7 @@ type Config struct {
 // DefaultConfig provides a default Config for a given Node Type 'tp'.
 // NOTE: Currently, configs are identical, but this will change.
 func DefaultConfig(tp node.Type) *Config {
-	return &Config{
+	cfg := &Config{
 		Node:   node.DefaultConfig(tp),
 		Core:   core.DefaultConfig(),
 		State:  state.DefaultConfig(),
@@ -48,6 +48,9 @@ func DefaultConfig(tp node.Type) *Config {
 		Header: header.DefaultConfig(tp),
 		DASer:  das.DefaultConfig(tp),
 	}
+	// set discovered peers limit according to concurrency limit
+	cfg.Share.Discovery.PeersLimit = min(30, max(10, uint(cfg.DASer.ConcurrencyLimit)))
+	return cfg
 }
 
 // SaveConfig saves Config 'cfg' under the given 'path'.

--- a/nodebuilder/share/p2p_constructors.go
+++ b/nodebuilder/share/p2p_constructors.go
@@ -129,8 +129,7 @@ func archivalDiscoveryAndPeerManager(cfg *Config) fx.Option {
 
 			// archival peers are a small subset of the network, so we limit
 			// the number of peers to discover to 5
-			archivalParams := *cfg.Discovery
-			archivalParams.PeersLimit = min(archivalParams.PeersLimit, 5)
+			archivalParams := limitArchivalPeers(*cfg.Discovery)
 
 			archivalDisc, err := discovery.NewDiscovery(
 				&archivalParams,
@@ -151,6 +150,11 @@ func archivalDiscoveryAndPeerManager(cfg *Config) fx.Option {
 			managers := map[string]*peers.Manager{fullNodesTag: fullManager, archivalNodesTag: archivalPeerManager}
 			return managers, []*discovery.Discovery{fullDisc, archivalDisc}, nil
 		})
+}
+
+func limitArchivalPeers(params discovery.Parameters) discovery.Parameters {
+	params.PeersLimit = min(params.PeersLimit, 5)
+	return params
 }
 
 func routingDiscovery(dht *dht.IpfsDHT) p2pdisc.Discovery {

--- a/nodebuilder/share/p2p_constructors.go
+++ b/nodebuilder/share/p2p_constructors.go
@@ -127,8 +127,13 @@ func archivalDiscoveryAndPeerManager(cfg *Config) fx.Option {
 				discOpts = append(discOpts, discOpt)
 			}
 
+			// archival peers are a small subset of the network, so we limit
+			// the number of peers to discover to 5
+			archivalParams := *cfg.Discovery
+			archivalParams.PeersLimit = min(archivalParams.PeersLimit, 5)
+
 			archivalDisc, err := discovery.NewDiscovery(
-				cfg.Discovery,
+				&archivalParams,
 				h,
 				disc,
 				archivalNodesTag,

--- a/nodebuilder/share/p2p_constructors_test.go
+++ b/nodebuilder/share/p2p_constructors_test.go
@@ -1,0 +1,20 @@
+package share
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/share/shwap/p2p/discovery"
+)
+
+func TestLimitArchivalPeers(t *testing.T) {
+	params := discovery.Parameters{PeersLimit: 10}
+	limited := limitArchivalPeers(params)
+	require.Equal(t, uint(5), limited.PeersLimit)
+	require.Equal(t, uint(10), params.PeersLimit)
+
+	params.PeersLimit = 3
+	limited = limitArchivalPeers(params)
+	require.Equal(t, uint(3), limited.PeersLimit)
+}

--- a/share/shwap/p2p/discovery/options.go
+++ b/share/shwap/p2p/discovery/options.go
@@ -10,6 +10,8 @@ import (
 // Parameters is the set of Parameters that must be configured for the Discovery module
 type Parameters struct {
 	// PeersLimit defines the soft limit of FNs to connect to via discovery.
+	// Node defaults derive this from the DASer's ConcurrencyLimit so that
+	// parallel sampling workers are not bottlenecked on a small peer set.
 	// Set 0 to disable.
 	PeersLimit uint
 	// AdvertiseInterval is a interval between advertising sessions.
@@ -33,7 +35,7 @@ type Option func(*options)
 // for the Discovery module
 func DefaultParameters() *Parameters {
 	return &Parameters{
-		PeersLimit:        5,
+		PeersLimit:        10,
 		AdvertiseInterval: time.Hour,
 	}
 }

--- a/specs/src/shrex/shrex.md
+++ b/specs/src/shrex/shrex.md
@@ -570,9 +570,11 @@ The discovery service operates with the following configurable parameters:
 #### PeersLimit
 
 - **Type**: Integer
-- **Default**: 5
-- **Purpose**: Maximum number of peers to maintain in the active peer set
-- **Rationale**: Limits resource consumption while ensuring sufficient peer diversity for data availability
+- **Discovery parameter default**: 10
+- **Full-node peer limit**: Node defaults use the DASer `ConcurrencyLimit`, with a minimum of 10 and a maximum of 30
+- **Archival-node peer limit**: Uses the configured `PeersLimit`, with a maximum of 5
+- **Purpose**: Sets the soft limit for each active peer set
+- **Rationale**: Full node discovery supports concurrent sampling. Current networks have few openly discoverable archival nodes. A limit of 5 is sufficient until networks have more archival nodes.
 
 #### AdvertiseInterval
 


### PR DESCRIPTION
Increasing the `PeersLimit` will help bridge nodes have a better chance of maintaining better performing peers in its node pool instead of arbitrarily limiting the # of peers it can discover.

TODO: 
- [x] potentially decouple archival peers lim from full