### PR TITLE
chore: remove dead BEFP scaffolding

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,21 +57,6 @@ jobs:
       - name: run da tests
         run: make test-integration SHORT=true TAGS=da
 
-  fraud_tests:
-    name: Integration Tests Fraud
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: set up go
-        uses: actions/setup-go@v7
-        with:
-          go-version: ${{ inputs.go-version }}
-
-      - name: run fraud tests
-        run: make test-integration TAGS=fraud
-
   nd_tests:
     name: Integration Tests ND
     runs-on: ubuntu-latest

--- a/nodebuilder/tests/swamp/swamp.go
+++ b/nodebuilder/tests/swamp/swamp.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/privval"
-	"github.com/cometbft/cometbft/types"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
@@ -276,16 +274,4 @@ func (s *Swamp) SetBootstrapper(t *testing.T, bootstrappers ...*nodebuilder.Node
 		require.NoError(t, err)
 		s.Bootstrappers = append(s.Bootstrappers, addrs[0])
 	}
-}
-
-// Validators retrieves keys from the app node in order to build the validators.
-func (s *Swamp) Validators(t *testing.T) (*types.ValidatorSet, types.PrivValidator) {
-	privPath := s.cfg.TmConfig.PrivValidatorKeyFile()
-	statePath := s.cfg.TmConfig.PrivValidatorStateFile()
-	priv := privval.LoadFilePV(privPath, statePath)
-	key, err := priv.GetPubKey()
-	require.NoError(t, err)
-	validator := types.NewValidator(key, 100)
-	set := types.NewValidatorSet([]*types.Validator{validator})
-	return set, priv
 }

--- a/share/eds/byzantine/byzantine.go
+++ b/share/eds/byzantine/byzantine.go
@@ -58,7 +58,7 @@ func NewErrByzantine(
 		}
 
 		sharesWithProof[index] = swp
-		// it is enough to collect half of the shares to construct the befp
+		// collecting half of the shares on the axis is enough to prove the byzantine encoding
 		if count++; count >= len(roots.RowRoots)/2 {
 			break
 		}

--- a/share/shwap/getters/cascade.go
+++ b/share/shwap/getters/cascade.go
@@ -201,8 +201,8 @@ func cascadeGetters[V any](
 
 		var byzantineErr *byzantine.ErrByzantine
 		if errors.As(err, &byzantineErr) {
-			// short circuit if byzantine error was detected (to be able to handle it correctly
-			// and create the BEFP)
+			// short circuit if byzantine data was detected: the square is provably
+			// incorrectly encoded, so there is no point trying the remaining getters.
 			utils.SetStatusAndEnd(span, byzantineErr)
 			return zero, byzantineErr
 		}


### PR DESCRIPTION
Bad encoding fraud proofs were removed in #4934, but a few pieces of scaffolding still pointed at the deleted feature. This cleans them up: it deletes the `fraud_tests` CI job (no file carries the `fraud` build tag anymore, so it was passing vacuously as a false green), removes the orphaned `Swamp.Validators` helper (zero callers — it only existed to feed the deleted `FraudMaker`) along with its now-unused imports, and fixes two stale comments in `cascade.go` and `byzantine.go` that referenced constructing a BEFP.

The byzantine-detection code itself (the cascade short-circuit and the availability error classification) is still functional and is intentionally left in place — only the dangling references were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)