### PR TITLE
blob: Reuse the header across GetAll namespace retrievals

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -424,11 +424,20 @@ func (s *Service) retrieve(
 		"namespace", namespace.String(),
 	)
 
-	span := trace.SpanFromContext(ctx)
 	header, err := s.headerGetter(ctx, height)
 	if err != nil {
 		return nil, nil, err
 	}
+	return s.retrieveWithHeader(ctx, header, namespace, sharesParser)
+}
+
+func (s *Service) retrieveWithHeader(
+	ctx context.Context,
+	header *header.ExtendedHeader,
+	namespace libshare.Namespace,
+	sharesParser *parser,
+) (_ *Blob, _ *Proof, err error) {
+	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
 		attribute.Int64("eds-size", int64(len(header.DAH.RowRoots))),
 	)
@@ -537,7 +546,7 @@ func (s *Service) retrieve(
 	for _, sh := range appShares {
 		if !sh.IsPadding() {
 			err = fmt.Errorf("incomplete blob with the "+
-				"namespace: %s detected at %d: %w", namespace.String(), height, err)
+				"namespace: %s detected at %d: %w", namespace.String(), header.Height(), err)
 			log.Error(err)
 		}
 	}
@@ -563,7 +572,7 @@ func (s *Service) getBlobs(
 	}
 	sharesParser := &parser{verifyFn: verifyFn}
 
-	_, _, err = s.retrieve(ctx, header.Height(), namespace, sharesParser)
+	_, _, err = s.retrieveWithHeader(ctx, header, namespace, sharesParser)
 	if err != nil && !errors.Is(err, ErrBlobNotFound) {
 		log.Errorf("retrieving blobs for the namespace (%s): %v", namespace.String(), err)
 		span.RecordError(err)

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"slices"
 	"sort"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -463,6 +464,39 @@ func TestBlobService_Get(t *testing.T) {
 			tt.expectedResult(blobs, err)
 		})
 	}
+}
+
+func TestServiceGetAllFetchesHeaderOnce(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	namespace, err := libshare.NewV0Namespace([]byte("present"))
+	require.NoError(t, err)
+	libBlob, err := libshare.NewBlob(namespace, []byte("data"), libshare.ShareVersionZero, nil)
+	require.NoError(t, err)
+	blobs, err := convertBlobs(libBlob)
+	require.NoError(t, err)
+	shares, err := BlobsToShares(blobs...)
+	require.NoError(t, err)
+
+	service := createService(ctx, t, shares)
+	headerGetter := service.headerGetter
+	var headerCalls atomic.Int32
+	service.headerGetter = func(ctx context.Context, height uint64) (*header.ExtendedHeader, error) {
+		headerCalls.Add(1)
+		return headerGetter(ctx, height)
+	}
+
+	absent1, err := libshare.NewV0Namespace([]byte("absent1"))
+	require.NoError(t, err)
+	absent2, err := libshare.NewV0Namespace([]byte("absent2"))
+	require.NoError(t, err)
+
+	got, err := service.GetAll(ctx, 1, []libshare.Namespace{namespace, absent1, absent2})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, blobs[0].Commitment, got[0].Commitment)
+	require.Equal(t, int32(1), headerCalls.Load())
 }
 
 // TestService_GetSingleBlobWithoutPadding creates two blobs with the same namespace


### PR DESCRIPTION
## Summary

- reuse the header already resolved by `GetAll` for every namespace retrieval
- avoid resolving streamed headers again in `Subscribe`
- add regression coverage for multi-namespace requests

## Problem

`GetAll` resolves the header before starting namespace retrievals, but each `getBlobs` call previously delegated to `retrieve(height, ...)`, which resolved the same header again.

For N namespaces, this resulted in N+1 `headerGetter` calls. Even the common single-namespace request performed two lookups. `Subscribe` had the same issue despite already receiving the header from its subscription stream.

## Solution

The height-based `retrieve` method remains the wrapper used by `Get`, `GetProof`, and `Included`. The retrieval logic now lives in `retrieveWithHeader`, allowing `getBlobs` to use the header its caller already has.

This changes the lookup count from N+1 to 1 for `GetAll`, and removes the redundant lookup from `Subscribe`, without changing the API, concurrency, or result ordering.

## Testing

- `go test ./blob -run '^(TestBlobService_Get|TestServiceGetAllFetchesHeaderOnce)$' -count=20 -timeout=3m`
- `go test ./blob -count=1 -timeout=5m`
- `go vet ./blob`
- `golangci-lint run --timeout 10m --new-from-merge-base=upstream/main`