### PR TITLE
feat!(p2p): switch Mocha network to mocha-5

### DIFF
--- a/api/client/example/example.go
+++ b/api/client/example/example.go
@@ -33,7 +33,7 @@ func main() {
 		},
 		SubmitConfig: client.SubmitConfig{
 			DefaultKeyName: keyname,
-			Network:        "mocha-4",
+			Network:        "mocha-5",
 			CoreGRPCConfig: client.CoreGRPCConfig{
 				Addr:       "celestia-testnet-consensus.itrocket.net:9090",
 				TLSEnabled: false,

--- a/api/client/readme.md
+++ b/api/client/readme.md
@@ -42,7 +42,7 @@ cfg := client.Config{
     },
     SubmitConfig: client.SubmitConfig{
         DefaultKeyName: "my_key",
-        Network:        "mocha-4",
+        Network:        "mocha-5",
         CoreGRPCConfig: client.CoreGRPCConfig{
             Addr:       "celestia-consensus.example.com:9090",
             TLSEnabled: true,
@@ -111,7 +111,7 @@ balance, err := celestiaClient.State.Balance(ctx)
 ### SubmitConfig
 
 - `DefaultKeyName`: Default key to use for transactions
-- `Network`: Network name (e.g., "mocha-4", "private")
+- `Network`: Network name (e.g., "mocha-5", "private")
 - `CoreGRPCConfig`: Configuration for Core node connection
 - `TxWorkerAccounts`: (Optional) Number of worker accounts for transaction submission. Default: 0
   - Value of 0 submits transactions immediately (without a submission queue)

--- a/api/docgen/exampledata/extendedHeader.json
+++ b/api/docgen/exampledata/extendedHeader.json
@@ -3,7 +3,7 @@
     "version": {
       "block": "11"
     },
-    "chain_id": "mocha-4",
+    "chain_id": "mocha-5",
     "height": "67374",
     "time": "2023-02-25T12:10:28.067566292Z",
     "last_block_id": {

--- a/api/docgen/exampledata/resourceManagerStats.json
+++ b/api/docgen/exampledata/resourceManagerStats.json
@@ -34,7 +34,7 @@
     }
   },
   "Protocols": {
-    "/celestia/mocha-4/ipfs/bitswap/1.2.0": {
+    "/celestia/mocha-5/ipfs/bitswap/1.2.0": {
       "NumStreamsInbound": 0,
       "NumStreamsOutbound": 4,
       "NumConnsInbound": 0,
@@ -42,7 +42,7 @@
       "NumFD": 0,
       "Memory": 0
     },
-    "/celestia/mocha-4/kad/1.0.0": {
+    "/celestia/mocha-5/kad/1.0.0": {
       "NumStreamsInbound": 0,
       "NumStreamsOutbound": 4,
       "NumConnsInbound": 0,

--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -140,7 +140,7 @@ func init() {
 	mathInt, _ := math.NewIntFromString("42")
 	add(mathInt)
 
-	pID := protocol.ID("/celestia/mocha/ipfs/bitswap")
+	pID := protocol.ID("/celestia/mocha-5/ipfs/bitswap")
 	add(pID)
 
 	peerID := peer.ID("12D3KooWPRb5h3g9MH7sx9qfbSQZG5cXv1a2Qs3o4aW5YmmzPq82")

--- a/celestia-node.mk
+++ b/celestia-node.mk
@@ -51,7 +51,7 @@ check-and-fund:
 		echo "Balance too low. Requesting funds from faucet..."; \
 		curl -X POST 'https://faucet.celestia-mocha.com/api/v1/faucet/give_me' \
 			-H 'Content-Type: application/json' \
-			-d '{"address": "'$$address'", "chainId": "mocha-4" }'; \
+			-d '{"address": "'$$address'", "chainId": "mocha-5" }'; \
 		echo "Waiting 10 seconds for transaction to process..."; \
 		sleep 10; \
 	fi
@@ -66,7 +66,7 @@ reset-node:
 	latest_hash=$$(echo $$block_response | jq -r '.result.block_id.hash'); \
 	echo "Latest block height: $$latest_block"; \
 	echo "Latest block hash: $$latest_hash"; \
-	config_file="$$HOME/.celestia-light-mocha-4/config.toml"; \
+	config_file="$$HOME/.celestia-light-mocha-5/config.toml"; \
 	echo "Updating config.toml..."; \
 	sed -i.bak -e "s/\(TrustedHash[[:space:]]*=[[:space:]]*\).*/\1\"$$latest_hash\"/" \
 		   -e "s/\(SampleFrom[[:space:]]*=[[:space:]]*\).*/\1$$latest_block/" \
@@ -76,7 +76,7 @@ reset-node:
 # Start the Celestia light node
 # Usage: make light-mocha-up [COMMAND=again] [CORE_IP=custom_ip]
 light-mocha-up:
-	@config_file="$$HOME/.celestia-light-mocha-4/config.toml"; \
+	@config_file="$$HOME/.celestia-light-mocha-5/config.toml"; \
 	if [ "$(COMMAND)" = "again" ]; then \
 		$(MAKE) reset-node; \
 	fi; \
@@ -97,7 +97,7 @@ light-mocha-up:
 			--p2p.network mocha; \
 	else \
 		celestia light start \
-			--core.ip full.consensus.mocha-4.celestia-mocha.com \
+			--core.ip consensus.celestia-mocha.com \
 			--core.port $(if $(CORE_PORT),$(CORE_PORT),9090) \
 			--rpc.skip-auth \
 			--rpc.addr 0.0.0.0 \

--- a/cmd/cel-shed/latency_monitor.go
+++ b/cmd/cel-shed/latency_monitor.go
@@ -77,7 +77,7 @@ func init() {
 	flags.String("core.grpc", "", "address of the core gRPC server (e.g. localhost:9090)")
 	flags.String("key.name", "", "name of the key to use for signing")
 	flags.String("key.path", "", "path to the keyring directory")
-	flags.String("network", "", "network name (e.g. mocha-4)")
+	flags.String("network", "", "network name (e.g. mocha-5)")
 	flags.String("metrics.endpoint", "", "OTLP metrics endpoint")
 	flags.Bool("metrics.tls", true, "Enable TLS connection to OTLP metric backend")
 	flags.Int("num-blobs", 10, "number of blobs to pre-generate for the monitor loop")

--- a/core/multisource_test.go
+++ b/core/multisource_test.go
@@ -175,20 +175,20 @@ func TestMultiSource_ChainID(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("first source responds", func(t *testing.T) {
-		ms := newMultiSource(tagged("a", &fakeSource{chainID: "mocha-4"}))
+		ms := newMultiSource(tagged("a", &fakeSource{chainID: "mocha-5"}))
 		id, err := ms.ChainID(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "mocha-4", id)
+		assert.Equal(t, "mocha-5", id)
 	})
 
 	t.Run("falls back past a failing source", func(t *testing.T) {
 		ms := newMultiSource(
 			tagged("a", &fakeSource{chainIDErr: errors.New("down")}),
-			tagged("b", &fakeSource{chainID: "mocha-4"}),
+			tagged("b", &fakeSource{chainID: "mocha-5"}),
 		)
 		id, err := ms.ChainID(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "mocha-4", id)
+		assert.Equal(t, "mocha-5", id)
 	})
 
 	t.Run("errors when all sources fail", func(t *testing.T) {
@@ -287,25 +287,25 @@ func TestMultiSource_Verify(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty expected is an error: a node must know its network", func(t *testing.T) {
-		ms := newMultiSource(tagged("a", &fakeSource{chainID: "mocha-4"}))
+		ms := newMultiSource(tagged("a", &fakeSource{chainID: "mocha-5"}))
 		require.Error(t, ms.Verify(ctx, ""))
 	})
 
 	t.Run("all on expected chain are kept", func(t *testing.T) {
 		ms := newMultiSource(
-			tagged("a", &fakeSource{chainID: "mocha-4"}),
-			tagged("b", &fakeSource{chainID: "mocha-4"}),
+			tagged("a", &fakeSource{chainID: "mocha-5"}),
+			tagged("b", &fakeSource{chainID: "mocha-5"}),
 		)
-		require.NoError(t, ms.Verify(ctx, "mocha-4"))
+		require.NoError(t, ms.Verify(ctx, "mocha-5"))
 		assert.Len(t, ms.sources, 2)
 	})
 
 	t.Run("wrong-chain source is pruned, others kept", func(t *testing.T) {
 		ms := newMultiSource(
-			tagged("good", &fakeSource{chainID: "mocha-4"}),
+			tagged("good", &fakeSource{chainID: "mocha-5"}),
 			tagged("bad", &fakeSource{chainID: "celestia"}),
 		)
-		require.NoError(t, ms.Verify(ctx, "mocha-4"))
+		require.NoError(t, ms.Verify(ctx, "mocha-5"))
 		require.Len(t, ms.sources, 1)
 		_, ok := ms.sources["good"]
 		assert.True(t, ok, "the surviving source must be the good one")
@@ -313,10 +313,10 @@ func TestMultiSource_Verify(t *testing.T) {
 
 	t.Run("unreachable source is pruned even when another is confirmed good", func(t *testing.T) {
 		ms := newMultiSource(
-			tagged("good", &fakeSource{chainID: "mocha-4"}),
+			tagged("good", &fakeSource{chainID: "mocha-5"}),
 			tagged("down", &fakeSource{chainIDErr: errors.New("unreachable")}),
 		)
-		require.NoError(t, ms.Verify(ctx, "mocha-4"))
+		require.NoError(t, ms.Verify(ctx, "mocha-5"))
 		require.Len(t, ms.sources, 1,
 			"a source that cannot vouch for its network must not enter the active set")
 		_, ok := ms.sources["good"]
@@ -328,7 +328,7 @@ func TestMultiSource_Verify(t *testing.T) {
 			tagged("a", &fakeSource{chainID: "celestia"}),
 			tagged("b", &fakeSource{chainID: "celestia"}),
 		)
-		err := ms.Verify(ctx, "mocha-4")
+		err := ms.Verify(ctx, "mocha-5")
 		require.Error(t, err)
 		assert.Empty(t, ms.sources, "all wrong-chain sources pruned")
 	})
@@ -338,7 +338,7 @@ func TestMultiSource_Verify(t *testing.T) {
 			tagged("a", &fakeSource{chainIDErr: errors.New("down")}),
 			tagged("b", &fakeSource{chainIDErr: errors.New("down")}),
 		)
-		err := ms.Verify(ctx, "mocha-4")
+		err := ms.Verify(ctx, "mocha-5")
 		require.Error(t, err, "cannot start without confirming at least one source")
 	})
 }
@@ -384,9 +384,9 @@ func TestMultiSource_SingleSource(t *testing.T) {
 	t.Run("chainID passthrough", func(t *testing.T) {
 		ctx := context.Background()
 
-		id, err := newMultiSource(tagged("only", &fakeSource{chainID: "mocha-4"})).ChainID(ctx)
+		id, err := newMultiSource(tagged("only", &fakeSource{chainID: "mocha-5"})).ChainID(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "mocha-4", id)
+		assert.Equal(t, "mocha-5", id)
 
 		_, err = newMultiSource(tagged("only", &fakeSource{chainIDErr: errors.New("down")})).ChainID(ctx)
 		require.Error(t, err, "a failing single source must surface as an error, like the bare fetcher")

--- a/nodebuilder/p2p/bootstrap.go
+++ b/nodebuilder/p2p/bootstrap.go
@@ -49,11 +49,8 @@ var bootstrapList = map[Network][]string{
 		"/dnsaddr/celestia-mainnet-boot.01node.com/p2p/12D3KooWJ77n9mC9xpKHeoEc49UkP4M5EixcPoKf5Xb1tsHo99P7",
 	},
 	Mocha: {
-		"/dnsaddr/da-bootstrapper-1-mocha-4.celestia-mocha.com/p2p/12D3KooWCBAbQbJSpCpCGKzqz3rAN4ixYbc63K68zJg9aisuAajg",
-		"/dnsaddr/da-bootstrapper-2-mocha-4.celestia-mocha.com/p2p/12D3KooWCUHPLqQXZzpTx1x3TAsdn3vYmTNDhzg66yG8hqoxGGN8",
-		"/dnsaddr/mocha-boot.pops.one/p2p/12D3KooWDzNyDSvTBdKQAmnsUdAyQCQWwM3ReXTmPaaf6LzfNwRs",
-		"/dnsaddr/celestia-mocha.qubelabs.io/p2p/12D3KooWQVmHy7JpfxpKZfLjvn12GjvMgKrWdsHkFbV2kKqQFBCG",
-		"/dnsaddr/celestia-testnet-boot.01node.com/p2p/12D3KooWR923Tc8SCzweyaGZ5VU2ahyS9VWrQ8mDz56RbHjHFdzW",
+		"/dns4/da-bootstrapper-1.celestia-mocha.com/tcp/2121/p2p/12D3KooWPHgLgPTtPjuKtZjXbZRiUSVMvFpqek8T1we93auG3uoK",
+		"/dns4/da-bootstrapper-2.celestia-mocha.com/tcp/2121/p2p/12D3KooWRmUch5JsfLgkDrhEGu8rSCeTP2nJvGPygkqRUWfqiAJ4",
 	},
 	Private: {},
 }

--- a/nodebuilder/p2p/genesis.go
+++ b/nodebuilder/p2p/genesis.go
@@ -24,6 +24,6 @@ func GenesisFor(net Network) (string, error) {
 // NOTE: Every time we add a new long-running network, its genesis hash has to be added here.
 var genesisList = map[Network]string{
 	Mainnet: "6BE39EFD10BA412A9DB5288488303F5DD32CF386707A5BEF33617F4C43301872",
-	Mocha:   "B93BBE20A0FBFDF955811B6420F8433904664D45DB4BF51022BE4200C1A1680D",
+	Mocha:   "8D8763ECEF33C0861CBEC98D5BCCD5FD71C09FCC3A980C52AEF8A4AFFCE8BA74",
 	Private: "",
 }

--- a/nodebuilder/p2p/network.go
+++ b/nodebuilder/p2p/network.go
@@ -14,7 +14,7 @@ const (
 	// DefaultNetwork is the default network of the current build.
 	DefaultNetwork = Mainnet
 	// Mocha testnet. See: celestiaorg/networks.
-	Mocha Network = "mocha-4"
+	Mocha Network = "mocha-5"
 	// Private can be used to set up any private network, including local testing setups.
 	Private Network = "private"
 	// Celestia mainnet. See: celestiaorg/networks.


### PR DESCRIPTION
Roll out the new mocha-5 testnet in place of mocha-4

Resolves [PROTOCO-2490](https://linear.app/celestia/issue/PROTOCO-2490/start-the-mocha-5-da-network)