### PR TITLE
docgen: fix invalid openrpc.json release asset

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -157,8 +157,9 @@ jobs:
         run: git checkout ${{ inputs.run-on-tag }}
 
       - run: |
-          set -e
+          set -eo pipefail
           make openrpc-gen > openrpc.json
+          jq -e . openrpc.json > /dev/null
           gh release upload "$LATEST_TAG" openrpc.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -184,6 +184,23 @@ jobs:
   #     - name: execute test run
   #       run: make test-unit-race ENABLE_VERBOSE=${{ runner.debug == '1' && 'true' || 'false' }}
 
+  openrpc_gen_check:
+    name: OpenRPC Gen Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: generate and validate openrpc.json
+        run: |
+          set -eo pipefail
+          make openrpc-gen > openrpc.json
+          jq -e . openrpc.json > /dev/null
+
   integration_test:
     name: Integration Tests
     needs: [go_mod_tidy_check, go_mod_parity_check, lint, lint-imports, unit_tests]

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -191,7 +191,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go-version }}
 

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -30,6 +30,7 @@ import (
 	"github.com/celestiaorg/celestia-node/das"
 	"github.com/celestiaorg/celestia-node/header"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/state"
 )
@@ -75,6 +76,7 @@ func init() {
 	add([]byte("byte array"))
 	add(time.Second)
 	add(node.Bridge)
+	add(p2p.Mainnet)
 	add(auth.Permission("admin"))
 
 	add(errors.New("error"))

--- a/api/docgen/openrpc.go
+++ b/api/docgen/openrpc.go
@@ -184,14 +184,18 @@ func NewOpenRPCDocument(comments, permissions Comments) *go_openrpc_reflect.Docu
 		return "", nil // noComment
 	}
 
-	appReflector.FnSchemaExamples = func(ty reflect.Type) (examples *meta_schema.Examples, err error) {
+	appReflector.FnSchemaExamples = func(ty reflect.Type) (*meta_schema.Examples, error) {
 		v, err := exampleValue(ty, ty) // This isn't ideal, but seems to work well enough.
 		if err != nil {
-			fmt.Println(err)
+			return nil, err
 		}
 		return &meta_schema.Examples{
 			meta_schema.AlwaysTrue(v),
 		}, nil
+	}
+
+	appReflector.FnSchemaTypeMap = func() func(ty reflect.Type) *jsonschema.Type {
+		return schemaTypeMap
 	}
 
 	appReflector.FnGetMethodDeprecated = func(_ reflect.Value, m reflect.Method, _ *ast.FuncDecl) (bool, error) {
@@ -213,6 +217,15 @@ func NewOpenRPCDocument(comments, permissions Comments) *go_openrpc_reflect.Docu
 
 	d.WithReflector(appReflector)
 	return d
+}
+
+// schemaTypeMap overrides the reflected JSON schema for types whose
+// MarshalJSON representation differs from their underlying Go kind.
+func schemaTypeMap(ty reflect.Type) *jsonschema.Type {
+	if ty == reflect.TypeOf(node.Type(0)) {
+		return &jsonschema.Type{Type: "string"}
+	}
+	return nil
 }
 
 const integerD = `{ "title": "number", "type": "number", "description": "Number is a number" }`


### PR DESCRIPTION
## Summary

Fixes #5159. Since v0.31.0 the released `openrpc.json` has been invalid — the first line is a generator error message, `p2p.Network` has a null example, and `node.Info.type` is described as `integer` even though `MarshalJSON` emits a string.

Root causes and fixes:

- `FnSchemaExamples` printed example-generation errors to stdout and returned `nil`. Since the release workflow redirects stdout into `openrpc.json`, that error line was prepended to the artifact and `make openrpc-gen` still exited `0`. Now it returns the error so generation actually fails.
- No example was registered for `p2p.Network`, so it fell through to the failure path above. Added `p2p.Mainnet` as the example.
- `node.Type` is a `uint8` with a `MarshalJSON` that emits a string. The default schema reflection saw `uint8` and produced `"integer"`. Wired `FnSchemaTypeMap` to a small mapper that returns `string` for `node.Type`.
- The release job had no validation between generation and upload. Added `jq -e` right before `gh release upload`.
- Nothing on PRs would have caught any of the above. Added a small `openrpc_gen_check` job in `go-ci.yml` that runs `make openrpc-gen | jq -e` on every PR.

## Test plan

- [x] `make openrpc-gen > /tmp/openrpc.json` exits 0 and stderr is empty
- [x] `jq -e . /tmp/openrpc.json` succeeds
- [x] `.methods[] | select(.name=="p2p.Network") | .result.schema.examples` → `["celestia"]`
- [x] `.methods[] | select(.name=="node.Info") | .result.schema.properties.type` → `{"type": "string"}`
- [x] `go build ./...` and `go test ./api/docgen/... ./cmd/celestia/... ./nodebuilder/node/... ./nodebuilder/p2p/...` pass
- [x] `golangci-lint run` on touched packages: 0 issues
- [ ] Confirm on the new `OpenRPC Gen Check` PR CI job passes