### PR TITLE
chore(nodebuilder/p2p): add 01node bootstrapper to Mocha [v0.31.x backport]

### DIFF
--- a/nodebuilder/p2p/bootstrap.go
+++ b/nodebuilder/p2p/bootstrap.go
@@ -57,6 +57,7 @@ var bootstrapList = map[Network][]string{
 		"/dns4/da-bootstrapper-2.celestia-mocha.com/tcp/2121/p2p/12D3KooWRmUch5JsfLgkDrhEGu8rSCeTP2nJvGPygkqRUWfqiAJ4",
 		"/dnsaddr/mocha-boot.pops.one/p2p/12D3KooWAj2P9akCYyzKUwmicvi1g6jxVE9Ld3tdmLqTque5NuZP",
 		"/dnsaddr/celestia-mocha.qubelabs.io/p2p/12D3KooWQVmHy7JpfxpKZfLjvn12GjvMgKrWdsHkFbV2kKqQFBCG",
+		"/dns4/celestia-mocha-boot.01node.com/tcp/2121/p2p/12D3KooWMCHtyp3Ld7tGJQavrbwmzbbevBxNqLxY28dYjHAwiwGV",
 	},
 	Private: {},
 }


### PR DESCRIPTION
## Overview

Backport of #5218 to `v0.31.x`. Clean cherry-pick of the original commit.

Adds the 01node community-operated bootstrapper to the Mocha (mocha-5) bootstrap list:

- `/dns4/celestia-mocha-boot.01node.com/tcp/2121/p2p/12D3KooWMCHtyp3Ld7tGJQavrbwmzbbevBxNqLxY28dYjHAwiwGV` (01node)

The `/dns4/.../tcp/2121` form is used (instead of `/dnsaddr` like the mainnet 01node entry) because the host has no `_dnsaddr` TXT records.

Verified locally on this branch with the `bootstrapper_health` test — the peer at that address answers with the expected peer ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)