### PR TITLE
fix(api/rpc/client): store multiCloser on client and close initialized connections on error (#5188)

### DIFF
--- a/api/rpc/client/client.go
+++ b/api/rpc/client/client.go
@@ -52,8 +52,11 @@ func (m *multiClientCloser) register(closer jsonrpc.ClientCloser) {
 // closeAll closes all saved clients.
 func (m *multiClientCloser) closeAll() {
 	for _, closer := range m.closers {
-		closer()
+		if closer != nil {
+			closer()
+		}
 	}
+	m.closers = nil
 }
 
 // Close closes the connections to all namespaces registered on the staticClient.
@@ -77,11 +80,12 @@ func newClient(ctx context.Context, addr string, authHeader http.Header) (*Clien
 	for name, module := range moduleMap(&client) {
 		closer, err := jsonrpc.NewClient(ctx, addr, name, module, authHeader)
 		if err != nil {
+			multiCloser.closeAll()
 			return nil, err
 		}
 		multiCloser.register(closer)
 	}
-
+	client.closer = multiCloser
 	return &client, nil
 }
 

--- a/api/rpc/client/client_test.go
+++ b/api/rpc/client/client_test.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiClientCloser(t *testing.T) {
+	called := 0
+	closer1 := func() { called++ }
+	closer2 := func() { called++ }
+
+	var mc multiClientCloser
+	mc.register(closer1)
+	mc.register(closer2)
+
+	require.Len(t, mc.closers, 2)
+	mc.closeAll()
+	require.Equal(t, 2, called)
+	require.Nil(t, mc.closers)
+
+	// Repeated calls to closeAll should be safe and no-op
+	require.NotPanics(t, func() {
+		mc.closeAll()
+	})
+	require.Equal(t, 2, called)
+}
+
+func TestClientCloseCallsClosers(t *testing.T) {
+	called := false
+	c := &Client{}
+	c.closer.register(func() { called = true })
+
+	c.Close()
+	require.True(t, called)
+}


### PR DESCRIPTION
Fixes #5188. In api/rpc/client.newClient, the multiClientCloser was stored in a local variable and discarded when newClient returned, causing Client.Close() to do nothing. This fix stores multiCloser on the returned Client instance, rolls back/closes any opened connections if initialization fails for a subsequent namespace, and sets closers to nil after closeAll to make repeated Close() calls idempotent.