### PR TITLE
perf(share/shwap/p2p/shrex/peers): Add EWMA to peer manager

### DIFF
--- a/share/shwap/p2p/shrex/client.go
+++ b/share/shwap/p2p/shrex/client.go
@@ -51,12 +51,13 @@ func (c *Client) WithMetrics() error {
 	return nil
 }
 
+// Get requests data from the given peer and returns the amount of bytes received.
 func (c *Client) Get(
 	ctx context.Context,
 	req request,
 	resp response,
 	peer peer.ID,
-) error {
+) (int64, error) {
 	logger := log.With(
 		"source", "client",
 		"name", req.Name(),
@@ -77,7 +78,7 @@ func (c *Client) Get(
 		"status", status, "duration",
 		time.Since(requestTime), "total bytes received", n,
 	)
-	return err
+	return n, err
 }
 
 // doRequest performs a request to the given peer

--- a/share/shwap/p2p/shrex/client.go
+++ b/share/shwap/p2p/shrex/client.go
@@ -51,13 +51,13 @@ func (c *Client) WithMetrics() error {
 	return nil
 }
 
-// Get requests data from the given peer and returns the amount of bytes received.
+// Get requests data from the given peer and returns the received byte count and payload-read duration.
 func (c *Client) Get(
 	ctx context.Context,
 	req request,
 	resp response,
 	peer peer.ID,
-) (int64, error) {
+) (int64, time.Duration, error) {
 	logger := log.With(
 		"source", "client",
 		"name", req.Name(),
@@ -65,7 +65,7 @@ func (c *Client) Get(
 		"peer", peer.String(),
 	)
 	requestTime := time.Now()
-	n, status, err := c.doRequest(ctx, logger, req, resp, peer)
+	n, payloadDuration, status, err := c.doRequest(ctx, logger, req, resp, peer)
 	// Surface ctx.Err() without masking typed wire errors like ErrNotFound.
 	if err != nil && ctx.Err() != nil {
 		err = errors.Join(err, ctx.Err())
@@ -78,7 +78,7 @@ func (c *Client) Get(
 		"status", status, "duration",
 		time.Since(requestTime), "total bytes received", n,
 	)
-	return n, err
+	return n, payloadDuration, err
 }
 
 // doRequest performs a request to the given peer
@@ -89,7 +89,7 @@ func (c *Client) doRequest(
 	req request,
 	resp response,
 	peer peer.ID,
-) (int64, status, error) {
+) (int64, time.Duration, status, error) {
 	streamOpenCtx, cancel := context.WithTimeout(ctx, streamOpenTimeout)
 	defer cancel()
 
@@ -102,9 +102,9 @@ func (c *Client) doRequest(
 	stream, err := c.host.NewStream(streamOpenCtx, peer, ProtocolID(c.params.NetworkID(), req.Name()))
 	if err != nil {
 		if isResourceExhausted(err) {
-			return 0, statusResourceExhaustedErr, ErrResourceExhausted
+			return 0, 0, statusResourceExhaustedErr, ErrResourceExhausted
 		}
-		return 0, statusOpenStreamErr, fmt.Errorf("open stream: %w", err)
+		return 0, 0, statusOpenStreamErr, fmt.Errorf("open stream: %w", err)
 	}
 	defer func() {
 		utils.CloseAndLog(log, "shrex/client stream", stream)
@@ -121,7 +121,7 @@ func (c *Client) doRequest(
 
 	_, err = req.WriteTo(stream)
 	if err != nil {
-		return 0, statusSendReqErr, fmt.Errorf("writing request: %w", err)
+		return 0, 0, statusSendReqErr, fmt.Errorf("writing request: %w", err)
 	}
 	span.AddEvent("wrote request to stream")
 
@@ -134,9 +134,10 @@ func (c *Client) doRequest(
 	statusLength, err := serde.Read(stream, &statusResp)
 	if err != nil {
 		if isResourceExhausted(err) {
-			return int64(statusLength), statusResourceExhaustedErr, ErrResourceExhausted
+			return int64(statusLength), 0, statusResourceExhaustedErr, ErrResourceExhausted
 		}
 		return int64(statusLength),
+			0,
 			statusReadStatusErr,
 			fmt.Errorf("unexpected error during reading the status from stream: %w", err)
 	}
@@ -146,16 +147,18 @@ func (c *Client) doRequest(
 	case shrexpb.Status_OK:
 	case shrexpb.Status_NOT_FOUND:
 		err = ErrNotFound
-		return int64(statusLength), statusNotFound, err
+		return int64(statusLength), 0, statusNotFound, err
 	case shrexpb.Status_INTERNAL:
 		err = ErrInternalServer
-		return int64(statusLength), statusInternalErr, err
+		return int64(statusLength), 0, statusInternalErr, err
 	default:
 		err = ErrInvalidRequest
-		return int64(statusLength), statusReadRespErr, err
+		return int64(statusLength), 0, statusReadRespErr, err
 	}
 
+	payloadStart := time.Now()
 	bytesRead, err := resp.ReadFrom(stream)
+	payloadDuration := time.Since(payloadStart)
 	st := statusSuccess
 	if err != nil {
 		err = fmt.Errorf("%w: %w", ErrInvalidResponse, err)
@@ -164,7 +167,7 @@ func (c *Client) doRequest(
 
 	span.AddEvent("read response from stream",
 		trace.WithAttributes(attribute.Int64("size", bytesRead)))
-	return int64(statusLength) + bytesRead, st, err
+	return int64(statusLength) + bytesRead, payloadDuration, st, err
 }
 
 func (c *Client) setStreamDeadlines(ctx context.Context, logger *zap.SugaredLogger, stream network.Stream) {

--- a/share/shwap/p2p/shrex/client_test.go
+++ b/share/shwap/p2p/shrex/client_test.go
@@ -39,7 +39,7 @@ func TestClient_StreamOpenTimeout(t *testing.T) {
 	t.Cleanup(cancel)
 
 	start := time.Now()
-	err = client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
+	_, _, err = client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
 	require.ErrorContains(t, err, "open stream")
 	require.Less(t, time.Since(start), 2*time.Second)
 }

--- a/share/shwap/p2p/shrex/exchange_test.go
+++ b/share/shwap/p2p/shrex/exchange_test.go
@@ -37,7 +37,7 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		id, err := shwap.NewNamespaceDataID(height, namespace)
 		data := shwap.NamespaceData{}
 		require.NoError(t, err)
-		err = client.Get(ctx, &id, &data, server.host.ID())
+		_, err = client.Get(ctx, &id, &data, server.host.ID())
 		require.ErrorIs(t, err, ErrNotFound)
 	})
 
@@ -59,7 +59,7 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		data := shwap.NamespaceData{}
 		require.NoError(t, err)
 
-		err = client.Get(ctx, &id, &data, server.host.ID())
+		_, err = client.Get(ctx, &id, &data, server.host.ID())
 		require.NoError(t, err)
 		require.Empty(t, data.Flatten())
 	})
@@ -94,7 +94,8 @@ func TestClient_AbortsOnCtxCancel(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		result <- client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
+		_, err := client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
+		result <- err
 	}()
 
 	select {

--- a/share/shwap/p2p/shrex/exchange_test.go
+++ b/share/shwap/p2p/shrex/exchange_test.go
@@ -2,6 +2,7 @@ package shrex
 
 import (
 	"context"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -37,7 +38,7 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		id, err := shwap.NewNamespaceDataID(height, namespace)
 		data := shwap.NamespaceData{}
 		require.NoError(t, err)
-		_, err = client.Get(ctx, &id, &data, server.host.ID())
+		_, _, err = client.Get(ctx, &id, &data, server.host.ID())
 		require.ErrorIs(t, err, ErrNotFound)
 	})
 
@@ -59,8 +60,10 @@ func TestExchange_RequestND_NotFound(t *testing.T) {
 		data := shwap.NamespaceData{}
 		require.NoError(t, err)
 
-		_, err = client.Get(ctx, &id, &data, server.host.ID())
+		resp := delayedResponse{ReaderFrom: &data, delay: 20 * time.Millisecond}
+		_, payloadDuration, err := client.Get(ctx, &id, &resp, server.host.ID())
 		require.NoError(t, err)
+		require.GreaterOrEqual(t, payloadDuration, resp.delay)
 		require.Empty(t, data.Flatten())
 	})
 }
@@ -94,7 +97,7 @@ func TestClient_AbortsOnCtxCancel(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		_, err := client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
+		_, _, err := client.Get(ctx, &id, &shwap.NamespaceData{}, hosts[1].ID())
 		result <- err
 	}()
 
@@ -112,6 +115,16 @@ func TestClient_AbortsOnCtxCancel(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("client did not return promptly after context cancellation")
 	}
+}
+
+type delayedResponse struct {
+	io.ReaderFrom
+	delay time.Duration
+}
+
+func (r *delayedResponse) ReadFrom(reader io.Reader) (int64, error) {
+	time.Sleep(r.delay)
+	return r.ReaderFrom.ReadFrom(reader)
 }
 
 func createMocknet(t *testing.T, amount int) []libhost.Host {

--- a/share/shwap/p2p/shrex/peers/doc.go
+++ b/share/shwap/p2p/shrex/peers/doc.go
@@ -20,7 +20,8 @@
 //
 // This gives the peer manager an ability to block peers that gossip invalid shares, but also access a list of peers
 // that are known to have been gossiping valid shares.
-// The peers are then returned on request using a round-robin algorithm to return a different peer each time.
+// The peers are then returned on request by power-of-two-choices: two random peers are sampled and
+// the one with the higher observed throughput is returned.
 // If no peers are found, the peer manager will rely on full nodes retrieved from discovery.
 //
 // The peer manager is only concerned with recent heights, thus it retrieves peers that

--- a/share/shwap/p2p/shrex/peers/doc.go
+++ b/share/shwap/p2p/shrex/peers/doc.go
@@ -21,7 +21,8 @@
 // This gives the peer manager an ability to block peers that gossip invalid shares, but also access a list of peers
 // that are known to have been gossiping valid shares.
 // The peers are then returned on request by power-of-two-choices: two random peers are sampled and
-// the one with the higher observed throughput is returned.
+// the one with the higher observed throughput is returned. Unmeasured peers are tried first so
+// they can establish a score.
 // If no peers are found, the peer manager will rely on full nodes retrieved from discovery.
 //
 // The peer manager is only concerned with recent heights, thus it retrieves peers that

--- a/share/shwap/p2p/shrex/peers/manager.go
+++ b/share/shwap/p2p/shrex/peers/manager.go
@@ -31,6 +31,8 @@ const (
 	// ResultCooldownPeer will put returned peer on cooldown, meaning it won't be available by Peer
 	// method for some time
 	ResultCooldownPeer = "result_cooldown_peer"
+	// ResultCooldownPeerNoPenalty puts the returned peer on cooldown without decreasing its score.
+	ResultCooldownPeerNoPenalty = "result_cooldown_peer_no_penalty"
 	// ResultBlacklistPeer puts the peer on cooldown. When blacklisting is enabled, the peer is also
 	// disconnected and blocked from future p2p communication by the libp2p connection gater.
 	ResultBlacklistPeer = "result_blacklist_peer"
@@ -307,6 +309,8 @@ func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID, source peerS
 			}
 		case ResultCooldownPeer:
 			m.stats.decreaseScore(peerID)
+			m.putOnCooldown(datahash, peerID)
+		case ResultCooldownPeerNoPenalty:
 			m.putOnCooldown(datahash, peerID)
 		case ResultBlacklistPeer:
 			m.putOnCooldown(datahash, peerID)

--- a/share/shwap/p2p/shrex/peers/manager.go
+++ b/share/shwap/p2p/shrex/peers/manager.go
@@ -31,8 +31,8 @@ const (
 	// ResultCooldownPeer will put returned peer on cooldown, meaning it won't be available by Peer
 	// method for some time
 	ResultCooldownPeer = "result_cooldown_peer"
-	// ResultBlacklistPeer will blacklist peer. Blacklisted peers will be disconnected and blocked from
-	// any p2p communication in future by libp2p Gater
+	// ResultBlacklistPeer puts the peer on cooldown. When blacklisting is enabled, the peer is also
+	// disconnected and blocked from future p2p communication by the libp2p connection gater.
 	ResultBlacklistPeer = "result_blacklist_peer"
 
 	// eventbusBufSize is the size of the buffered channel to handle
@@ -80,8 +80,8 @@ type Manager struct {
 	// nodes collects nodes' peer.IDs found via discovery
 	nodes *pool
 
-	// scores ranks peers by observed throughput and is shared by all pools
-	scores *scoreboard
+	// stats ranks peers by observed throughput and is shared by all pools
+	stats *peerStats
 
 	// hashes that are not in the chain, bounded by an LRU to avoid unbounded growth
 	blacklistedHashes *lru.Cache[string, struct{}]
@@ -94,9 +94,9 @@ type Manager struct {
 }
 
 // DoneFunc updates internal state depending on call results. Should be called once per returned
-// peer from Peer method. Samples of successful transfers are optional and update the peer's
+// peer from Peer method. Stats from a successful transfer are optional and update the peer's
 // throughput score.
-type DoneFunc func(result, ...Sample)
+type DoneFunc func(result, ...TransferStats)
 
 type syncPool struct {
 	*pool
@@ -126,9 +126,9 @@ func NewManager(
 		return nil, fmt.Errorf("shrex/peer-manager: creating blacklisted hashes cache: %w", err)
 	}
 
-	scores, err := newScoreboard()
+	peerStats, err := newPeerStats()
 	if err != nil {
-		return nil, fmt.Errorf("shrex/peer-manager: creating scoreboard: %w", err)
+		return nil, fmt.Errorf("shrex/peer-manager: creating peer stats: %w", err)
 	}
 
 	s := &Manager{
@@ -137,7 +137,7 @@ func NewManager(
 		host:                  host,
 		pools:                 make(map[string]*syncPool),
 		blacklistedHashes:     blacklistedHashes,
-		scores:                scores,
+		stats:                 peerStats,
 		headerSubDone:         make(chan struct{}),
 		disconnectedPeersDone: make(chan struct{}),
 		tag:                   tag,
@@ -150,7 +150,7 @@ func NewManager(
 		}
 	}
 
-	s.nodes = newPool(s.params.PeerCooldown, s.scores)
+	s.nodes = newPool(s.params.PeerCooldown, s.stats)
 	return s, nil
 }
 
@@ -293,11 +293,7 @@ func (m *Manager) newPeer(
 }
 
 func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID, source peerSource) DoneFunc {
-	return func(result result, samples ...Sample) {
-		for _, sample := range samples {
-			m.scores.observe(peerID, sample)
-		}
-
+	return func(result result, stats ...TransferStats) {
 		log.Debugw("set peer result",
 			"hash", datahash.String(),
 			"peer", peerID.String(),
@@ -306,20 +302,24 @@ func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID, source peerS
 		m.metrics.observeDoneResult(source, result)
 		switch result {
 		case ResultNoop:
+			for _, transfer := range stats {
+				m.stats.updateStats(peerID, transfer)
+			}
 		case ResultCooldownPeer:
-			if source == sourceDiscoveredNodes {
-				m.nodes.putOnCooldown(peerID)
-				return
-			}
-			p := m.getPool(datahash.String())
-			if p == nil {
-				// pool was removed
-				return
-			}
-			p.putOnCooldown(peerID)
+			m.stats.decreaseScore(peerID)
+			m.putOnCooldown(datahash, peerID)
 		case ResultBlacklistPeer:
+			m.putOnCooldown(datahash, peerID)
 			m.blacklistPeers(reasonMisbehave, peerID)
 		}
+	}
+}
+
+// putOnCooldown makes a peer unavailable in both places it can be selected from.
+func (m *Manager) putOnCooldown(datahash share.DataHash, peerID peer.ID) {
+	m.nodes.putOnCooldown(peerID)
+	if p := m.getPool(datahash.String()); p != nil {
+		p.putOnCooldown(peerID)
 	}
 }
 
@@ -429,7 +429,7 @@ func (m *Manager) getOrCreatePool(datahash string, height uint64) *syncPool {
 	if !ok {
 		p = &syncPool{
 			height:    height,
-			pool:      newPool(m.params.PeerCooldown, m.scores),
+			pool:      newPool(m.params.PeerCooldown, m.stats),
 			createdAt: time.Now(),
 		}
 		m.pools[datahash] = p

--- a/share/shwap/p2p/shrex/peers/manager.go
+++ b/share/shwap/p2p/shrex/peers/manager.go
@@ -80,6 +80,9 @@ type Manager struct {
 	// nodes collects nodes' peer.IDs found via discovery
 	nodes *pool
 
+	// scores ranks peers by observed throughput and is shared by all pools
+	scores *scoreboard
+
 	// hashes that are not in the chain, bounded by an LRU to avoid unbounded growth
 	blacklistedHashes *lru.Cache[string, struct{}]
 
@@ -91,8 +94,9 @@ type Manager struct {
 }
 
 // DoneFunc updates internal state depending on call results. Should be called once per returned
-// peer from Peer method
-type DoneFunc func(result)
+// peer from Peer method. Samples of successful transfers are optional and update the peer's
+// throughput score.
+type DoneFunc func(result, ...Sample)
 
 type syncPool struct {
 	*pool
@@ -122,12 +126,18 @@ func NewManager(
 		return nil, fmt.Errorf("shrex/peer-manager: creating blacklisted hashes cache: %w", err)
 	}
 
+	scores, err := newScoreboard()
+	if err != nil {
+		return nil, fmt.Errorf("shrex/peer-manager: creating scoreboard: %w", err)
+	}
+
 	s := &Manager{
 		params:                params,
 		connGater:             connGater,
 		host:                  host,
 		pools:                 make(map[string]*syncPool),
 		blacklistedHashes:     blacklistedHashes,
+		scores:                scores,
 		headerSubDone:         make(chan struct{}),
 		disconnectedPeersDone: make(chan struct{}),
 		tag:                   tag,
@@ -140,7 +150,7 @@ func NewManager(
 		}
 	}
 
-	s.nodes = newPool(s.params.PeerCooldown)
+	s.nodes = newPool(s.params.PeerCooldown, s.scores)
 	return s, nil
 }
 
@@ -283,7 +293,11 @@ func (m *Manager) newPeer(
 }
 
 func (m *Manager) doneFunc(datahash share.DataHash, peerID peer.ID, source peerSource) DoneFunc {
-	return func(result result) {
+	return func(result result, samples ...Sample) {
+		for _, sample := range samples {
+			m.scores.observe(peerID, sample)
+		}
+
 		log.Debugw("set peer result",
 			"hash", datahash.String(),
 			"peer", peerID.String(),
@@ -415,7 +429,7 @@ func (m *Manager) getOrCreatePool(datahash string, height uint64) *syncPool {
 	if !ok {
 		p = &syncPool{
 			height:    height,
-			pool:      newPool(m.params.PeerCooldown),
+			pool:      newPool(m.params.PeerCooldown, m.scores),
 			createdAt: time.Now(),
 		}
 		m.pools[datahash] = p

--- a/share/shwap/p2p/shrex/peers/manager_test.go
+++ b/share/shwap/p2p/shrex/peers/manager_test.go
@@ -29,6 +29,45 @@ import (
 )
 
 func TestManager(t *testing.T) {
+	t.Run("blacklist result does not change stats", func(t *testing.T) {
+		stats, err := newPeerStats()
+		require.NoError(t, err)
+
+		manager := &Manager{
+			stats: stats,
+			nodes: newPool(time.Hour, stats),
+			pools: make(map[string]*syncPool),
+		}
+		transfer := TransferStats{Bytes: 100 << 20, Duration: time.Second}
+		stats.updateStats("peer1", transfer)
+
+		manager.doneFunc(share.DataHash{1}, "peer1", sourceDiscoveredNodes)(ResultBlacklistPeer, transfer)
+		score, measured := stats.score("peer1")
+		require.True(t, measured)
+		require.Equal(t, float64(transfer.Bytes), score)
+	})
+
+	t.Run("cooldown applies to both peer pools", func(t *testing.T) {
+		stats, err := newPeerStats()
+		require.NoError(t, err)
+
+		hash := share.DataHash{1}
+		manager := &Manager{
+			stats: stats,
+			nodes: newPool(time.Hour, stats),
+			pools: map[string]*syncPool{
+				hash.String(): {pool: newPool(time.Hour, stats)},
+			},
+		}
+		manager.nodes.add("peer1")
+		manager.pools[hash.String()].add("peer1")
+
+		manager.doneFunc(hash, "peer1", sourceShrexSub)(ResultCooldownPeer)
+
+		require.Zero(t, manager.nodes.len())
+		require.Zero(t, manager.pools[hash.String()].len())
+	})
+
 	t.Run("Verify pool by headerSub", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		t.Cleanup(cancel)

--- a/share/shwap/p2p/shrex/peers/manager_test.go
+++ b/share/shwap/p2p/shrex/peers/manager_test.go
@@ -68,6 +68,32 @@ func TestManager(t *testing.T) {
 		require.Zero(t, manager.pools[hash.String()].len())
 	})
 
+	t.Run("cooldown without penalty preserves score", func(t *testing.T) {
+		stats, err := newPeerStats()
+		require.NoError(t, err)
+
+		hash := share.DataHash{1}
+		manager := &Manager{
+			stats: stats,
+			nodes: newPool(time.Hour, stats),
+			pools: map[string]*syncPool{
+				hash.String(): {pool: newPool(time.Hour, stats)},
+			},
+		}
+		manager.nodes.add("peer1")
+		manager.pools[hash.String()].add("peer1")
+		transfer := TransferStats{Bytes: 100 << 20, Duration: time.Second}
+		stats.updateStats("peer1", transfer)
+
+		manager.doneFunc(hash, "peer1", sourceDiscoveredNodes)(ResultCooldownPeerNoPenalty)
+
+		score, measured := stats.score("peer1")
+		require.True(t, measured)
+		require.Equal(t, float64(transfer.Bytes), score)
+		require.Zero(t, manager.nodes.len())
+		require.Zero(t, manager.pools[hash.String()].len())
+	})
+
 	t.Run("Verify pool by headerSub", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		t.Cleanup(cancel)

--- a/share/shwap/p2p/shrex/peers/pool.go
+++ b/share/shwap/p2p/shrex/peers/pool.go
@@ -70,13 +70,10 @@ func (p *pool) tryGet() (peer.ID, bool) {
 		return first, true
 	}
 
-	second, _, ok := p.activeFrom(rand.IntN(len(p.peersList))) //nolint:gosec
+	second, _, _ := p.activeFrom(rand.IntN(len(p.peersList))) //nolint:gosec
 	if second == first {
 		// both draws landed on the same peer, take the next active one instead
-		second, _, ok = p.activeFrom(idx + 1)
-	}
-	if !ok {
-		return first, true
+		second, _, _ = p.activeFrom(idx + 1)
 	}
 
 	return p.stats.selectPeer(first, second), true

--- a/share/shwap/p2p/shrex/peers/pool.go
+++ b/share/shwap/p2p/shrex/peers/pool.go
@@ -19,9 +19,9 @@ type pool struct {
 	cooldown    *timedQueue
 	activeCount int
 
-	// scores ranks peers by observed throughput and is shared with all other pools of the
+	// stats ranks peers by observed throughput and is shared with all other pools of the
 	// same Manager
-	scores *scoreboard
+	stats *peerStats
 
 	hasPeer   bool
 	hasPeerCh chan struct{}
@@ -38,11 +38,11 @@ const (
 )
 
 // newPool returns new empty pool.
-func newPool(peerCooldownTime time.Duration, scores *scoreboard) *pool {
+func newPool(peerCooldownTime time.Duration, stats *peerStats) *pool {
 	p := &pool{
 		peersList:        make([]peer.ID, 0),
 		statuses:         make(map[peer.ID]status),
-		scores:           scores,
+		stats:            stats,
 		hasPeerCh:        make(chan struct{}),
 		cleanupThreshold: defaultCleanupThreshold,
 	}
@@ -52,8 +52,8 @@ func newPool(peerCooldownTime time.Duration, scores *scoreboard) *pool {
 
 // tryGet returns peer along with bool flag indicating success of operation.
 // Peers are selected by power-of-two-choices: two random active peers are sampled and the one
-// with the higher throughput score wins. Sampling instead of always taking the best score keeps
-// concurrent callers from herding onto a single peer.
+// with the higher throughput score wins. Unmeasured peers get priority so every peer can establish
+// a score. Sampling instead of always taking the best score limits herding onto a single peer.
 func (p *pool) tryGet() (peer.ID, bool) {
 	p.m.Lock()
 	defer p.m.Unlock()
@@ -79,10 +79,7 @@ func (p *pool) tryGet() (peer.ID, bool) {
 		return first, true
 	}
 
-	if p.scores.score(second) > p.scores.score(first) {
-		return second, true
-	}
-	return first, true
+	return p.stats.selectPeer(first, second), true
 }
 
 // activeFrom returns the first active peer at or after idx, wrapping around the peers list.

--- a/share/shwap/p2p/shrex/peers/pool.go
+++ b/share/shwap/p2p/shrex/peers/pool.go
@@ -2,6 +2,7 @@ package peers
 
 import (
 	"context"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -10,14 +11,17 @@ import (
 
 const defaultCleanupThreshold = 2
 
-// pool stores peers and provides methods for simple round-robin access.
+// pool stores peers and provides methods for throughput-based access.
 type pool struct {
 	m           sync.RWMutex
 	peersList   []peer.ID
 	statuses    map[peer.ID]status
 	cooldown    *timedQueue
 	activeCount int
-	nextIdx     int
+
+	// scores ranks peers by observed throughput and is shared with all other pools of the
+	// same Manager
+	scores *scoreboard
 
 	hasPeer   bool
 	hasPeerCh chan struct{}
@@ -34,10 +38,11 @@ const (
 )
 
 // newPool returns new empty pool.
-func newPool(peerCooldownTime time.Duration) *pool {
+func newPool(peerCooldownTime time.Duration, scores *scoreboard) *pool {
 	p := &pool{
 		peersList:        make([]peer.ID, 0),
 		statuses:         make(map[peer.ID]status),
+		scores:           scores,
 		hasPeerCh:        make(chan struct{}),
 		cleanupThreshold: defaultCleanupThreshold,
 	}
@@ -46,6 +51,9 @@ func newPool(peerCooldownTime time.Duration) *pool {
 }
 
 // tryGet returns peer along with bool flag indicating success of operation.
+// Peers are selected by power-of-two-choices: two random active peers are sampled and the one
+// with the higher throughput score wins. Sampling instead of always taking the best score keeps
+// concurrent callers from herding onto a single peer.
 func (p *pool) tryGet() (peer.ID, bool) {
 	p.m.Lock()
 	defer p.m.Unlock()
@@ -54,29 +62,38 @@ func (p *pool) tryGet() (peer.ID, bool) {
 		return "", false
 	}
 
-	// if pointer is out of range, point to first element
-	if p.nextIdx > len(p.peersList)-1 {
-		p.nextIdx = 0
+	first, idx, ok := p.activeFrom(rand.IntN(len(p.peersList))) //nolint:gosec
+	if !ok {
+		return "", false
+	}
+	if p.activeCount == 1 {
+		return first, true
 	}
 
-	start := p.nextIdx
-	for {
-		peerID := p.peersList[p.nextIdx]
+	second, _, ok := p.activeFrom(rand.IntN(len(p.peersList))) //nolint:gosec
+	if second == first {
+		// both draws landed on the same peer, take the next active one instead
+		second, _, ok = p.activeFrom(idx + 1)
+	}
+	if !ok {
+		return first, true
+	}
 
-		p.nextIdx++
-		if p.nextIdx == len(p.peersList) {
-			p.nextIdx = 0
-		}
+	if p.scores.score(second) > p.scores.score(first) {
+		return second, true
+	}
+	return first, true
+}
 
-		if p.statuses[peerID] == active {
-			return peerID, true
-		}
-
-		// full circle passed
-		if p.nextIdx == start {
-			return "", false
+// activeFrom returns the first active peer at or after idx, wrapping around the peers list.
+func (p *pool) activeFrom(idx int) (peer.ID, int, bool) {
+	for i := range p.peersList {
+		j := (idx + i) % len(p.peersList)
+		if p.statuses[p.peersList[j]] == active {
+			return p.peersList[j], j, true
 		}
 	}
+	return "", 0, false
 }
 
 // next sends a peer to the returned channel when it becomes available.

--- a/share/shwap/p2p/shrex/peers/pool_test.go
+++ b/share/shwap/p2p/shrex/peers/pool_test.go
@@ -12,9 +12,9 @@ import (
 func newTestPool(t *testing.T, peerCooldownTime time.Duration) *pool {
 	t.Helper()
 
-	scores, err := newScoreboard()
+	stats, err := newPeerStats()
 	require.NoError(t, err)
-	return newPool(peerCooldownTime, scores)
+	return newPool(peerCooldownTime, stats)
 }
 
 func TestPool(t *testing.T) {
@@ -44,8 +44,8 @@ func TestPool(t *testing.T) {
 		p := newTestPool(t, time.Second)
 		p.add("fast", "slow")
 
-		p.scores.observe("fast", Sample{Bytes: 100 << 20, Duration: time.Second})
-		p.scores.observe("slow", Sample{Bytes: 1 << 10, Duration: time.Second})
+		p.stats.updateStats("fast", TransferStats{Bytes: 100 << 20, Duration: time.Second})
+		p.stats.updateStats("slow", TransferStats{Bytes: 1 << 10, Duration: time.Second})
 
 		// with two active peers both are always sampled, so the faster one always wins
 		for range 10 {
@@ -55,26 +55,24 @@ func TestPool(t *testing.T) {
 		}
 	})
 
-	t.Run("unmeasured peer wins against measured slow peer", func(t *testing.T) {
+	t.Run("unmeasured peer wins against any measured peer", func(t *testing.T) {
 		p := newTestPool(t, time.Second)
-		p.add("slow", "unmeasured")
+		p.add("fast", "unmeasured")
 
-		p.scores.observe("slow", Sample{Bytes: 1 << 10, Duration: time.Second})
+		p.stats.updateStats("fast", TransferStats{Bytes: 100 << 20, Duration: time.Second})
 
-		for range 10 {
-			peerID, ok := p.tryGet()
-			require.True(t, ok)
-			require.Equal(t, peer.ID("unmeasured"), peerID)
-		}
+		peerID, ok := p.tryGet()
+		require.True(t, ok)
+		require.Equal(t, peer.ID("unmeasured"), peerID)
 	})
 
 	t.Run("does not herd onto the fastest peer", func(t *testing.T) {
 		p := newTestPool(t, time.Second)
 		p.add("fast", "mid1", "mid2", "mid3")
 
-		p.scores.observe("fast", Sample{Bytes: 100 << 20, Duration: time.Second})
+		p.stats.updateStats("fast", TransferStats{Bytes: 100 << 20, Duration: time.Second})
 		for _, mid := range []peer.ID{"mid1", "mid2", "mid3"} {
-			p.scores.observe(mid, Sample{Bytes: 1 << 20, Duration: time.Second})
+			p.stats.updateStats(mid, TransferStats{Bytes: 1 << 20, Duration: time.Second})
 		}
 
 		got := make(map[peer.ID]int)

--- a/share/shwap/p2p/shrex/peers/pool_test.go
+++ b/share/shwap/p2p/shrex/peers/pool_test.go
@@ -9,9 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newTestPool(t *testing.T, peerCooldownTime time.Duration) *pool {
+	t.Helper()
+
+	scores, err := newScoreboard()
+	require.NoError(t, err)
+	return newPool(peerCooldownTime, scores)
+}
+
 func TestPool(t *testing.T) {
 	t.Run("add / remove peers", func(t *testing.T) {
-		p := newPool(time.Second)
+		p := newTestPool(t, time.Second)
 
 		peers := []peer.ID{"peer1", "peer1", "peer2", "peer3"}
 		// adding same peer twice should not produce copies
@@ -32,37 +40,69 @@ func TestPool(t *testing.T) {
 		require.False(t, ok)
 	})
 
-	t.Run("round robin", func(t *testing.T) {
-		p := newPool(time.Second)
+	t.Run("prefers peer with higher throughput", func(t *testing.T) {
+		p := newTestPool(t, time.Second)
+		p.add("fast", "slow")
 
-		peers := []peer.ID{"peer1", "peer1", "peer2", "peer3"}
-		// adding same peer twice should not produce copies
+		p.scores.observe("fast", Sample{Bytes: 100 << 20, Duration: time.Second})
+		p.scores.observe("slow", Sample{Bytes: 1 << 10, Duration: time.Second})
+
+		// with two active peers both are always sampled, so the faster one always wins
+		for range 10 {
+			peerID, ok := p.tryGet()
+			require.True(t, ok)
+			require.Equal(t, peer.ID("fast"), peerID)
+		}
+	})
+
+	t.Run("unmeasured peer wins against measured slow peer", func(t *testing.T) {
+		p := newTestPool(t, time.Second)
+		p.add("slow", "unmeasured")
+
+		p.scores.observe("slow", Sample{Bytes: 1 << 10, Duration: time.Second})
+
+		for range 10 {
+			peerID, ok := p.tryGet()
+			require.True(t, ok)
+			require.Equal(t, peer.ID("unmeasured"), peerID)
+		}
+	})
+
+	t.Run("does not herd onto the fastest peer", func(t *testing.T) {
+		p := newTestPool(t, time.Second)
+		p.add("fast", "mid1", "mid2", "mid3")
+
+		p.scores.observe("fast", Sample{Bytes: 100 << 20, Duration: time.Second})
+		for _, mid := range []peer.ID{"mid1", "mid2", "mid3"} {
+			p.scores.observe(mid, Sample{Bytes: 1 << 20, Duration: time.Second})
+		}
+
+		got := make(map[peer.ID]int)
+		for range 100 {
+			peerID, ok := p.tryGet()
+			require.True(t, ok)
+			got[peerID]++
+		}
+
+		// the fastest peer wins every pair it is sampled in, but the pairs it is not
+		// sampled in still go to other peers
+		require.Greater(t, got["fast"], 0)
+		require.Less(t, got["fast"], 100)
+	})
+
+	t.Run("removed peers are never returned", func(t *testing.T) {
+		p := newTestPool(t, time.Second)
+
+		peers := []peer.ID{"peer1", "peer2", "peer3"}
 		p.add(peers...)
-		require.Equal(t, 3, p.activeCount)
-
-		peerID, ok := p.tryGet()
-		require.True(t, ok)
-		require.Equal(t, peer.ID("peer1"), peerID)
-
-		peerID, ok = p.tryGet()
-		require.True(t, ok)
-		require.Equal(t, peer.ID("peer2"), peerID)
-
-		peerID, ok = p.tryGet()
-		require.True(t, ok)
-		require.Equal(t, peer.ID("peer3"), peerID)
-
-		peerID, ok = p.tryGet()
-		require.True(t, ok)
-		require.Equal(t, peer.ID("peer1"), peerID)
-
 		p.remove("peer2", "peer3")
 		require.Equal(t, 1, p.activeCount)
 
-		// pointer should skip removed items until found active one
-		peerID, ok = p.tryGet()
-		require.True(t, ok)
-		require.Equal(t, peer.ID("peer1"), peerID)
+		for range 10 {
+			peerID, ok := p.tryGet()
+			require.True(t, ok)
+			require.Equal(t, peer.ID("peer1"), peerID)
+		}
 	})
 
 	t.Run("wait for peer", func(t *testing.T) {
@@ -73,7 +113,7 @@ func TestPool(t *testing.T) {
 		longCtx, cancel := context.WithTimeout(context.Background(), timeout)
 		t.Cleanup(cancel)
 
-		p := newPool(time.Second)
+		p := newTestPool(t, time.Second)
 		done := make(chan struct{})
 
 		go func() {
@@ -103,30 +143,13 @@ func TestPool(t *testing.T) {
 		}
 	})
 
-	t.Run("nextIdx got removed", func(t *testing.T) {
-		p := newPool(time.Second)
-
-		peers := []peer.ID{"peer1", "peer2", "peer3"}
-		p.add(peers...)
-		p.nextIdx = 2
-		p.remove(peers[p.nextIdx])
-
-		// if previous nextIdx was removed, tryGet should iterate until available peer found
-		peerID, ok := p.tryGet()
-		require.True(t, ok)
-		require.Equal(t, peers[0], peerID)
-	})
-
 	t.Run("cleanup", func(t *testing.T) {
-		p := newPool(time.Second)
+		p := newTestPool(t, time.Second)
 		p.cleanupThreshold = 3
 
 		peers := []peer.ID{"peer1", "peer2", "peer3", "peer4", "peer5"}
 		p.add(peers...)
 		require.Equal(t, len(peers), p.activeCount)
-
-		// point to last element that will be removed, to check how pointer will be updated
-		p.nextIdx = len(peers) - 1
 
 		// remove some, but not trigger cleanup yet
 		p.remove(peers[3:]...)
@@ -137,15 +160,11 @@ func TestPool(t *testing.T) {
 		p.remove(peers[2])
 		require.Equal(t, len(peers)-3, p.activeCount)
 		require.Equal(t, len(peers)-3, len(p.statuses))
-
-		// nextIdx pointer should be updated after next tryGet
-		p.tryGet()
-		require.Equal(t, 1, p.nextIdx)
 	})
 
 	t.Run("cooldown blocks get", func(t *testing.T) {
 		ttl := time.Second / 10
-		p := newPool(ttl)
+		p := newTestPool(t, ttl)
 
 		peerID := peer.ID("peer1")
 		p.add(peerID)
@@ -168,7 +187,7 @@ func TestPool(t *testing.T) {
 	})
 
 	t.Run("put on cooldown removed item should be noop", func(t *testing.T) {
-		p := newPool(time.Second)
+		p := newTestPool(t, time.Second)
 		p.cleanupThreshold = 3
 
 		peerID := peer.ID("peer1")

--- a/share/shwap/p2p/shrex/peers/pool_test.go
+++ b/share/shwap/p2p/shrex/peers/pool_test.go
@@ -55,6 +55,19 @@ func TestPool(t *testing.T) {
 		}
 	})
 
+	t.Run("finds second active peer", func(t *testing.T) {
+		p := newTestPool(t, time.Second)
+		p.add("peer1", "peer2")
+
+		first, idx, ok := p.activeFrom(0)
+		require.True(t, ok)
+
+		second, _, ok := p.activeFrom(idx + 1)
+		require.True(t, ok)
+		require.NotEmpty(t, second)
+		require.NotEqual(t, first, second)
+	})
+
 	t.Run("unmeasured peer wins against any measured peer", func(t *testing.T) {
 		p := newTestPool(t, time.Second)
 		p.add("fast", "unmeasured")

--- a/share/shwap/p2p/shrex/peers/score.go
+++ b/share/shwap/p2p/shrex/peers/score.go
@@ -1,0 +1,73 @@
+package peers
+
+import (
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Sample is an observed data transfer, reported by the caller of Peer through DoneFunc.
+type Sample struct {
+	Bytes    int64
+	Duration time.Duration
+}
+
+// scoreboard keeps an EWMA of observed throughput (bytes/s) per peer. It is shared by all pools
+// of a Manager, so a peer keeps its score across datahashes.
+type scoreboard struct {
+	m      sync.Mutex
+	scores *lru.Cache[peer.ID, float64]
+
+	// seed is the score of a peer that has not been measured yet.
+	seed float64
+	// alpha is the weight given to the newest sample.
+	alpha float64
+}
+
+func newScoreboard() (*scoreboard, error) {
+	// scores of evicted peers are simply re-seeded on next observation, so bounding the cache
+	// only costs accuracy for peers we have not talked to in a long time.
+	scores, err := lru.New[peer.ID, float64](1024)
+	if err != nil {
+		return nil, err
+	}
+
+	return &scoreboard{
+		scores: scores,
+		// optimistic seed: above the throughput a single peer serves in practice, so an
+		// unmeasured peer wins against measured mediocre ones and gets a chance to prove itself
+		seed: 10 << 20,
+		// adapt over a handful of requests
+		alpha: 0.25,
+	}, nil
+}
+
+// score returns the peer's throughput in bytes/s.
+func (s *scoreboard) score(peerID peer.ID) float64 {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if score, ok := s.scores.Get(peerID); ok {
+		return score
+	}
+	return s.seed
+}
+
+// observe folds the sample into the peer's throughput score.
+func (s *scoreboard) observe(peerID peer.ID, sample Sample) {
+	if sample.Bytes <= 0 || sample.Duration <= 0 {
+		return
+	}
+	rate := float64(sample.Bytes) / sample.Duration.Seconds()
+
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	prev, ok := s.scores.Get(peerID)
+	if !ok {
+		prev = s.seed
+	}
+	s.scores.Add(peerID, prev+s.alpha*(rate-prev))
+}

--- a/share/shwap/p2p/shrex/peers/score.go
+++ b/share/shwap/p2p/shrex/peers/score.go
@@ -8,66 +8,110 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// Sample is an observed data transfer, reported by the caller of Peer through DoneFunc.
-type Sample struct {
+const (
+	peerStatsCacheSize = 1024
+	defaultPeerScore   = 10 << 20
+	peerScoreAlpha     = 0.25
+	peerScoreDecay     = 0.8
+)
+
+// TransferStats describes a successful data transfer reported through DoneFunc.
+type TransferStats struct {
 	Bytes    int64
 	Duration time.Duration
 }
 
-// scoreboard keeps an EWMA of observed throughput (bytes/s) per peer. It is shared by all pools
-// of a Manager, so a peer keeps its score across datahashes.
-type scoreboard struct {
-	m      sync.Mutex
-	scores *lru.Cache[peer.ID, float64]
-
-	// seed is the score of a peer that has not been measured yet.
-	seed float64
-	// alpha is the weight given to the newest sample.
-	alpha float64
+type peerStat struct {
+	score    float64
+	measured bool
 }
 
-func newScoreboard() (*scoreboard, error) {
-	// scores of evicted peers are simply re-seeded on next observation, so bounding the cache
-	// only costs accuracy for peers we have not talked to in a long time.
-	scores, err := lru.New[peer.ID, float64](1024)
+// peerStats keeps an EWMA of observed throughput (bytes/s) per peer. It is shared by all pools
+// of a Manager, so a peer keeps its score across data hashes.
+type peerStats struct {
+	m      sync.Mutex
+	scores *lru.Cache[peer.ID, peerStat]
+}
+
+func newPeerStats() (*peerStats, error) {
+	// Scores of evicted peers are measured again on their next successful request. Bounding the
+	// cache only costs accuracy for peers we have not talked to in a long time.
+	scores, err := lru.New[peer.ID, peerStat](peerStatsCacheSize)
 	if err != nil {
 		return nil, err
 	}
 
-	return &scoreboard{
+	return &peerStats{
 		scores: scores,
-		// optimistic seed: above the throughput a single peer serves in practice, so an
-		// unmeasured peer wins against measured mediocre ones and gets a chance to prove itself
-		seed: 10 << 20,
-		// adapt over a handful of requests
-		alpha: 0.25,
 	}, nil
 }
 
-// score returns the peer's throughput in bytes/s.
-func (s *scoreboard) score(peerID peer.ID) float64 {
+// score returns the peer's throughput in bytes/s and whether it has been measured.
+func (s *peerStats) score(peerID peer.ID) (float64, bool) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	if score, ok := s.scores.Get(peerID); ok {
-		return score
-	}
-	return s.seed
+	stat, ok := s.scores.Get(peerID)
+	return stat.score, ok && stat.measured
 }
 
-// observe folds the sample into the peer's throughput score.
-func (s *scoreboard) observe(peerID peer.ID, sample Sample) {
-	if sample.Bytes <= 0 || sample.Duration <= 0 {
+// selectPeer returns the better of two peers. A new peer gets one priority selection, then uses
+// defaultPeerScore until the request reports its result.
+func (s *peerStats) selectPeer(first, second peer.ID) peer.ID {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	firstStat, firstKnown := s.scores.Get(first)
+	secondStat, secondKnown := s.scores.Get(second)
+
+	selected := first
+	switch {
+	case firstKnown && !secondKnown:
+		selected = second
+	case firstKnown && secondKnown && secondStat.score > firstStat.score:
+		selected = second
+	}
+
+	selectedKnown := firstKnown
+	if selected == second {
+		selectedKnown = secondKnown
+	}
+	if !selectedKnown {
+		s.scores.Add(selected, peerStat{score: defaultPeerScore})
+	}
+	return selected
+}
+
+// updateStats folds a successful transfer into the peer's throughput score.
+func (s *peerStats) updateStats(peerID peer.ID, stats TransferStats) {
+	if stats.Bytes <= 0 || stats.Duration <= 0 {
 		return
 	}
-	rate := float64(sample.Bytes) / sample.Duration.Seconds()
+	rate := float64(stats.Bytes) / stats.Duration.Seconds()
 
 	s.m.Lock()
 	defer s.m.Unlock()
 
 	prev, ok := s.scores.Get(peerID)
-	if !ok {
-		prev = s.seed
+	if !ok || !prev.measured {
+		s.scores.Add(peerID, peerStat{score: rate, measured: true})
+		return
 	}
-	s.scores.Add(peerID, prev+s.alpha*(rate-prev))
+	prev.score += peerScoreAlpha * (rate - prev.score)
+	s.scores.Add(peerID, prev)
+}
+
+// decreaseScore lowers a peer's score after a failed request. An unmeasured peer starts from
+// defaultPeerScore so one failing peer cannot remain permanently preferred for exploration.
+func (s *peerStats) decreaseScore(peerID peer.ID) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	stat, ok := s.scores.Get(peerID)
+	if !ok {
+		stat.score = defaultPeerScore
+	}
+	stat.score *= peerScoreDecay
+	stat.measured = true
+	s.scores.Add(peerID, stat)
 }

--- a/share/shwap/p2p/shrex/peers/score_test.go
+++ b/share/shwap/p2p/shrex/peers/score_test.go
@@ -1,47 +1,100 @@
 package peers
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 
-// TestScoreboard tests that peers are seeded optimistically and that observed transfers move
-// their score towards the observed rate.
-func TestScoreboard(t *testing.T) {
-	t.Run("unmeasured peer gets optimistic seed", func(t *testing.T) {
-		s, err := newScoreboard()
+func TestPeerStats(t *testing.T) {
+	t.Run("unmeasured peer has no score", func(t *testing.T) {
+		s, err := newPeerStats()
 		require.NoError(t, err)
 
-		require.Equal(t, s.seed, s.score("peer1"))
+		_, measured := s.score("peer1")
+		require.False(t, measured)
+	})
+
+	t.Run("first transfer sets score", func(t *testing.T) {
+		s, err := newPeerStats()
+		require.NoError(t, err)
+
+		s.updateStats("peer1", TransferStats{Bytes: 100 << 20, Duration: time.Second})
+
+		score, measured := s.score("peer1")
+		require.True(t, measured)
+		require.Equal(t, float64(100<<20), score)
+	})
+
+	t.Run("unmeasured peer gets priority once", func(t *testing.T) {
+		s, err := newPeerStats()
+		require.NoError(t, err)
+
+		s.updateStats("measured", TransferStats{Bytes: 100 << 20, Duration: time.Second})
+		require.Equal(t, peer.ID("unmeasured"), s.selectPeer("measured", "unmeasured"))
+
+		_, measured := s.score("unmeasured")
+		require.False(t, measured)
+		require.Equal(t, peer.ID("measured"), s.selectPeer("measured", "unmeasured"))
 	})
 
 	t.Run("score moves towards observed rate", func(t *testing.T) {
-		s, err := newScoreboard()
+		s, err := newPeerStats()
 		require.NoError(t, err)
 
-		rate := 100 << 20
-		for range 100 {
-			s.observe("peer1", Sample{Bytes: int64(rate), Duration: time.Second})
+		s.updateStats("peer1", TransferStats{Bytes: 1 << 20, Duration: time.Second})
+		s.updateStats("peer1", TransferStats{Bytes: 5 << 20, Duration: time.Second})
+
+		score, measured := s.score("peer1")
+		require.True(t, measured)
+		require.Equal(t, float64(2<<20), score)
+	})
+
+	t.Run("failed request decreases score", func(t *testing.T) {
+		s, err := newPeerStats()
+		require.NoError(t, err)
+
+		s.updateStats("peer1", TransferStats{Bytes: 100 << 20, Duration: time.Second})
+		s.decreaseScore("peer1")
+
+		score, measured := s.score("peer1")
+		require.True(t, measured)
+		require.Equal(t, float64(100<<20)*peerScoreDecay, score)
+	})
+
+	t.Run("failed unmeasured peer gets a reduced default score", func(t *testing.T) {
+		s, err := newPeerStats()
+		require.NoError(t, err)
+
+		s.decreaseScore("peer1")
+
+		score, measured := s.score("peer1")
+		require.True(t, measured)
+		require.Equal(t, float64(defaultPeerScore)*peerScoreDecay, score)
+	})
+
+	t.Run("empty stats are ignored", func(t *testing.T) {
+		s, err := newPeerStats()
+		require.NoError(t, err)
+
+		s.updateStats("peer1", TransferStats{Bytes: 0, Duration: time.Second})
+		s.updateStats("peer1", TransferStats{Bytes: 1 << 20, Duration: 0})
+
+		_, measured := s.score("peer1")
+		require.False(t, measured)
+	})
+
+	t.Run("peer stats stay bounded", func(t *testing.T) {
+		s, err := newPeerStats()
+		require.NoError(t, err)
+
+		for i := range peerStatsCacheSize * 3 {
+			s.updateStats(peer.ID(strconv.Itoa(i)), TransferStats{Bytes: 1, Duration: time.Second})
 		}
-		require.InEpsilon(t, float64(rate), s.score("peer1"), 0.01)
-	})
 
-	t.Run("slow peer scores below seed", func(t *testing.T) {
-		s, err := newScoreboard()
-		require.NoError(t, err)
-
-		s.observe("peer1", Sample{Bytes: 1 << 10, Duration: time.Second})
-		require.Less(t, s.score("peer1"), s.seed)
-	})
-
-	t.Run("empty samples are ignored", func(t *testing.T) {
-		s, err := newScoreboard()
-		require.NoError(t, err)
-
-		s.observe("peer1", Sample{Bytes: 0, Duration: time.Second})
-		s.observe("peer1", Sample{Bytes: 1 << 20, Duration: 0})
-		require.Equal(t, s.seed, s.score("peer1"))
+		require.Equal(t, peerStatsCacheSize, s.scores.Len())
 	})
 }

--- a/share/shwap/p2p/shrex/peers/score_test.go
+++ b/share/shwap/p2p/shrex/peers/score_test.go
@@ -1,0 +1,47 @@
+package peers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestScoreboard tests that peers are seeded optimistically and that observed transfers move
+// their score towards the observed rate.
+func TestScoreboard(t *testing.T) {
+	t.Run("unmeasured peer gets optimistic seed", func(t *testing.T) {
+		s, err := newScoreboard()
+		require.NoError(t, err)
+
+		require.Equal(t, s.seed, s.score("peer1"))
+	})
+
+	t.Run("score moves towards observed rate", func(t *testing.T) {
+		s, err := newScoreboard()
+		require.NoError(t, err)
+
+		rate := 100 << 20
+		for range 100 {
+			s.observe("peer1", Sample{Bytes: int64(rate), Duration: time.Second})
+		}
+		require.InEpsilon(t, float64(rate), s.score("peer1"), 0.01)
+	})
+
+	t.Run("slow peer scores below seed", func(t *testing.T) {
+		s, err := newScoreboard()
+		require.NoError(t, err)
+
+		s.observe("peer1", Sample{Bytes: 1 << 10, Duration: time.Second})
+		require.Less(t, s.score("peer1"), s.seed)
+	})
+
+	t.Run("empty samples are ignored", func(t *testing.T) {
+		s, err := newScoreboard()
+		require.NoError(t, err)
+
+		s.observe("peer1", Sample{Bytes: 0, Duration: time.Second})
+		s.observe("peer1", Sample{Bytes: 1 << 20, Duration: 0})
+		require.Equal(t, s.seed, s.score("peer1"))
+	})
+}

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -131,7 +131,7 @@ func (sg *Getter) GetSamples(
 			"colIndex", request.ShareIndex,
 		)
 		errGroup.Go(func() error {
-			req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
+			req := func(ctx context.Context, peer libpeer.ID) (int64, time.Duration, error) {
 				return sg.client.Get(ctx, &request, &samples[i], peer)
 			}
 			verify := func() error {
@@ -183,7 +183,7 @@ func (sg *Getter) GetRow(ctx context.Context, header *header.ExtendedHeader, row
 		"rowIndex", rowIndex,
 	)
 
-	req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
+	req := func(ctx context.Context, peer libpeer.ID) (int64, time.Duration, error) {
 		return sg.client.Get(ctx, &request, &response, peer)
 	}
 
@@ -227,7 +227,7 @@ func (sg *Getter) GetEDS(ctx context.Context, header *header.ExtendedHeader) (*r
 		"hash", header.DAH.String(),
 	)
 
-	req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
+	req := func(ctx context.Context, peer libpeer.ID) (int64, time.Duration, error) {
 		response.shares = nil
 		return sg.client.Get(ctx, &request, response, peer)
 	}
@@ -289,7 +289,7 @@ func (sg *Getter) GetNamespaceData(
 		"namespace", namespace.String(),
 	)
 
-	req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
+	req := func(ctx context.Context, peer libpeer.ID) (int64, time.Duration, error) {
 		return sg.client.Get(ctx, &request, &response, peer)
 	}
 
@@ -348,7 +348,7 @@ func (sg *Getter) GetRangeNamespaceData(
 		"to", to,
 	)
 
-	req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
+	req := func(ctx context.Context, peer libpeer.ID) (int64, time.Duration, error) {
 		return sg.client.Get(ctx, &request, &response, peer)
 	}
 
@@ -395,8 +395,9 @@ func (sg *Getter) getPeer(
 
 // requestFn defines a function type that wraps the actual request logic as a closure.
 // The closure captures additional request parameters and then executes
-// the request with the provided context and peer ID, returning the amount of bytes received.
-type requestFn func(context.Context, libpeer.ID) (int64, error)
+// the request with the provided context and peer ID, returning the received byte count and
+// payload-read duration.
+type requestFn func(context.Context, libpeer.ID) (int64, time.Duration, error)
 
 // handleFn defines a function type that wraps response handling logic as a closure.
 // The closure captures the response data and validation parameters performing the verification.
@@ -441,8 +442,7 @@ func (sg *Getter) executeRequest(
 		reqStart := time.Now()
 		reqCtx, cancel := utils.CtxWithSplitTimeout(ctx, sg.minAttemptsCount-attempt+1, sg.minRequestTimeout)
 
-		bytesRead, getErr := req(reqCtx, peer)
-		requestDuration := time.Since(reqStart)
+		bytesRead, payloadDuration, getErr := req(reqCtx, peer)
 		cancel()
 		switch {
 		case getErr == nil:
@@ -454,7 +454,7 @@ func (sg *Getter) executeRequest(
 			}
 			// report throughput of verified data only, so a peer can't earn a good score by
 			// serving invalid responses fast
-			setStatus(peers.ResultNoop, peers.TransferStats{Bytes: bytesRead, Duration: requestDuration})
+			setStatus(peers.ResultNoop, peers.TransferStats{Bytes: bytesRead, Duration: payloadDuration})
 			sg.metrics.recordAttempts(ctx, reqType, attempt, true)
 			return nil
 		case ctx.Err() != nil:

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -131,7 +131,7 @@ func (sg *Getter) GetSamples(
 			"colIndex", request.ShareIndex,
 		)
 		errGroup.Go(func() error {
-			req := func(ctx context.Context, peer libpeer.ID) error {
+			req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
 				return sg.client.Get(ctx, &request, &samples[i], peer)
 			}
 			verify := func() error {
@@ -183,7 +183,7 @@ func (sg *Getter) GetRow(ctx context.Context, header *header.ExtendedHeader, row
 		"rowIndex", rowIndex,
 	)
 
-	req := func(ctx context.Context, peer libpeer.ID) error {
+	req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
 		return sg.client.Get(ctx, &request, &response, peer)
 	}
 
@@ -227,7 +227,7 @@ func (sg *Getter) GetEDS(ctx context.Context, header *header.ExtendedHeader) (*r
 		"hash", header.DAH.String(),
 	)
 
-	req := func(ctx context.Context, peer libpeer.ID) error {
+	req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
 		response.shares = nil
 		return sg.client.Get(ctx, &request, response, peer)
 	}
@@ -289,7 +289,7 @@ func (sg *Getter) GetNamespaceData(
 		"namespace", namespace.String(),
 	)
 
-	req := func(ctx context.Context, peer libpeer.ID) error {
+	req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
 		return sg.client.Get(ctx, &request, &response, peer)
 	}
 
@@ -348,7 +348,7 @@ func (sg *Getter) GetRangeNamespaceData(
 		"to", to,
 	)
 
-	req := func(ctx context.Context, peer libpeer.ID) error {
+	req := func(ctx context.Context, peer libpeer.ID) (int64, error) {
 		return sg.client.Get(ctx, &request, &response, peer)
 	}
 
@@ -395,8 +395,8 @@ func (sg *Getter) getPeer(
 
 // requestFn defines a function type that wraps the actual request logic as a closure.
 // The closure captures additional request parameters and then executes
-// the request with the provided context and peer ID.
-type requestFn func(context.Context, libpeer.ID) error
+// the request with the provided context and peer ID, returning the amount of bytes received.
+type requestFn func(context.Context, libpeer.ID) (int64, error)
 
 // handleFn defines a function type that wraps response handling logic as a closure.
 // The closure captures the response data and validation parameters performing the verification.
@@ -441,17 +441,19 @@ func (sg *Getter) executeRequest(
 		reqStart := time.Now()
 		reqCtx, cancel := utils.CtxWithSplitTimeout(ctx, sg.minAttemptsCount-attempt+1, sg.minRequestTimeout)
 
-		getErr = req(reqCtx, peer)
+		bytesRead, getErr := req(reqCtx, peer)
 		cancel()
 		switch {
 		case getErr == nil:
-			setStatus(peers.ResultNoop)
 			verifyErr := handle()
 			if verifyErr != nil {
 				getErr = verifyErr
 				setStatus(peers.ResultBlacklistPeer)
 				break
 			}
+			// report throughput of verified data only, so a peer can't earn a good score by
+			// serving invalid responses fast
+			setStatus(peers.ResultNoop, peers.Sample{Bytes: bytesRead, Duration: time.Since(reqStart)})
 			sg.metrics.recordAttempts(ctx, reqType, attempt, true)
 			return nil
 		case errors.Is(getErr, context.DeadlineExceeded),

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -465,7 +465,7 @@ func (sg *Getter) executeRequest(
 			setStatus(peers.ResultCooldownPeer)
 		case errors.Is(getErr, shrex.ErrNotFound):
 			getErr = shwap.ErrNotFound
-			setStatus(peers.ResultCooldownPeer)
+			setStatus(peers.ResultCooldownPeerNoPenalty)
 		case errors.Is(getErr, shrex.ErrResourceExhausted):
 			// peer is temporarily overloaded, not misbehaving; put it on cooldown so
 			// the peer manager won't hand it out again until it has had time to recover,

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -442,6 +442,7 @@ func (sg *Getter) executeRequest(
 		reqCtx, cancel := utils.CtxWithSplitTimeout(ctx, sg.minAttemptsCount-attempt+1, sg.minRequestTimeout)
 
 		bytesRead, getErr := req(reqCtx, peer)
+		requestDuration := time.Since(reqStart)
 		cancel()
 		switch {
 		case getErr == nil:
@@ -453,9 +454,12 @@ func (sg *Getter) executeRequest(
 			}
 			// report throughput of verified data only, so a peer can't earn a good score by
 			// serving invalid responses fast
-			setStatus(peers.ResultNoop, peers.Sample{Bytes: bytesRead, Duration: time.Since(reqStart)})
+			setStatus(peers.ResultNoop, peers.TransferStats{Bytes: bytesRead, Duration: requestDuration})
 			sg.metrics.recordAttempts(ctx, reqType, attempt, true)
 			return nil
+		case ctx.Err() != nil:
+			// The caller stopped the request; this says nothing about the peer's health.
+			setStatus(peers.ResultNoop)
 		case errors.Is(getErr, context.DeadlineExceeded),
 			errors.Is(getErr, context.Canceled):
 			setStatus(peers.ResultCooldownPeer)

--- a/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
@@ -517,7 +517,7 @@ func TestShrexGetter(t *testing.T) {
 
 func TestGetter_PrefersHigherThroughputPeer(t *testing.T) {
 	test := newPeerScoringTest(t)
-	test.slow.delay = 30 * time.Millisecond
+	test.slow.payloadDelay = 30 * time.Millisecond
 
 	// The first two requests give each unmeasured peer one request to establish its score.
 	test.getEDS(t)
@@ -534,7 +534,7 @@ func TestGetter_PrefersHigherThroughputPeer(t *testing.T) {
 
 func TestGetter_FallsBackWhenPreferredPeerDegrades(t *testing.T) {
 	test := newPeerScoringTest(t)
-	test.slow.delay = 30 * time.Millisecond
+	test.slow.payloadDelay = 30 * time.Millisecond
 	test.getEDS(t)
 	test.getEDS(t)
 
@@ -558,7 +558,7 @@ func TestGetter_FallsBackWhenPreferredPeerDegrades(t *testing.T) {
 
 func TestGetter_InvalidResponseUsesTemporaryCooldown(t *testing.T) {
 	test := newPeerScoringTest(t)
-	test.slow.delay = 30 * time.Millisecond
+	test.slow.payloadDelay = 30 * time.Millisecond
 	test.getEDS(t)
 	test.getEDS(t)
 
@@ -681,39 +681,40 @@ func (test *peerScoringTest) edsProtocol(t *testing.T) protocol.ID {
 type observedStore struct {
 	store.AccessorGetter
 
-	delay    time.Duration
-	requests atomic.Int64
-	corrupt  atomic.Bool
+	payloadDelay time.Duration
+	requests     atomic.Int64
+	corrupt      atomic.Bool
 }
 
 func (s *observedStore) GetByHeight(ctx context.Context, height uint64) (eds.AccessorStreamer, error) {
 	s.requests.Add(1)
-	if s.delay > 0 {
-		timer := time.NewTimer(s.delay)
-		defer timer.Stop()
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
-
 	accessor, err := s.AccessorGetter.GetByHeight(ctx, height)
 	if err != nil {
 		return nil, err
 	}
-	return observedAccessor{AccessorStreamer: accessor, corrupt: &s.corrupt}, nil
+	return observedAccessor{
+		AccessorStreamer: accessor,
+		payloadDelay:     s.payloadDelay,
+		corrupt:          &s.corrupt,
+	}, nil
 }
 
 type observedAccessor struct {
 	eds.AccessorStreamer
-	corrupt *atomic.Bool
+	payloadDelay time.Duration
+	corrupt      *atomic.Bool
 }
 
 func (a observedAccessor) Reader() (io.Reader, error) {
 	reader, err := a.AccessorStreamer.Reader()
-	if err != nil || !a.corrupt.Load() {
+	if err != nil {
 		return reader, err
+	}
+	if a.payloadDelay > 0 {
+		reader = &delayedReader{Reader: reader, delay: a.payloadDelay}
+	}
+	if !a.corrupt.Load() {
+		return reader, nil
 	}
 
 	data, err := io.ReadAll(reader)
@@ -722,6 +723,20 @@ func (a observedAccessor) Reader() (io.Reader, error) {
 	}
 	data[0] ^= 0xFF
 	return bytes.NewReader(data), nil
+}
+
+type delayedReader struct {
+	io.Reader
+	delay   time.Duration
+	delayed bool
+}
+
+func (r *delayedReader) Read(data []byte) (int, error) {
+	if !r.delayed {
+		time.Sleep(r.delay)
+		r.delayed = true
+	}
+	return r.Reader.Read(data)
 }
 
 func newStore(t *testing.T) (*store.Store, error) {

--- a/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex_test.go
@@ -1,8 +1,10 @@
 package shrex_getter //nolint:stylecheck // underscore in pkg name will be fixed with shrex refactoring
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"sync/atomic"
 	"testing"
@@ -11,6 +13,8 @@ import (
 	"github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
@@ -511,6 +515,215 @@ func TestShrexGetter(t *testing.T) {
 	})
 }
 
+func TestGetter_PrefersHigherThroughputPeer(t *testing.T) {
+	test := newPeerScoringTest(t)
+	test.slow.delay = 30 * time.Millisecond
+
+	// The first two requests give each unmeasured peer one request to establish its score.
+	test.getEDS(t)
+	test.getEDS(t)
+	require.EqualValues(t, 1, test.fast.requests.Load())
+	require.EqualValues(t, 1, test.slow.requests.Load())
+
+	for range 5 {
+		test.getEDS(t)
+	}
+	require.EqualValues(t, 6, test.fast.requests.Load())
+	require.EqualValues(t, 1, test.slow.requests.Load())
+}
+
+func TestGetter_FallsBackWhenPreferredPeerDegrades(t *testing.T) {
+	test := newPeerScoringTest(t)
+	test.slow.delay = 30 * time.Millisecond
+	test.getEDS(t)
+	test.getEDS(t)
+
+	var rejected atomic.Int64
+	test.fastHost.SetStreamHandler(test.edsProtocol(t), func(stream network.Stream) {
+		var request shwap.EdsID
+		_, _ = request.ReadFrom(stream)
+		rejected.Add(1)
+		_ = stream.ResetWithError(network.StreamResourceLimitExceeded)
+	})
+
+	test.getEDS(t)
+	require.EqualValues(t, 1, rejected.Load())
+	require.EqualValues(t, 2, test.slow.requests.Load())
+
+	peerID, done, err := test.manager.Peer(test.ctx, test.header.DAH.Hash(), test.header.Height())
+	require.NoError(t, err)
+	done(peers.ResultNoop)
+	require.Equal(t, test.slowHost.ID(), peerID, "the degraded peer must remain on cooldown")
+}
+
+func TestGetter_InvalidResponseUsesTemporaryCooldown(t *testing.T) {
+	test := newPeerScoringTest(t)
+	test.slow.delay = 30 * time.Millisecond
+	test.getEDS(t)
+	test.getEDS(t)
+
+	test.fast.corrupt.Store(true)
+	test.getEDS(t)
+	require.EqualValues(t, 2, test.fast.requests.Load())
+	require.EqualValues(t, 2, test.slow.requests.Load())
+	require.True(t, test.connGater.InterceptPeerDial(test.fastHost.ID()),
+		"blacklisting is disabled, so the connection gater must not block the peer")
+
+	test.fast.corrupt.Store(false)
+	require.Eventually(t, func() bool {
+		peerID, done, err := test.manager.Peer(test.ctx, test.header.DAH.Hash(), test.header.Height())
+		if err != nil {
+			return false
+		}
+		done(peers.ResultNoop)
+		return peerID == test.fastHost.ID()
+	}, time.Second, 10*time.Millisecond, "the peer must return after its temporary cooldown")
+
+	test.getEDS(t)
+	require.EqualValues(t, 3, test.fast.requests.Load(), "the invalid response must not reset the peer score")
+	require.EqualValues(t, 2, test.slow.requests.Load())
+}
+
+type peerScoringTest struct {
+	ctx context.Context
+
+	getter    *Getter
+	manager   *peers.Manager
+	connGater *conngater.BasicConnectionGater
+	header    *header.ExtendedHeader
+	expected  *rsmt2d.ExtendedDataSquare
+	fast      *observedStore
+	slow      *observedStore
+	fastHost  host.Host
+	slowHost  host.Host
+}
+
+func newPeerScoringTest(t *testing.T) *peerScoringTest {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	net, err := mocknet.FullMeshConnected(3)
+	require.NoError(t, err)
+	hosts := net.Hosts()
+	clientHost, fastHost, slowHost := hosts[0], hosts[1], hosts[2]
+
+	st, err := newStore(t)
+	require.NoError(t, err)
+	expected, roots, _ := generateTestEDS(t)
+	const height = 1
+	require.NoError(t, st.PutODSQ4(ctx, roots, height, expected))
+
+	fast := &observedStore{AccessorGetter: st}
+	slow := &observedStore{AccessorGetter: st}
+	newShrexServer(ctx, t, fast, fastHost)
+	newShrexServer(ctx, t, slow, slowHost)
+
+	client, err := shrex.NewClient(shrex.DefaultClientParameters(), clientHost)
+	require.NoError(t, err)
+	require.NoError(t, client.WithMetrics())
+
+	connGater, err := conngater.NewBasicConnectionGater(ds_sync.MutexWrap(datastore.NewMapDatastore()))
+	require.NoError(t, err)
+	params := *peers.DefaultParameters()
+	params.PeerCooldown = 200 * time.Millisecond
+	manager, err := peers.NewManager(params, clientHost, connGater, "scored_full")
+	require.NoError(t, err)
+	archivalManager, err := peers.NewManager(params, clientHost, connGater, "scored_archival")
+	require.NoError(t, err)
+
+	getter := NewGetter(client, manager, archivalManager, availability.RequestWindow)
+	require.NoError(t, getter.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stop := context.WithTimeout(context.Background(), time.Second)
+		defer stop()
+		require.NoError(t, getter.Stop(stopCtx))
+	})
+
+	manager.UpdateNodePool(fastHost.ID(), true)
+	manager.UpdateNodePool(slowHost.ID(), true)
+
+	extHeader := headertest.RandExtendedHeaderWithRoot(t, roots)
+	extHeader.RawHeader.Height = height
+	extHeader.RawHeader.Time = time.Now()
+
+	return &peerScoringTest{
+		ctx:       ctx,
+		getter:    getter,
+		manager:   manager,
+		connGater: connGater,
+		header:    extHeader,
+		expected:  expected,
+		fast:      fast,
+		slow:      slow,
+		fastHost:  fastHost,
+		slowHost:  slowHost,
+	}
+}
+
+func (test *peerScoringTest) getEDS(t *testing.T) {
+	t.Helper()
+
+	got, err := test.getter.GetEDS(test.ctx, test.header)
+	require.NoError(t, err)
+	require.Equal(t, test.expected.Flattened(), got.Flattened())
+}
+
+func (test *peerScoringTest) edsProtocol(t *testing.T) protocol.ID {
+	t.Helper()
+
+	id, err := shwap.NewEdsID(test.header.Height())
+	require.NoError(t, err)
+	return shrex.ProtocolID(shrex.DefaultClientParameters().NetworkID(), id.Name())
+}
+
+type observedStore struct {
+	store.AccessorGetter
+
+	delay    time.Duration
+	requests atomic.Int64
+	corrupt  atomic.Bool
+}
+
+func (s *observedStore) GetByHeight(ctx context.Context, height uint64) (eds.AccessorStreamer, error) {
+	s.requests.Add(1)
+	if s.delay > 0 {
+		timer := time.NewTimer(s.delay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	accessor, err := s.AccessorGetter.GetByHeight(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+	return observedAccessor{AccessorStreamer: accessor, corrupt: &s.corrupt}, nil
+}
+
+type observedAccessor struct {
+	eds.AccessorStreamer
+	corrupt *atomic.Bool
+}
+
+func (a observedAccessor) Reader() (io.Reader, error) {
+	reader, err := a.AccessorStreamer.Reader()
+	if err != nil || !a.corrupt.Load() {
+		return reader, err
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	data[0] ^= 0xFF
+	return bytes.NewReader(data), nil
+}
+
 func newStore(t *testing.T) (*store.Store, error) {
 	t.Helper()
 
@@ -552,7 +765,22 @@ func testManager(
 func newShrexClientServer(
 	ctx context.Context, t *testing.T, edsStore store.AccessorGetter, srvHost, clHost host.Host,
 ) (*shrex.Client, *shrex.Server) {
-	// create server and register handler
+	t.Helper()
+
+	server := newShrexServer(ctx, t, edsStore, srvHost)
+
+	// create client and connect it to server
+	client, err := shrex.NewClient(shrex.DefaultClientParameters(), clHost)
+	require.NoError(t, err)
+	require.NoError(t, client.WithMetrics())
+	return client, server
+}
+
+func newShrexServer(
+	ctx context.Context, t *testing.T, edsStore store.AccessorGetter, srvHost host.Host,
+) *shrex.Server {
+	t.Helper()
+
 	server, err := shrex.NewServer(shrex.DefaultServerParameters(), srvHost, edsStore)
 	require.NoError(t, err)
 	require.NoError(t, server.WithMetrics())
@@ -560,12 +788,7 @@ func newShrexClientServer(
 	t.Cleanup(func() {
 		_ = server.Stop(ctx)
 	})
-
-	// create client and connect it to server
-	client, err := shrex.NewClient(shrex.DefaultClientParameters(), clHost)
-	require.NoError(t, err)
-	require.NoError(t, client.WithMetrics())
-	return client, server
+	return server
 }
 
 type wrappedStore struct {


### PR DESCRIPTION
# _Please read until the divider_

This PR replaces round-robin peer selection with throughput-aware selection for shrex requests.

Each peer receives an exponentially weighted moving average (EWMA) score. The score represents the observed transfer rate in bytes per second.

The peer manager samples two active peers and selects the peer with the higher score. This approach favors faster peers without sorting the full pool.

## Details

- Return the received byte count from shrex client requests.
- Record throughput only after the response passes validation.
- Exclude local validation and EDS construction time from the transfer duration.
- Share peer statistics across all pools in one peer manager.
- Bound peer statistics to 1,024 entries with an LRU cache.
- Give an unmeasured peer one priority selection to establish its score.
- Use a provisional score until the first request reports its result.
- Decrease a peer score by 20% after a timeout, overload, or other recoverable error.
- Put a failed peer on cooldown in both the data-hash pool and the discovery pool.
- Do not penalise a peer when the caller cancels the request.
- Keep the peer score unchanged after a blacklist result.
- Keep permanent peer blocking behind EnableBlackListing.

## Peer safety

Only successful and valid responses update throughput scores. A fast invalid response cannot improve the score of its sender.

A blacklist result puts the peer on temporary cooldown. It does not change the peer score.

When EnableBlackListing is false, the peer remains connected and returns after cooldown. When enabled, the connection gater blocks and disconnects the peer.

---------------------------------------------

_Read optionally - mostly for Rene memory_

## Follow-ups

### FLUP: Investigate and redesign peer blacklisting

Peer blacklisting remains disabled because it historically produced false positives. These false positives could permanently isolate honest nodes.

The follow-up must:

- Find the historical false-positive paths.
- Audit every producer of ResultBlacklistPeer.
- Separate cryptographically invalid data from incomplete network responses.
- Separate remote peer errors from local validation and context errors.
- Review hash blacklisting during forks, header delays, and subscription delays.
- Define recoverable cooldown, score penalties, and permanent blocking as separate actions.
- Consider strike thresholds, expiry times, and corroboration from other peers.
- Add coverage for honest peers that return errors under valid network conditions.
- Keep EnableBlackListing disabled until these cases are understood.

### FLUP: Add Tastora coverage for peer scoring

Suggested tests:

  - `shrex_peer_failover_and_recovery`
    Stop or pause one serving node. Make sure that another peer serves
    the request. Restart the node and make sure that the network
    recovers.

  - `shrex_concurrent_request_stability`
    Send concurrent EDS, sample, and namespace requests through several
    nodes. Make sure that requests complete without crashes or permanent
    stalls.
