### PR TITLE
das: Group adjacent retry heights

### DIFF
--- a/das/coordinator_test.go
+++ b/das/coordinator_test.go
@@ -253,7 +253,7 @@ func TestCoordinator(t *testing.T) {
 
 	t.Run("persist retry count after on restart", func(t *testing.T) {
 		testParams := defaultTestParams()
-		testParams.dasParams.ConcurrencyLimit = 5
+		testParams.dasParams.ConcurrencyLimit = 1
 		ctx, cancel := context.WithTimeout(context.Background(), testParams.timeoutDelay)
 
 		ch := checkpoint{

--- a/das/state.go
+++ b/das/state.go
@@ -190,7 +190,7 @@ func (s *coordinatorState) catchupJob() (next job, found bool) {
 	return j, true
 }
 
-// retryJob creates a job to retry previously failed header
+// retryJob creates a job to retry adjacent previously failed headers.
 func (s *coordinatorState) retryJob() (next job, found bool) {
 	for h, attempt := range s.failed {
 		if !attempt.canRetry() {
@@ -198,11 +198,40 @@ func (s *coordinatorState) retryJob() (next job, found bool) {
 			continue
 		}
 
-		// move header from failed into retry
-		delete(s.failed, h)
-		s.inRetry[h] = attempt
-		j := s.newJob(retryJob, h, h)
-		return j, true
+		from, to, size := h, h, uint64(1)
+		for from > 0 && size < s.samplingRange {
+			previousHeight := from - 1
+			attempt, ok := s.failed[previousHeight]
+			if !ok || !attempt.canRetry() {
+				break
+			}
+			from = previousHeight
+			size++
+		}
+
+		for size < s.samplingRange {
+			nextHeight := to + 1
+			if nextHeight == 0 {
+				break
+			}
+			attempt, ok := s.failed[nextHeight]
+			if !ok || !attempt.canRetry() {
+				break
+			}
+			to = nextHeight
+			size++
+		}
+
+		for height := from; ; height++ {
+			attempt := s.failed[height]
+			delete(s.failed, height)
+			s.inRetry[height] = attempt
+			if height == to {
+				break
+			}
+		}
+
+		return s.newJob(retryJob, from, to), true
 	}
 
 	return job{}, false

--- a/das/state_test.go
+++ b/das/state_test.go
@@ -4,9 +4,83 @@ import (
 	"errors"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_retryJobGroupsAdjacentFailures(t *testing.T) {
+	now := time.Now()
+	ready := now.Add(-time.Hour)
+	delayed := now.Add(time.Hour)
+	state := coordinatorState{
+		samplingRange: 3,
+		failed: map[uint64]retryAttempt{
+			10: {count: 1, after: ready},
+			11: {count: 2, after: ready},
+			12: {count: 3, after: ready},
+			13: {count: 4, after: delayed},
+			14: {count: 5, after: ready},
+			15: {count: 6, after: ready},
+		},
+		inRetry: make(map[uint64]retryAttempt),
+	}
+
+	jobs := make([]job, 0, 2)
+	for range 2 {
+		got, found := state.retryJob()
+		assert.True(t, found)
+		jobs = append(jobs, got)
+	}
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].from < jobs[j].from })
+	assert.Equal(t, retryJob, jobs[0].jobType)
+	assert.Equal(t, uint64(10), jobs[0].from)
+	assert.Equal(t, uint64(12), jobs[0].to)
+	assert.Equal(t, retryJob, jobs[1].jobType)
+	assert.Equal(t, uint64(14), jobs[1].from)
+	assert.Equal(t, uint64(15), jobs[1].to)
+
+	got, found := state.retryJob()
+	assert.False(t, found)
+	assert.Equal(t, job{}, got)
+	assert.Equal(t, map[uint64]retryAttempt{13: {count: 4, after: delayed}}, state.failed)
+	assert.Equal(t, map[uint64]retryAttempt{
+		10: {count: 1, after: ready},
+		11: {count: 2, after: ready},
+		12: {count: 3, after: ready},
+		14: {count: 5, after: ready},
+		15: {count: 6, after: ready},
+	}, state.inRetry)
+
+	state.handleRetryResult(result{
+		job:    jobs[0],
+		failed: map[uint64]int{11: 1},
+	})
+	assert.Equal(t, map[uint64]retryAttempt{
+		11: {count: 3, after: ready},
+		13: {count: 4, after: delayed},
+	}, state.failed)
+	assert.Equal(t, map[uint64]retryAttempt{
+		14: {count: 5, after: ready},
+		15: {count: 6, after: ready},
+	}, state.inRetry)
+
+	limited := coordinatorState{
+		samplingRange: 2,
+		failed: map[uint64]retryAttempt{
+			20: {after: ready},
+			21: {after: ready},
+			22: {after: ready},
+			23: {after: ready},
+		},
+		inRetry: make(map[uint64]retryAttempt),
+	}
+	limitedJob, found := limited.retryJob()
+	assert.True(t, found)
+	assert.Equal(t, uint64(1), limitedJob.to-limitedJob.from)
+	assert.Len(t, limited.failed, 2)
+	assert.Len(t, limited.inRetry, 2)
+}
 
 func Test_coordinatorStats(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

The DAS coordinator currently schedules one retry worker per failed height. Contiguous failures therefore consume separate worker slots even though regular catch-up jobs already process bounded height ranges.

Group adjacent failures whose retry backoff has elapsed into a single retry job, capped by `SamplingRange`. Preserve retry state per height so partial success, later backoff, and checkpoint recovery continue to work independently.

Closes #2096.

## Testing

- `go test ./das/... -count=20`
- `go test -race ./das/... -count=10`
- `go vet ./das/...`
- `golangci-lint run --new-from-rev=upstream/main ./das/...`
- `make lint-imports`
- `go mod tidy -diff`
- `./scripts/check-go-mod-parity.sh`