### PR TITLE
share/eds: Preserve intermediate nodes after cancellation

### DIFF
--- a/share/eds/retriever.go
+++ b/share/eds/retriever.go
@@ -107,9 +107,12 @@ func (r *Retriever) Retrieve(ctx context.Context, roots *share.AxisRoots) (*rsmt
 // quadrant request retries. Also, provides an API
 // to reconstruct the block once enough shares are fetched.
 type retrievalSession struct {
-	roots *share.AxisRoots
-	bget  blockservice.BlockGetter
-	adder *ipld.NmtNodeAdder
+	roots           *share.AxisRoots
+	bget            blockservice.BlockGetter
+	adder           *ipld.NmtNodeAdder
+	cancelAdder     context.CancelFunc
+	stopAdderCancel func() bool
+	commitTimeout   time.Duration
 
 	// TODO(@Wondertan): Extract into a separate data structure
 	// https://github.com/celestiaorg/rsmt2d/issues/135
@@ -128,7 +131,9 @@ type retrievalSession struct {
 func (r *Retriever) newSession(ctx context.Context, roots *share.AxisRoots) (*retrievalSession, error) {
 	size := len(roots.RowRoots)
 
-	adder := ipld.NewNmtNodeAdder(ctx, r.bServ, ipld.MaxSizeBatchOption(size))
+	// Keep the write batch alive long enough to commit after the retrieval context is canceled.
+	adderCtx, cancelAdder := context.WithCancel(context.WithoutCancel(ctx))
+	adder := ipld.NewNmtNodeAdder(adderCtx, r.bServ, ipld.MaxSizeBatchOption(size))
 	proofsVisitor := ipld.ProofsAdderFromCtx(ctx).VisitFn()
 	visitor := func(hash []byte, children ...[]byte) {
 		// use proofs adder if provided, to cache collected proofs while recomputing the eds
@@ -145,6 +150,7 @@ func (r *Retriever) newSession(ctx context.Context, roots *share.AxisRoots) (*re
 
 	square, err := rsmt2d.NewExtendedDataSquare(share.DefaultRSMT2DCodec(), treeFn, uint(size), libshare.ShareSize)
 	if err != nil {
+		cancelAdder()
 		return nil, err
 	}
 
@@ -152,6 +158,8 @@ func (r *Retriever) newSession(ctx context.Context, roots *share.AxisRoots) (*re
 		roots:           roots,
 		bget:            blockservice.NewSession(ctx, r.bServ),
 		adder:           adder,
+		cancelAdder:     cancelAdder,
+		commitTimeout:   blockTime,
 		squareQuadrants: newQuadrants(roots),
 		squareCellsLks:  make([][]sync.Mutex, size),
 		squareSig:       make(chan struct{}, 1),
@@ -159,6 +167,15 @@ func (r *Retriever) newSession(ctx context.Context, roots *share.AxisRoots) (*re
 		square:          square,
 		span:            trace.SpanFromContext(ctx),
 	}
+	ses.stopAdderCancel = context.AfterFunc(ctx, func() {
+		timer := time.NewTimer(ses.commitTimeout)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			ses.cancelAdder()
+		case <-adderCtx.Done():
+		}
+	})
 	for i := range ses.squareCellsLks {
 		ses.squareCellsLks[i] = make([]sync.Mutex, size)
 	}
@@ -211,9 +228,14 @@ func (rs *retrievalSession) isReconstructed() bool {
 
 func (rs *retrievalSession) close(success bool) {
 	defer rs.span.End()
+	defer rs.cancelAdder()
+	defer rs.stopAdderCancel()
 	if success {
 		return
 	}
+	// Bound the detached batch so a stalled write cannot block retrieval shutdown forever.
+	commitTimer := time.AfterFunc(rs.commitTimeout, rs.cancelAdder)
+	defer commitTimer.Stop()
 	// commit intermediate nodes to the blockservice if failed to reconstruct
 	err := rs.adder.Commit()
 	if err != nil {

--- a/share/eds/retriever_test.go
+++ b/share/eds/retriever_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ipfs/boxo/blockservice"
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -94,6 +95,143 @@ func TestRetriever_MultipleRandQuadrants(t *testing.T) {
 
 	_, err = ses.Reconstruct(ctx)
 	assert.NoError(t, err)
+}
+
+func TestRetriever_PersistsIntermediateNodesAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{}, 1)
+	gate := make(chan struct{})
+	bServ := &gatedBlockService{
+		BlockService: ipld.NewMemBlockservice(),
+		started:      started,
+		gate:         gate,
+	}
+	ses, roots, flattened, width := newPartialRetrievalSession(t, ctx, bServ)
+
+	reconstructed := make(chan error, 1)
+	go func() {
+		_, err := ses.Reconstruct(ctx)
+		reconstructed <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		close(gate)
+		t.Fatal("timed out waiting for intermediate NMT write")
+	}
+	cancel()
+	close(gate)
+	require.ErrorIs(t, <-reconstructed, rsmt2d.ErrUnrepairableDataSquare)
+	ses.close(false)
+
+	gotShare, err := ipld.GetShare(
+		context.Background(),
+		bServ,
+		ipld.MustCidFromNamespacedSha256(roots.RowRoots[3]),
+		0,
+		width,
+	)
+	require.NoError(t, err)
+	require.Equal(t, flattened[12], gotShare.ToBytes())
+}
+
+func TestRetriever_IntermediateNodeCommitIsBounded(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{}, 1)
+	canceled := make(chan struct{}, 1)
+	gate := make(chan struct{})
+	defer close(gate)
+	bServ := &gatedBlockService{
+		BlockService: ipld.NewMemBlockservice(),
+		started:      started,
+		canceled:     canceled,
+		gate:         gate,
+	}
+	ses, _, _, _ := newPartialRetrievalSession(t, ctx, bServ)
+	ses.commitTimeout = 10 * time.Millisecond
+
+	reconstructed := make(chan error, 1)
+	go func() {
+		_, err := ses.Reconstruct(ctx)
+		reconstructed <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for intermediate NMT write")
+	}
+	cancel()
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out canceling intermediate NMT write")
+	}
+	select {
+	case err := <-reconstructed:
+		require.ErrorIs(t, err, rsmt2d.ErrUnrepairableDataSquare)
+	case <-time.After(time.Second):
+		t.Fatal("timed out reconstructing after cancellation")
+	}
+	closed := make(chan struct{})
+	go func() {
+		ses.close(false)
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out closing retrieval session")
+	}
+}
+
+func newPartialRetrievalSession(
+	t *testing.T,
+	ctx context.Context,
+	bServ blockservice.BlockService,
+) (*retrievalSession, *share.AxisRoots, [][]byte, int) {
+	t.Helper()
+	eds := edstest.RandEDS(t, 2)
+	roots, err := share.NewAxisRoots(eds)
+	require.NoError(t, err)
+	ses, err := NewRetriever(bServ).newSession(ctx, roots)
+	require.NoError(t, err)
+	flattened := eds.Flattened()
+	width := int(eds.Width())
+	// These cells repair row 3 while leaving the rest of the square unrepairable.
+	for _, index := range []int{11, 14, 15} {
+		row, column := index/width, index%width
+		require.NoError(t, ses.square.SetCell(uint(row), uint(column), flattened[index]))
+	}
+	return ses, roots, flattened, width
+}
+
+type gatedBlockService struct {
+	blockservice.BlockService
+	started  chan<- struct{}
+	canceled chan<- struct{}
+	gate     <-chan struct{}
+}
+
+func (b *gatedBlockService) AddBlocks(ctx context.Context, blks []blocks.Block) error {
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-b.gate:
+	case <-ctx.Done():
+		select {
+		case b.canceled <- struct{}{}:
+		default:
+		}
+		return ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return b.BlockService.AddBlocks(ctx, blks)
 }
 
 func TestByzantineError(t *testing.T) {


### PR DESCRIPTION
## Summary

Failed EDS reconstruction can repair shares and calculate intermediate NMT nodes that should be reused by later retrieval attempts. The NMT write batch currently inherits the retrieval context, so cancellation invalidates the batch before `close(false)` can commit those nodes.

This change gives the batch a separate, bounded lifecycle. Failed retrievals can commit intermediate nodes after the request context is canceled, while a stalled write or commit is canceled after one block interval. Successful retrievals still close the batch without committing intermediate nodes.

The regression tests verify that a repaired share remains retrievable after cancellation and that blocked batch writes cannot prevent retrieval shutdown.

Closes #3314.

## Testing

- `go test ./share/eds -count=1`
- `go test -race ./share/eds -run '^(TestRetriever_PersistsIntermediateNodesAfterCancellation|TestRetriever_IntermediateNodeCommitIsBounded)$' -cpu=1 -count=10`
- `go vet ./share/eds`
- `make lint-imports`
- `golangci-lint run --new-from-rev origin/main ./...`
- `./scripts/check-go-mod-parity.sh`
