### PR TITLE
perf(shrex/client): reduce memory usage by removing the buffer

### DIFF
--- a/share/eds/read.go
+++ b/share/eds/read.go
@@ -75,12 +75,20 @@ func ReadShares(r io.Reader, shareSize, odsSize int) ([]libshare.Share, error) {
 
 // fillRow parses buf into the given row of shares. The shares alias buf, so it must not be reused.
 func fillRow(shares []libshare.Share, buf []byte, row, shareSize, odsSize int) error {
-	for i := 0; i*shareSize < len(buf); i++ {
+	if len(buf)%shareSize != 0 {
+		return fmt.Errorf("row buffer of %d bytes is not share-aligned (share size %d)", len(buf), shareSize)
+	}
+	nShares := len(buf) / shareSize
+	start := row * odsSize
+	if row < 0 || start+nShares > len(shares) {
+		return fmt.Errorf("row %d writes shares [%d:%d) out of %d", row, start, start+nShares, len(shares))
+	}
+	for i := range nShares {
 		sh, err := libshare.NewShare(buf[i*shareSize : (i+1)*shareSize])
 		if err != nil {
 			return err
 		}
-		shares[row*odsSize+i] = sh
+		shares[start+i] = sh
 	}
 	return nil
 }

--- a/share/eds/read.go
+++ b/share/eds/read.go
@@ -39,29 +39,48 @@ func ReadAccessor(ctx context.Context, reader io.Reader, root *share.AxisRoots) 
 	return rsmt2d, nil
 }
 
-// ReadShares reads shares from the provided io.Reader until EOF. If EOF is reached, the remaining shares
-// are populated as tail padding shares. Provided reader must contain shares in row-major order.
+// ReadShares reads shares from the provided io.Reader until EOF. If EOF is reached on a share
+// boundary, the remaining shares are populated as tail padding shares. Provided reader must contain
+// shares in row-major order.
 func ReadShares(r io.Reader, shareSize, odsSize int) ([]libshare.Share, error) {
 	shares := make([]libshare.Share, odsSize*odsSize)
+	rowSize := shareSize * odsSize
 	var total int
-	for i := range shares {
-		shr := make([]byte, shareSize)
-		n, err := io.ReadFull(r, shr)
-		if errors.Is(err, io.EOF) {
-			for ; i < len(shares); i++ {
+	for row := range odsSize {
+		buf := make([]byte, rowSize)
+		n, err := io.ReadFull(r, buf)
+		total += n
+		if err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+				return nil, fmt.Errorf("reading shares: %w, bytes read: %v", err, total)
+			}
+			// a partial share means the stream ended mid-share
+			if n%shareSize != 0 {
+				return nil, fmt.Errorf("reading shares: %w, bytes read: %v", io.ErrUnexpectedEOF, total)
+			}
+			if err := fillRow(shares, buf[:n], row, shareSize, odsSize); err != nil {
+				return nil, err
+			}
+			for i := row*odsSize + n/shareSize; i < len(shares); i++ {
 				shares[i] = libshare.TailPaddingShare()
 			}
 			return shares, nil
 		}
-		if err != nil {
-			return nil, fmt.Errorf("reading shares: %w, bytes read: %v", err, total+n)
-		}
-		newShare, err := libshare.NewShare(shr)
-		if err != nil {
+		if err := fillRow(shares, buf, row, shareSize, odsSize); err != nil {
 			return nil, err
 		}
-		shares[i] = newShare
-		total += n
 	}
 	return shares, nil
+}
+
+// fillRow parses buf into the given row of shares. The shares alias buf, so it must not be reused.
+func fillRow(shares []libshare.Share, buf []byte, row, shareSize, odsSize int) error {
+	for i := 0; i*shareSize < len(buf); i++ {
+		sh, err := libshare.NewShare(buf[i*shareSize : (i+1)*shareSize])
+		if err != nil {
+			return err
+		}
+		shares[row*odsSize+i] = sh
+	}
+	return nil
 }

--- a/share/eds/read_test.go
+++ b/share/eds/read_test.go
@@ -1,0 +1,84 @@
+package eds
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v4/share"
+)
+
+// rawODS returns odsSize*odsSize random shares and their row-major byte serialization.
+func rawODS(t *testing.T, odsSize int) ([]byte, []libshare.Share) {
+	t.Helper()
+	shares, err := libshare.RandShares(odsSize * odsSize)
+	require.NoError(t, err)
+
+	buf := make([]byte, 0, len(shares)*libshare.ShareSize)
+	for _, sh := range shares {
+		buf = append(buf, sh.ToBytes()...)
+	}
+	return buf, shares
+}
+
+func TestReadShares_Full(t *testing.T) {
+	const odsSize = 4
+	raw, want := rawODS(t, odsSize)
+
+	got, err := ReadShares(bytes.NewReader(raw), libshare.ShareSize, odsSize)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestReadShares_EOFMidRowBoundary(t *testing.T) {
+	const odsSize = 4
+	raw, want := rawODS(t, odsSize)
+
+	// end mid-row on a share boundary; the rest must become tail padding
+	const kept = 2*odsSize + 2
+	truncated := raw[:kept*libshare.ShareSize]
+
+	got, err := ReadShares(bytes.NewReader(truncated), libshare.ShareSize, odsSize)
+	require.NoError(t, err)
+
+	for i := range got {
+		if i < kept {
+			require.Equal(t, want[i], got[i], "share %d", i)
+		} else {
+			require.Equal(t, libshare.TailPaddingShare(), got[i], "share %d should be tail padding", i)
+		}
+	}
+}
+
+func TestReadShares_EOFRowBoundary(t *testing.T) {
+	const odsSize = 4
+	raw, want := rawODS(t, odsSize)
+
+	// end exactly on a row boundary; remaining rows become tail padding
+	const kept = 2 * odsSize
+	truncated := raw[:kept*libshare.ShareSize]
+
+	got, err := ReadShares(bytes.NewReader(truncated), libshare.ShareSize, odsSize)
+	require.NoError(t, err)
+
+	for i := range got {
+		if i < kept {
+			require.Equal(t, want[i], got[i], "share %d", i)
+		} else {
+			require.Equal(t, libshare.TailPaddingShare(), got[i], "share %d", i)
+		}
+	}
+}
+
+func TestReadShares_MidShareTruncationErrors(t *testing.T) {
+	const odsSize = 4
+	raw, _ := rawODS(t, odsSize)
+
+	// end mid-share; must error rather than pad
+	truncated := raw[:libshare.ShareSize+10]
+
+	_, err := ReadShares(bytes.NewReader(truncated), libshare.ShareSize, odsSize)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}

--- a/share/shwap/p2p/shrex/shrex_getter/eds_response.go
+++ b/share/shwap/p2p/shrex/shrex_getter/eds_response.go
@@ -1,28 +1,53 @@
 package shrex_getter
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
+
+	libshare "github.com/celestiaorg/go-square/v4/share"
 
 	"github.com/celestiaorg/celestia-node/share"
 	"github.com/celestiaorg/celestia-node/share/eds"
 )
 
-// edsResponse adapts eds.ReadAccessor to the shrex response
+// edsResponse streams the raw ODS shares off the shrex stream. Reconstruction and hash
+// verification are deferred to verify (run in the build step) so the libp2p stream isn't held
+// open during that CPU-bound work.
 type edsResponse struct {
-	ctx  context.Context
-	root *share.AxisRoots
-	eds  *eds.Rsmt2D
+	odsSize int
+	shares  []libshare.Share
+	eds     *eds.Rsmt2D
 }
 
 func (r *edsResponse) ReadFrom(src io.Reader) (int64, error) {
 	cr := &countingReader{r: src}
-	accessor, err := eds.ReadAccessor(r.ctx, cr, r.root)
+	shares, err := eds.ReadShares(cr, libshare.ShareSize, r.odsSize)
 	if err != nil {
 		return cr.n, err
 	}
-	r.eds = accessor
+	r.shares = shares
 	return cr.n, nil
+}
+
+func (r *edsResponse) verify(ctx context.Context, root *share.AxisRoots) error {
+	square, err := eds.Rsmt2DFromShares(r.shares, r.odsSize)
+	if err != nil {
+		return err
+	}
+	datahash, err := square.DataHash(ctx)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(datahash, root.Hash()) {
+		return fmt.Errorf(
+			"content integrity mismatch: imported root %s doesn't match expected root %s",
+			datahash, root.Hash(),
+		)
+	}
+	r.eds = square
+	return nil
 }
 
 // countingReader tracks bytes read so ReadFrom can report the transferred size

--- a/share/shwap/p2p/shrex/shrex_getter/eds_response.go
+++ b/share/shwap/p2p/shrex/shrex_getter/eds_response.go
@@ -1,0 +1,38 @@
+package shrex_getter
+
+import (
+	"context"
+	"io"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+)
+
+// edsResponse adapts eds.ReadAccessor to the shrex response
+type edsResponse struct {
+	ctx  context.Context
+	root *share.AxisRoots
+	eds  *eds.Rsmt2D
+}
+
+func (r *edsResponse) ReadFrom(src io.Reader) (int64, error) {
+	cr := &countingReader{r: src}
+	accessor, err := eds.ReadAccessor(r.ctx, cr, r.root)
+	if err != nil {
+		return cr.n, err
+	}
+	r.eds = accessor
+	return cr.n, nil
+}
+
+// countingReader tracks bytes read so ReadFrom can report the transferred size
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}

--- a/share/shwap/p2p/shrex/shrex_getter/eds_response_test.go
+++ b/share/shwap/p2p/shrex/shrex_getter/eds_response_test.go
@@ -1,0 +1,64 @@
+package shrex_getter //nolint:stylecheck // underscore in pkg name will be fixed with shrex refactoring
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v4/share"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+)
+
+func TestEDSResponse_ReadFrom(t *testing.T) {
+	const odsSize = 4
+	ctx := context.Background()
+
+	square := edstest.RandEDS(t, odsSize)
+	roots, err := share.NewAxisRoots(square)
+	require.NoError(t, err)
+
+	reader, err := (&eds.Rsmt2D{ExtendedDataSquare: square}).Reader()
+	require.NoError(t, err)
+
+	resp := &edsResponse{ctx: ctx, root: roots}
+	n, err := resp.ReadFrom(reader)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(odsSize*odsSize*libshare.ShareSize), n)
+	require.NotNil(t, resp.eds)
+	require.True(t, square.Equals(resp.eds.ExtendedDataSquare))
+}
+
+func TestEDSResponse_ReadFrom_RootMismatch(t *testing.T) {
+	const odsSize = 4
+	ctx := context.Background()
+
+	square := edstest.RandEDS(t, odsSize)
+	reader, err := (&eds.Rsmt2D{ExtendedDataSquare: square}).Reader()
+	require.NoError(t, err)
+
+	// roots of an unrelated square make ReadAccessor fail the integrity check
+	otherRoots, err := share.NewAxisRoots(edstest.RandEDS(t, odsSize))
+	require.NoError(t, err)
+
+	resp := &edsResponse{ctx: ctx, root: otherRoots}
+	_, err = resp.ReadFrom(reader)
+	require.Error(t, err)
+	require.Nil(t, resp.eds)
+}
+
+func TestCountingReader(t *testing.T) {
+	data := bytes.Repeat([]byte{0xab}, 1<<16+7)
+	cr := &countingReader{r: bytes.NewReader(data)}
+
+	out, err := io.ReadAll(cr)
+	require.NoError(t, err)
+	require.Equal(t, data, out)
+	require.Equal(t, int64(len(data)), cr.n)
+}

--- a/share/shwap/p2p/shrex/shrex_getter/eds_response_test.go
+++ b/share/shwap/p2p/shrex/shrex_getter/eds_response_test.go
@@ -26,11 +26,12 @@ func TestEDSResponse_ReadFrom(t *testing.T) {
 	reader, err := (&eds.Rsmt2D{ExtendedDataSquare: square}).Reader()
 	require.NoError(t, err)
 
-	resp := &edsResponse{ctx: ctx, root: roots}
+	resp := &edsResponse{odsSize: odsSize}
 	n, err := resp.ReadFrom(reader)
 	require.NoError(t, err)
-
 	require.Equal(t, int64(odsSize*odsSize*libshare.ShareSize), n)
+
+	require.NoError(t, resp.verify(ctx, roots))
 	require.NotNil(t, resp.eds)
 	require.True(t, square.Equals(resp.eds.ExtendedDataSquare))
 }
@@ -43,13 +44,15 @@ func TestEDSResponse_ReadFrom_RootMismatch(t *testing.T) {
 	reader, err := (&eds.Rsmt2D{ExtendedDataSquare: square}).Reader()
 	require.NoError(t, err)
 
-	// roots of an unrelated square make ReadAccessor fail the integrity check
+	// roots of an unrelated square make verify fail the integrity check
 	otherRoots, err := share.NewAxisRoots(edstest.RandEDS(t, odsSize))
 	require.NoError(t, err)
 
-	resp := &edsResponse{ctx: ctx, root: otherRoots}
+	resp := &edsResponse{odsSize: odsSize}
 	_, err = resp.ReadFrom(reader)
-	require.Error(t, err)
+	require.NoError(t, err)
+
+	require.Error(t, resp.verify(ctx, otherRoots))
 	require.Nil(t, resp.eds)
 }
 

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -219,7 +219,7 @@ func (sg *Getter) GetEDS(ctx context.Context, header *header.ExtendedHeader) (*r
 		return nil, err
 	}
 
-	response := &edsResponse{ctx: ctx, root: header.DAH}
+	response := &edsResponse{odsSize: len(header.DAH.RowRoots) / 2}
 
 	logger := log.With(
 		"source", "shrex_getter",
@@ -228,15 +228,15 @@ func (sg *Getter) GetEDS(ctx context.Context, header *header.ExtendedHeader) (*r
 	)
 
 	req := func(ctx context.Context, peer libpeer.ID) error {
-		response.eds = nil
+		response.shares = nil
 		return sg.client.Get(ctx, &request, response, peer)
 	}
 
 	build := func() error {
-		if response.eds == nil {
+		if response.shares == nil {
 			return errors.New("nil response")
 		}
-		return nil
+		return response.verify(ctx, header.DAH)
 	}
 
 	err = sg.executeRequest(ctx, logger, header, request.Name(), req, build)

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -243,7 +243,10 @@ func (sg *Getter) GetEDS(ctx context.Context, header *header.ExtendedHeader) (*r
 	if err != nil {
 		return nil, err
 	}
-	return response.eds.ExtendedDataSquare, err
+	if response.eds == nil {
+		return nil, errors.New("shrex/eds: verified response missing reconstructed square")
+	}
+	return response.eds.ExtendedDataSquare, nil
 }
 
 func (sg *Getter) GetNamespaceData(

--- a/share/shwap/p2p/shrex/shrex_getter/shrex.go
+++ b/share/shwap/p2p/shrex/shrex_getter/shrex.go
@@ -1,7 +1,6 @@
 package shrex_getter
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -220,10 +219,7 @@ func (sg *Getter) GetEDS(ctx context.Context, header *header.ExtendedHeader) (*r
 		return nil, err
 	}
 
-	var (
-		buff     = bytes.NewBuffer(make([]byte, 0))
-		response = &eds.Rsmt2D{}
-	)
+	response := &edsResponse{ctx: ctx, root: header.DAH}
 
 	logger := log.With(
 		"source", "shrex_getter",
@@ -232,23 +228,22 @@ func (sg *Getter) GetEDS(ctx context.Context, header *header.ExtendedHeader) (*r
 	)
 
 	req := func(ctx context.Context, peer libpeer.ID) error {
-		buff.Reset()
-		return sg.client.Get(ctx, &request, buff, peer)
+		response.eds = nil
+		return sg.client.Get(ctx, &request, response, peer)
 	}
 
 	build := func() error {
-		if buff.Len() == 0 {
+		if response.eds == nil {
 			return errors.New("nil response")
 		}
-		response, err = eds.ReadAccessor(ctx, buff, header.DAH)
-		return err
+		return nil
 	}
 
 	err = sg.executeRequest(ctx, logger, header, request.Name(), req, build)
 	if err != nil {
 		return nil, err
 	}
-	return response.ExtendedDataSquare, err
+	return response.eds.ExtendedDataSquare, err
 }
 
 func (sg *Getter) GetNamespaceData(


### PR DESCRIPTION
Resolves [PROTOCO-2384](https://linear.app/celestia/issue/PROTOCO-2384/remove-internal-bytesbuffer-from-geteds)
Reduce memory usage by removing an internal buffer. And stream the EDS directly. 
