### PR TITLE
das: Wake coordinator at retry deadlines

### DIFF
--- a/das/coordinator.go
+++ b/das/coordinator.go
@@ -74,7 +74,16 @@ func (sc *samplingCoordinator) run(ctx context.Context, cp checkpoint) {
 			sc.runWorker(ctx, next)
 		}
 
+		var retryDeadline <-chan time.Time
+		if !sc.concurrencyLimitReached() {
+			if after, found := sc.state.nextRetryTime(); found {
+				retryDeadline = time.After(time.Until(after))
+			}
+		}
+
 		select {
+		case <-retryDeadline:
+			// Check for retries that have reached their deadline.
 		case head := <-sc.updHeadCh:
 			if sc.state.isNewHead(head.Height()) {
 				if !sc.recentJobsLimitReached() {

--- a/das/coordinator_test.go
+++ b/das/coordinator_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cometbft/cometbft/types"
@@ -293,6 +294,39 @@ func TestCoordinator(t *testing.T) {
 
 		st := coordinator.state.unsafeStats()
 		require.Equal(t, ch, newCheckpoint(st))
+	})
+}
+
+func TestCoordinatorWakesForRetryDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		params := DefaultParameters()
+		params.ConcurrencyLimit = 1
+		params.SamplingRange = 1
+
+		attempts := 0
+		retried := make(chan struct{})
+		sample := func(context.Context, *header.ExtendedHeader) error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("sampling failed")
+			}
+			close(retried)
+			return nil
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		coordinator := newSamplingCoordinator(params, getterStub{}, sample)
+		go coordinator.run(ctx, checkpoint{SampleFrom: 1, NetworkHead: 1})
+
+		select {
+		case <-retried:
+		case <-time.After(2 * defaultBackoffInitialInterval):
+			t.Fatal("retry did not run after its deadline")
+		}
+
+		cancel()
+		require.NoError(t, coordinator.wait(t.Context()))
 	})
 }
 

--- a/das/state.go
+++ b/das/state.go
@@ -307,7 +307,19 @@ func (s *coordinatorState) waitCatchUp(ctx context.Context) error {
 	return nil
 }
 
-// canRetry returns true if the time stored in the "after" has passed.
+func (s *coordinatorState) nextRetryTime() (time.Time, bool) {
+	var next time.Time
+	found := false
+	for _, attempt := range s.failed {
+		if !found || attempt.after.Before(next) {
+			next = attempt.after
+			found = true
+		}
+	}
+	return next, found
+}
+
+// canRetry returns true once the retry deadline has been reached.
 func (r retryAttempt) canRetry() bool {
-	return r.after.Before(time.Now())
+	return !r.after.After(time.Now())
 }


### PR DESCRIPTION
## Summary

- wake the sampling coordinator when the earliest failed height becomes eligible for retry
- treat a retry as ready when its deadline is reached
- cover the quiet coordinator path with a virtual-time regression test

## Motivation

After a sampling failure, the coordinator records when the height may be retried. Once no other work is ready, however, the run loop waits only for a new head, a worker result, a stats request, or cancellation. The retry deadline itself does not wake it.

This makes retry timing depend on unrelated activity. During quiet periods a retry can be delayed well past its backoff, and it can remain pending indefinitely when background checkpointing is disabled.

The coordinator now waits for the earliest retry deadline whenever worker capacity is available.

## Related work

This is independent of #5169 and #5173. Those changes affect how ready retries are grouped and how their deadlines are selected; this change ensures the coordinator wakes when a deadline arrives.

## Testing

- `go test ./das -run '^TestCoordinatorWakesForRetryDeadline$' -count=100`
- `go test ./das -run '^TestCoordinator$' -count=20`
- `go test ./das -count=1`
- `go vet ./das`
- `golangci-lint run --new-from-merge-base=upstream/main --timeout 10m`