### PR TITLE
p2p: Start listening with the node lifecycle

### DIFF
--- a/nodebuilder/p2p/addrs.go
+++ b/nodebuilder/p2p/addrs.go
@@ -8,17 +8,26 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-// Listen returns invoke function that starts listening for inbound connections with libp2p.Host.
+func parseListenAddrs(addrs []string) ([]ma.Multiaddr, error) {
+	parsed := make([]ma.Multiaddr, len(addrs))
+	for i, addr := range addrs {
+		maddr, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			return nil, fmt.Errorf("failure to parse config.P2P.ListenAddresses: %w", err)
+		}
+		parsed[i] = maddr
+	}
+	return parsed, nil
+}
+
+// Listen returns a function that starts listening for inbound connections with libp2p.Host.
 func Listen(cfg *Config) func(h hst.Host) (err error) {
 	return func(h hst.Host) (err error) {
-		maListen := make([]ma.Multiaddr, len(cfg.ListenAddresses))
-		for i, addr := range cfg.ListenAddresses {
-			maListen[i], err = ma.NewMultiaddr(addr)
-			if err != nil {
-				return fmt.Errorf("failure to parse config.P2P.ListenAddresses: %w", err)
-			}
+		addrs, err := parseListenAddrs(cfg.ListenAddresses)
+		if err != nil {
+			return err
 		}
-		return h.Network().Listen(maListen...)
+		return h.Network().Listen(addrs...)
 	}
 }
 

--- a/nodebuilder/p2p/module.go
+++ b/nodebuilder/p2p/module.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	logging "github.com/ipfs/go-log/v2"
+	hst "github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/metrics"
 	"go.uber.org/fx"
 
@@ -13,7 +14,12 @@ var log = logging.Logger("module/p2p")
 
 // ConstructModule collects all the components and services related to p2p.
 func ConstructModule(tp node.Type, cfg *Config) fx.Option {
-	// sanitize config values before constructing module
+	// validate config values before constructing module
+	_, err := parseListenAddrs(cfg.ListenAddresses)
+	if err != nil {
+		return fx.Error(err)
+	}
+
 	baseComponents := fx.Options(
 		fx.Supply(cfg),
 		fx.Provide(Key),
@@ -30,7 +36,8 @@ func ConstructModule(tp node.Type, cfg *Config) fx.Option {
 		fx.Provide(addrsFactory(cfg.AnnounceAddresses, cfg.NoAnnounceAddresses)),
 		fx.Provide(metrics.NewBandwidthCounter),
 		fx.Provide(newModule),
-		fx.Invoke(Listen(cfg)),
+		// Construct the routed host eagerly so the P2P lifecycle hooks are registered.
+		fx.Invoke(func(_ hst.Host) {}),
 		fx.Provide(resourceManager),
 		fx.Provide(resourceManagerOpt(allowList)),
 	)

--- a/nodebuilder/p2p/module_test.go
+++ b/nodebuilder/p2p/module_test.go
@@ -2,10 +2,12 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 
@@ -15,6 +17,7 @@ import (
 
 func testModule(tp node.Type) fx.Option {
 	cfg := DefaultConfig(tp)
+	cfg.ListenAddresses = []string{"/ip4/127.0.0.1/tcp/0"}
 	// TODO(@Wondertan): Most of these can be deduplicated
 	//  by moving Store into the modnode and introducing there a TestModNode module
 	//  that testers would import
@@ -41,11 +44,46 @@ func TestModuleBuild(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.tp.String(), func(t *testing.T) {
-			app := fxtest.New(t, testModule(tt.tp))
+			var host HostBase
+			var module Module
+			app := fxtest.New(t, testModule(tt.tp), fx.Populate(&host, &module))
+			require.Empty(t, host.Network().ListenAddresses())
 			app.RequireStart()
+			require.NotEmpty(t, host.Network().ListenAddresses())
 			app.RequireStop()
+			require.Empty(t, host.Network().ListenAddresses())
 		})
 	}
+}
+
+func TestModuleStartFailureClosesListeners(t *testing.T) {
+	startErr := errors.New("start failed")
+	listenersStarted := false
+	var host HostBase
+	app := fxtest.New(
+		t,
+		testModule(node.Light),
+		fx.Populate(&host),
+		fx.Invoke(func(lc fx.Lifecycle) {
+			lc.Append(fx.Hook{OnStart: func(context.Context) error {
+				listenersStarted = len(host.Network().ListenAddresses()) > 0
+				return startErr
+			}})
+		}),
+	)
+
+	err := app.Start(t.Context())
+	require.ErrorIs(t, err, startErr)
+	require.True(t, listenersStarted)
+	require.Empty(t, host.Network().ListenAddresses())
+}
+
+func TestModuleRejectsInvalidListenAddress(t *testing.T) {
+	cfg := DefaultConfig(node.Light)
+	cfg.ListenAddresses = []string{"invalid"}
+
+	app := fx.New(fx.NopLogger, ConstructModule(node.Light, &cfg))
+	require.ErrorContains(t, app.Err(), "failure to parse config.P2P.ListenAddresses")
 }
 
 func TestModuleBuild_WithMetrics(t *testing.T) {

--- a/nodebuilder/p2p/routing.go
+++ b/nodebuilder/p2p/routing.go
@@ -16,6 +16,7 @@ import (
 func newDHT(
 	ctx context.Context,
 	lc fx.Lifecycle,
+	cfg *Config,
 	tp node.Type,
 	network Network,
 	bootstrappers Bootstrappers,
@@ -42,13 +43,16 @@ func newDHT(
 	if err != nil {
 		return nil, err
 	}
-	stopFn := func(context.Context) error {
+	// Register cleanup first so Fx runs it if Listen or Bootstrap fails.
+	lc.Append(fx.Hook{OnStop: func(context.Context) error {
 		return dht.Close()
-	}
-	lc.Append(fx.Hook{
-		OnStart: dht.Bootstrap,
-		OnStop:  stopFn,
-	})
+	}})
+	lc.Append(fx.Hook{OnStart: func(ctx context.Context) error {
+		if err := Listen(cfg)(host); err != nil {
+			return err
+		}
+		return dht.Bootstrap(ctx)
+	}})
 	return dht, nil
 }
 


### PR DESCRIPTION
## Summary

- bind libp2p listeners from the node lifecycle instead of Fx graph construction
- register DHT and host cleanup before listener startup so rollback closes both resources
- preserve construction-time address validation and TLS listener upgrades

## Motivation

The p2p module previously invoked `Listen` while Fx was constructing the dependency graph. A node could accept inbound connections before `Node.Start`, and a later construction failure could leave bound sockets without a returned node to stop.

The listener and DHT bootstrap now run from the same `OnStart` hook. Cleanup hooks are registered first, so a bind failure, bootstrap failure, or any later startup failure closes the DHT and host in the correct order.

## Testing

- `go test ./nodebuilder/p2p -run '^(TestModuleBuild|TestModuleStartFailureClosesListeners|TestModuleRejectsInvalidListenAddress)$' -count=20`
- `go test ./nodebuilder/p2p -count=1`
- `go vet ./nodebuilder/p2p`
- `golangci-lint run --new-from-merge-base=upstream/main --timeout 10m`