### PR TITLE
fix(test): remove Corto network from TestBootstrapperHealth

### DIFF
--- a/nodebuilder/p2p/bootstrap_health_test.go
+++ b/nodebuilder/p2p/bootstrap_health_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBootstrapperHealth(t *testing.T) {
-	networks := []Network{Mainnet, Mocha, Corto}
+	networks := []Network{Mainnet, Mocha}
 	for _, network := range networks {
 		t.Run(string(network), func(t *testing.T) {
 			bootstrappers, err := BootstrappersFor(network)


### PR DESCRIPTION
Removed corto network from test as we don't have publicly available bootstrappers