### PR TITLE
fix(store/file): deduplicate concurrent ODS cache fills

### DIFF
--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -403,6 +403,9 @@ func (o *ODS) readODS() (square, error) {
 		// not cached, read and cache
 		o.lock.Lock()
 		defer o.lock.Unlock()
+		if o.ods != nil {
+			return o.ods, nil
+		}
 	}
 
 	offset := o.hdr.OffsetWithRoots()

--- a/store/file/ods_test.go
+++ b/store/file/ods_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -52,6 +54,42 @@ func TestReadODSFromFile(t *testing.T) {
 		original := eds.Row(uint(i))[:eds.Width()/2]
 		require.True(t, len(original) == len(row))
 		require.Equal(t, original, libshare.ToBytes(row))
+	}
+}
+
+func TestReadODSConcurrentColdCache(t *testing.T) {
+	previousProcs := runtime.GOMAXPROCS(1)
+	t.Cleanup(func() { runtime.GOMAXPROCS(previousProcs) })
+
+	f := createODSFile(t, edstest.RandEDS(t, 8))
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+	f.lock.Lock()
+
+	const readers = 8
+	type result struct {
+		ods square
+		err error
+	}
+	results := make(chan result, readers)
+	var ready sync.WaitGroup
+	ready.Add(readers)
+	for range readers {
+		go func() {
+			ready.Done()
+			ods, err := f.readODS()
+			results <- result{ods: ods, err: err}
+		}()
+	}
+	ready.Wait()
+	runtime.Gosched()
+	f.lock.Unlock()
+
+	first := <-results
+	require.NoError(t, first.err)
+	for range readers - 1 {
+		got := <-results
+		require.NoError(t, got.err)
+		require.Same(t, &first.ods[0][0], &got.ods[0][0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- recheck the ODS cache after acquiring the write lock
- reuse the first materialized square across concurrent cold readers
- add a deterministic concurrency regression test

## Benchmark
Eight concurrent cold readers, ODS size 128:
- time: 411.17 ms -> 51.68 ms
- allocated: 70.28 MB -> 8.79 MB
- allocations: 131,116 -> 16,400

## Testing
- go test ./store/file -run '^TestReadODSConcurrentColdCache$' -count=100
- go vet ./store/file
- golangci-lint run ./store/file/... --timeout 10m

Related to #3513