### PR TITLE
fix(rpc/client): close namespace connections

### DIFF
--- a/api/rpc/client/client.go
+++ b/api/rpc/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/filecoin-project/go-jsonrpc"
 
@@ -40,6 +41,7 @@ type Client struct {
 // multiClientCloser is a wrapper struct to close clients across multiple namespaces.
 type multiClientCloser struct {
 	closers []jsonrpc.ClientCloser
+	once    sync.Once
 }
 
 // register adds a new closer to the multiClientCloser
@@ -49,12 +51,14 @@ func (m *multiClientCloser) register(closer jsonrpc.ClientCloser) {
 
 // closeAll closes all saved clients.
 func (m *multiClientCloser) closeAll() {
-	for _, closer := range m.closers {
-		closer()
-	}
+	m.once.Do(func() {
+		for _, closer := range m.closers {
+			closer()
+		}
+	})
 }
 
-// Close closes the connections to all namespaces registered on the staticClient.
+// Close closes the connections to all namespaces registered on the client.
 func (c *Client) Close() {
 	c.closer.closeAll()
 }
@@ -70,14 +74,14 @@ func NewClient(ctx context.Context, addr, token string) (*Client, error) {
 }
 
 func newClient(ctx context.Context, addr string, authHeader http.Header) (*Client, error) {
-	var multiCloser multiClientCloser
 	var client Client
 	for name, module := range moduleMap(&client) {
 		closer, err := jsonrpc.NewClient(ctx, addr, name, module, authHeader)
 		if err != nil {
+			client.Close()
 			return nil, err
 		}
-		multiCloser.register(closer)
+		client.closer.register(closer)
 	}
 
 	return &client, nil

--- a/api/rpc/client/client_test.go
+++ b/api/rpc/client/client_test.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-jsonrpc"
+	"github.com/stretchr/testify/require"
+)
+
+type testNodeHandler struct{}
+
+func (testNodeHandler) Ready(context.Context) (bool, error) {
+	return true, nil
+}
+
+func TestClientCloseClosesConnections(t *testing.T) {
+	server := jsonrpc.NewServer()
+	server.Register("node", testNodeHandler{})
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	client, err := newClient(ctx, wsURL(httpServer.URL), nil)
+	require.NoError(t, err)
+
+	ready, err := client.Node.Ready(ctx)
+	require.NoError(t, err)
+	require.True(t, ready)
+
+	client.Close()
+	require.NotPanics(t, client.Close)
+
+	callCtx, cancelCall := context.WithTimeout(ctx, time.Second)
+	t.Cleanup(cancelCall)
+	_, err = client.Node.Ready(callCtx)
+	require.Error(t, err)
+}
+
+func TestNewClientClosesConnectionsOnError(t *testing.T) {
+	server := jsonrpc.NewServer()
+	firstClosed := make(chan struct{})
+	var connections atomic.Int32
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if connections.Add(1) > 1 {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		server.ServeHTTP(w, r)
+		close(firstClosed)
+	}))
+	t.Cleanup(httpServer.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	client, err := newClient(ctx, wsURL(httpServer.URL), nil)
+	require.Error(t, err)
+	require.Nil(t, client)
+	require.Eventually(t, func() bool {
+		select {
+		case <-firstClosed:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
+func wsURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http")
+}


### PR DESCRIPTION
## Summary
- retain every JSON-RPC namespace connection closer
- close initialized connections when a later namespace fails
- make Client.Close safe to call more than once

## Problem
The namespace closers were collected in a local value and discarded before returning. Client.Close therefore left WebSocket connections and their goroutines running. Partial initialization also leaked previously opened connections.

## Testing
- go test ./api/rpc/client -count=50
- go test ./api/rpc/... -count=1
- go vet ./api/rpc/client
- golangci-lint run ./api/rpc/client/... --timeout 10m

Fixes #5188