### PR TITLE
perf(share/discovery): Exponential backoff on peer loss

### DIFF
--- a/share/shwap/p2p/discovery/backoff.go
+++ b/share/shwap/p2p/discovery/backoff.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -16,11 +17,20 @@ const (
 	gcInterval = time.Minute
 	// connectTimeout is the timeout used for dialing peers and discovering peer addresses.
 	connectTimeout = time.Minute * 2
+
+	// minBackoff and maxBackoff bound the backoff applied to a peer on connection
+	// failure or loss. The delay is minBackoff*backoffBase^failures, capped at maxBackoff.
+	minBackoff = time.Second * 10
+	maxBackoff = time.Minute * 10
+	// backoffBase is the base of the exponent growing the delay per failure.
+	backoffBase = 2
 )
 
 var (
-	defaultBackoffFactory = backoff.NewFixedBackoff(time.Minute * 10)
-	errBackoffNotEnded    = errors.New("share/discovery: backoff period has not ended")
+	defaultBackoffFactory = backoff.NewExponentialBackoff(
+		minBackoff, maxBackoff, backoff.NoJitter, minBackoff, backoffBase, 0, rand.NewSource(0),
+	)
+	errBackoffNotEnded = errors.New("share/discovery: backoff period has not ended")
 )
 
 // backoffConnector wraps a libp2p.Host to establish a connection with peers
@@ -57,6 +67,10 @@ func (b *backoffConnector) Connect(ctx context.Context, p peer.AddrInfo) error {
 	defer cancel()
 
 	err := b.h.Connect(ctx, p)
+	if err == nil {
+		// a reachable peer should not carry the delay accumulated by past failures
+		b.reset(p.ID)
+	}
 	// we don't want to add backoff when the context is canceled.
 	if !errors.Is(err, context.Canceled) {
 		b.Backoff(p.ID)
@@ -80,6 +94,16 @@ func (b *backoffConnector) Backoff(p peer.ID) {
 	b.cacheData[p] = data
 }
 
+// reset restarts the peer's delay growth from minBackoff.
+func (b *backoffConnector) reset(p peer.ID) {
+	b.cacheLk.Lock()
+	defer b.cacheLk.Unlock()
+
+	if data, ok := b.cacheData[p]; ok {
+		data.backoff.Reset()
+	}
+}
+
 // HasBackoff checks if peer is in backoff.
 func (b *backoffConnector) HasBackoff(p peer.ID) bool {
 	b.cacheLk.Lock()
@@ -98,13 +122,20 @@ func (b *backoffConnector) GC(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			b.cacheLk.Lock()
-			for id, cache := range b.cacheData {
-				if cache.nexttry.Before(time.Now()) {
-					delete(b.cacheData, id)
-				}
-			}
-			b.cacheLk.Unlock()
+			b.gc()
+		}
+	}
+}
+
+// gc drops peers that have been out of backoff for longer than maxBackoff. The grace
+// period keeps the accumulated delay of a repeatedly failing peer from being forgotten.
+func (b *backoffConnector) gc() {
+	b.cacheLk.Lock()
+	defer b.cacheLk.Unlock()
+
+	for id, cache := range b.cacheData {
+		if time.Now().After(cache.nexttry.Add(maxBackoff)) {
+			delete(b.cacheData, id)
 		}
 	}
 }

--- a/share/shwap/p2p/discovery/backoff_test.go
+++ b/share/shwap/p2p/discovery/backoff_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/discovery/backoff"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
@@ -44,4 +45,69 @@ func TestBackoff_ResetBackoffPeriod(t *testing.T) {
 	nexttry := b.cacheData[info.ID].nexttry
 	b.Backoff(info.ID)
 	require.True(t, b.cacheData[info.ID].nexttry.After(nexttry))
+}
+
+// TestBackoff_Exponential tests that the delay of a peer grows exponentially
+// with every failure and is capped at maxBackoff.
+func TestBackoff_Exponential(t *testing.T) {
+	b := newBackoffConnector(nil, defaultBackoffFactory)
+	id := peer.ID("peer")
+
+	for _, want := range []time.Duration{minBackoff, 2 * minBackoff, 4 * minBackoff, 8 * minBackoff} {
+		now := time.Now()
+		b.Backoff(id)
+		require.InDelta(t, want, b.cacheData[id].nexttry.Sub(now), float64(time.Second))
+	}
+
+	for range 10 {
+		b.Backoff(id)
+	}
+	now := time.Now()
+	b.Backoff(id)
+	require.InDelta(t, maxBackoff, b.cacheData[id].nexttry.Sub(now), float64(time.Second))
+}
+
+// TestBackoff_GCKeepsGrowth tests that gc retains the accumulated delay of a peer
+// for maxBackoff past its expiry and drops the peer afterwards.
+func TestBackoff_GCKeepsGrowth(t *testing.T) {
+	b := newBackoffConnector(nil, defaultBackoffFactory)
+	id := peer.ID("peer")
+	b.Backoff(id)
+
+	expire := func(d time.Duration) {
+		b.cacheData[id] = backoffData{nexttry: time.Now().Add(-d), backoff: b.cacheData[id].backoff}
+	}
+
+	expire(time.Second)
+	b.gc()
+	require.Contains(t, b.cacheData, id)
+
+	now := time.Now()
+	b.Backoff(id)
+	require.InDelta(t, 2*minBackoff, b.cacheData[id].nexttry.Sub(now), float64(time.Second))
+
+	expire(maxBackoff + time.Second)
+	b.gc()
+	require.NotContains(t, b.cacheData, id)
+}
+
+// TestBackoff_ResetOnConnect tests that a successful dial drops the peer's delay
+// back to minBackoff.
+func TestBackoff_ResetOnConnect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	t.Cleanup(cancel)
+	m, err := mocknet.FullMeshLinked(2)
+	require.NoError(t, err)
+	b := newBackoffConnector(m.Hosts()[0], defaultBackoffFactory)
+	info := host.InfoFromHost(m.Hosts()[1])
+
+	for range 5 {
+		b.Backoff(info.ID)
+	}
+	// clear the delay so that Connect is not rejected by it
+	b.cacheData[info.ID] = backoffData{backoff: b.cacheData[info.ID].backoff}
+
+	now := time.Now()
+	require.NoError(t, b.Connect(ctx, *info))
+	require.InDelta(t, minBackoff, b.cacheData[info.ID].nexttry.Sub(now), float64(time.Second))
 }


### PR DESCRIPTION
Replaces the fixed 10m discovery backoff with an exponential one: 10s doubling to a 10m cap. A peer lost transiently is re-dialable in 10s instead of being locked out for 10 minutes, which keeps the discovered peer pool from shrinking during EDS sync.

Part of PROTOCO-2120
