### PR TITLE
perf(store/file): reuse ODS reconstruction workers

### DIFF
--- a/store/file/ods.go
+++ b/store/file/ods.go
@@ -260,7 +260,7 @@ func (o *ODS) Sample(ctx context.Context, idx shwap.SampleCoords) (shwap.Sample,
 
 // AxisHalf returns half of shares axis of the given type and index. Side is determined by
 // implementation. Implementations should indicate the side in the returned AxisHalf.
-func (o *ODS) AxisHalf(_ context.Context, axisType rsmt2d.Axis, axisIdx int) (shwap.AxisHalf, error) {
+func (o *ODS) AxisHalf(ctx context.Context, axisType rsmt2d.Axis, axisIdx int) (shwap.AxisHalf, error) {
 	// Read the axis from the file if the axis is a row and from the top half of the square, or if the
 	// axis is a column and from the left half of the square.
 	if axisIdx < o.size()/2 {
@@ -277,7 +277,7 @@ func (o *ODS) AxisHalf(_ context.Context, axisType rsmt2d.Axis, axisIdx int) (sh
 		return shwap.AxisHalf{}, err
 	}
 
-	half, err := ods.computeAxisHalf(axisType, axisIdx)
+	half, err := ods.computeAxisHalf(ctx, axisType, axisIdx)
 	if err != nil {
 		return shwap.AxisHalf{}, fmt.Errorf("computing axis half: %w", err)
 	}

--- a/store/file/square.go
+++ b/store/file/square.go
@@ -1,8 +1,10 @@
 package file
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"runtime"
 
 	"golang.org/x/sync/errgroup"
 
@@ -85,55 +87,81 @@ func (s square) axisHalf(axisType rsmt2d.Axis, axisIdx int) (shwap.AxisHalf, err
 }
 
 func (s square) computeAxisHalf(
+	ctx context.Context,
 	axisType rsmt2d.Axis,
 	axisIdx int,
 ) (shwap.AxisHalf, error) {
 	shares := make([]libshare.Share, s.size())
+	result := shwap.AxisHalf{
+		Shares:   shares,
+		IsParity: false,
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+
+	enc, err := codec.Encoder(s.size() * 2)
+	if err != nil {
+		return result, fmt.Errorf("getting encoder: %w", err)
+	}
 
 	// extend opposite half of the square while collecting Shares for the first half of required axis
-	g := errgroup.Group{}
+	g, groupCtx := errgroup.WithContext(ctx)
+	jobs := make(chan int)
+	g.Go(func() error {
+		defer close(jobs)
+		for i := range s.size() {
+			select {
+			case jobs <- i:
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			}
+		}
+		return nil
+	})
+
 	opposite := oppositeAxis(axisType)
-	for i := range s.size() {
+	for range min(s.size(), runtime.GOMAXPROCS(0)) {
 		g.Go(func() error {
-			half, err := s.axisHalf(opposite, i)
-			if err != nil {
-				return err
-			}
-
-			enc, err := codec.Encoder(s.size() * 2)
-			if err != nil {
-				return fmt.Errorf("getting encoder: %w", err)
-			}
-
 			shards := make([][]byte, s.size()*2)
-			if half.IsParity {
-				copy(shards[s.size():], libshare.ToBytes(half.Shares))
-			} else {
-				copy(shards, libshare.ToBytes(half.Shares))
-			}
-
 			target := make([]bool, s.size()*2)
 			target[axisIdx] = true
 
-			err = enc.ReconstructSome(shards, target)
-			if err != nil {
-				return fmt.Errorf("reconstruct some: %w", err)
-			}
+			for i := range jobs {
+				half, err := s.axisHalf(opposite, i)
+				if err != nil {
+					return err
+				}
 
-			shard, err := libshare.NewShare(shards[axisIdx])
-			if err != nil {
-				return fmt.Errorf("creating share: %w", err)
+				for i := range shards {
+					shards[i] = shards[i][:0]
+				}
+				if half.IsParity {
+					copy(shards[s.size():], libshare.ToBytes(half.Shares))
+				} else {
+					copy(shards, libshare.ToBytes(half.Shares))
+				}
+
+				if err := enc.ReconstructSome(shards, target); err != nil {
+					return fmt.Errorf("reconstruct some: %w", err)
+				}
+
+				raw := shards[axisIdx]
+				shards[axisIdx] = nil
+				share, err := libshare.NewShare(raw)
+				if err != nil {
+					return fmt.Errorf("creating share: %w", err)
+				}
+				shares[i] = share
 			}
-			shares[i] = shard
 			return nil
 		})
 	}
 
-	err := g.Wait()
-	return shwap.AxisHalf{
-		Shares:   shares,
-		IsParity: false,
-	}, err
+	if err := g.Wait(); err != nil {
+		return result, err
+	}
+	return result, ctx.Err()
 }
 
 func oppositeAxis(axis rsmt2d.Axis) rsmt2d.Axis {

--- a/store/file/square_test.go
+++ b/store/file/square_test.go
@@ -1,0 +1,83 @@
+package file
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v4/share"
+	"github.com/celestiaorg/rsmt2d"
+)
+
+func TestComputeAxisHalf(t *testing.T) {
+	previous := runtime.GOMAXPROCS(2)
+	t.Cleanup(func() { runtime.GOMAXPROCS(previous) })
+
+	for _, tc := range []struct {
+		name string
+		size int
+	}{
+		{name: "FF8", size: 8},
+		{name: "FF16", size: 256},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := randomSquare(t, tc.size)
+			for _, axis := range []rsmt2d.Axis{rsmt2d.Row, rsmt2d.Col} {
+				t.Run(axis.String(), func(t *testing.T) {
+					expected := encodedAxisHalf(t, s, axis, tc.size)
+
+					half, err := s.computeAxisHalf(context.Background(), axis, tc.size)
+					require.NoError(t, err)
+					require.False(t, half.IsParity)
+					require.Equal(t, expected, libshare.ToBytes(half.Shares))
+				})
+			}
+		})
+	}
+}
+
+func TestComputeAxisHalfCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := randomSquare(t, 2).computeAxisHalf(ctx, rsmt2d.Row, 2)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func randomSquare(t *testing.T, size int) square {
+	t.Helper()
+	shares, err := libshare.RandShares(size * size)
+	require.NoError(t, err)
+
+	s := make(square, size)
+	for i := range s {
+		s[i] = shares[i*size : (i+1)*size]
+	}
+	return s
+}
+
+func encodedAxisHalf(t *testing.T, s square, axisType rsmt2d.Axis, axisIdx int) [][]byte {
+	t.Helper()
+
+	enc, err := codec.Encoder(s.size() * 2)
+	require.NoError(t, err)
+
+	shares := make([]libshare.Share, s.size())
+	for i := range s.size() {
+		half, err := s.axisHalf(oppositeAxis(axisType), i)
+		require.NoError(t, err)
+
+		shards := make([][]byte, s.size()*2)
+		copy(shards, libshare.ToBytes(half.Shares))
+		for i := s.size(); i < len(shards); i++ {
+			shards[i] = make([]byte, libshare.ShareSize)
+		}
+		require.NoError(t, enc.Encode(shards))
+
+		shares[i], err = libshare.NewShare(shards[axisIdx])
+		require.NoError(t, err)
+	}
+	return libshare.ToBytes(shares)
+}


### PR DESCRIPTION
## Summary
- bound axis reconstruction to min(square size, GOMAXPROCS) workers
- reuse reconstruction buffers within each worker
- stop dispatching work when the context is canceled
- preserve ownership of zero-copy result shares

## Benchmark
ODS size 128:
- row: 7.52 -> 6.53 ms, 10.93 -> 2.88 MB/op
- column: 7.35 -> 5.91 ms, 10.52 -> 2.47 MB/op
- allocations reduced by approximately 85%

## Testing
- focused reconstruction tests repeated 20 times
- existing ODS AxisHalf tests
- go vet ./store/file
- golangci-lint run ./store/file/... --timeout 10m

Related to #3513