### PR TITLE
feat: adding json or text format options for version command

### DIFF
--- a/cmd/celestia/version.go
+++ b/cmd/celestia/version.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -8,18 +9,48 @@ import (
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
 )
 
+const (
+	outputFlag = "output"
+
+	outputText = "text"
+	outputJSON = "json"
+)
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show information about the current binary build",
 	Args:  cobra.NoArgs,
-	Run:   printBuildInfo,
+	RunE:  printBuildInfo,
 }
 
-func printBuildInfo(_ *cobra.Command, _ []string) {
+func init() {
+	versionCmd.Flags().StringP(outputFlag, "o", outputText, "output format of the build information: text or json")
+}
+
+func printBuildInfo(cmd *cobra.Command, _ []string) error {
+	output, err := cmd.Flags().GetString(outputFlag)
+	if err != nil {
+		return err
+	}
+
 	buildInfo := node.GetBuildInfo()
-	fmt.Printf("Semantic version: %s\n", buildInfo.SemanticVersion)
-	fmt.Printf("Commit: %s\n", buildInfo.LastCommit)
-	fmt.Printf("Build Date: %s\n", buildInfo.BuildTime)
-	fmt.Printf("System version: %s\n", buildInfo.SystemVersion)
-	fmt.Printf("Golang version: %s\n", buildInfo.GolangVersion)
+
+	switch output {
+	case outputJSON:
+		bytes, err := json.MarshalIndent(buildInfo, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(bytes))
+	case outputText:
+		fmt.Printf("Semantic version: %s\n", buildInfo.SemanticVersion)
+		fmt.Printf("Commit: %s\n", buildInfo.LastCommit)
+		fmt.Printf("Build Date: %s\n", buildInfo.BuildTime)
+		fmt.Printf("System version: %s\n", buildInfo.SystemVersion)
+		fmt.Printf("Golang version: %s\n", buildInfo.GolangVersion)
+	default:
+		return fmt.Errorf("invalid --%s value %q: must be one of [%s, %s]", outputFlag, output, outputText, outputJSON)
+	}
+
+	return nil
 }

--- a/nodebuilder/node/buildInfo.go
+++ b/nodebuilder/node/buildInfo.go
@@ -20,11 +20,11 @@ const (
 
 // BuildInfo represents all necessary information about current build.
 type BuildInfo struct {
-	BuildTime       string
-	LastCommit      string
-	SemanticVersion string
-	SystemVersion   string
-	GolangVersion   string
+	BuildTime       string `json:"build_date"`
+	LastCommit      string `json:"commit"`
+	SemanticVersion string `json:"semantic_version"`
+	SystemVersion   string `json:"system_version"`
+	GolangVersion   string `json:"golang_version"`
 }
 
 func (b *BuildInfo) GetSemanticVersion() string {


### PR DESCRIPTION

closes #5202 

Enabling support to output structured json via the `version` command. 

`celestia --output json`
`celestia -o json`

defaults to `text` to preserve existing behaviour.

<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Consider adding a label (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->
