### PR TITLE
core: Avoid duplicate authenticated gRPC retries

### DIFF
--- a/api/client/grpc.go
+++ b/api/client/grpc.go
@@ -72,9 +72,11 @@ func grpcClient(cfg CoreGRPCConfig) (*grpc.ClientConn, error) {
 		if !cfg.TLSEnabled {
 			log.Warn("auth token is set but TLS is disabled, this is insecure")
 		}
+		// The base retry interceptors already compose with this chain.
+		// Adding them again would nest retries.
 		opts = append(opts,
-			grpc.WithChainUnaryInterceptor(authInterceptor(cfg.AuthToken), retryInterceptor),
-			grpc.WithChainStreamInterceptor(authStreamInterceptor(cfg.AuthToken), retryStreamInterceptor),
+			grpc.WithChainUnaryInterceptor(authInterceptor(cfg.AuthToken)),
+			grpc.WithChainStreamInterceptor(authStreamInterceptor(cfg.AuthToken)),
 		)
 	}
 	normalizedAddr := utils.NormalizeGRPCAddress(cfg.Addr)

--- a/api/client/grpc_test.go
+++ b/api/client/grpc_test.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"testing"
+
+	"google.golang.org/grpc"
+
+	"github.com/celestiaorg/celestia-node/internal/grpctest"
+)
+
+func TestGRPCClientAuthUsesSingleRetryInterceptor(t *testing.T) {
+	grpctest.VerifySingleRetryInterceptor(t, func(
+		_ *testing.T,
+		addr string,
+		token string,
+	) (*grpc.ClientConn, error) {
+		return grpcClient(CoreGRPCConfig{Addr: addr, AuthToken: token})
+	})
+}

--- a/internal/grpctest/retry.go
+++ b/internal/grpctest/retry.go
@@ -1,0 +1,123 @@
+package grpctest
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type retryHealthServer struct {
+	healthpb.UnimplementedHealthServer
+	token          string
+	unaryAttempts  atomic.Int32
+	streamAttempts atomic.Int32
+}
+
+func (s *retryHealthServer) Check(
+	ctx context.Context,
+	_ *healthpb.HealthCheckRequest,
+) (*healthpb.HealthCheckResponse, error) {
+	if !hasToken(ctx, s.token) {
+		return nil, status.Error(codes.Unauthenticated, "missing token")
+	}
+	if s.unaryAttempts.Add(1) == 1 {
+		return nil, status.Error(codes.Unavailable, "retry")
+	}
+	return &healthpb.HealthCheckResponse{}, nil
+}
+
+func (s *retryHealthServer) Watch(
+	_ *healthpb.HealthCheckRequest,
+	stream grpc.ServerStreamingServer[healthpb.HealthCheckResponse],
+) error {
+	if !hasToken(stream.Context(), s.token) {
+		return status.Error(codes.Unauthenticated, "missing token")
+	}
+	if s.streamAttempts.Add(1) == 1 {
+		return status.Error(codes.Unavailable, "retry")
+	}
+	return stream.Send(&healthpb.HealthCheckResponse{})
+}
+
+// VerifySingleRetryInterceptor checks that per-call options reach the client's retry interceptor.
+func VerifySingleRetryInterceptor(
+	t *testing.T,
+	newClient func(*testing.T, string, string) (*grpc.ClientConn, error),
+) {
+	t.Helper()
+	const token = "test-token"
+
+	t.Run("unary", func(t *testing.T) {
+		addr, server := startServer(t, token)
+		conn := connect(t, newClient, addr, token)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, err := healthpb.NewHealthClient(conn).Check(
+			ctx,
+			&healthpb.HealthCheckRequest{},
+			grpc_retry.Disable(),
+		)
+		require.Equal(t, codes.Unavailable, status.Code(err))
+		require.Equal(t, int32(1), server.unaryAttempts.Load())
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		addr, server := startServer(t, token)
+		conn := connect(t, newClient, addr, token)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		stream, err := healthpb.NewHealthClient(conn).Watch(
+			ctx,
+			&healthpb.HealthCheckRequest{},
+			grpc_retry.Disable(),
+		)
+		require.NoError(t, err)
+		_, err = stream.Recv()
+		require.Equal(t, codes.Unavailable, status.Code(err))
+		require.Equal(t, int32(1), server.streamAttempts.Load())
+	})
+}
+
+func connect(
+	t *testing.T,
+	newClient func(*testing.T, string, string) (*grpc.ClientConn, error),
+	addr string,
+	token string,
+) *grpc.ClientConn {
+	t.Helper()
+	conn, err := newClient(t, addr, token)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	return conn
+}
+
+func startServer(t *testing.T, token string) (string, *retryHealthServer) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &retryHealthServer{token: token}
+	grpcServer := grpc.NewServer()
+	healthpb.RegisterHealthServer(grpcServer, server)
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+	return listener.Addr().String(), server
+}
+
+func hasToken(ctx context.Context, token string) bool {
+	md, ok := metadata.FromIncomingContext(ctx)
+	tokens := md.Get("x-token")
+	return ok && len(tokens) == 1 && tokens[0] == token
+}

--- a/nodebuilder/core/constructors.go
+++ b/nodebuilder/core/constructors.go
@@ -92,9 +92,11 @@ func grpcClient(lc fx.Lifecycle, cfg EndpointConfig) (*grpc.ClientConn, error) {
 		if err != nil {
 			return nil, err
 		}
+		// The base retry interceptors already compose with this chain.
+		// Adding them again would nest retries.
 		opts = append(opts,
-			grpc.WithChainUnaryInterceptor(authInterceptor(xToken), retryInterceptor),
-			grpc.WithChainStreamInterceptor(authStreamInterceptor(xToken), retryStreamInterceptor),
+			grpc.WithChainUnaryInterceptor(authInterceptor(xToken)),
+			grpc.WithChainStreamInterceptor(authStreamInterceptor(xToken)),
 		)
 	}
 	opts = append(opts,

--- a/nodebuilder/core/grpc_test.go
+++ b/nodebuilder/core/grpc_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/fx/fxtest"
+	"google.golang.org/grpc"
+
+	"github.com/celestiaorg/celestia-node/internal/grpctest"
+)
+
+func TestGRPCClientAuthUsesSingleRetryInterceptor(t *testing.T) {
+	grpctest.VerifySingleRetryInterceptor(t, func(
+		t *testing.T,
+		addr string,
+		token string,
+	) (*grpc.ClientConn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		tokenDir := t.TempDir()
+		if err := os.WriteFile(
+			filepath.Join(tokenDir, "xtoken.json"),
+			[]byte(`{"x-token":"`+token+`"}`),
+			0o600,
+		); err != nil {
+			return nil, err
+		}
+
+		return grpcClient(fxtest.NewLifecycle(t), EndpointConfig{
+			IP:         host,
+			Port:       port,
+			XTokenPath: tokenDir,
+		})
+	})
+}


### PR DESCRIPTION
## Summary

Authenticated core gRPC clients registered the same unary and stream retry interceptors twice: once as the primary interceptors and again in the authentication chains.

This nested the retry loops and prevented retry-specific call options such as `grpc_retry.Disable()` from reaching the inner interceptor. With the default maximum of five attempts, a persistent `Unavailable` response could result in up to 25 transport attempts.

This change keeps one retry interceptor for each RPC type and adds only the authentication interceptors to the chains. Authentication behavior remains unchanged for both the API client and the nodebuilder core client.

## Testing

Added regression coverage for authenticated unary and server-streaming calls in both clients. The tests verify that `grpc_retry.Disable()` returns the initial `Unavailable` error after exactly one server attempt.

- `go test ./api/client ./nodebuilder/core`
- `go test -race ./api/client ./nodebuilder/core -run '^TestGRPCClientAuthUsesSingleRetryInterceptor$' -count=10`
- `make test-unit-fast`
- `make lint-imports`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `./scripts/check-go-mod-parity.sh`