### PR TITLE
fix(share/shwap): bound rows read in NamespaceData.ReadFrom

### DIFF
--- a/share/shwap/namespace_data.go
+++ b/share/shwap/namespace_data.go
@@ -55,6 +55,13 @@ func (nd NamespaceData) Verify(root *share.AxisRoots, namespace libshare.Namespa
 	return nil
 }
 
+// maxNamespaceDataRows bounds the number of rows read from a stream. A namespace
+// can span at most every row of the extended square, so any response exceeding
+// this is malformed. Without it a peer can stream length-delimited rows until the
+// read deadline, growing the requester's heap unbounded (serde caps each row at
+// 1 MiB but not their count).
+var maxNamespaceDataRows = 2 * share.MaxSquareSize
+
 // ReadFrom reads NamespaceData from the provided reader implementing io.ReaderFrom.
 // It reads series of length-delimited RowNamespaceData until EOF draining the stream.
 func (nd *NamespaceData) ReadFrom(reader io.Reader) (int64, error) {
@@ -71,6 +78,9 @@ func (nd *NamespaceData) ReadFrom(reader io.Reader) (int64, error) {
 			return n, err
 		}
 
+		if len(ndNew) >= maxNamespaceDataRows {
+			return n, fmt.Errorf("namespace data exceeds %d rows", maxNamespaceDataRows)
+		}
 		ndNew = append(ndNew, rnd)
 	}
 

--- a/share/shwap/namespace_data.go
+++ b/share/shwap/namespace_data.go
@@ -55,12 +55,8 @@ func (nd NamespaceData) Verify(root *share.AxisRoots, namespace libshare.Namespa
 	return nil
 }
 
-// maxNamespaceDataRows bounds the number of rows read from a stream. A namespace
-// can span at most every row of the extended square, so any response exceeding
-// this is malformed. Without it a peer can stream length-delimited rows until the
-// read deadline, growing the requester's heap unbounded (serde caps each row at
-// 1 MiB but not their count).
-var maxNamespaceDataRows = 2 * share.MaxSquareSize
+// maxNamespaceDataRows bounds the number of rows read from a stream.
+var maxNamespaceDataRows = share.MaxSquareSize
 
 // ReadFrom reads NamespaceData from the provided reader implementing io.ReaderFrom.
 // It reads series of length-delimited RowNamespaceData until EOF draining the stream.

--- a/share/shwap/namespace_data_test.go
+++ b/share/shwap/namespace_data_test.go
@@ -1,0 +1,70 @@
+package shwap_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	libshare "github.com/celestiaorg/go-square/v4/share"
+
+	"github.com/celestiaorg/celestia-node/share"
+	"github.com/celestiaorg/celestia-node/share/eds"
+	"github.com/celestiaorg/celestia-node/share/eds/edstest"
+	"github.com/celestiaorg/celestia-node/share/shwap"
+)
+
+func TestNamespaceDataReadFromCapsRows(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	maxRows := 2 * share.MaxSquareSize
+
+	// serialize a single valid row to replay as the attacker's payload.
+	const odsSize = 8
+	namespace := libshare.RandomNamespace()
+	randEDS, _ := edstest.RandEDSWithNamespace(t, namespace, odsSize, odsSize)
+	nd, err := eds.NamespaceData(ctx, &eds.Rsmt2D{ExtendedDataSquare: randEDS}, namespace)
+	require.NoError(t, err)
+	require.NotEmpty(t, nd)
+
+	var row bytes.Buffer
+	_, err = nd[0].WriteTo(&row)
+	require.NoError(t, err)
+
+	// one more row than the largest possible extended square.
+	var stream bytes.Buffer
+	for range maxRows + 1 {
+		stream.Write(row.Bytes())
+	}
+
+	var got shwap.NamespaceData
+	_, err = got.ReadFrom(&stream)
+	require.Error(t, err)
+	require.Empty(t, got, "no rows must be committed when the cap is exceeded")
+}
+
+// TestNamespaceDataReadFromRoundTrip ensures a well-formed response of legitimate
+// size still round-trips through WriteTo/ReadFrom unchanged.
+func TestNamespaceDataReadFromRoundTrip(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	const odsSize = 8
+	namespace := libshare.RandomNamespace()
+	randEDS, _ := edstest.RandEDSWithNamespace(t, namespace, odsSize*odsSize/2, odsSize)
+	nd, err := eds.NamespaceData(ctx, &eds.Rsmt2D{ExtendedDataSquare: randEDS}, namespace)
+	require.NoError(t, err)
+	require.NotEmpty(t, nd)
+
+	var buf bytes.Buffer
+	_, err = shwap.NamespaceData(nd).WriteTo(&buf)
+	require.NoError(t, err)
+
+	var got shwap.NamespaceData
+	_, err = got.ReadFrom(&buf)
+	require.NoError(t, err)
+	require.Equal(t, shwap.NamespaceData(nd), got)
+}

--- a/share/shwap/namespace_data_test.go
+++ b/share/shwap/namespace_data_test.go
@@ -20,7 +20,7 @@ func TestNamespaceDataReadFromCapsRows(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	maxRows := 2 * share.MaxSquareSize
+	maxRows := share.MaxSquareSize
 
 	// serialize a single valid row to replay as the attacker's payload.
 	const odsSize = 8
@@ -34,7 +34,7 @@ func TestNamespaceDataReadFromCapsRows(t *testing.T) {
 	_, err = nd[0].WriteTo(&row)
 	require.NoError(t, err)
 
-	// one more row than the largest possible extended square.
+	// one more row than a namespace can occupy in the largest possible ODS.
 	var stream bytes.Buffer
 	for range maxRows + 1 {
 		stream.Write(row.Bytes())
@@ -60,11 +60,11 @@ func TestNamespaceDataReadFromRoundTrip(t *testing.T) {
 	require.NotEmpty(t, nd)
 
 	var buf bytes.Buffer
-	_, err = shwap.NamespaceData(nd).WriteTo(&buf)
+	_, err = nd.WriteTo(&buf)
 	require.NoError(t, err)
 
 	var got shwap.NamespaceData
 	_, err = got.ReadFrom(&buf)
 	require.NoError(t, err)
-	require.Equal(t, shwap.NamespaceData(nd), got)
+	require.Equal(t, nd, got)
 }


### PR DESCRIPTION
`NamespaceData.ReadFrom` reads length-delimited rows off the stream until EOF with no cap on the row count. `serde` limits each row to 1 MiB but not how many arrive, so a peer serving a `GetNamespaceData` / `GetRangeNamespaceData` request can keep streaming rows until the client's read deadline, growing the requester's heap
unbounded. The row count is not bounded anywhere on the receive side (the libp2p resource-manager limits are server/handler-side only).

