### PR TITLE
ci: sync GitHub releases to the Linear release pipeline

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -13,10 +13,14 @@ permissions:
 
 jobs:
   sync:
-    if: github.event.release.prerelease == false
+    # Guard on the tag as well as the prerelease flag: the flag is set per
+    # release and a testnet tag published without it would otherwise sync.
+    if: github.event.release.prerelease == false && !contains(github.event.release.tag_name, '-')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      # Pinned to a commit SHA: this job holds LINEAR_ACCESS_KEY, so a repointed
+      # mutable tag would run third-party code alongside the credential.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,48 @@
+name: linear-release
+
+# Sync each published GitHub release to the celestia-node release pipeline in
+# Linear so issues fixed by PRs in the release move from Merged to Released.
+# Pre-releases (-arabica, -mocha, -corto) are testnet-only and skipped.
+# https://linear.app/celestia/settings/releases/pipelines/celestia-node
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      # Scan from the previous mainnet tag reachable from this release. The
+      # action's default base is the previous Linear release, which may be on
+      # another release branch (e.g. v0.31.x vs main) and would misattribute
+      # commits. Pre-release tags contain a hyphen (v0.33.0-mocha) and are
+      # excluded so commits they shipped still land in the next mainnet release.
+      - name: Find previous mainnet tag
+        id: prev
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          prev=$(git describe --tags --abbrev=0 --exclude='*-*' "${TAG}^")
+          echo "tag=${prev}" >> "$GITHUB_OUTPUT"
+      - uses: linear/linear-release-action@53ad0f863963e7f8e270fba18426bbb55ef55384 # v0.17.2
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ github.event.release.tag_name }}
+          base_ref: ${{ steps.prev.outputs.tag }}
+          links: GitHub release=${{ github.event.release.html_url }}
+      # The pipeline is a scheduled pipeline, so sync leaves the release In
+      # Progress. Complete it so linked issues move to Released.
+      - uses: linear/linear-release-action@53ad0f863963e7f8e270fba18426bbb55ef55384 # v0.17.2
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+          version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Linear's Done status was split into Merged and Released. Linear's GitHub integration already moves issues to Merged when a PR lands on main, but nothing moves them to Released. This adds a workflow that runs the [Linear Release action](https://github.com/marketplace/actions/linear-release) on every published mainnet GitHub release, syncing it to the [celestia-node release pipeline](https://linear.app/celestia/settings/releases/pipelines/celestia-node) so issues fixed by PRs in the release are marked Released. Testnet pre-releases (`-arabica`, `-mocha`, `-corto`) are skipped, guarded on the tag suffix as well as the release's prerelease flag, which is set per release rather than derived from the tag. Mirrors celestiaorg/celestia-app#7809.

The scan base is the previous mainnet tag reachable from the release tag rather than the action's default of the previous Linear release, which may sit on another release branch (v0.31.x vs main) and misattribute commits. The pipeline is a scheduled pipeline, so a `complete` step follows `sync`; otherwise the release stays In Progress and issues never move. Verified the tag lookup on v0.33.0, v0.32.1, and v0.31.4 and ran actionlint and yamllint.

The job uses the `LINEAR_ACCESS_KEY` repo secret, which is already set, so every action it runs is pinned to a commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
