### PR TITLE
cmd: Comply with POSIX utility syntax

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -24,7 +24,7 @@ var ttlFlagName = "ttl"
 
 func AuthCmd(fsets ...*flag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "auth [permission-level (e.g. read || write || admin)]",
+		Use:   "auth (read | write | admin)",
 		Short: "Signs and outputs a hex-encoded JWT token with the given permissions.",
 		Long: "Signs and outputs a hex-encoded JWT token with the given permissions. NOTE: only use this command when " +
 			"the node has already been initialized and started.",

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -24,7 +24,7 @@ var ttlFlagName = "ttl"
 
 func AuthCmd(fsets ...*flag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "auth (read | write | admin)",
+		Use:   "auth (public | read | write | admin)",
 		Short: "Signs and outputs a hex-encoded JWT token with the given permissions.",
 		Long: "Signs and outputs a hex-encoded JWT token with the given permissions. NOTE: only use this command when " +
 			"the node has already been initialized and started.",

--- a/cmd/cel-shed/datastore.go
+++ b/cmd/cel-shed/datastore.go
@@ -20,12 +20,12 @@ func init() {
 }
 
 var datastoreCmd = &cobra.Command{
-	Use:   "datastore [subcommand]",
+	Use:   "datastore [command]",
 	Short: "Collection of datastore related utilities",
 }
 
 var eraseCmd = &cobra.Command{
-	Use:   "erase <ds_key>",
+	Use:   "erase ds_key",
 	Short: "Erase datastore namespace",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := nodebuilder.DiscoverStopped()
@@ -67,7 +67,7 @@ var sampleDataKeys = []ds.Key{
 }
 
 var eraseSamplesCmd = &cobra.Command{
-	Use:   "erase-samples [subcommand]",
+	Use:   "erase-samples",
 	Short: "Erase samples data and state. Useful to resample, avoiding resyncing headers",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		path, err := nodebuilder.DiscoverStopped()

--- a/cmd/cel-shed/eds_store_stress.go
+++ b/cmd/cel-shed/eds_store_stress.go
@@ -62,7 +62,7 @@ func init() {
 }
 
 var edsStoreCmd = &cobra.Command{
-	Use:   "eds-store [subcommand]",
+	Use:   "eds-store [command]",
 	Short: "Collection of eds-store related utilities",
 }
 

--- a/cmd/cel-shed/hash_presence.go
+++ b/cmd/cel-shed/hash_presence.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 var hashCmd = &cobra.Command{
-	Use:   "hash [subcommand] [flags]",
+	Use:   "hash [command]",
 	Short: "Commands to interact with EDS hashes",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		path, err := cmd.Flags().GetString(nodeStorePathFlag)
@@ -55,7 +55,7 @@ var hashCmd = &cobra.Command{
 }
 
 var hasHashCmd = &cobra.Command{
-	Use:     "has [root hash] [flags]",
+	Use:     "has root_hash",
 	Aliases: []string{"exists"},
 	Short:   "Command to check whether a hash is present in the eds store",
 	Args:    cobra.ExactArgs(1),
@@ -80,7 +80,7 @@ var hasHashCmd = &cobra.Command{
 }
 
 var getByHashCmd = &cobra.Command{
-	Use:   "get [root hash] [flag]",
+	Use:   "get root_hash",
 	Short: "Command to get the eds from the eds store by its hash",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/cel-shed/header.go
+++ b/cmd/cel-shed/header.go
@@ -13,7 +13,7 @@ import (
 )
 
 var headerCmd = &cobra.Command{
-	Use:   "header [subcommand]",
+	Use:   "header [command]",
 	Short: "Collection of header module related utilities",
 }
 
@@ -25,7 +25,7 @@ const (
 const startFromFlag = "start-from"
 
 var headerStoreReset = &cobra.Command{
-	Use:          "store-reset <node_store_path> [--head <num>] [--tail <num>]",
+	Use:          "store-reset node_store_path",
 	Short:        "Forcefully resets header store tail or head to be at the given height. Requires the node being stopped",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,7 +95,7 @@ var headerStoreReset = &cobra.Command{
 }
 
 var headerStoreRecover = &cobra.Command{
-	Use: "store-recover <node_store_path> [--start-from <num>]",
+	Use: "store-recover node_store_path",
 	Short: `Recovers header store tail by forward iterating over the store until some header is found to be the new tail.
 	Requires the node being stopped`,
 	SilenceUsage: true,

--- a/cmd/cel-shed/main.go
+++ b/cmd/cel-shed/main.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 var rootCmd = &cobra.Command{
-	Use: "cel-shed [subcommand]",
+	Use: "cel-shed [command]",
 	CompletionOptions: cobra.CompletionOptions{
 		DisableDefaultCmd: true,
 	},

--- a/cmd/cel-shed/ods_verify.go
+++ b/cmd/cel-shed/ods_verify.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 var odsVerifyCmd = &cobra.Command{
-	Use:   "ods-verify <node_store_path>",
+	Use:   "ods-verify node_store_path",
 	Short: "Verifies ODS files against header store. Reads by height and datahash, validates metadata.",
 	Long: `Loops over header store and for each header:
 - Reads ODS file by height

--- a/cmd/cel-shed/p2p.go
+++ b/cmd/cel-shed/p2p.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 var p2pCmd = &cobra.Command{
-	Use:   "p2p [subcommand]",
+	Use:   "p2p [command]",
 	Short: "Collection of p2p related utilities",
 }
 
@@ -50,7 +50,7 @@ var p2pNewKeyCmd = &cobra.Command{
 }
 
 var p2pPeerIDCmd = &cobra.Command{
-	Use:   "peer-id",
+	Use:   "peer-id key",
 	Short: "Get peer-id out of public or private Ed25519 key",
 	RunE: func(_ *cobra.Command, args []string) error {
 		decKey, err := hex.DecodeString(args[0])
@@ -93,7 +93,7 @@ var (
 )
 
 var p2pConnectBootstrappersCmd = &cobra.Command{
-	Use:   "connect-bootstrappers [network]",
+	Use:   "connect-bootstrappers network",
 	Short: "Connect to bootstrappers of a certain network",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if errorOnAnyFailure && errorOnAllFailure {

--- a/cmd/cel-shed/shwap.go
+++ b/cmd/cel-shed/shwap.go
@@ -15,12 +15,12 @@ func init() {
 }
 
 var shwapCmd = &cobra.Command{
-	Use:   "shwap [subcommand]",
+	Use:   "shwap [command]",
 	Short: "Collection of shwap related utilities",
 }
 
 var shwapCIDType = &cobra.Command{
-	Use:   "cid-type",
+	Use:   "cid-type cid",
 	Short: "Decodes Bitswap CID composed over Shwap CID",
 	RunE: func(_ *cobra.Command, args []string) error {
 		cid, err := cid.Decode(args[0])

--- a/cmd/cel-shed/square.go
+++ b/cmd/cel-shed/square.go
@@ -19,12 +19,12 @@ func init() {
 }
 
 var squareCmd = &cobra.Command{
-	Use:   "square [subcommand]",
+	Use:   "square [command]",
 	Short: "Collection of square-related utilities",
 }
 
 var constructFromCoreCmd = &cobra.Command{
-	Use:   "construct-from-core [core endpoint in ip:port format] [height]",
+	Use:   "construct-from-core core_endpoint height",
 	Short: "Constructs a complete data square and extended header from a signed core block",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conn, err := grpc.NewClient(args[0], grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/cmd/celestia/main.go
+++ b/cmd/celestia/main.go
@@ -47,7 +47,7 @@ func run() error {
 }
 
 var rootCmd = &cobra.Command{
-	Use: "celestia [  bridge  ||  light  ] [subcommand]",
+	Use: "celestia [command]",
 	Short: `
 	    ____      __          __  _
 	  / ____/__  / /__  _____/ /_(_)___ _

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -24,7 +24,7 @@ func NewBridge(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command
 		pruner.Flags(),
 	}
 	cmd := &cobra.Command{
-		Use:   "bridge [subcommand]",
+		Use:   "bridge [command]",
 		Args:  cobra.NoArgs,
 		Short: "Manage your Bridge node",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
@@ -52,7 +52,7 @@ func NewLight(options ...func(*cobra.Command, []*pflag.FlagSet)) *cobra.Command 
 		pruner.Flags(),
 	}
 	cmd := &cobra.Command{
-		Use:   "light [subcommand]",
+		Use:   "light [command]",
 		Args:  cobra.NoArgs,
 		Short: "Manage your Light node",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {

--- a/nodebuilder/blob/cmd/blob.go
+++ b/nodebuilder/blob/cmd/blob.go
@@ -38,7 +38,7 @@ var Cmd = &cobra.Command{
 }
 
 var getCmd = &cobra.Command{
-	Use:  "get [height] [namespace] [commitment]",
+	Use:  "get height namespace commitment",
 	Args: cobra.ExactArgs(3),
 	Short: "Returns the blob for the given namespace by commitment at a particular height.\n" +
 		"Note:\n* Both namespace and commitment input parameters are expected to be in their hex representation.",
@@ -79,7 +79,7 @@ var getCmd = &cobra.Command{
 }
 
 var getAllCmd = &cobra.Command{
-	Use:  "get-all [height] [namespace]",
+	Use:  "get-all height namespace",
 	Args: cobra.ExactArgs(2),
 	Short: "Returns all blobs for the given namespace at a particular height.\n" +
 		"Note:\n* Namespace input parameter is expected to be in its hex representation.",
@@ -112,7 +112,7 @@ var getAllCmd = &cobra.Command{
 }
 
 var submitCmd = &cobra.Command{
-	Use: "submit [namespace] [blobData]",
+	Use: "submit [namespace blobData]",
 	Args: func(cmd *cobra.Command, args []string) error {
 		path, err := cmd.Flags().GetString(flagFileInput)
 		if err != nil {
@@ -237,7 +237,7 @@ func getBlobFromArguments(namespaceArg, blobArg string) (*blob.Blob, error) {
 }
 
 var getProofCmd = &cobra.Command{
-	Use:  "get-proof [height] [namespace] [commitment]",
+	Use:  "get-proof height namespace commitment",
 	Args: cobra.ExactArgs(3),
 	Short: "Retrieves the blob in the given namespaces at the given height by commitment and returns its Proof.\n" +
 		"Note:\n* Both namespace and commitment input parameters are expected to be in their hex representation.",

--- a/nodebuilder/header/cmd/header.go
+++ b/nodebuilder/header/cmd/header.go
@@ -61,7 +61,7 @@ var networkHeadCmd = &cobra.Command{
 }
 
 var getByHashCmd = &cobra.Command{
-	Use:   "get-by-hash",
+	Use:   "get-by-hash hash",
 	Short: "Returns the header of the given hash from the node's header store.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -81,7 +81,7 @@ var getByHashCmd = &cobra.Command{
 }
 
 var getByHeightCmd = &cobra.Command{
-	Use:   "get-by-height",
+	Use:   "get-by-height height",
 	Short: "Returns the ExtendedHeader at the given height if it is currently available.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/nodebuilder/node/cmd/node.go
+++ b/nodebuilder/node/cmd/node.go
@@ -38,7 +38,7 @@ var nodeInfoCmd = &cobra.Command{
 }
 
 var logCmd = &cobra.Command{
-	Use:   "log-level",
+	Use:   "log-level module:level...",
 	Args:  cobra.MinimumNArgs(1),
 	Short: "Sets log level for module.",
 	Long: "Allows to set log level for module to in format <module>:<level>" +
@@ -67,7 +67,7 @@ var logCmd = &cobra.Command{
 }
 
 var verifyCmd = &cobra.Command{
-	Use:   "permissions",
+	Use:   "permissions token",
 	Args:  cobra.ExactArgs(1),
 	Short: "Returns the permissions assigned to the given token.",
 
@@ -84,7 +84,7 @@ var verifyCmd = &cobra.Command{
 }
 
 var authCmd = &cobra.Command{
-	Use:   "set-permissions",
+	Use:   "set-permissions permission...",
 	Args:  cobra.MinimumNArgs(1),
 	Short: "Signs and returns a new token with the given permissions.",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/nodebuilder/p2p/cmd/p2p.go
+++ b/nodebuilder/p2p/cmd/p2p.go
@@ -109,7 +109,7 @@ var peersCmd = &cobra.Command{
 }
 
 var peerInfoCmd = &cobra.Command{
-	Use:   "peer-info [param]",
+	Use:   "peer-info peer.ID",
 	Short: "Gets PeerInfo for a given peer",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -141,7 +141,7 @@ var peerInfoCmd = &cobra.Command{
 }
 
 var connectCmd = &cobra.Command{
-	Use:   "connect [peer.ID, address]",
+	Use:   "connect peer.ID address",
 	Short: "Establishes a connection with the given peer",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -175,7 +175,7 @@ var connectCmd = &cobra.Command{
 }
 
 var closePeerCmd = &cobra.Command{
-	Use:   "close-peer [peer.ID]",
+	Use:   "close-peer peer.ID",
 	Short: "Closes the connection with the given peer",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -199,7 +199,7 @@ var closePeerCmd = &cobra.Command{
 }
 
 var connectednessCmd = &cobra.Command{
-	Use:   "connectedness [peer.ID]",
+	Use:   "connectedness peer.ID",
 	Short: "Checks the connection state between current and given peers",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -254,7 +254,7 @@ var natStatusCmd = &cobra.Command{
 }
 
 var blockPeerCmd = &cobra.Command{
-	Use:   "block-peer [peer.ID]",
+	Use:   "block-peer peer.ID",
 	Short: "Blocks the given peer",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -290,7 +290,7 @@ var blockPeerCmd = &cobra.Command{
 }
 
 var unblockPeerCmd = &cobra.Command{
-	Use:   "unblock-peer [peer.ID]",
+	Use:   "unblock-peer peer.ID",
 	Short: "Unblocks the given peer",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -356,7 +356,7 @@ var blockedPeersCmd = &cobra.Command{
 }
 
 var protectCmd = &cobra.Command{
-	Use:   "protect [peer.ID, tag]",
+	Use:   "protect peer.ID tag",
 	Short: "Protects the given peer from being pruned by the given tag",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -392,7 +392,7 @@ var protectCmd = &cobra.Command{
 }
 
 var unprotectCmd = &cobra.Command{
-	Use:   "unprotect [peer.ID, tag]",
+	Use:   "unprotect peer.ID tag",
 	Short: "Removes protection from the given peer.",
 	Long: "Removes a protection that may have been placed on a peer, under the specified tag." +
 		"The return value indicates whether the peer continues to be protected after this call, by way of a different tag",
@@ -430,7 +430,7 @@ var unprotectCmd = &cobra.Command{
 }
 
 var protectedCmd = &cobra.Command{
-	Use:   "protected [peer.ID, tag]",
+	Use:   "protected peer.ID tag",
 	Short: "Ensures that a given peer is protected under a specific tag",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -486,7 +486,7 @@ var bandwidthStatsCmd = &cobra.Command{
 }
 
 var peerBandwidthCmd = &cobra.Command{
-	Use:   "peer-bandwidth [peer.ID]",
+	Use:   "peer-bandwidth peer.ID",
 	Short: "Gets stats struct with bandwidth metrics associated with the given peer.ID",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -517,7 +517,7 @@ var peerBandwidthCmd = &cobra.Command{
 }
 
 var bandwidthForProtocolCmd = &cobra.Command{
-	Use:   "protocol-bandwidth [protocol.ID]",
+	Use:   "protocol-bandwidth protocol.ID",
 	Short: "Gets stats struct with bandwidth metrics associated with the given protocol.ID",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -543,7 +543,7 @@ var bandwidthForProtocolCmd = &cobra.Command{
 }
 
 var pubsubPeersCmd = &cobra.Command{
-	Use:   "pubsub-peers [topic]",
+	Use:   "pubsub-peers topic",
 	Short: "Lists the peers we are connected to in the given topic",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -573,7 +573,7 @@ var pubsubPeersCmd = &cobra.Command{
 }
 
 var pubsubTopicsCmd = &cobra.Command{
-	Use:   "pubsub-topics ",
+	Use:   "pubsub-topics",
 	Short: "Lists pubsub(GossipSub) topics the node participates in",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -597,7 +597,7 @@ var pubsubTopicsCmd = &cobra.Command{
 }
 
 var connectionInfoCmd = &cobra.Command{
-	Use:   "connection-state [peerID]",
+	Use:   "connection-state peer.ID",
 	Short: "Gets connection info for a given peer ID",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -643,7 +643,7 @@ var connectionInfoCmd = &cobra.Command{
 }
 
 var pingCmd = &cobra.Command{
-	Use:   "ping [peerID]",
+	Use:   "ping peer.ID",
 	Short: "Pings given peer and tell how much time that took or errors",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/nodebuilder/share/cmd/share.go
+++ b/nodebuilder/share/cmd/share.go
@@ -44,7 +44,7 @@ var Cmd = &cobra.Command{
 }
 
 var sharesAvailableCmd = &cobra.Command{
-	Use:   "available",
+	Use:   "available height",
 	Short: "Subjectively validates if Shares committed to the given EDS are available on the Network.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -174,7 +174,7 @@ var getEDS = &cobra.Command{
 }
 
 var getRange = &cobra.Command{
-	Use:   "get-range [height] [start] [end(exclusive)]",
+	Use:   "get-range height start end(exclusive)",
 	Short: "Gets a range of shares from the given height within the given ODS indexes",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/nodebuilder/state/cmd/state.go
+++ b/nodebuilder/state/cmd/state.go
@@ -103,7 +103,7 @@ var balanceCmd = &cobra.Command{
 }
 
 var balanceForAddressCmd = &cobra.Command{
-	Use: "balance-for-address [address]",
+	Use: "balance-for-address address",
 	Short: "Retrieves the Celestia coin balance for the given address and verifies the returned balance against " +
 		"the corresponding block's AppHash.",
 	Args: cobra.ExactArgs(1),
@@ -125,7 +125,7 @@ var balanceForAddressCmd = &cobra.Command{
 }
 
 var transferCmd = &cobra.Command{
-	Use:   "transfer [address] [amount]",
+	Use:   "transfer address amount",
 	Short: "Sends the given amount of coins from default wallet of the node to the given account address.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -156,7 +156,7 @@ var transferCmd = &cobra.Command{
 }
 
 var cancelUnbondingDelegationCmd = &cobra.Command{
-	Use:   "cancel-unbonding-delegation [address] [amount] [height]",
+	Use:   "cancel-unbonding-delegation validator_address amount height",
 	Short: "Cancels a user's pending undelegation from a validator.",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -193,7 +193,7 @@ var cancelUnbondingDelegationCmd = &cobra.Command{
 }
 
 var beginRedelegateCmd = &cobra.Command{
-	Use:   "begin-redelegate [srcAddress] [dstAddress] [amount]",
+	Use:   "begin-redelegate source_validator_address destination_validator_address amount",
 	Short: "Sends a user's delegated tokens to a new validator for redelegation",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -230,9 +230,9 @@ var beginRedelegateCmd = &cobra.Command{
 }
 
 var undelegateCmd = &cobra.Command{
-	Use:   "undelegate [valAddress] [amount]",
+	Use:   "undelegate validator_address amount",
 	Short: "Undelegates a user's delegated tokens, unbonding them from the current validator.",
-	Args:  cobra.ExactArgs(4),
+	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
@@ -261,9 +261,9 @@ var undelegateCmd = &cobra.Command{
 }
 
 var delegateCmd = &cobra.Command{
-	Use:   "delegate [valAddress] [amount]",
+	Use:   "delegate validator_address amount",
 	Short: "Sends a user's liquid tokens to a validator for delegation.",
-	Args:  cobra.ExactArgs(4),
+	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := cmdnode.ParseClientFromCtx(cmd.Context())
 		if err != nil {
@@ -292,7 +292,7 @@ var delegateCmd = &cobra.Command{
 }
 
 var withdrawDelegatorRewardCmd = &cobra.Command{
-	Use:   "withdraw-delegator-reward [valAddress]",
+	Use:   "withdraw-delegator-reward validator_address",
 	Short: "Withdraws a delegator's rewards from a validator.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -317,7 +317,7 @@ var withdrawDelegatorRewardCmd = &cobra.Command{
 }
 
 var queryDelegationRewardsCmd = &cobra.Command{
-	Use:   "get-delegation-rewards [valAddress]",
+	Use:   "get-delegation-rewards validator_address",
 	Short: "Retrieves the pending rewards for a delegation to a given validator.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -338,7 +338,7 @@ var queryDelegationRewardsCmd = &cobra.Command{
 }
 
 var queryDelegationCmd = &cobra.Command{
-	Use:   "get-delegation [valAddress]",
+	Use:   "get-delegation validator_address",
 	Short: "Retrieves the delegation information between a delegator and a validator.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -359,7 +359,7 @@ var queryDelegationCmd = &cobra.Command{
 }
 
 var queryUnbondingCmd = &cobra.Command{
-	Use:   "get-unbonding [valAddress]",
+	Use:   "get-unbonding validator_address",
 	Short: "Retrieves the unbonding status between a delegator and a validator.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -380,7 +380,7 @@ var queryUnbondingCmd = &cobra.Command{
 }
 
 var queryRedelegationCmd = &cobra.Command{
-	Use:   "get-redelegations [srcAddress] [dstAddress]",
+	Use:   "get-redelegations source_validator_address destination_validator_address",
 	Short: "Retrieves the status of the redelegations between a delegator and a validator.",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -410,7 +410,7 @@ var queryRedelegationCmd = &cobra.Command{
 }
 
 var grantFeeCmd = &cobra.Command{
-	Use: "grant-fee [granteeAddress]",
+	Use: "grant-fee grantee_address",
 	Short: "Grant an allowance to a specified grantee account to pay the fees for their transactions.\n" +
 		"Grantee can spend any amount of tokens in case the spend limit is not set.",
 	Args: cobra.ExactArgs(1),
@@ -436,7 +436,7 @@ var grantFeeCmd = &cobra.Command{
 }
 
 var revokeGrantFeeCmd = &cobra.Command{
-	Use:   "revoke-grant-fee [granteeAddress]",
+	Use:   "revoke-grant-fee grantee_address",
 	Short: "Removes permission for grantee to submit PFB transactions which will be paid by granter.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/nodebuilder/state/cmd/state_test.go
+++ b/nodebuilder/state/cmd/state_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelegationCommandsAcceptDocumentedOperands(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "delegate", cmd: delegateCmd},
+		{name: "undelegate", cmd: undelegateCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.cmd.Args(tt.cmd, []string{"validator_address", "1000"}))
+			require.Error(t, tt.cmd.Args(tt.cmd, []string{"validator_address"}))
+			require.Error(t, tt.cmd.Args(tt.cmd, []string{"validator_address", "1000", "extra"}))
+		})
+	}
+}


### PR DESCRIPTION
Closes #2880

## Description

Make the `celestia` and `cel-shed` usage lines follow the POSIX utility argument syntax conventions referenced by the issue.

## Changes made

- show required operands without square brackets
- reserve square brackets for optional commands and the optional blob-submit operand pair
- use `|` for mutually exclusive operands and `...` for repeatable operands
- remove duplicate flag notation because Cobra appends `[flags]` itself
- add missing operand names to usage lines
- correct `delegate` and `undelegate` from stale `ExactArgs(4)` to `ExactArgs(2)`; both commands have accepted only `validator_address` and `amount` since fee/gas moved to flags in #3349
- add regression coverage for the delegation argument validators

## Validation

- `make build`
- `make cel-shed`
- `make test-unit`
- tests for every changed command package
- `golangci-lint` on every changed package: 0 issues
- manually checked representative `--help` output for root, share, state, p2p, and cel-shed commands

A repository-wide `golangci-lint run` also reports six pre-existing findings in unchanged files (`cmd/rpc.go`, `api/client/grpc.go`, `blob/service_test.go`, `nodebuilder/tests/swamp/swamp.go`, and two shwap files).