### PR TITLE
blob: Cancel subscriptions when service stops

### DIFF
--- a/blob/service.go
+++ b/blob/service.go
@@ -113,20 +113,27 @@ func (s *Service) Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan 
 	log.Infow("subscribing for blobs",
 		"namespaces", ns.String(),
 	)
-	headerCh, err := s.headerSub(ctx)
+	serviceCtx := s.ctx
+	subCtx, cancel := context.WithCancel(ctx)
+	stopPropagate := context.AfterFunc(serviceCtx, cancel)
+	headerCh, err := s.headerSub(subCtx)
 	if err != nil {
+		stopPropagate()
+		cancel()
 		return nil, err
 	}
 
 	blobCh := make(chan *SubscriptionResponse, 16)
 	go func() {
 		defer close(blobCh)
+		defer cancel()
+		defer stopPropagate()
 
 		for {
 			select {
 			case header, ok := <-headerCh:
-				if ctx.Err() != nil {
-					log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
+				if subCtx.Err() != nil {
+					log.Debugw("blobsub: canceling subscription due to subscription ctx closing", "namespace", ns.ID())
 					return
 				}
 				if !ok {
@@ -142,10 +149,10 @@ func (s *Service) Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan 
 				var blobs []*Blob
 				var err error
 				for {
-					blobs, err = s.getAll(ctx, header, []libshare.Namespace{ns})
-					if ctx.Err() != nil {
+					blobs, err = s.getAll(subCtx, header, []libshare.Namespace{ns})
+					if subCtx.Err() != nil {
 						// context canceled, continuing would lead to unexpected missed heights for the client
-						log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
+						log.Debugw("blobsub: canceling subscription due to subscription ctx closing", "namespace", ns.ID())
 						return
 					}
 					if err == nil {
@@ -158,6 +165,9 @@ func (s *Service) Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan 
 				case <-ctx.Done():
 					log.Debugw("blobsub: pending response canceled due to user ctx closing", "namespace", ns.ID())
 					return
+				case <-serviceCtx.Done():
+					log.Debugw("blobsub: pending response canceled due to service ctx closing", "namespace", ns.ID())
+					return
 				case blobCh <- &SubscriptionResponse{
 					Blobs:  blobs,
 					Height: header.Height(),
@@ -167,7 +177,7 @@ func (s *Service) Subscribe(ctx context.Context, ns libshare.Namespace) (<-chan 
 			case <-ctx.Done():
 				log.Debugw("blobsub: canceling subscription due to user ctx closing", "namespace", ns.ID())
 				return
-			case <-s.ctx.Done():
+			case <-serviceCtx.Done():
 				log.Debugw("blobsub: canceling subscription due to service ctx closing", "namespace", ns.ID())
 				return
 			}

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -774,6 +774,67 @@ func TestService_Subscribe(t *testing.T) {
 	})
 }
 
+func TestService_SubscribeStopCancelsInFlightWork(t *testing.T) {
+	ctx := context.Background()
+	namespace := libshare.RandomBlobNamespace()
+	head := headertest.RandExtendedHeader(t)
+	testTimeout := 2 * time.Second
+
+	ctrl := gomock.NewController(t)
+	shareGetter := mock.NewMockGetter(ctrl)
+	retrievalCtxCh := make(chan context.Context, 1)
+	shareGetter.EXPECT().GetNamespaceData(gomock.Any(), gomock.Any(), namespace).
+		DoAndReturn(func(ctx context.Context, _ *header.ExtendedHeader, _ libshare.Namespace) (shwap.NamespaceData, error) {
+			retrievalCtxCh <- ctx
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+
+	headerCtxCh := make(chan context.Context, 1)
+	headerSub := func(ctx context.Context) (<-chan *header.ExtendedHeader, error) {
+		headerCtxCh <- ctx
+		headerCh := make(chan *header.ExtendedHeader, 1)
+		headerCh <- head
+		return headerCh, nil
+	}
+	headerGetter := func(context.Context, uint64) (*header.ExtendedHeader, error) {
+		return head, nil
+	}
+
+	service := NewService(nil, shareGetter, headerGetter, headerSub)
+	require.NoError(t, service.Start(ctx))
+	responseCh, err := service.Subscribe(ctx, namespace)
+	require.NoError(t, err)
+	headerCtx := <-headerCtxCh
+
+	var retrievalCtx context.Context
+	select {
+	case retrievalCtx = <-retrievalCtxCh:
+	case <-time.After(testTimeout):
+		t.Fatal("blob retrieval did not start")
+	}
+
+	require.NoError(t, service.Stop(context.Background()))
+	require.NoError(t, ctx.Err())
+
+	select {
+	case <-retrievalCtx.Done():
+	case <-time.After(testTimeout):
+		t.Fatal("service stop did not cancel blob retrieval")
+	}
+	select {
+	case <-headerCtx.Done():
+	case <-time.After(testTimeout):
+		t.Fatal("service stop did not cancel header subscription")
+	}
+	select {
+	case _, ok := <-responseCh:
+		require.False(t, ok)
+	case <-time.After(testTimeout):
+		t.Fatal("service stop did not close blob subscription")
+	}
+}
+
 func TestService_Subscribe_MultipleNamespaces(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	t.Cleanup(cancel)


### PR DESCRIPTION
## Summary

- bind live blob subscription work to both caller and service lifecycle contexts
- cancel the underlying header subscription whenever the blob subscription exits
- add regression coverage for stopping the service during an in-flight retrieval

## Problem

`Subscribe` passed only the caller context to the header subscription and blob retrieval. `Service.Stop` could therefore leave an in-flight retrieval blocked and the response channel open, despite the API contract.

## Solution

Derive a subscription context from the caller context and propagate service lifecycle cancellation through `context.AfterFunc`. The derived context is used for both the header stream and namespace retrieval and is canceled on every exit path.

## Testing

- `go test ./blob -run '^TestService_SubscribeStopCancelsInFlightWork$' -count=20 -timeout=5m`
- `go test ./blob -count=1 -timeout=10m`
- `go vet ./blob`
- `golangci-lint run --timeout 10m --new-from-merge-base=upstream/main ./blob/...`