### PR TITLE
das: Jitter retry scheduling

### DIFF
--- a/das/backoff.go
+++ b/das/backoff.go
@@ -1,22 +1,23 @@
 package das
 
 import (
+	"math/rand/v2"
 	"time"
 )
 
 var (
-	// first retry attempt should happen after defaultBackoffInitialInterval
+	// defaultBackoffInitialInterval is the upper bound for the first retry delay
 	defaultBackoffInitialInterval = time.Minute
-	// next retry attempt will happen with delay of previous one multiplied by defaultBackoffMultiplier
+	// each retry delay upper bound grows by defaultBackoffMultiplier
 	defaultBackoffMultiplier = 4
-	// after defaultBackoffMaxRetryCount amount of attempts retry backoff interval will stop growing
+	// after defaultBackoffMaxRetryCount attempts the retry delay upper bound will stop growing
 	// and each retry attempt will produce WARN log
 	defaultBackoffMaxRetryCount = 4
 )
 
 // retryStrategy defines a backoff for retries.
 type retryStrategy struct {
-	// attempts delays will follow durations stored in retryIntervals
+	// retryIntervals stores the upper bound for each retry delay
 	retryIntervals []time.Duration
 }
 
@@ -38,11 +39,11 @@ func (s retryStrategy) nextRetry(lastRetry retryAttempt, lastAttempt time.Time,
 
 	if lastRetry.count > len(s.retryIntervals) {
 		// try count exceeded backoff try limit
-		lastRetry.after = lastAttempt.Add(s.retryIntervals[len(s.retryIntervals)-1])
+		lastRetry.after = lastAttempt.Add(rand.N(s.retryIntervals[len(s.retryIntervals)-1])) //nolint:gosec
 		return lastRetry, true
 	}
 
-	lastRetry.after = lastAttempt.Add(s.retryIntervals[lastRetry.count-1])
+	lastRetry.after = lastAttempt.Add(rand.N(s.retryIntervals[lastRetry.count-1])) //nolint:gosec
 	return lastRetry, false
 }
 

--- a/das/backoff_test.go
+++ b/das/backoff_test.go
@@ -53,6 +53,7 @@ func Test_retryStrategy_nextRetry(t *testing.T) {
 		backoff             retryStrategy
 		args                args
 		wantRetry           retryAttempt
+		wantMaxDelay        time.Duration
 		wantRetriesExceeded bool
 	}{
 		{
@@ -76,8 +77,8 @@ func Test_retryStrategy_nextRetry(t *testing.T) {
 			},
 			wantRetry: retryAttempt{
 				count: 2,
-				after: tNow.Add(time.Minute),
 			},
+			wantMaxDelay:        time.Minute,
 			wantRetriesExceeded: false,
 		},
 		{
@@ -89,21 +90,24 @@ func Test_retryStrategy_nextRetry(t *testing.T) {
 			},
 			wantRetry: retryAttempt{
 				count: 3,
-				after: tNow.Add(time.Minute),
 			},
+			wantMaxDelay:        time.Minute,
 			wantRetriesExceeded: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := retryStrategy{
-				retryIntervals: tt.backoff.retryIntervals,
-			}
-			gotRetry, gotRetriesExceeded := s.nextRetry(tt.args.retry, tt.args.lastAttempt)
-			assert.Equalf(t, tt.wantRetry, gotRetry,
+			gotRetry, gotRetriesExceeded := tt.backoff.nextRetry(tt.args.retry, tt.args.lastAttempt)
+			assert.Equalf(t, tt.wantRetry.count, gotRetry.count,
 				"nextRetry(%v, %v)", tt.args.retry, tt.args.lastAttempt)
 			assert.Equalf(t, tt.wantRetriesExceeded, gotRetriesExceeded,
 				"nextRetry(%v, %v)", tt.args.retry, tt.args.lastAttempt)
+			if tt.wantMaxDelay == 0 {
+				assert.True(t, gotRetry.after.IsZero())
+				return
+			}
+			assert.False(t, gotRetry.after.Before(tt.args.lastAttempt))
+			assert.True(t, gotRetry.after.Before(tt.args.lastAttempt.Add(tt.wantMaxDelay)))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

DAS retry deadlines are currently deterministic. Nodes that fail at roughly the same time therefore wait for the same exponentially growing intervals and can retry in lockstep.

Apply full jitter to every retry by choosing a delay in `[0, current backoff interval