### PR TITLE
nodebuilder: Hold store lock until datastore closes

### DIFF
--- a/nodebuilder/store.go
+++ b/nodebuilder/store.go
@@ -140,12 +140,12 @@ func (f *fsStore) Datastore() (datastore.Batching, error) {
 }
 
 func (f *fsStore) Close() (err error) {
-	err = errors.Join(err, f.dirLock.Close())
 	f.dataMu.Lock()
 	if f.data != nil {
 		err = errors.Join(err, f.data.Close())
 	}
 	f.dataMu.Unlock()
+	err = errors.Join(err, f.dirLock.Close())
 	return err
 }
 

--- a/nodebuilder/store_test.go
+++ b/nodebuilder/store_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/flock"
+	"github.com/ipfs/go-datastore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -54,6 +55,56 @@ func TestRepo(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+type blockingCloseDatastore struct {
+	datastore.Batching
+	started chan struct{}
+	release chan struct{}
+}
+
+func (ds *blockingCloseDatastore) Close() error {
+	close(ds.started)
+	<-ds.release
+	return nil
+}
+
+func TestFSStoreCloseHoldsDirLockUntilDatastoreClosed(t *testing.T) {
+	dir := t.TempDir()
+	dirLock := flock.New(lockPath(dir))
+	locked, err := dirLock.TryLock()
+	require.NoError(t, err)
+	require.True(t, locked)
+
+	data := &blockingCloseDatastore{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	store := &fsStore{path: dir, data: data, dirLock: dirLock}
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- store.Close()
+	}()
+
+	<-data.started
+	contender := flock.New(lockPath(dir))
+	acquiredDuringClose, tryErr := contender.TryLock()
+	var unlockErr error
+	if acquiredDuringClose {
+		unlockErr = contender.Unlock()
+	}
+
+	close(data.release)
+	closeErr := <-closeDone
+	require.NoError(t, tryErr)
+	require.NoError(t, unlockErr)
+	require.NoError(t, closeErr)
+	require.False(t, acquiredDuringClose)
+
+	acquiredAfterClose, err := contender.TryLock()
+	require.NoError(t, err)
+	require.True(t, acquiredAfterClose)
+	require.NoError(t, contender.Unlock())
 }
 
 func TestDiscoverOpened(t *testing.T) {


### PR DESCRIPTION
## Summary

`fsStore.Close` currently releases the external directory lock before the datastore finishes closing. Another process can acquire that lock while Badger is still flushing and holding its internal storage locks, then fail during an otherwise valid store reopen.

Close the datastore under `dataMu` before releasing the directory lock. Preserve both close errors with `errors.Join`.

Add a deterministic regression test that blocks datastore shutdown and verifies a competing process cannot acquire the directory lock until shutdown completes.

## Testing

- `go test ./nodebuilder -count=1`
- `go test ./nodebuilder -run '^TestFSStoreCloseHoldsDirLockUntilDatastoreClosed$' -count=10`
- `go vet ./nodebuilder`
- `golangci-lint run --new-from-rev=upstream/main ./nodebuilder`
- `make lint-imports`
- `go mod tidy -diff`
- `./scripts/check-go-mod-parity.sh`