### PR TITLE
das: Reset running state after failed start

### DIFF
--- a/das/daser.go
+++ b/das/daser.go
@@ -76,11 +76,13 @@ func (d *DASer) Start(ctx context.Context) error {
 
 	cp, err := d.checkpoint(ctx)
 	if err != nil {
+		d.running.Store(false)
 		return err
 	}
 
 	sub, err := d.hsub.Subscribe()
 	if err != nil {
+		d.running.Store(false)
 		return err
 	}
 

--- a/das/daser_test.go
+++ b/das/daser_test.go
@@ -2,6 +2,7 @@ package das
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -104,6 +105,43 @@ func TestDASer_Restart(t *testing.T) {
 	assert.EqualValues(t, 60, checkpoint.SampleFrom-1)
 }
 
+func TestDASer_StartFailureAllowsRetry(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("checkpoint", func(t *testing.T) {
+		checkpointErr := errors.New("checkpoint failed")
+		daser, err := NewDASer(
+			mocks.NewMockAvailability(gomock.NewController(t)),
+			new(headertest.Subscriber),
+			errorTailStore{err: checkpointErr},
+			ds_sync.MutexWrap(datastore.NewMapDatastore()),
+		)
+		require.NoError(t, err)
+
+		for range 2 {
+			require.ErrorIs(t, daser.Start(ctx), checkpointErr)
+		}
+		require.NoError(t, daser.Stop(ctx))
+	})
+
+	t.Run("subscription", func(t *testing.T) {
+		getter, _ := createDASerSubcomponents(t, 1, 0)
+		subscribeErr := errors.New("subscribe failed")
+		daser, err := NewDASer(
+			mocks.NewMockAvailability(gomock.NewController(t)),
+			errorSubscriber{err: subscribeErr},
+			getter,
+			ds_sync.MutexWrap(datastore.NewMapDatastore()),
+		)
+		require.NoError(t, err)
+
+		for range 2 {
+			require.ErrorIs(t, daser.Start(ctx), subscribeErr)
+		}
+		require.NoError(t, daser.Stop(ctx))
+	})
+}
+
 func TestDASerSampleTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
@@ -193,6 +231,27 @@ func (m benchGetterStub) GetByHeight(context.Context, uint64) (*header.ExtendedH
 }
 
 type getterStub struct{}
+
+type errorTailStore struct {
+	libhead.Store[*header.ExtendedHeader]
+	err error
+}
+
+func (s errorTailStore) Tail(context.Context) (*header.ExtendedHeader, error) {
+	return nil, s.err
+}
+
+type errorSubscriber struct {
+	err error
+}
+
+func (s errorSubscriber) Subscribe() (libhead.Subscription[*header.ExtendedHeader], error) {
+	return nil, s.err
+}
+
+func (errorSubscriber) SetVerifier(func(context.Context, *header.ExtendedHeader) error) error {
+	return nil
+}
 
 func (m getterStub) Head(
 	context.Context,


### PR DESCRIPTION
## Summary

- reset the DASer running state when initialization fails before workers start
- allow startup to be retried after checkpoint or header subscription errors
- add regression coverage for both failure paths and a subsequent `Stop`

## Problem

`DASer.Start` marked the service as running before loading its checkpoint and creating the header subscription. If either operation failed, the flag remained set even though no worker goroutines or cancel function had been initialized.

A later `Start` therefore returned `da: DASer already started` instead of retrying initialization. Calling `Stop` after the failed start could also enter the shutdown path with an uninitialized cancel function.

## Solution

Restore the running flag on both initialization error paths. The successful startup path and the atomic guard against starting an already running DASer remain unchanged.

## Testing

- `go test ./das -run '^TestDASer_StartFailureAllowsRetry$' -count=50 -timeout=5m`
- `go test ./das -run '^TestDASer' -count=10 -timeout=10m`
- `go vet ./das`
- `golangci-lint run --timeout 10m --new-from-merge-base=upstream/main ./das/...`