### PR TITLE
docs: document `CELESTIA_HOME` in the environment-variable table

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ make light-mocha-up CORE_IP=<ip>     # Use custom core IP
 
 ## Environment variables
 
-| Variable                | Explanation                         | Default value | Required |
-| ----------------------- | ----------------------------------- | ------------- | -------- |
-| `CELESTIA_BOOTSTRAPPER` | Start the node in bootstrapper mode | `false`       | Optional |
+| Variable                | Explanation                                                               | Default value                             | Required |
+| ----------------------- | ------------------------------------------------------------------------- | ----------------------------------------- | -------- |
+| `CELESTIA_BOOTSTRAPPER` | Start the node in bootstrapper mode                                       | `false`                                   | Optional |
+| `CELESTIA_HOME`         | Use this exact directory as the node store, instead of the default layout | `$HOME/.celestia-<node type>[-<network>]` | Optional |
 
 ## Package-specific documentation
 


### PR DESCRIPTION
## What this adds

One row: `CELESTIA_HOME`.

It is read at `nodebuilder/store.go:218`, inside `DefaultNodeStorePath`, and when set it is returned **verbatim** as the node store path:

```go
home := os.Getenv("CELESTIA_HOME")
if home != "" {
    return home, nil
}
```

so the default `.celestia-<node type>[-<network>]` suffix is **not** appended. That asymmetry is the part worth writing down: an operator who sets `CELESTIA_HOME` expecting a parent directory ends up with a different path than the default layout would produce, and today the only way to learn that is to read `store.go`.

## Scope

This PR originally added six variables. Per @vgonkivs's review everything else has been dropped and only `CELESTIA_HOME` remains. The branch has also been rebased onto current `main`, which it was 19 commits behind.

The diff is **+4/−3** in `README.md`: the new row, plus re-padding the three existing table lines so the columns stay aligned. Nothing else in the file is touched.
