### PR TITLE
shwap/bitswap: Bound idle session retention

### DIFF
--- a/share/shwap/p2p/bitswap/getter.go
+++ b/share/shwap/p2p/bitswap/getter.go
@@ -28,6 +28,9 @@ var disablePooling = os.Getenv("CELESTIA_BITSWAP_DISABLE_POOLING") == "1"
 
 var tracer = otel.Tracer("shwap/bitswap")
 
+// Keep at most one idle session per default DAS worker in each pool.
+const maxIdleSessions = 16
+
 // Getter implements share.Getter.
 type Getter struct {
 	exchange  exchange.SessionExchange
@@ -283,7 +286,7 @@ func (g *Getter) isArchival(hdr *header.ExtendedHeader) bool {
 }
 
 // getSession takes a session out of the respective session pool
-func (g *Getter) getSession(isArchival bool) (ses exchange.Fetcher, release func()) {
+func (g *Getter) getSession(isArchival bool) (exchange.Fetcher, func()) {
 	if disablePooling {
 		ctx, cancel := context.WithCancel(context.Background())
 		f := g.exchange.NewSession(ctx)
@@ -291,11 +294,9 @@ func (g *Getter) getSession(isArchival bool) (ses exchange.Fetcher, release func
 	}
 
 	if isArchival {
-		ses = g.archivalPool.get()
-		return ses, func() { g.archivalPool.put(ses) }
+		return g.archivalPool.get()
 	}
-	ses = g.availablePool.get()
-	return ses, func() { g.availablePool.put(ses) }
+	return g.availablePool.get()
 }
 
 // edsFromRows imports given Rows and computes EDS out of them, assuming enough Rows were provided.
@@ -333,36 +334,51 @@ func edsFromRows(roots *share.AxisRoots, rows []shwap.Row) (*rsmt2d.ExtendedData
 // pool is a pool of Bitswap sessions.
 type pool struct {
 	lock     sync.Mutex
-	sessions []exchange.Fetcher
+	sessions []*pooledSession
 	ctx      context.Context
 	exchange exchange.SessionExchange
+}
+
+type pooledSession struct {
+	exchange.Fetcher
+	cancel context.CancelFunc
 }
 
 func newPool(ex exchange.SessionExchange) *pool {
 	return &pool{
 		exchange: ex,
-		sessions: make([]exchange.Fetcher, 0),
+		sessions: make([]*pooledSession, 0, maxIdleSessions),
 	}
 }
 
 // get returns a session from the pool or creates a new one if the pool is empty.
-func (p *pool) get() exchange.Fetcher {
+func (p *pool) get() (exchange.Fetcher, func()) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
+	var ses *pooledSession
 	if len(p.sessions) == 0 {
-		return p.exchange.NewSession(p.ctx)
+		ctx, cancel := context.WithCancel(p.ctx)
+		ses = &pooledSession{
+			Fetcher: p.exchange.NewSession(ctx),
+			cancel:  cancel,
+		}
+	} else {
+		ses = p.sessions[len(p.sessions)-1]
+		p.sessions = p.sessions[:len(p.sessions)-1]
 	}
 
-	ses := p.sessions[len(p.sessions)-1]
-	p.sessions = p.sessions[:len(p.sessions)-1]
-	return ses
+	return ses.Fetcher, func() { p.put(ses) }
 }
 
 // put returns a session to the pool.
-func (p *pool) put(ses exchange.Fetcher) {
+func (p *pool) put(ses *pooledSession) {
 	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	p.sessions = append(p.sessions, ses)
+	if p.ctx.Err() == nil && len(p.sessions) < maxIdleSessions {
+		p.sessions = append(p.sessions, ses)
+		p.lock.Unlock()
+		return
+	}
+	p.lock.Unlock()
+	ses.cancel()
 }

--- a/share/shwap/p2p/bitswap/getter_test.go
+++ b/share/shwap/p2p/bitswap/getter_test.go
@@ -43,13 +43,14 @@ func (m *mockSessionExchange) NewSession(ctx context.Context) exchange.Fetcher {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.sessionCount++
-	return &mockFetcher{id: m.sessionCount}
+	return &mockFetcher{id: m.sessionCount, ctx: ctx}
 }
 
 // mockFetcher is a mock implementation of exchange.Fetcher
 type mockFetcher struct {
 	exchange.Fetcher
-	id int
+	id  int
+	ctx context.Context
 }
 
 func TestPoolGetFromEmptyPool(t *testing.T) {
@@ -58,9 +59,11 @@ func TestPoolGetFromEmptyPool(t *testing.T) {
 	ctx := context.Background()
 	p.ctx = ctx
 
-	ses := p.get().(*mockFetcher)
-	require.NotNil(t, ses)
-	require.Equal(t, 1, ses.id)
+	ses, release := p.get()
+	defer release()
+	fetcher := ses.(*mockFetcher)
+	require.NotNil(t, fetcher)
+	require.Equal(t, 1, fetcher.id)
 }
 
 func TestPoolPutAndGet(t *testing.T) {
@@ -70,15 +73,16 @@ func TestPoolPutAndGet(t *testing.T) {
 	p.ctx = ctx
 
 	// Get a session
-	ses := p.get().(*mockFetcher)
+	ses, release := p.get()
 
 	// Put it back
-	p.put(ses)
+	release()
 
 	// Get again
-	ses2 := p.get().(*mockFetcher)
+	ses2, release2 := p.get()
+	defer release2()
 
-	require.Equal(t, ses.id, ses2.id)
+	require.Equal(t, ses.(*mockFetcher).id, ses2.(*mockFetcher).id)
 }
 
 func TestPoolConcurrency(t *testing.T) {
@@ -90,27 +94,57 @@ func TestPoolConcurrency(t *testing.T) {
 	const numGoroutines = 50
 	var wg sync.WaitGroup
 
-	sessionIDSet := make(map[int]struct{})
-	lock := sync.Mutex{}
-
 	// Start multiple goroutines to get sessions
 	for range numGoroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ses := p.get()
-			mockSes := ses.(*mockFetcher)
-			p.put(ses)
-			lock.Lock()
-			sessionIDSet[mockSes.id] = struct{}{}
-			lock.Unlock()
+			_, release := p.get()
+			release()
 		}()
 	}
 	wg.Wait()
 
-	// Since the pool reuses sessions, the number of unique session IDs should be less than or equal to numGoroutines
-	if len(sessionIDSet) > numGoroutines {
-		t.Fatalf("expected number of unique sessions to be less than or equal to %d, got %d",
-			numGoroutines, len(sessionIDSet))
+	require.LessOrEqual(t, len(p.sessions), maxIdleSessions)
+}
+
+func TestPoolBoundsIdleSessions(t *testing.T) {
+	ex := &mockSessionExchange{}
+	p := newPool(ex)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	p.ctx = ctx
+
+	sessions := make([]exchange.Fetcher, maxIdleSessions+1)
+	releases := make([]func(), maxIdleSessions+1)
+	for i := range sessions {
+		sessions[i], releases[i] = p.get()
 	}
+	for _, release := range releases {
+		release()
+	}
+
+	require.Len(t, p.sessions, maxIdleSessions)
+	require.ErrorIs(t, sessions[maxIdleSessions].(*mockFetcher).ctx.Err(), context.Canceled)
+	for _, ses := range sessions[:maxIdleSessions] {
+		require.NoError(t, ses.(*mockFetcher).ctx.Err())
+	}
+
+	_, release := p.get()
+	release()
+	require.Equal(t, maxIdleSessions+1, ex.sessionCount)
+}
+
+func TestPoolDiscardsSessionReleasedAfterStop(t *testing.T) {
+	ex := &mockSessionExchange{}
+	p := newPool(ex)
+	ctx, cancel := context.WithCancel(context.Background())
+	p.ctx = ctx
+
+	ses, release := p.get()
+	cancel()
+	release()
+
+	require.Empty(t, p.sessions)
+	require.ErrorIs(t, ses.(*mockFetcher).ctx.Err(), context.Canceled)
 }


### PR DESCRIPTION
## Summary

- bound each Bitswap idle session pool to 16 retained sessions
- cancel overflow sessions when requests return
- preserve active request concurrency and session reuse

## Motivation

The session pools currently grow to the highest concurrency observed by the Getter and retain every created session until shutdown. Bitswap sessions are context-owned and keep run loops, timers, peer state, and a SessionManager entry alive, so a short request burst permanently raises idle resource usage.

The limit matches the default DAS concurrency and applies only when sessions are returned to the pool. Active requests are never queued or rejected. Sessions above the idle limit are canceled so Boxo performs its normal cleanup.

This preserves the session reuse benefits introduced in #3947 while bounding resources retained after transient concurrency spikes.

## Testing

- `go test ./share/shwap/p2p/bitswap -run '^TestPool' -count=100`
- `go test ./share/shwap/p2p/bitswap -count=1`
- `go vet ./share/shwap/p2p/bitswap`
- `golangci-lint run --new-from-merge-base=upstream/main --timeout 10m`