### PR TITLE
chore(p2p): add 01node bootstrapper to mocha-5

### DIFF
--- a/nodebuilder/p2p/bootstrap.go
+++ b/nodebuilder/p2p/bootstrap.go
@@ -53,6 +53,7 @@ var bootstrapList = map[Network][]string{
 		"/dns4/da-bootstrapper-2.celestia-mocha.com/tcp/2121/p2p/12D3KooWRmUch5JsfLgkDrhEGu8rSCeTP2nJvGPygkqRUWfqiAJ4",
 		"/dnsaddr/mocha-boot.pops.one/p2p/12D3KooWAj2P9akCYyzKUwmicvi1g6jxVE9Ld3tdmLqTque5NuZP",
 		"/dnsaddr/celestia-mocha.qubelabs.io/p2p/12D3KooWQVmHy7JpfxpKZfLjvn12GjvMgKrWdsHkFbV2kKqQFBCG",
+		"/dns4/celestia-mocha-boot.01node.com/tcp/2121/p2p/12D3KooWMCHtyp3Ld7tGJQavrbwmzbbevBxNqLxY28dYjHAwiwGV",
 	},
 	Private: {},
 }


### PR DESCRIPTION
## Overview

Adds the 01node community-operated bootstrapper to the Mocha (mocha-5) bootstrap list:

- `/dns4/celestia-mocha-boot.01node.com/tcp/2121/p2p/12D3KooWMCHtyp3Ld7tGJQavrbwmzbbevBxNqLxY28dYjHAwiwGV` (01node)

The `/dns4/.../tcp/2121` form is used (instead of `/dnsaddr` like the mainnet 01node entry) because the host has no `_dnsaddr` TXT records.

Verified locally with the `bootstrapper_health` test — the peer at that address answers with the expected peer ID:

```
--- PASS: TestBootstrapperHealth/mocha-5/12D3KooWMCHtyp3Ld7tGJQavrbwmzbbevBxNqLxY28dYjHAwiwGV (0.98s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)