### PR TITLE
config: Support IPv6 literal endpoints

### DIFF
--- a/libs/utils/address.go
+++ b/libs/utils/address.go
@@ -32,7 +32,11 @@ func NormalizeGRPCAddress(addr string) string {
 func SanitizeAddr(addr string) (string, error) {
 	original := addr
 	addr = NormalizeAddress(addr)
-	addr = strings.Split(addr, ":")[0]
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		addr = host
+	} else if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+		addr = strings.TrimSuffix(strings.TrimPrefix(addr, "["), "]")
+	}
 	if addr == "" {
 		return "", fmt.Errorf("%w: %s", ErrInvalidIP, original)
 	}

--- a/libs/utils/address_test.go
+++ b/libs/utils/address_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const ipv6Loopback = "::1"
+
 func TestSanitizeAddr(t *testing.T) {
 	tests := []struct {
 		addr string
@@ -21,6 +23,14 @@ func TestSanitizeAddr(t *testing.T) {
 		{addr: "tcp://192.168.42.42:5050/", want: "192.168.42.42"},
 		// Testcase: invariant ip
 		{addr: "192.168.42.42", want: "192.168.42.42"},
+		// Testcase: invariant IPv6
+		{addr: ipv6Loopback, want: ipv6Loopback},
+		// Testcase: trims IPv6 brackets
+		{addr: "[::1]", want: ipv6Loopback},
+		// Testcase: trims IPv6 brackets and port
+		{addr: "[::1]:5050", want: ipv6Loopback},
+		// Testcase: trims protocol prefix, IPv6 brackets, port, and trailing slash suffix
+		{addr: "https://[2001:db8::1]:5050/", want: "2001:db8::1"},
 		// Testcase: empty addr
 		{addr: "", want: "", err: ErrInvalidIP},
 	}
@@ -47,6 +57,10 @@ func TestValidateAddr(t *testing.T) {
 		{addr: "192.168.42.42:5050", want: want{addr: "192.168.42.42"}},
 		// Testcase: ip is valid, no port
 		{addr: "192.168.42.42", want: want{addr: "192.168.42.42"}},
+		// Testcase: IPv6 is valid, no port
+		{addr: ipv6Loopback, want: want{addr: ipv6Loopback}},
+		// Testcase: IPv6 is valid with brackets and port
+		{addr: "[2001:db8::1]:5050", want: want{addr: "2001:db8::1"}},
 		// Testcase: resolves localhost
 		{addr: "http://localhost:8080/", want: want{unresolved: true}},
 		// Testcase: hostname is valid

--- a/nodebuilder/core/config.go
+++ b/nodebuilder/core/config.go
@@ -73,7 +73,8 @@ func (cfg *Config) Validate() error {
 	seen := map[string]struct{}{
 		net.JoinHostPort(cfg.IP, cfg.Port): {},
 	}
-	for _, additionalCfg := range cfg.AdditionalCoreEndpoints {
+	for i := range cfg.AdditionalCoreEndpoints {
+		additionalCfg := &cfg.AdditionalCoreEndpoints[i]
 		if err := additionalCfg.validate(); err != nil {
 			return fmt.Errorf("nodebuilder/core: invalid additional core endpoint configuration: %w", err)
 		}

--- a/nodebuilder/core/config_test.go
+++ b/nodebuilder/core/config_test.go
@@ -155,3 +155,15 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSanitizesAdditionalIPv6Endpoint(t *testing.T) {
+	cfg := Config{
+		EndpointConfig: EndpointConfig{IP: "127.0.0.1", Port: DefaultPort},
+		AdditionalCoreEndpoints: []EndpointConfig{
+			{IP: "[::1]", Port: DefaultPort},
+		},
+	}
+
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, "::1", cfg.AdditionalCoreEndpoints[0].IP)
+}

--- a/nodebuilder/core/flags_test.go
+++ b/nodebuilder/core/flags_test.go
@@ -44,6 +44,22 @@ func TestParseFlags(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "only core.ip IPv6",
+			args: []string{"--core.ip=::1"},
+			inputCfg: Config{
+				EndpointConfig: EndpointConfig{
+					Port: DefaultPort,
+				},
+			},
+			expectedCfg: Config{
+				EndpointConfig: EndpointConfig{
+					IP:   "::1",
+					Port: DefaultPort,
+				},
+			},
+			expectError: false,
+		},
+		{
 			name:     "only core.ip, empty port values",
 			args:     []string{"--core.ip=127.0.0.1"},
 			inputCfg: Config{},

--- a/nodebuilder/rpc/config.go
+++ b/nodebuilder/rpc/config.go
@@ -2,9 +2,9 @@ package rpc
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/celestiaorg/celestia-node/libs/utils"
 )
@@ -78,16 +78,15 @@ func DefaultCORSConfig() CORSConfig {
 }
 
 func (cfg *Config) RequestURL() string {
-	if strings.HasPrefix(cfg.Address, "://") {
-		parts := strings.Split(cfg.Address, "://")
-		return fmt.Sprintf("%s://%s:%s", parts[0], parts[1], cfg.Port)
-	}
-
 	protocol := "http"
 	if cfg.TLSEnabled {
 		protocol = "https"
 	}
-	return fmt.Sprintf("%s://%s:%s", protocol, cfg.Address, cfg.Port)
+	address := cfg.Address
+	if sanitized, err := utils.SanitizeAddr(address); err == nil {
+		address = sanitized
+	}
+	return fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(address, cfg.Port))
 }
 
 func (cfg *Config) Validate() error {

--- a/nodebuilder/rpc/config_test.go
+++ b/nodebuilder/rpc/config_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const ipv4Loopback = "127.0.0.1"
+
 // TestDefaultConfig tests that the default rpc config is correct.
 func TestDefaultConfig(t *testing.T) {
 	expected := Config{
@@ -24,6 +26,41 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, expected, DefaultConfig())
 }
 
+func TestRequestURL(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "IPv4",
+			cfg:  Config{Address: ipv4Loopback, Port: "8080"},
+			want: "http://127.0.0.1:8080",
+		},
+		{
+			name: "IPv6",
+			cfg:  Config{Address: "::1", Port: "8080"},
+			want: "http://[::1]:8080",
+		},
+		{
+			name: "bracketed IPv6",
+			cfg:  Config{Address: "[::1]", Port: "8080"},
+			want: "http://[::1]:8080",
+		},
+		{
+			name: "TLS IPv6",
+			cfg:  Config{Address: "2001:db8::1", Port: "8080", TLSEnabled: true},
+			want: "https://[2001:db8::1]:8080",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.cfg.RequestURL())
+		})
+	}
+}
+
 func TestConfigValidate(t *testing.T) {
 	tests := []struct {
 		name string
@@ -33,7 +70,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			name: "valid config",
 			cfg: Config{
-				Address: "127.0.0.1",
+				Address: ipv4Loopback,
 				Port:    "8080",
 			},
 			err: false,
@@ -49,7 +86,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			name: "invalid port",
 			cfg: Config{
-				Address: "127.0.0.1",
+				Address: ipv4Loopback,
 				Port:    "invalid",
 			},
 			err: true,


### PR DESCRIPTION
## Summary

`SanitizeAddr` split addresses on every colon, so raw IPv6 literals such as `::1` were truncated and rejected by Core configuration. RPC client URLs were also assembled with string formatting, producing malformed URLs for IPv6 hosts.

Preserve raw IPv6 literals, normalize bracketed host/port forms with the standard library, and build RPC URLs with `net.JoinHostPort`. Core primary and additional endpoints now retain canonical unbracketed addresses, while generated HTTP URLs add the required brackets.

IPv4 and hostname behavior remains unchanged. This change covers IPv6 literal addresses; DNS resolution policy is outside its scope.

Related to #1385 and #3745.

## Testing

- `go test ./libs/utils ./nodebuilder/core ./nodebuilder/rpc -count=10`
- `go test -race ./libs/utils ./nodebuilder/core ./nodebuilder/rpc -run 'Test(SanitizeAddr|ValidateAddr|ParseFlags|RequestURL|ValidateSanitizesAdditionalIPv6Endpoint)$' -count=10`
- `golangci-lint run --new-from-rev=origin/main ./libs/utils/... ./nodebuilder/core/... ./nodebuilder/rpc/...`
- `go vet ./libs/utils ./nodebuilder/core ./nodebuilder/rpc`
- `make lint-imports`
- `go mod tidy -diff`
- `./scripts/check-go-mod-parity.sh`