### PR TITLE
cmd: Load configured RPC URL with explicit token

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -53,7 +53,7 @@ func RPCFlags() *flag.FlagSet {
 }
 
 func InitClient(cmd *cobra.Command, _ []string) error {
-	if authTokenFlag == "" {
+	if authTokenFlag == "" || requestURL == "" {
 		rootErrMsg := "cant access the auth token"
 
 		storePath, err := getStorePath(cmd)
@@ -70,16 +70,18 @@ func InitClient(cmd *cobra.Command, _ []string) error {
 			requestURL = cfg.RPC.RequestURL()
 		}
 
-		// only get token if auth is not skipped
-		if cfg.RPC.SkipAuth {
-			authTokenFlag = "skip" // arbitrary value required
-		} else {
-			token, err := getToken(storePath)
-			if err != nil {
-				return fmt.Errorf("%s: %w", rootErrMsg, err)
-			}
+		if authTokenFlag == "" {
+			// only get token if auth is not skipped
+			if cfg.RPC.SkipAuth {
+				authTokenFlag = "skip" // arbitrary value required
+			} else {
+				token, err := getToken(storePath)
+				if err != nil {
+					return fmt.Errorf("%s: %w", rootErrMsg, err)
+				}
 
-			authTokenFlag = token
+				authTokenFlag = token
+			}
 		}
 	}
 

--- a/cmd/rpc_test.go
+++ b/cmd/rpc_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-node/nodebuilder"
+	nodemod "github.com/celestiaorg/celestia-node/nodebuilder/node"
+)
+
+func TestInitClientLoadsLocalURLWithExplicitToken(t *testing.T) {
+	previousURL := requestURL
+	previousToken := authTokenFlag
+	previousTimeout := timeoutFlag
+	t.Cleanup(func() {
+		requestURL = previousURL
+		authTokenFlag = previousToken
+		timeoutFlag = previousTimeout
+	})
+
+	storePath := t.TempDir()
+	cfg := nodebuilder.DefaultConfig(nodemod.Light)
+	cfg.RPC.Address = "127.0.0.2"
+	cfg.RPC.Port = "12345"
+	require.NoError(t, nodebuilder.SaveConfig(filepath.Join(storePath, "config.toml"), cfg))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.Flags().AddFlagSet(RPCFlags())
+	require.NoError(t, cmd.Flags().Set(nodeStoreFlag, storePath))
+	require.NoError(t, cmd.Flags().Set("token", "token"))
+
+	require.NoError(t, InitClient(cmd, nil))
+	client, err := ParseClientFromCtx(cmd.Context())
+	require.NoError(t, err)
+	client.Close()
+	require.Equal(t, cfg.RPC.RequestURL(), requestURL)
+	require.Equal(t, "token", authTokenFlag)
+}


### PR DESCRIPTION
## Summary

`InitClient` only loaded the local node configuration when `--token` was omitted. Passing `--token` without `--url` therefore left the RPC endpoint empty and caused client initialization to fail, even though the `--url` flag documents a config fallback.

Load the local configuration whenever either value is missing, then resolve the URL and token independently. This preserves an explicit token while filling an omitted URL from the node config, without changing existing behavior for the other flag combinations.

## Testing

- `go test ./cmd -count=1`
- `go test -race ./cmd -run '^TestInitClientLoadsLocalURLWithExplicitToken$' -count=20`
- `golangci-lint run --new-from-rev=origin/main ./cmd/...`
- `make lint-imports`
- `go mod tidy -diff`
- `./scripts/check-go-mod-parity.sh`