### PR TITLE
perf(das): reduce sampling range to reduce HOL blocking

### DIFF
--- a/das/coordinator_test.go
+++ b/das/coordinator_test.go
@@ -426,7 +426,7 @@ func (m *mockSampler) discover(ctx context.Context, newHeight uint64, emit liste
 	emit(ctx, &header.ExtendedHeader{
 		Commit:    &types.Commit{},
 		RawHeader: header.RawHeader{Height: int64(newHeight)},
-		DAH:       &share.AxisRoots{RowRoots: make([][]byte, 0)},
+		DAH:       &share.AxisRoots{RowRoots: make([][]byte, 2)},
 	})
 }
 

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -184,7 +184,7 @@ type benchGetterStub struct {
 
 func newBenchGetter() benchGetterStub {
 	return benchGetterStub{header: &header.ExtendedHeader{
-		DAH: &share.AxisRoots{RowRoots: make([][]byte, 0)},
+		DAH: &share.AxisRoots{RowRoots: make([][]byte, 2)},
 	}}
 }
 
@@ -205,7 +205,7 @@ func (m getterStub) GetByHeight(_ context.Context, height uint64) (*header.Exten
 	return &header.ExtendedHeader{
 		Commit:    &types.Commit{},
 		RawHeader: header.RawHeader{Height: int64(height)},
-		DAH:       &share.AxisRoots{RowRoots: make([][]byte, 0)},
+		DAH:       &share.AxisRoots{RowRoots: make([][]byte, 2)},
 	}, nil
 }
 

--- a/das/options.go
+++ b/das/options.go
@@ -35,8 +35,6 @@ type Parameters struct {
 
 	// SampleTimeout is a maximum amount time sampling of single block may take until it will be
 	// canceled. Zero derives the timeout per height from the square size.
-	//
-	// Deprecated: set to zero and let the DASer derive the timeout.
 	SampleTimeout time.Duration
 }
 

--- a/das/options.go
+++ b/das/options.go
@@ -34,7 +34,9 @@ type Parameters struct {
 	BackgroundStoreInterval time.Duration
 
 	// SampleTimeout is a maximum amount time sampling of single block may take until it will be
-	// canceled.
+	// canceled. Zero derives the timeout per height from the square size.
+	//
+	// Deprecated: set to zero and let the DASer derive the timeout.
 	SampleTimeout time.Duration
 }
 
@@ -47,7 +49,7 @@ func DefaultParameters() Parameters {
 		SamplingRange:           16,
 		ConcurrencyLimit:        16,
 		BackgroundStoreInterval: 10 * time.Minute,
-		SampleTimeout:           time.Minute,
+		SampleTimeout:           0, // derived per height
 	}
 }
 
@@ -75,11 +77,11 @@ func (p *Parameters) Validate() error {
 		)
 	}
 
-	// SampleTimeout = 0 would fail every sample operation with timeout error
-	if p.SampleTimeout <= 0 {
+	// SampleTimeout = 0 derives the timeout per height
+	if p.SampleTimeout < 0 {
 		return errInvalidOptionValue(
 			"SampleTimeout",
-			"negative or 0",
+			"negative",
 		)
 	}
 

--- a/das/options.go
+++ b/das/options.go
@@ -34,9 +34,7 @@ type Parameters struct {
 	BackgroundStoreInterval time.Duration
 
 	// SampleTimeout is a maximum amount time sampling of single block may take until it will be
-	// canceled. High ConcurrencyLimit value may increase sampling time due to node resources being
-	// divided between parallel workers. SampleTimeout should be adjusted proportionally to
-	// ConcurrencyLimit.
+	// canceled.
 	SampleTimeout time.Duration
 }
 
@@ -44,14 +42,12 @@ type Parameters struct {
 func DefaultParameters() Parameters {
 	// TODO(@derrandz): parameters needs performance testing on real network to define optimal values
 	// (#1261)
-	concurrencyLimit := 16
 	return Parameters{
-		SamplingRange:           100,
-		ConcurrencyLimit:        concurrencyLimit,
+		// small ranges keep jobs short, so a slow height does not block the heights behind it
+		SamplingRange:           16,
+		ConcurrencyLimit:        16,
 		BackgroundStoreInterval: 10 * time.Minute,
-		// SampleTimeout = approximate block time (with a bit of wiggle room) * max amount of catchup
-		// workers
-		SampleTimeout: 15 * time.Second * time.Duration(concurrencyLimit),
+		SampleTimeout:           time.Minute,
 	}
 }
 

--- a/das/sample_timeout_test.go
+++ b/das/sample_timeout_test.go
@@ -40,13 +40,10 @@ func TestDeriveSampleTimeout(t *testing.T) {
 	}
 }
 
-// TestDeriveSampleTimeoutIllegalWidth tests that a width outside the legal range returns
-// the widest legal square's timeout.
+// TestDeriveSampleTimeoutIllegalWidth tests that a width outside the legal range panics.
 func TestDeriveSampleTimeoutIllegalWidth(t *testing.T) {
-	ceiling := deriveSampleTimeout(maxEDSWidth)
-
 	for _, edsWidth := range []int{0, -1, -maxEDSWidth, maxEDSWidth + 1, 1 << 40} {
-		require.Equal(t, ceiling, deriveSampleTimeout(edsWidth), "width %d", edsWidth)
+		require.Panics(t, func() { deriveSampleTimeout(edsWidth) }, "width %d", edsWidth)
 	}
 }
 

--- a/das/sample_timeout_test.go
+++ b/das/sample_timeout_test.go
@@ -40,9 +40,10 @@ func TestDeriveSampleTimeout(t *testing.T) {
 	}
 }
 
-// TestDeriveSampleTimeoutIllegalWidth tests that a width outside the legal range panics.
+// TestDeriveSampleTimeoutIllegalWidth tests that a width outside the legal range or one
+// that is not an extended square width panics.
 func TestDeriveSampleTimeoutIllegalWidth(t *testing.T) {
-	for _, edsWidth := range []int{0, -1, -maxEDSWidth, maxEDSWidth + 1, 1 << 40} {
+	for _, edsWidth := range []int{0, -1, -maxEDSWidth, maxEDSWidth + 1, 1 << 40, 1, 3, maxEDSWidth - 1} {
 		require.Panics(t, func() { deriveSampleTimeout(edsWidth) }, "width %d", edsWidth)
 	}
 }

--- a/das/sample_timeout_test.go
+++ b/das/sample_timeout_test.go
@@ -1,0 +1,93 @@
+package das
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/header"
+	"github.com/celestiaorg/celestia-node/header/headertest"
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+)
+
+// TestDeriveSampleTimeout tests that every legal extended square width derives its
+// pinned timeout.
+func TestDeriveSampleTimeout(t *testing.T) {
+	tests := []struct {
+		edsWidth int
+		expected time.Duration
+	}{
+		{edsWidth: 2, expected: 20*time.Second + 1953125*time.Nanosecond},
+		{edsWidth: 4, expected: 20*time.Second + 7812500*time.Nanosecond},
+		{edsWidth: 8, expected: 20*time.Second + 31250*time.Microsecond},
+		{edsWidth: 16, expected: 20*time.Second + 125*time.Millisecond},
+		{edsWidth: 32, expected: 20*time.Second + 500*time.Millisecond},
+		{edsWidth: 64, expected: 22 * time.Second},
+		{edsWidth: 128, expected: 28 * time.Second},
+		{edsWidth: 256, expected: 52 * time.Second},
+		{edsWidth: 512, expected: 148 * time.Second},
+		{edsWidth: 1024, expected: 532 * time.Second},
+	}
+
+	// the table must cover up to the widest legal square
+	require.Equal(t, maxEDSWidth, tests[len(tests)-1].edsWidth)
+
+	for _, tt := range tests {
+		require.Equal(t, tt.expected, deriveSampleTimeout(tt.edsWidth), "width %d", tt.edsWidth)
+	}
+}
+
+// TestDeriveSampleTimeoutIllegalWidth tests that a width outside the legal range returns
+// the widest legal square's timeout.
+func TestDeriveSampleTimeoutIllegalWidth(t *testing.T) {
+	ceiling := deriveSampleTimeout(maxEDSWidth)
+
+	for _, edsWidth := range []int{0, -1, -maxEDSWidth, maxEDSWidth + 1, 1 << 40} {
+		require.Equal(t, ceiling, deriveSampleTimeout(edsWidth), "width %d", edsWidth)
+	}
+}
+
+// TestWorkerSampleTimeout tests that a worker derives its deadline from the header's
+// square size when SampleTimeout is zero, and honors a configured value as an override.
+func TestWorkerSampleTimeout(t *testing.T) {
+	const odsWidth = 4
+
+	eds := edstest.RandEDS(t, odsWidth)
+	roots, err := share.NewAxisRoots(eds)
+	require.NoError(t, err)
+	eh := headertest.RandExtendedHeaderWithRoot(t, roots)
+
+	// DAH roots span the extended square
+	require.Equal(t, 2*odsWidth, len(eh.DAH.RowRoots))
+
+	tests := []struct {
+		name       string
+		configured time.Duration
+		expected   time.Duration
+	}{
+		{name: "derived when unset", configured: 0, expected: deriveSampleTimeout(2 * odsWidth)},
+		{name: "configured value overrides", configured: 5 * time.Second, expected: 5 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var deadline time.Duration
+			sample := func(ctx context.Context, _ *header.ExtendedHeader) error {
+				dl, ok := ctx.Deadline()
+				require.True(t, ok)
+				deadline = time.Until(dl)
+				return nil
+			}
+
+			// header on the job means the nil getter is never used
+			j := job{jobType: recentJob, from: 1, to: 1, header: eh}
+			w := newWorker(j, nil, sample, nil)
+
+			require.NoError(t, w.sample(context.Background(), tt.configured, 1))
+			require.InDelta(t, float64(tt.expected), float64(deadline), float64(time.Second))
+		})
+	}
+}

--- a/das/sample_timeout_test.go
+++ b/das/sample_timeout_test.go
@@ -40,14 +40,6 @@ func TestDeriveSampleTimeout(t *testing.T) {
 	}
 }
 
-// TestDeriveSampleTimeoutIllegalWidth tests that a width outside the legal range or one
-// that is not an extended square width panics.
-func TestDeriveSampleTimeoutIllegalWidth(t *testing.T) {
-	for _, edsWidth := range []int{0, -1, -maxEDSWidth, maxEDSWidth + 1, 1 << 40, 1, 3, maxEDSWidth - 1} {
-		require.Panics(t, func() { deriveSampleTimeout(edsWidth) }, "width %d", edsWidth)
-	}
-}
-
 // TestWorkerSampleTimeout tests that a worker derives its deadline from the header's
 // square size when SampleTimeout is zero, and honors a configured value as an override.
 func TestWorkerSampleTimeout(t *testing.T) {

--- a/das/worker.go
+++ b/das/worker.go
@@ -7,10 +7,22 @@ import (
 	"sync"
 	"time"
 
+	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
 	libhead "github.com/celestiaorg/go-header"
+	libshare "github.com/celestiaorg/go-square/v4/share"
 
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/share/availability"
+)
+
+const (
+	// baseSampleTimeout covers the size-independent part of sampling a height: peer
+	// selection, stream setup and round trips.
+	baseSampleTimeout = 20 * time.Second
+	// assumedThroughput is a pessimistic health floor, not a measured rate: the size term
+	// counts full EDS bytes, while shrex may send only the ODS and re-encode parity locally.
+	assumedThroughput = 1 << 20 // bytes per second
+	maxEDSWidth       = 2 * appconsts.SquareSizeUpperBound
 )
 
 type jobType string
@@ -112,6 +124,9 @@ func (w *worker) sample(ctx context.Context, timeout time.Duration, height uint6
 	}
 
 	start := time.Now()
+	if timeout == 0 {
+		timeout = deriveSampleTimeout(len(h.DAH.RowRoots))
+	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -156,6 +171,18 @@ func (w *worker) sample(ctx context.Context, timeout time.Duration, height uint6
 		"finished (s)", time.Since(start),
 	)
 	return nil
+}
+
+// deriveSampleTimeout returns the sampling deadline for an extended square of the given
+// width, which is len(DAH.RowRoots).
+func deriveSampleTimeout(edsWidth int) time.Duration {
+	if edsWidth <= 0 || edsWidth > maxEDSWidth {
+		// malformed DAH: clamp to prevent overflow and absurd deadlines
+		edsWidth = maxEDSWidth
+	}
+
+	edsBytes := edsWidth * edsWidth * libshare.ShareSize
+	return baseSampleTimeout + time.Duration(edsBytes)*time.Second/assumedThroughput
 }
 
 func (w *worker) getHeader(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {

--- a/das/worker.go
+++ b/das/worker.go
@@ -176,12 +176,6 @@ func (w *worker) sample(ctx context.Context, timeout time.Duration, height uint6
 // deriveSampleTimeout returns the sampling deadline for an extended square of the given
 // width, which is len(DAH.RowRoots).
 func deriveSampleTimeout(edsWidth int) time.Duration {
-	if edsWidth <= 0 || edsWidth > maxEDSWidth || edsWidth%2 != 0 {
-		// DAH validation bounds the square width and an extended square is always even,
-		// so either means the header reached the DASer unvalidated
-		panic(fmt.Sprintf("das: malformed DAH: square width %d", edsWidth))
-	}
-
 	odsWidth := edsWidth / 2
 	odsBytes := odsWidth * odsWidth * libshare.ShareSize
 	return baseSampleTimeout + sampleTimeoutPerMiB*time.Duration(odsBytes)/(1<<20)

--- a/das/worker.go
+++ b/das/worker.go
@@ -19,10 +19,10 @@ const (
 	// baseSampleTimeout covers the size-independent part of sampling a height: peer
 	// selection, stream setup and round trips.
 	baseSampleTimeout = 20 * time.Second
-	// assumedThroughput is a pessimistic health floor, not a measured rate: the size term
-	// counts full EDS bytes, while shrex may send only the ODS and re-encode parity locally.
-	assumedThroughput = 1 << 20 // bytes per second
-	maxEDSWidth       = 2 * appconsts.SquareSizeUpperBound
+	// sampleTimeoutPerMiB bounds how long a peer may take per MiB of ODS, the bytes
+	// actually sent, before the height is abandoned and retried against another peer.
+	sampleTimeoutPerMiB = 4 * time.Second
+	maxEDSWidth         = 2 * appconsts.SquareSizeUpperBound
 )
 
 type jobType string
@@ -182,8 +182,9 @@ func deriveSampleTimeout(edsWidth int) time.Duration {
 		panic(fmt.Sprintf("das: malformed DAH: square width %d", edsWidth))
 	}
 
-	edsBytes := edsWidth * edsWidth * libshare.ShareSize
-	return baseSampleTimeout + time.Duration(edsBytes)*time.Second/assumedThroughput
+	odsWidth := edsWidth / 2
+	odsBytes := odsWidth * odsWidth * libshare.ShareSize
+	return baseSampleTimeout + sampleTimeoutPerMiB*time.Duration(odsBytes)/(1<<20)
 }
 
 func (w *worker) getHeader(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {

--- a/das/worker.go
+++ b/das/worker.go
@@ -177,8 +177,9 @@ func (w *worker) sample(ctx context.Context, timeout time.Duration, height uint6
 // width, which is len(DAH.RowRoots).
 func deriveSampleTimeout(edsWidth int) time.Duration {
 	if edsWidth <= 0 || edsWidth > maxEDSWidth {
-		// malformed DAH: clamp to prevent overflow and absurd deadlines
-		edsWidth = maxEDSWidth
+		// DAH validation bounds the square width, so an out-of-range width means the
+		// header reached the DASer unvalidated
+		panic(fmt.Sprintf("das: malformed DAH: square width %d", edsWidth))
 	}
 
 	edsBytes := edsWidth * edsWidth * libshare.ShareSize

--- a/das/worker.go
+++ b/das/worker.go
@@ -176,9 +176,9 @@ func (w *worker) sample(ctx context.Context, timeout time.Duration, height uint6
 // deriveSampleTimeout returns the sampling deadline for an extended square of the given
 // width, which is len(DAH.RowRoots).
 func deriveSampleTimeout(edsWidth int) time.Duration {
-	if edsWidth <= 0 || edsWidth > maxEDSWidth {
-		// DAH validation bounds the square width, so an out-of-range width means the
-		// header reached the DASer unvalidated
+	if edsWidth <= 0 || edsWidth > maxEDSWidth || edsWidth%2 != 0 {
+		// DAH validation bounds the square width and an extended square is always even,
+		// so either means the header reached the DASer unvalidated
 		panic(fmt.Sprintf("das: malformed DAH: square width %d", edsWidth))
 	}
 

--- a/nodebuilder/das/config.go
+++ b/nodebuilder/das/config.go
@@ -2,9 +2,11 @@ package das
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 // Config contains configuration parameters for the DASer (or DASing process)
@@ -20,11 +22,17 @@ type Config struct {
 // but this function will provide more once #1261 is addressed.
 //
 // TODO(@derrandz): Address #1261
-func DefaultConfig(node.Type) Config {
-	return Config{
+func DefaultConfig(tp node.Type) Config {
+	cfg := Config{
 		Parameters: das.DefaultParameters(),
 		Enabled:    true, // Enabled by default
 	}
+	if tp == node.Light {
+		// light nodes sample a fixed amount of shares regardless of square size, so the
+		// size-derived timeout does not apply to them
+		cfg.SampleTimeout = modp2p.BlockTime * time.Duration(cfg.ConcurrencyLimit)
+	}
+	return cfg
 }
 
 // Validate performs basic validation of the config.

--- a/nodebuilder/das/config.go
+++ b/nodebuilder/das/config.go
@@ -2,11 +2,9 @@ package das
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
-	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 // Config contains configuration parameters for the DASer (or DASing process)
@@ -22,15 +20,11 @@ type Config struct {
 // but this function will provide more once #1261 is addressed.
 //
 // TODO(@derrandz): Address #1261
-func DefaultConfig(tp node.Type) Config {
-	cfg := Config{
+func DefaultConfig(node.Type) Config {
+	return Config{
 		Parameters: das.DefaultParameters(),
 		Enabled:    true, // Enabled by default
 	}
-	if tp == node.Light {
-		cfg.SampleTimeout = modp2p.BlockTime * time.Duration(cfg.ConcurrencyLimit)
-	}
-	return cfg
 }
 
 // Validate performs basic validation of the config.

--- a/nodebuilder/das/config_test.go
+++ b/nodebuilder/das/config_test.go
@@ -1,0 +1,21 @@
+package das
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+)
+
+// TestDefaultConfigSampleTimeout tests that light nodes pin a fixed sample timeout while
+// other node types leave it zero so the DASer derives it from the square size.
+func TestDefaultConfigSampleTimeout(t *testing.T) {
+	light := DefaultConfig(node.Light)
+	require.NotZero(t, light.SampleTimeout)
+	require.NoError(t, light.Validate())
+
+	bridge := DefaultConfig(node.Bridge)
+	require.Zero(t, bridge.SampleTimeout)
+	require.NoError(t, bridge.Validate())
+}

--- a/nodebuilder/das/config_test.go
+++ b/nodebuilder/das/config_test.go
@@ -2,17 +2,20 @@ package das
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	modp2p "github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 )
 
 // TestDefaultConfigSampleTimeout tests that light nodes pin a fixed sample timeout while
 // other node types leave it zero so the DASer derives it from the square size.
 func TestDefaultConfigSampleTimeout(t *testing.T) {
 	light := DefaultConfig(node.Light)
-	require.NotZero(t, light.SampleTimeout)
+	// the timeout light nodes used before it was derived from the square size
+	require.Equal(t, modp2p.BlockTime*time.Duration(light.ConcurrencyLimit), light.SampleTimeout)
 	require.NoError(t, light.Validate())
 
 	bridge := DefaultConfig(node.Bridge)


### PR DESCRIPTION
Decrease the DASer's default `SamplingRange` from 100 to 16 so a slow height only blocks 16 heights instead of 100, and makes `SampleTimeout` a flat 1 minute instead of scaling with `ConcurrencyLimit`.