### PR TITLE
shrex/peers: Avoid cooldown lock-order deadlock

### DIFF
--- a/share/shwap/p2p/shrex/peers/pool.go
+++ b/share/shwap/p2p/shrex/peers/pool.go
@@ -12,12 +12,13 @@ const defaultCleanupThreshold = 2
 
 // pool stores peers and provides methods for simple round-robin access.
 type pool struct {
-	m           sync.RWMutex
-	peersList   []peer.ID
-	statuses    map[peer.ID]status
-	cooldown    *timedQueue
-	activeCount int
-	nextIdx     int
+	m              sync.RWMutex
+	peersList      []peer.ID
+	statuses       map[peer.ID]status
+	cooldown       *timedQueue
+	cooldownTokens map[peer.ID]uint64
+	activeCount    int
+	nextIdx        int
 
 	hasPeer   bool
 	hasPeerCh chan struct{}
@@ -38,6 +39,7 @@ func newPool(peerCooldownTime time.Duration) *pool {
 	p := &pool{
 		peersList:        make([]peer.ID, 0),
 		statuses:         make(map[peer.ID]status),
+		cooldownTokens:   make(map[peer.ID]uint64),
 		hasPeerCh:        make(chan struct{}),
 		cleanupThreshold: defaultCleanupThreshold,
 	}
@@ -129,6 +131,7 @@ func (p *pool) remove(peers ...peer.ID) {
 	for _, peerID := range peers {
 		if status, ok := p.statuses[peerID]; ok && status != removed {
 			p.statuses[peerID] = removed
+			delete(p.cooldownTokens, peerID)
 			if status == active {
 				p.activeCount--
 			}
@@ -183,7 +186,7 @@ func (p *pool) putOnCooldown(peerID peer.ID) {
 	defer p.m.Unlock()
 
 	if status, ok := p.statuses[peerID]; ok && status == active {
-		p.cooldown.push(peerID)
+		p.cooldownTokens[peerID] = p.cooldown.push(peerID)
 
 		p.statuses[peerID] = cooldown
 		p.activeCount--
@@ -191,15 +194,17 @@ func (p *pool) putOnCooldown(peerID peer.ID) {
 	}
 }
 
-func (p *pool) afterCooldown(peerID peer.ID) {
+func (p *pool) afterCooldown(peerID peer.ID, token uint64) {
 	p.m.Lock()
 	defer p.m.Unlock()
 
-	// item could have been already removed by the time afterCooldown is called
-	if status, ok := p.statuses[peerID]; !ok || status != cooldown {
+	// The peer could have been removed or entered a new cooldown cycle.
+	currentToken, ok := p.cooldownTokens[peerID]
+	if p.statuses[peerID] != cooldown || !ok || currentToken != token {
 		return
 	}
 
+	delete(p.cooldownTokens, peerID)
 	p.statuses[peerID] = active
 	p.activeCount++
 	p.checkHasPeers()

--- a/share/shwap/p2p/shrex/peers/pool_test.go
+++ b/share/shwap/p2p/shrex/peers/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
@@ -180,5 +181,79 @@ func TestPool(t *testing.T) {
 
 		_, ok := p.tryGet()
 		require.False(t, ok)
+	})
+
+	t.Run("stale cooldown callback", func(t *testing.T) {
+		ttl := time.Second
+		mock := clock.NewMock()
+		p := newPool(ttl)
+		p.cooldown.clock = mock
+
+		peerID := peer.ID("peer1")
+		p.add(peerID)
+		p.putOnCooldown(peerID)
+		firstToken := p.cooldownTokens[peerID]
+
+		callbackStarted := make(chan struct{})
+		releaseCallback := make(chan struct{})
+		callbackDone := make(chan uint64, 1)
+		onPop := p.cooldown.onPop
+		p.cooldown.onPop = func(id peer.ID, token uint64) {
+			if token == firstToken {
+				close(callbackStarted)
+				<-releaseCallback
+			}
+			onPop(id, token)
+			callbackDone <- token
+		}
+
+		advanceDone := make(chan struct{})
+		go func() {
+			mock.Add(ttl)
+			close(advanceDone)
+		}()
+
+		select {
+		case <-callbackStarted:
+		case <-time.After(ttl):
+			t.Fatal("first cooldown callback did not start")
+		}
+
+		p.remove(peerID)
+		require.NotContains(t, p.cooldownTokens, peerID)
+		p.add(peerID)
+		p.putOnCooldown(peerID)
+		secondToken := p.cooldownTokens[peerID]
+		require.NotEqual(t, firstToken, secondToken)
+
+		close(releaseCallback)
+		select {
+		case token := <-callbackDone:
+			require.Equal(t, firstToken, token)
+		case <-time.After(ttl):
+			t.Fatal("first cooldown callback did not finish")
+		}
+		select {
+		case <-advanceDone:
+		case <-time.After(ttl):
+			t.Fatal("clock advance did not finish")
+		}
+
+		_, ok := p.tryGet()
+		require.False(t, ok)
+		require.Equal(t, 1, p.cooldown.len())
+
+		mock.Add(ttl)
+		select {
+		case token := <-callbackDone:
+			require.Equal(t, secondToken, token)
+		case <-time.After(ttl):
+			t.Fatal("second cooldown callback did not finish")
+		}
+
+		actual, ok := p.tryGet()
+		require.True(t, ok)
+		require.Equal(t, peerID, actual)
+		require.Zero(t, p.cooldown.len())
 	})
 }

--- a/share/shwap/p2p/shrex/peers/timedqueue.go
+++ b/share/shwap/p2p/shrex/peers/timedqueue.go
@@ -18,16 +18,18 @@ type timedQueue struct {
 	ttl   time.Duration
 	clock clock.Clock
 	after *clock.Timer
-	// onPop will be called on item peer.ID after it is released
-	onPop func(peer.ID)
+	// onPop will be called on an item after it is released
+	onPop     func(peer.ID, uint64)
+	nextToken uint64
 }
 
 type item struct {
 	peer.ID
 	createdAt time.Time
+	token     uint64
 }
 
-func newTimedQueue(ttl time.Duration, onPop func(peer.ID)) *timedQueue {
+func newTimedQueue(ttl time.Duration, onPop func(peer.ID, uint64)) *timedQueue {
 	return &timedQueue{
 		items: make([]item, 0),
 		clock: clock.New(),
@@ -42,17 +44,17 @@ func (q *timedQueue) releaseExpired() {
 	expired := q.releaseUnsafe()
 	q.Unlock()
 
-	for _, peerID := range expired {
-		q.onPop(peerID)
+	for _, item := range expired {
+		q.onPop(item.ID, item.token)
 	}
 }
 
-func (q *timedQueue) releaseUnsafe() []peer.ID {
+func (q *timedQueue) releaseUnsafe() []item {
 	if len(q.items) == 0 {
 		return nil
 	}
 
-	var expired []peer.ID
+	var expired []item
 	for _, next := range q.items {
 		timeIn := q.clock.Since(next.createdAt)
 		if timeIn < q.ttl {
@@ -63,7 +65,7 @@ func (q *timedQueue) releaseUnsafe() []peer.ID {
 		}
 
 		// item is expired
-		expired = append(expired, next.ID)
+		expired = append(expired, next)
 	}
 
 	if len(expired) > 0 {
@@ -73,19 +75,22 @@ func (q *timedQueue) releaseUnsafe() []peer.ID {
 	return expired
 }
 
-func (q *timedQueue) push(peerID peer.ID) {
+func (q *timedQueue) push(peerID peer.ID) uint64 {
 	q.Lock()
 	defer q.Unlock()
 
+	q.nextToken++
 	q.items = append(q.items, item{
 		ID:        peerID,
 		createdAt: q.clock.Now(),
+		token:     q.nextToken,
 	})
 
 	// if it is the first item in queue, create a timer to call releaseExpired after its expiration
 	if len(q.items) == 1 {
 		q.after = q.clock.AfterFunc(q.ttl, q.releaseExpired)
 	}
+	return q.nextToken
 }
 
 func (q *timedQueue) len() int {

--- a/share/shwap/p2p/shrex/peers/timedqueue.go
+++ b/share/shwap/p2p/shrex/peers/timedqueue.go
@@ -36,19 +36,23 @@ func newTimedQueue(ttl time.Duration, onPop func(peer.ID)) *timedQueue {
 	}
 }
 
-// releaseExpired will release all expired items
+// releaseExpired releases all expired items.
 func (q *timedQueue) releaseExpired() {
 	q.Lock()
-	defer q.Unlock()
-	q.releaseUnsafe()
+	expired := q.releaseUnsafe()
+	q.Unlock()
+
+	for _, peerID := range expired {
+		q.onPop(peerID)
+	}
 }
 
-func (q *timedQueue) releaseUnsafe() {
+func (q *timedQueue) releaseUnsafe() []peer.ID {
 	if len(q.items) == 0 {
-		return
+		return nil
 	}
 
-	var i int
+	var expired []peer.ID
 	for _, next := range q.items {
 		timeIn := q.clock.Since(next.createdAt)
 		if timeIn < q.ttl {
@@ -59,14 +63,14 @@ func (q *timedQueue) releaseUnsafe() {
 		}
 
 		// item is expired
-		q.onPop(next.ID)
-		i++
+		expired = append(expired, next.ID)
 	}
 
-	if i > 0 {
-		copy(q.items, q.items[i:])
-		q.items = q.items[:len(q.items)-i]
+	if len(expired) > 0 {
+		copy(q.items, q.items[len(expired):])
+		q.items = q.items[:len(q.items)-len(expired)]
 	}
+	return expired
 }
 
 func (q *timedQueue) push(peerID peer.ID) {

--- a/share/shwap/p2p/shrex/peers/timedqueue_test.go
+++ b/share/shwap/p2p/shrex/peers/timedqueue_test.go
@@ -15,11 +15,13 @@ func TestTimedQueue(t *testing.T) {
 		ttl := time.Second
 
 		popCh := make(chan peer.ID, 1)
-		queue := newTimedQueue(ttl, func(id peer.ID) {
+		queue := newTimedQueue(ttl, func(id peer.ID, _ uint64) {
 			popCh <- id
 		})
 		mock := clock.NewMock()
 		queue.clock = mock
+		queue.releaseExpired()
+		require.Zero(t, queue.len())
 
 		// push first item | global time : 0
 		queue.push(peers[0])
@@ -63,7 +65,7 @@ func TestTimedQueue(t *testing.T) {
 		callbackDone := make(chan peer.ID, 1)
 
 		var queue *timedQueue
-		queue = newTimedQueue(ttl, func(id peer.ID) {
+		queue = newTimedQueue(ttl, func(id peer.ID, _ uint64) {
 			queue.push("peer2")
 			callbackDone <- id
 		})

--- a/share/shwap/p2p/shrex/peers/timedqueue_test.go
+++ b/share/shwap/p2p/shrex/peers/timedqueue_test.go
@@ -14,12 +14,9 @@ func TestTimedQueue(t *testing.T) {
 		peers := []peer.ID{"peer1", "peer2"}
 		ttl := time.Second
 
-		popCh := make(chan struct{}, 1)
+		popCh := make(chan peer.ID, 1)
 		queue := newTimedQueue(ttl, func(id peer.ID) {
-			go func() {
-				require.Contains(t, peers, id)
-				popCh <- struct{}{}
-			}()
+			popCh <- id
 		})
 		mock := clock.NewMock()
 		queue.clock = mock
@@ -42,7 +39,8 @@ func TestTimedQueue(t *testing.T) {
 		mock.Add(1)
 
 		select {
-		case <-popCh:
+		case id := <-popCh:
+			require.Equal(t, peers[0], id)
 		case <-time.After(ttl):
 			t.Fatal("first item is not released")
 		}
@@ -51,10 +49,45 @@ func TestTimedQueue(t *testing.T) {
 		// first item should be released after ttl/2 gap timeout | global time : 3/2*ttl
 		mock.Add(ttl / 2)
 		select {
-		case <-popCh:
+		case id := <-popCh:
+			require.Equal(t, peers[1], id)
 		case <-time.After(ttl):
 			t.Fatal("second item is not released")
 		}
 		require.Equal(t, queue.len(), 0)
+	})
+
+	t.Run("callback does not hold queue lock", func(t *testing.T) {
+		ttl := time.Second
+		mock := clock.NewMock()
+		callbackDone := make(chan peer.ID, 1)
+
+		var queue *timedQueue
+		queue = newTimedQueue(ttl, func(id peer.ID) {
+			queue.push("peer2")
+			callbackDone <- id
+		})
+		queue.clock = mock
+		queue.push("peer1")
+
+		advanceDone := make(chan struct{})
+		go func() {
+			mock.Add(ttl)
+			close(advanceDone)
+		}()
+
+		select {
+		case id := <-callbackDone:
+			require.Equal(t, peer.ID("peer1"), id)
+		case <-time.After(ttl):
+			t.Fatal("callback blocked while accessing queue")
+		}
+
+		select {
+		case <-advanceDone:
+		case <-time.After(ttl):
+			t.Fatal("clock advance did not finish")
+		}
+		require.Equal(t, 1, queue.len())
 	})
 }


### PR DESCRIPTION
Concurrent cooldown insertion and expiry can deadlock peer selection: insertion acquires the pool lock before the queue lock, while expiry acquires them in reverse order.

Use `pool.m` to protect both peer state and the cooldown queue. The queue has no mutex. The timer callback acquires the pool lock once, removes expired entries, and reactivates peers without acquiring that lock again. Metrics read the cooldown count under the pool read lock.

Removing a peer also removes its pending cooldown entry. If the first entry changes, reschedule the timer for the next expiry; stop it if the queue is empty. A timer callback that has already started checks the current queue under the pool lock, so it cannot end a new cooldown early. This requires no per-cycle tokens.
