### PR TITLE
core: Reject incomplete gRPC responses

### DIFF
--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -229,7 +229,11 @@ func (f *BlockFetcher) IsSyncing(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return resp.SyncInfo.CatchingUp, nil
+	syncInfo := resp.GetSyncInfo()
+	if syncInfo == nil {
+		return false, fmt.Errorf("core/fetcher: sync info not available in status response")
+	}
+	return syncInfo.CatchingUp, nil
 }
 
 // IsSyncingFrom reports the sync status for the source that announced the
@@ -339,7 +343,10 @@ func partsToBlock(parts []*tmproto.Part) (*types.Block, error) {
 	partSet := types.NewPartSetFromHeader(types.PartSetHeader{
 		Total: uint32(len(parts)),
 	}, types.BlockPartSizeBytes)
-	for _, part := range parts {
+	for i, part := range parts {
+		if part == nil {
+			return nil, fmt.Errorf("core/fetcher: block part at position %d is nil", i)
+		}
 		ok, err := partSet.AddPartWithoutProof(&types.Part{Index: part.Index, Bytes: part.Bytes})
 		if err != nil {
 			return nil, err

--- a/core/fetcher_nil_test.go
+++ b/core/fetcher_nil_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type missingSyncInfoClient struct {
+	coregrpc.BlockAPIClient
+}
+
+func (c *missingSyncInfoClient) Status(
+	context.Context,
+	*coregrpc.StatusRequest,
+	...grpc.CallOption,
+) (*coregrpc.StatusResponse, error) {
+	return &coregrpc.StatusResponse{}, nil
+}
+
+func TestBlockFetcherRejectsMissingSyncInfo(t *testing.T) {
+	fetcher := &BlockFetcher{client: &missingSyncInfoClient{}}
+
+	_, err := fetcher.IsSyncing(context.Background())
+	require.EqualError(t, err, "core/fetcher: sync info not available in status response")
+}
+
+func TestPartsToBlockRejectsNilPart(t *testing.T) {
+	_, err := partsToBlock([]*tmproto.Part{nil})
+	require.EqualError(t, err, "core/fetcher: block part at position 0 is nil")
+}


### PR DESCRIPTION
## Summary

Core gRPC responses can omit optional protobuf fields even when the RPC succeeds. `BlockFetcher.IsSyncing` currently dereferences a missing `SyncInfo`, and block reconstruction dereferences missing `BlockPart` values, causing the bridge to panic on incomplete responses.

Return contextual errors for missing sync information and block parts. The shared `partsToBlock` guard protects both block-by-height and block-by-hash streams without duplicate checks.

Related to #3816.

## Testing

- `go test ./core -count=1`
- `go test -race ./core -run '^(TestBlockFetcherRejectsMissingSyncInfo|TestPartsToBlockRejectsNilPart)$' -count=20`
- `go vet ./core`
- `golangci-lint run --new-from-rev=upstream/main ./core/...`
- `make lint-imports`
- `go mod tidy -diff`
- `./scripts/check-go-mod-parity.sh`