### PR TITLE
core: Back off failed block subscriptions

### DIFF
--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
@@ -15,7 +16,10 @@ import (
 	libhead "github.com/celestiaorg/go-header"
 )
 
-const newBlockSubscriber = "NewBlock/Events"
+const (
+	newBlockSubscriber        = "NewBlock/Events"
+	subscriptionRetryInterval = 5 * time.Second
+)
 
 type SignedBlock struct {
 	Header       *types.Header       `json:"header"`
@@ -182,10 +186,14 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan BlockEv
 				return
 			default:
 			}
+			attemptedAt := time.Now()
 
 			subscription, err := f.client.SubscribeNewHeights(ctx, &coregrpc.SubscribeNewHeightsRequest{})
 			if err != nil {
 				log.Warnw("fetcher: failed to subscribe to new block events", "err", err)
+				if !waitForSubscriptionRetry(ctx, attemptedAt) {
+					return
+				}
 				continue
 			}
 
@@ -194,11 +202,30 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan BlockEv
 			if err != nil {
 				log.Warnw("fetcher: error receiving new height", "err", err.Error())
 				_ = subscription.CloseSend() // inform client that the subscription won't be used anymore
+				if !waitForSubscriptionRetry(ctx, attemptedAt) {
+					return
+				}
 				continue
 			}
 		}
 	}()
 	return eventCh, nil
+}
+
+func waitForSubscriptionRetry(ctx context.Context, attemptedAt time.Time) bool {
+	delay := time.Until(attemptedAt.Add(subscriptionRetryInterval))
+	if delay <= 0 {
+		return true
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func (f *BlockFetcher) receive(

--- a/core/fetcher_retry_test.go
+++ b/core/fetcher_retry_test.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type hardErrorSubscriptionClient struct {
+	coregrpc.BlockAPIClient
+	attempts     chan struct{}
+	subscribeErr error
+}
+
+func (c *hardErrorSubscriptionClient) SubscribeNewHeights(
+	context.Context,
+	*coregrpc.SubscribeNewHeightsRequest,
+	...grpc.CallOption,
+) (coregrpc.BlockAPI_SubscribeNewHeightsClient, error) {
+	select {
+	case c.attempts <- struct{}{}:
+	default:
+	}
+	if c.subscribeErr != nil {
+		return nil, c.subscribeErr
+	}
+	return hardErrorSubscription{}, nil
+}
+
+type hardErrorSubscription struct {
+	grpc.ClientStream
+}
+
+func (hardErrorSubscription) Recv() (*coregrpc.SubscribeNewHeightsResponse, error) {
+	return nil, status.Error(codes.PermissionDenied, "denied")
+}
+
+func (hardErrorSubscription) CloseSend() error {
+	return nil
+}
+
+func TestBlockFetcherSubscriptionHardErrorBacksOff(t *testing.T) {
+	tests := []struct {
+		name         string
+		subscribeErr error
+	}{
+		{name: "subscribe", subscribeErr: status.Error(codes.PermissionDenied, "denied")},
+		{name: "receive"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			client := &hardErrorSubscriptionClient{
+				attempts:     make(chan struct{}, 2),
+				subscribeErr: test.subscribeErr,
+			}
+			fetcher := &BlockFetcher{client: client}
+
+			startedAt := time.Now()
+			events, err := fetcher.SubscribeNewBlockEvent(ctx)
+			require.NoError(t, err)
+
+			select {
+			case <-client.attempts:
+			case <-time.After(time.Second):
+				t.Fatal("subscription was not attempted")
+			}
+
+			select {
+			case <-client.attempts:
+			case _, ok := <-events:
+				require.True(t, ok, "subscription stopped instead of retrying")
+			case <-time.After(2 * subscriptionRetryInterval):
+				t.Fatal("subscription was not retried")
+			}
+			require.GreaterOrEqual(t, time.Since(startedAt), subscriptionRetryInterval)
+
+			cancel()
+			select {
+			case _, ok := <-events:
+				require.False(t, ok)
+			case <-time.After(time.Second):
+				t.Fatal("subscription did not stop after cancellation")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`SubscribeNewBlockEvent` immediately retries when creating a subscription or receiving from it fails. The gRPC retry interceptor only backs off selected retryable status codes, so persistent hard errors can drive a tight resubscription loop and repeated warning logs.

Enforce a minimum five-second interval between subscription attempts. Measure the interval from the start of each attempt so a slow failure or a previously healthy stream can reconnect immediately, while immediately failing attempts are rate-limited. Keep the wait context-aware so shutdown is not delayed.

Follow-up to #4093.

## Testing

- `go test ./core -count=1`
- `go test -race ./core -run '^TestBlockFetcherSubscriptionHardErrorBacksOff$' -count=3`
- `go vet ./core`
- `golangci-lint run --new-from-rev=upstream/main ./core`
- `make lint-imports`
- `go mod tidy -diff`
- `./scripts/check-go-mod-parity.sh`