### PR TITLE
rpc: Share limiter across concurrent first requests

### DIFF
--- a/api/rpc/middleware.go
+++ b/api/rpc/middleware.go
@@ -37,9 +37,13 @@ func rateLimit(rps, burst, cacheSize int, next http.Handler) http.Handler {
 	rateL := rate.Limit(rps)
 	getLimiter := func(ip string) *rate.Limiter {
 		limiter, ok := cache.Get(ip)
-		if !ok {
-			limiter = rate.NewLimiter(rateL, burst)
-			cache.Add(ip, limiter)
+		if ok {
+			return limiter
+		}
+
+		limiter = rate.NewLimiter(rateL, burst)
+		if existing, found, _ := cache.PeekOrAdd(ip, limiter); found {
+			return existing
 		}
 		return limiter
 	}

--- a/api/rpc/middleware_test.go
+++ b/api/rpc/middleware_test.go
@@ -126,6 +126,51 @@ func TestRateLimit_DifferentIPsIndependent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestRateLimit_ConcurrentFirstRequestsShareBurst(t *testing.T) {
+	const (
+		runs     = 50
+		requests = 64
+	)
+
+	for run := range runs {
+		handler := rateLimit(0, 1, testCacheSize, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		ready := make(chan struct{}, requests)
+		start := make(chan struct{})
+		statuses := make(chan int, requests)
+
+		for range requests {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = testRemoteAddr
+			go func() {
+				ready <- struct{}{}
+				<-start
+
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				statuses <- w.Code
+			}()
+		}
+
+		for range requests {
+			<-ready
+		}
+		close(start)
+
+		allowed := 0
+		for range requests {
+			status := <-statuses
+			if status == http.StatusOK {
+				allowed++
+				continue
+			}
+			require.Equal(t, http.StatusTooManyRequests, status)
+		}
+		require.Equal(t, 1, allowed, "run %d", run)
+	}
+}
+
 // TestRateLimit_EvictedIPGetsFreshBurst verifies that when the LRU cache fills
 // up and an IP's limiter is evicted, the IP gets a brand-new bucket (full burst)
 // on its next request — not the old, exhausted state.


### PR DESCRIPTION
## Summary

The per-IP rate limiter currently performs the cache lookup and insertion as separate operations. Concurrent first requests from the same IP can therefore create independent token buckets and each consume a full initial burst.

Use the LRU cache's atomic `PeekOrAdd` operation after a cache miss so every concurrent request shares the same limiter. Keep the existing `Get` fast path so normal cache hits continue to update recency.

Add a concurrent regression test that disables token refill and verifies exactly one request consumes a burst of one.

Follow-up to #4909.

## Testing

- `go test ./api/rpc -count=1`
- `go test -race ./api/rpc -run '^TestRateLimit_ConcurrentFirstRequestsShareBurst$' -count=20`
- `go vet ./api/rpc`
- `golangci-lint run --new-from-rev=upstream/main ./api/rpc`
- `make lint-imports`
- `go mod tidy -diff`
- `./scripts/check-go-mod-parity.sh`